### PR TITLE
Refactor Task model and service to integrate methods directly into task Objects [PLT-89163]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.0.0-beta.6",
+    "version": "1.0.0-beta.7",
     "description": "UiPath TypeScript SDK",
     "type": "module",
     "main": "./dist/index.js",

--- a/src/models/task/task.models.ts
+++ b/src/models/task/task.models.ts
@@ -1,9 +1,7 @@
 import type { 
-  TaskCreateResponse,
-  TaskGetResponse, 
+  RawTaskCreateResponse,
+  RawTaskGetResponse, 
   TaskType,
-  TaskStatus, 
-  TaskPriority, 
   TaskAssignmentResult, 
   TaskAssignmentRequest,
   TaskCompletionRequest,
@@ -14,12 +12,13 @@ import type {
   TaskCreateRequest
 } from './task.types';
 
+// Define the task service interface
 export interface TaskServiceModel {
-  getAll(options?: TaskGetAllOptions): Promise<Task<TaskGetResponse>[]>;
+  getAll(options?: TaskGetAllOptions): Promise<TaskGetResponse[]>;
 
-  getById(id: number, options?: TaskGetByIdOptions, folderId?: number): Promise<Task<TaskGetResponse>>;
+  getById(id: number, options?: TaskGetByIdOptions, folderId?: number): Promise<TaskGetResponse>;
 
-  create(request: TaskCreateRequest, folderId: number): Promise<Task<TaskCreateResponse>>;
+  create(request: TaskCreateRequest, folderId: number): Promise<TaskCreateResponse>;
 
   assign(request: TaskAssignmentRequest, folderId?: number): Promise<TaskAssignmentResult[]>;
   
@@ -34,159 +33,106 @@ export interface TaskServiceModel {
   ): Promise<void>;
 }
 
-type TaskResponseData = TaskGetResponse | TaskCreateResponse;
-export class Task<T extends TaskResponseData > {
-  constructor(
-    private readonly _data: T,
-    private readonly service: TaskServiceModel,
-  ) {}
-  get id(): number {
-    return this._data.id;
-  }
-
-  get key(): string {
-    return this._data.key;
-  }
-
-  get title(): string {
-    return this._data.title;
-  }
-
-  get status(): TaskStatus {
-    return this._data.status;
-  }
-
-  get priority(): TaskPriority  {
-    return this._data.priority;
-  }
-
-  get type(): TaskType {
-    return this._data.type;
-  }
-
-  get assignedToUserId(): number | null { 
-    return this._data.assignedToUserId;
-  }
-
-  get creatorUserId(): number {
-    return this._data.creatorUserId;
-  }
-
-  get folderId(): number {
-    return this._data.organizationUnitId;
-  }
-
-  get createdTime(): string {
-    return this._data.creationTime;
-  }
-
-  get completedTime(): string | null {   
-    return this._data.completionTime;
-  }
-
-  // Access to raw task data
-  get data(): T {
-    return this._data;
-  }
-
-  // Task methods
+// Method interface that will be added to task objects
+export interface TaskMethods {
   /**
    * Assigns this task to a user or users
    * 
    * @param options - Assignment options (requires at least one of: userId, userNameOrEmail)
    * @returns Promise resolving to task assignment results
-   * 
-   * @example
-   * ```typescript
-   * // Assign to a user by ID
-   * await task.assign({ userId: 123 });
-   * 
-   * // Assign to a user by email
-   * await task.assign({ userNameOrEmail: 'user@example.com' });
-   * ```
    */
-  async assign(options: TaskAssignOptions): Promise<TaskAssignmentResult[]> {
-    if (!this.id) throw new Error('Task ID is undefined');
-    
-    return this.service.assign({
-      taskId: this.id,
-      ...options
-    }, this.folderId);
-  }
-  
+  assign(options: TaskAssignOptions): Promise<TaskAssignmentResult[]>;
+
   /**
    * Reassigns this task to a new user
    * 
    * @param options - Assignment options (requires at least one of: userId, userNameOrEmail)
    * @returns Promise resolving to task assignment results
-   * 
-   * @example
-   * ```typescript
-   * // Reassign to a user by ID
-   * await task.reassign({ userId: 456 });
-   * 
-   * // Reassign to a user by email
-   * await task.reassign({ userNameOrEmail: 'user@example.com' });
-   * ```
    */
-  async reassign(options: TaskAssignOptions): Promise<TaskAssignmentResult[]> {
-    if (!this.id) throw new Error('Task ID is undefined');
-    
-    return this.service.reassign({
-      taskId: this.id,
-      ...options
-    }, this.folderId);
-  }
+  reassign(options: TaskAssignOptions): Promise<TaskAssignmentResult[]>;
 
   /**
    * Unassigns this task (removes current assignee)
    * 
    * @returns Promise resolving to task assignment results
-   * 
-   * @example
-   * ```typescript
-   * // Unassign the task
-   * await task.unassign();
-   * ```
    */
-  async unassign(): Promise<TaskAssignmentResult[]> {
-    if (!this.id) throw new Error('Task ID is undefined');
-    
-    return this.service.unassign(this.id, this.folderId);
-  }
+  unassign(): Promise<TaskAssignmentResult[]>;
 
   /**
    * Completes this task with optional data and action
    * 
    * @param options - Completion options
    * @returns Promise resolving to void
-   * 
-   * @example
-   * ```typescript
-   * // Complete a task with type
-   * await task.complete({ type: TaskType.ExternalTask });
-   * 
-   * // Complete with data and action
-   * await task.complete({
-   *   type: TaskType.AppTask,
-   *   data: { result: true },
-   *   action: 'approve'
-   * });
-   * ```
    */
-  async complete(options: TaskCompleteOptions): Promise<void> {
-    if (!this.id) throw new Error('Task ID is undefined');
-    const folderId = this.folderId;
-    if (!folderId) throw new Error('Folder ID is required');
+  complete(options: TaskCompleteOptions): Promise<void>;
+}
+
+// Combined types for task data with methods
+export type TaskGetResponse = RawTaskGetResponse & TaskMethods;
+export type TaskCreateResponse = RawTaskCreateResponse & TaskMethods;
+
+/**
+ * Creates methods for a task
+ * 
+ * @param taskData - The task data (response from API)
+ * @param service - The task service instance
+ * @returns Object containing task methods
+ */
+function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse, service: TaskServiceModel): TaskMethods {
+  return {
+    async assign(options: TaskAssignOptions): Promise<TaskAssignmentResult[]> {
+      if (!taskData.id) throw new Error('Task ID is undefined');
+      
+      return service.assign({
+        taskId: taskData.id,
+        ...options
+      }, taskData.organizationUnitId);
+    },
     
-    return this.service.complete(
-      options.type,
-      {
-        taskId: this.id,
-        data: options.data,
-        action: options.action
-      },
-      folderId
-    );
-  }
+    async reassign(options: TaskAssignOptions): Promise<TaskAssignmentResult[]> {
+      if (!taskData.id) throw new Error('Task ID is undefined');
+      
+      return service.reassign({
+        taskId: taskData.id,
+        ...options
+      }, taskData.organizationUnitId);
+    },
+
+    async unassign(): Promise<TaskAssignmentResult[]> {
+      if (!taskData.id) throw new Error('Task ID is undefined');
+      
+      return service.unassign(taskData.id, taskData.organizationUnitId);
+    },
+
+    async complete(options: TaskCompleteOptions): Promise<void> {
+      if (!taskData.id) throw new Error('Task ID is undefined');
+      const folderId = taskData.organizationUnitId;
+      if (!folderId) throw new Error('Folder ID is required');
+      
+      return service.complete(
+        options.type,
+        {
+          taskId: taskData.id,
+          data: options.data,
+          action: options.action
+        },
+        folderId
+      );
+    }
+  };
+}
+
+/**
+ * Creates an actionable task by combining API task data with operational methods.
+ * 
+ * @param taskData - The task data from API
+ * @param service - The task service instance
+ * @returns A task object with added methods
+ */
+export function createTaskWithMethods(
+  taskData: RawTaskGetResponse | RawTaskCreateResponse, 
+  service: TaskServiceModel
+): TaskGetResponse | TaskCreateResponse {
+  const methods = createTaskMethods(taskData, service);
+  return Object.assign({}, taskData, methods) as TaskGetResponse | TaskCreateResponse;
 } 

--- a/src/models/task/task.types.ts
+++ b/src/models/task/task.types.ts
@@ -64,7 +64,7 @@ export interface TaskSlaDetail {
 
 export interface TaskAssignment {
   assignee?: UserLoginInfo;
-  task?: TaskGetResponse;
+  task?: RawTaskGetResponse;
   id?: number;
 }
 
@@ -98,7 +98,7 @@ export interface TaskCreateRequest {
   priority?: TaskPriority;
 }
 
-export interface TaskCreateResponse extends TaskBaseResponse {
+export interface RawTaskCreateResponse extends TaskBaseResponse {
   waitJobState: JobState | null;
   assignedToUser: UserLoginInfo | null;
   taskSlaDetails: TaskSlaDetail[] | null;
@@ -107,7 +107,7 @@ export interface TaskCreateResponse extends TaskBaseResponse {
   processingTime: number | null;
 }
 
-export interface TaskGetResponse extends TaskBaseResponse {
+export interface RawTaskGetResponse extends TaskBaseResponse {
   isCompleted: boolean;
   encrypted: boolean;
   bulkFormLayoutId: number | null;


### PR DESCRIPTION
Before - the getById would return a Task object :
`Task(_data: {}, _service:{})`
Now -  it returns an object with methods attached :
```
{
id:
createdBy:
....
assign: [AsyncFunction: assign],
reassign: [AsyncFunction: reassign],
unassign: [AsyncFunction: unassign],
complete: [AsyncFunction: complete]
}
```