### PR TITLE
Add CRUD operations for entity data [PLT-88285]

### DIFF
--- a/src/models/data-fabric/entity.models.ts
+++ b/src/models/data-fabric/entity.models.ts
@@ -1,4 +1,14 @@
-import { EntityGetByIdOptions, EntityGetByIdResponse } from './entity.types';
+import { 
+  EntityGetByIdOptions, 
+  EntityGetByIdResponse, 
+  EntityInsertOptions, 
+  EntityInsertResponse,
+  EntityUpdateOptions,
+  EntityUpdateResponse,
+  EntityDeleteOptions,
+  EntityDeleteResponse,
+  EntityRecord
+} from './entity.types';
 
 /**
  * Entity service model interface
@@ -7,9 +17,116 @@ export interface EntityServiceModel {
   /**
    * Gets entity data by entity ID
    * 
-   * @param entityId - UUID of the entity
+   * @param id - UUID of the entity
    * @param options - Query options
    * @returns Promise resolving to query response
    */
-  getById(entityId: string, options?: EntityGetByIdOptions): Promise<EntityGetByIdResponse>;
+  getById(id: string, options?: EntityGetByIdOptions): Promise<Entity>;
+
+  /**
+   * Inserts data into an entity by entity ID
+   * 
+   * @param id - UUID of the entity
+   * @param data - Array of records to insert
+   * @param options - Insert options
+   * @returns Promise resolving to insert response
+   */
+  insertById(id: string, data: Record<string, any>[], options?: EntityInsertOptions): Promise<EntityInsertResponse>;
+
+  /**
+   * Updates data in an entity by entity ID
+   * 
+   * @param id - UUID of the entity
+   * @param data - Array of records to update. Each record MUST contain the record Id.
+   * @param options - Update options
+   * @returns Promise resolving to update response
+   */
+  updateById(id: string, data: EntityRecord[], options?: EntityUpdateOptions): Promise<EntityUpdateResponse>;
+
+  /**
+   * Deletes data from an entity by entity ID
+   * 
+   * @param id - UUID of the entity
+   * @param recordIds - Array of record UUIDs to delete
+   * @param options - Delete options
+   * @returns Promise resolving to delete response
+   */
+  deleteById(id: string, recordIds: string[], options?: EntityDeleteOptions): Promise<EntityDeleteResponse>;
+}
+
+/**
+ * Entity model class representing a Data Fabric entity
+ */
+export class Entity {
+  /**
+   * The unique identifier for this entity
+   */
+  public readonly id: string;
+
+  /**
+   * The entity data records
+   */
+  public readonly data: EntityRecord[];
+
+  /**
+   * The entity field metadata
+   */
+  public readonly fields: EntityGetByIdResponse['fields'];
+
+  /**
+   * The total count of records
+   */
+  public readonly totalCount: number;
+
+  /**
+   * Creates a new Entity instance
+   * 
+   * @param response - The entity response data
+   * @param id - The entity ID
+   * @param service - The service to use for operations
+   */
+  constructor(
+    response: EntityGetByIdResponse,
+    id: string,
+    private readonly _service: EntityServiceModel
+  ) {
+    this.id = id;
+    this.data = response.data;
+    this.fields = response.fields;
+    this.totalCount = response.totalCount;
+  }
+
+  /**
+   * Insert data into this entity
+   * 
+   * @param data - Array of records to insert
+   * @param options - Insert options
+   * @returns Promise resolving to insert response
+   */
+  async insert(data: Record<string, any>[], options?: EntityInsertOptions): Promise<EntityInsertResponse> {
+    return this._service.insertById(this.id, data, options);
+  }
+
+  /**
+   * Update data in this entity
+   * 
+   * @param data - Array of records to update. Each record MUST contain the record Id,
+   *               otherwise the update will fail.
+   * @param options - Update options
+   * @returns Promise resolving to update response
+   */
+  async update(data: EntityRecord[], options?: EntityUpdateOptions): Promise<EntityUpdateResponse> {
+    return this._service.updateById(this.id, data, options);
+  }
+
+  /**
+   * Delete data from this entity
+   * 
+   * @param recordIds - Array of record UUIDs to delete
+   * @param options - Delete options
+   * @returns Promise resolving to delete response
+   */
+  async delete(recordIds: string[], options?: EntityDeleteOptions): Promise<EntityDeleteResponse> {
+    return this._service.deleteById(this.id, recordIds, options);
+  }
 }

--- a/src/models/data-fabric/entity.types.ts
+++ b/src/models/data-fabric/entity.types.ts
@@ -28,11 +28,26 @@ export interface EntityFieldMetaData {
 }
 
 /**
+ * Represents a single entity record 
+ */
+export interface EntityRecord {
+  /**
+   * Unique identifier for the record
+   */
+  id: string;
+  
+  /**
+   * Additional dynamic fields for the entity
+   */
+  [key: string]: any;
+}
+
+/**
  * Interface for getById response
  */
 export interface EntityGetByIdResponse {
   totalCount: number;
-  data: Record<string, any>[];
+  data: EntityRecord[];
   fields: EntityFieldMetaData[];
 }
 
@@ -43,3 +58,66 @@ export interface EntityGetByIdOptions extends BaseOptions {
   /** Level of entity expansion (default: 0) */
   expansionLevel?: number;
 }
+
+/**
+ * Common options for entity operations that modify multiple records
+ */
+export interface EntityOperationOptions {
+  /** Level of entity expansion (default: 0) */
+  expansionLevel?: number;
+  /** Whether to fail on first error (default: false) */
+  failOnFirst?: boolean;
+}
+
+/**
+ * Options for inserting data into an entity
+ */
+export type EntityInsertOptions = EntityOperationOptions;
+
+/**
+ * Options for updating data in an entity
+ */
+export type EntityUpdateOptions = EntityOperationOptions;
+
+/**
+ * Options for deleting data from an entity
+ */
+export interface EntityDeleteOptions {
+  /** Whether to fail on first error (default: false) */
+  failOnFirst?: boolean;
+}
+
+/**
+ * Represents a failure record in an entity operation
+ */
+export interface FailureRecord {
+  /** Error message */
+  error?: string;
+  /** Original record that failed */
+  record?: Record<string, any>;
+}
+
+/**
+ * Response from an entity operation that modifies multiple records
+ */
+export interface EntityOperationResponse {
+  /** Records that were successfully processed */
+  successRecords: Record<string, any>[];
+  /** Records that failed processing */
+  failureRecords: FailureRecord[];
+}
+
+/**
+ * Response from inserting data into an entity
+ */
+export type EntityInsertResponse = EntityOperationResponse;
+
+/**
+ * Response from updating data in an entity
+ */
+export type EntityUpdateResponse = EntityOperationResponse;
+
+/**
+ * Response from deleting data from an entity
+ */
+export type EntityDeleteResponse = EntityOperationResponse;

--- a/src/services/data-fabric/entity.ts
+++ b/src/services/data-fabric/entity.ts
@@ -2,16 +2,23 @@ import { BaseService } from '../base-service';
 import { Config } from '../../core/config/config';
 import { ExecutionContext } from '../../core/context/execution-context';
 import { TokenManager } from '../../core/auth/token-manager';
-import { EntityServiceModel } from '../../models/data-fabric/entity.models';
+import { EntityServiceModel, Entity } from '../../models/data-fabric/entity.models';
 import {
   EntityGetByIdResponse,
   EntityGetByIdOptions,
-  EntityFieldMetaData
+  EntityFieldMetaData,
+  EntityInsertOptions,
+  EntityInsertResponse,
+  EntityUpdateOptions,
+  EntityUpdateResponse,
+  EntityDeleteOptions,
+  EntityDeleteResponse,
+  EntityRecord
 } from '../../models/data-fabric/entity.types';
 import { EntityMetadataResponse } from '../../models/data-fabric/entity.internal-types';
 import { DATA_FABRIC_ENDPOINTS } from '../../utils/constants/endpoints';
 import { createParams } from '../../utils/http/params';
-import { transformData } from '../../utils/transform';
+import { transformData, pascalToCamelCaseKeys } from '../../utils/transform';
 import { EntityMap, EntityFieldTypeMap, SqlFieldType } from '../../models/data-fabric/entity.constants';
 
 /**
@@ -27,20 +34,20 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * 
    * @param entityId - UUID of the entity
    * @param options - Query options including start, limit, and expansionLevel
-   * @returns Promise resolving to query response
+   * @returns Promise resolving to an Entity instance
    * 
    * @example
    * ```typescript
    * // Basic usage
-   * const result = await sdk.entity.getById("123e4567-e89b-12d3-a456-426614174000");
+   * const entity = await sdk.entity.getById(<entityId>);
    * 
    * // With expansion level
-   * const result = await sdk.entity.getById("123e4567-e89b-12d3-a456-426614174000", {
+   * const entity = await sdk.entity.getById(<entityId>, {
    *   expansionLevel: 1
    * });
    * ```
    */
-  async getById(id: string, options: EntityGetByIdOptions = {}): Promise<EntityGetByIdResponse> {
+  async getById(id: string, options: EntityGetByIdOptions = {}): Promise<Entity> {
     const params = createParams({
       expansionLevel: options.expansionLevel
     });
@@ -57,13 +64,147 @@ export class EntityService extends BaseService implements EntityServiceModel {
     // Get entity fields
     const fields = await this._getEntityFields(id);
 
+    // Convert PascalCase keys to camelCase
+    const dataWithCamelCase = pascalToCamelCaseKeys(response.data);
+    
     // Transform the response using EntityMap 
-    const transformedData = transformData(response.data, EntityMap);
+    const transformedData = transformData(dataWithCamelCase, EntityMap);
 
-    return {
+    const entityData = {
       ...transformedData,
       fields
     } as EntityGetByIdResponse;
+
+    // Return a new Entity instance
+    return new Entity(entityData, id, this);
+  }
+
+  /**
+   * Inserts data into an entity by entity ID
+   * 
+   * @param entityId - UUID of the entity
+   * @param data - Array of records to insert
+   * @param options - Insert options
+   * @returns Promise resolving to insert response
+   * 
+   * @example
+   * ```typescript
+   * // Basic usage
+   * const result = await sdk.entity.insertById(<entityId>, [
+   *   { name: "John", age: 30 },
+   *   { name: "Jane", age: 25 }
+   * ]);
+   * 
+   * // With options
+   * const result = await sdk.entity.insertById(<entityId>, [
+   *   { name: "John", age: 30 },
+   *   { name: "Jane", age: 25 }
+   * ], {
+   *   expansionLevel: 1,
+   *   failOnFirst: true
+   * });
+   * ```
+   */
+  async insertById(id: string, data: Record<string, any>[], options: EntityInsertOptions = {}): Promise<EntityInsertResponse> {
+    const params = createParams({
+      expansionLevel: options.expansionLevel,
+      failOnFirst: options.failOnFirst
+    });
+
+    const response = await this.post<EntityInsertResponse>(
+      DATA_FABRIC_ENDPOINTS.ENTITY.INSERT_BY_ID(id),
+      data,
+      {
+        params,
+        ...options
+      }
+    );
+
+    // Convert PascalCase response to camelCase
+    const camelResponse = pascalToCamelCaseKeys(response.data);
+    return camelResponse;
+  }
+
+  /**
+   * Updates data in an entity by entity ID
+   * 
+   * @param entityId - UUID of the entity
+   * @param data - Array of records to update. Each record MUST contain the record Id,
+   *               otherwise the update will fail.
+   * @param options - Update options
+   * @returns Promise resolving to update response
+   * 
+   * @example
+   * ```typescript
+   * // Basic usage
+   * const result = await sdk.entity.updateById(<entityId>, [
+   *   { Id: "123", name: "John Updated", age: 31 },
+   *   { Id: "456", name: "Jane Updated", age: 26 }
+   * ]);
+   * 
+   * // With options
+   * const result = await sdk.entity.updateById(<entityId>, [
+   *   { Id: "123", name: "John Updated", age: 31 },
+   *   { Id: "456", name: "Jane Updated", age: 26 }
+   * ], {
+   *   expansionLevel: 1,
+   *   failOnFirst: true
+   * });
+   * ```
+   */
+  async updateById(id: string, data: EntityRecord[], options: EntityUpdateOptions = {}): Promise<EntityUpdateResponse> {
+    const params = createParams({
+      expansionLevel: options.expansionLevel,
+      failOnFirst: options.failOnFirst
+    });
+
+    const response = await this.post<EntityUpdateResponse>(
+      DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_BY_ID(id),
+      data,
+      {
+        params,
+        ...options
+      }
+    );
+
+    // Convert PascalCase response to camelCase
+    const camelResponse = pascalToCamelCaseKeys(response.data);
+    return camelResponse;
+  }
+
+  /**
+   * Deletes data from an entity by entity ID
+   * 
+   * @param entityId - UUID of the entity
+   * @param recordIds - Array of record UUIDs to delete
+   * @param options - Delete options
+   * @returns Promise resolving to delete response
+   * 
+   * @example
+   * ```typescript
+   * // Basic usage
+   * const result = await sdk.entity.deleteById(<entityId>, [
+   *   <recordId-1>, <recordId-2>
+   * ]);
+   * ```
+   */
+  async deleteById(id: string, recordIds: string[], options: EntityDeleteOptions = {}): Promise<EntityDeleteResponse> {
+    const params = createParams({
+      failOnFirst: options.failOnFirst
+    });
+
+    const response = await this.post<EntityDeleteResponse>(
+      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_BY_ID(id),
+      recordIds,
+      {
+        params,
+        ...options
+      }
+    );
+
+    // Convert PascalCase response to camelCase
+    const camelResponse = pascalToCamelCaseKeys(response.data);
+    return camelResponse;
   }
 
   /**

--- a/src/utils/constants/endpoints.ts
+++ b/src/utils/constants/endpoints.ts
@@ -47,6 +47,9 @@ export const DATA_FABRIC_ENDPOINTS = {
   ENTITY: {
     GET_BY_ID: (entityId: string) => `datafabric_/api/EntityService/entity/${entityId}/read`,
     GET_ENTITY_METADATA: (entityId: string) => `datafabric_/api/Entity/${entityId}`,
+    INSERT_BY_ID: (entityId: string) => `datafabric_/api/EntityService/entity/${entityId}/insert-batch`,
+    UPDATE_BY_ID: (entityId: string) => `datafabric_/api/EntityService/entity/${entityId}/update-batch`,
+    DELETE_BY_ID: (entityId: string) => `datafabric_/api/EntityService/entity/${entityId}/delete-batch`,
   },
 } as const;
 


### PR DESCRIPTION
Usage:
1. Insert
```
(a) 
const result = await sdk.entity.insertById(<id>, [
  { Name: "John", Num: 30 },
  { Name: "Jane", Num: 25 }
]);

(b) 
const entity = await sdk.entity.getById(<id>);
const result = await entity.insert([
  { Name: "John", Num: 30 },
  { Name: "Jane", Num: 25 }
]);

```
2. Update
```
// Each record MUST contain the record Id, otherwise the update will fail.
(a)
const result = await sdk.entity.updateById(<entityId>, [
   { id: <recordId>, name: "John Updated", age: 31 },
   { id: "456", name: "Jane Updated", age: 26 }
]);

(b)
const entity = await sdk.entity.getById(<id>);
const result = await entity.update(
[
   { id: "123", name: "John Updated", age: 31 },
   { id: "456", name: "Jane Updated", age: 26 }
]);

```

2. Delete
```
(a)
const result = await sdk.entity.deleteById(<entityId>, [
  <recordId-1>, <recordId-2>
 ]);

(b)
const entity = await sdk.entity.getById(<id>);
const result = await entity.delete([
  <recordId-1>, <recordId-2>
 ]);

```
