### PR TITLE
Add getExecutionHistory for case instances [PLT-90153]

### DIFF
--- a/src/models/maestro/case-instances.constants.ts
+++ b/src/models/maestro/case-instances.constants.ts
@@ -26,6 +26,15 @@ export const StageSLAMap: { [key: string]: string } = {
   };
 
 /**
+ * Maps UTC time fields to simpler field names
+ * Used for transforming execution history responses
+ */
+export const TimeFieldTransformMap: { [key: string]: string } = {
+  startedTimeUtc: 'startedTime',
+  completedTimeUtc: 'completedTime',
+};
+
+/**
  * Constants for case instance stage processing
  */
 export const CASE_STAGE_CONSTANTS = {

--- a/src/models/maestro/case-instances.models.ts
+++ b/src/models/maestro/case-instances.models.ts
@@ -3,7 +3,8 @@ import {
   CaseInstanceGetAllWithPaginationOptions,
   CaseInstanceOperationOptions,
   CaseInstanceOperationResponse,
-  CaseGetStageResponse
+  CaseGetStageResponse,
+  CaseInstanceExecutionHistoryResponse
 } from './case-instances.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 import { OperationResponse } from '../common/types';
@@ -137,6 +138,33 @@ export interface CaseInstancesServiceModel {
    * @returns Promise resolving to operation result with instance data
    */
   resume(instanceId: string, folderKey: string, options?: CaseInstanceOperationOptions): Promise<OperationResponse<CaseInstanceOperationResponse>>;
+
+  /**
+   * Get execution history for a case instance
+   * @param instanceId - The ID of the case instance
+   * @param folderKey - Required folder key 
+   * @returns Promise resolving to instance execution history
+   * {@link CaseInstanceExecutionHistoryResponse}
+   * @example
+   * ```typescript
+   * // Get execution history for a case instance
+   * const history = await sdk.maestro.cases.instances.getExecutionHistory(
+   *   <instanceId>,
+   *   <folderKey>
+   * );
+   * 
+   * // Access element executions
+   * if (history.elementExecutions) {
+   *   for (const execution of history.elementExecutions) {
+   *     console.log(`Element: ${execution.elementName} - Status: ${execution.status}`);
+   *   }
+   * }
+   * ```
+   */
+  getExecutionHistory(
+    instanceId: string, 
+    folderKey: string
+  ): Promise<CaseInstanceExecutionHistoryResponse>;
 
   /**
    * Get stages and its associated tasks information for a case instance 

--- a/src/models/maestro/case-instances.types.ts
+++ b/src/models/maestro/case-instances.types.ts
@@ -203,16 +203,48 @@ export interface CaseGetStageResponse {
 /**
  * Case element execution metadata
  */
-export interface CaseExecutionMetadata {
+export interface ElementExecutionMetadata {
+  completedTime: string | null;
   elementId: string;
+  elementName: string;
+  parentElementId: string | null;
+  startedTime: string;
+  /** Element status (e.g., "Completed", "Faulted", "Running") */
   status: string;
-  startedTimeUtc: string;
-  completedTimeUtc: string;
+  processKey: string;
+  /** External reference link, eg link to the HITL task in Action Center */
+  externalLink: string;
+  /** List of element runs for the element */
+  elementRuns: ElementRunMetadata[];
 }
 
 /**
- * Case instance element execution response
+ * Response for getting case instance element executions
  */
-export interface CaseInstanceElementExecutionsResponse {
-  elementExecutions: CaseExecutionMetadata[];
+export interface CaseInstanceExecutionHistoryResponse {
+  creationUserKey: string | null;
+  folderKey: string;
+  instanceDisplayName: string;
+  instanceId: string;
+  packageId: string;
+  packageKey: string;
+  packageVersion: string;
+  processKey: string;
+  source: string;
+  /** Element status (e.g., "Completed", "Faulted", "Running", "Pausing", "Canceling") */
+  status: string;
+  startedTime: string;
+  completedTime: string | null;
+  elementExecutions: ElementExecutionMetadata[];
+}
+
+/**
+ * Element run metadata
+ */
+export interface ElementRunMetadata {
+  status: string;
+  startedTime: string;
+  completedTime: string | null;
+  elementRunId: string;
+  parentElementRunId: string | null;
 }


### PR DESCRIPTION
`const history = await sdk.maestro.cases.instances.getExecutionHistory(instanceId, folderKey);`

Example Response :
```
{
    instanceId: string                    // Id of the case instance
    instanceDisplayName: string           // Human-readable name of the instance
    status: string                        // Instance status (e.g., "Completed", "Failed", "Running")

    startedTime: string                   // When the instance started 
    completedTime: string | null          // When the instance completed (null if still running)

    folderKey: string                     // Folder identifier for authorization
    organizationId: string                // Organization UUID
    tenantId: string                      // Tenant UUID

    packageId: string                     // same as in getCaseInstance Response
    packageKey: string                    // same as in getCaseInstance Response
    packageVersion: string                // Package version number
    processKey: string                    // Process UUID

    source: string                        //  (e.g., "Manual")
    creationUserKey: string | null        // User who created the instance

    // Element executions array
    elementExecutions: [                  // Array of all element executions in the case
      {
        // Element identification
        elementId: string                  // Unique element identifier
        elementName: string                // Display name of the element

        // Execution status and timing
        status: string                     // Element status (e.g., "Completed", "Failed", "Running")
        startedTime: string                // When element started
        completedTime: string | null       // When element completed (null if running)

        parentElementId: string | null     
        processKey: string                
        externalLink: string               // External reference link, eg link to the hitl task in action center

        // Element runs
        elementRuns: [                     // Array of individual run attempts
          {
            elementRunId: string           // Unique run identifier
            status: string                 // Run status
            startedTime: string            // When this run started
            completedTime: string | null   // When this run completed
            parentElementRunId: string | null  // Parent run
          }
        ]
      }
    ]
  }
```