### PR TITLE
Add Base64 encoding/decoding for pagination

### DIFF
--- a/src/core/telemetry/client.ts
+++ b/src/core/telemetry/client.ts
@@ -187,6 +187,11 @@ class TelemetryClient {
      */
     public track(eventName: string, name?: string, extraAttributes: TelemetryAttributes = {}): void {
         try {
+            // Skip if logger not initialized
+            if (!this.logger) {
+                return;
+            }
+            
             const finalDisplayName = name || eventName;
             
             const attributes = this.getEnrichedAttributes(extraAttributes, eventName);

--- a/src/utils/encoding/base64.ts
+++ b/src/utils/encoding/base64.ts
@@ -1,0 +1,52 @@
+/**
+ * Base64 encoding/decoding
+ */
+import { isBrowser } from '../platform';
+
+/**
+ * Encodes a string to base64
+ * @param str - The string to encode
+ * @returns Base64 encoded string
+ */
+export function encodeBase64(str: string): string {
+  // TextEncoder for UTF-8 encoding (works in both browser and Node.js)
+  const encoder = new TextEncoder();
+  const data = encoder.encode(str);
+  
+  // Convert Uint8Array to base64
+  if (isBrowser) {
+    // Browser environment
+    // Convert Uint8Array to binary string then to base64
+    const binaryString = Array.from(data, byte => String.fromCharCode(byte)).join('');
+    return btoa(binaryString);
+  } else {
+    // Node.js environment
+    return Buffer.from(data).toString('base64');
+  }
+}
+
+/**
+ * Decodes a base64 string
+ * @param base64 - The base64 string to decode
+ * @returns Decoded string
+ */
+export function decodeBase64(base64: string): string {
+  let bytes: Uint8Array;
+  
+  if (isBrowser) {
+    // Browser environment
+    const binaryString = atob(base64);
+    bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+  } else {
+    // Node.js environment
+    bytes = new Uint8Array(Buffer.from(base64, 'base64'));
+  }
+  
+  // TextDecoder for UTF-8 decoding (works in both browser and Node.js)
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes);
+}
+

--- a/src/utils/encoding/index.ts
+++ b/src/utils/encoding/index.ts
@@ -1,0 +1,1 @@
+export * from './base64';

--- a/src/utils/pagination/helpers.ts
+++ b/src/utils/pagination/helpers.ts
@@ -13,6 +13,7 @@ import { ODATA_PREFIX } from '../constants/common';
 import { addPrefixToKeys } from '../transform';
 import { DEFAULT_ITEMS_FIELD, DEFAULT_TOTAL_COUNT_FIELD } from './constants';
 import { filterUndefined } from '../object';
+import { decodeBase64 } from '../encoding/base64';
 
 /**
  * Helper functions for pagination that can be used across services
@@ -35,7 +36,7 @@ export class PaginationHelpers {
   static parseCursor(cursorString: string): CursorData {
     try {
       const cursorData: CursorData = JSON.parse(
-        Buffer.from(cursorString, 'base64').toString('utf-8')
+        decodeBase64(cursorString)
       );
       return cursorData;
     } catch (error) {

--- a/src/utils/pagination/pagination-manager.ts
+++ b/src/utils/pagination/pagination-manager.ts
@@ -1,6 +1,7 @@
 import { PaginatedResponse, PaginationCursor } from './types';
 import { CursorData, PaginationType, PaginationInfo } from './internal-types';
 import { filterUndefined } from '../object';
+import { encodeBase64 } from '../encoding/base64';
 
 /**
  * PaginationManager handles the conversion between uniform cursor-based pagination
@@ -39,7 +40,7 @@ export class PaginationManager {
     }
     
     return {
-      value: Buffer.from(JSON.stringify(cursorData)).toString('base64')
+      value: encodeBase64(JSON.stringify(cursorData))
     };
   }
 
@@ -63,7 +64,7 @@ export class PaginationManager {
       };
       
       previousCursor = {
-        value: Buffer.from(JSON.stringify(prevCursorData)).toString('base64')
+        value: encodeBase64(JSON.stringify(prevCursorData))
       };
     }
     


### PR DESCRIPTION
Problem : We were using Node's `Buffer` for encoding and decoding cursors which does not work in browser env.

Fix : 
1. Now we are using `Buffer` for node env and `btoa/atob` for browser env.
2. UTF-8 encoding/decoding is handled using `TextEncoder/TextDecoder` which works in both env.