### PR TITLE
Fix package build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.0.0",
+    "version": "1.0.0-beta.2",
     "description": "UiPath TypeScript SDK",
     "type": "module",
     "main": "./dist/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,15 +17,10 @@
     "paths": {
       "*": ["node_modules/*", "src/types/*"]
     },
-    "composite": true,
+    "composite": false,
     "declarationMap": true,
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "packages"],
-  "references": [
-    {
-      "path": "./packages/cli"
-    }
-  ]
+  "exclude": ["node_modules", "dist", "tests", "packages"]
 }


### PR DESCRIPTION
TypeScript's use of `composite: true` and project `references` caused builds to be skipped or coupled, preventing independent package compilation.
