### PR TITLE
Add default expand fields for TaskGetResponse [PLT-90248]

### DIFF
--- a/src/models/action-center/tasks.constants.ts
+++ b/src/models/action-center/tasks.constants.ts
@@ -17,4 +17,9 @@ export const TaskMap: { [key: string]: string } = {
   lastModificationTime: 'lastModifiedTime',
   creationTime: 'createdTime',
   organizationUnitId: 'folderId'
-}; 
+};
+
+/**
+ * Default expand parameters
+ */
+export const DEFAULT_TASK_EXPAND = 'AssignedToUser,CreatorUser,LastModifierUser'; 

--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -29,6 +29,30 @@ export interface TaskServiceModel {
    * @param options - Query options including optional folderId and pagination options
    * @returns Promise resolving to either an array of tasks NonPaginatedResponse<TaskGetResponse> or a PaginatedResponse<TaskGetResponse> when pagination options are used.
    * {@link TaskGetResponse}
+   *  @example
+   * ```typescript
+   * // Standard array return
+   * const tasks = await sdk.tasks.getAll();
+   * 
+   * // Get tasks within a specific folder
+   * const tasks = await sdk.tasks.getAll({ 
+   *   folderId: 123
+   * });
+   * 
+   * // First page with pagination
+   * const page1 = await sdk.tasks.getAll({ pageSize: 10 });
+   * 
+   * // Navigate using cursor
+   * if (page1.hasNextPage) {
+   *   const page2 = await sdk.tasks.getAll({ cursor: page1.nextCursor });
+   * }
+   * 
+   * // Jump to specific page
+   * const page5 = await sdk.tasks.getAll({
+   *   jumpToPage: 5,
+   *   pageSize: 10
+   * });
+   * ```
    */
   getAll<T extends TaskGetAllOptions = TaskGetAllOptions>(
     options?: T
@@ -38,16 +62,147 @@ export interface TaskServiceModel {
       : NonPaginatedResponse<TaskGetResponse>
   >;
 
+  /**
+   * Gets a task by ID
+   * IMPORTANT: For form tasks, folderId must be provided.
+   * @param id - The ID of the task to retrieve
+   * @param options - Optional query parameters
+   * @param folderId - Optional folder ID (REQUIRED for form tasks)
+   * @returns Promise resolving to the task
+   * {@link TaskGetResponse}
+   * @example
+   * ```typescript
+   * // Get a task by ID
+   * const task = await sdk.tasks.getById(<taskId>);
+   * 
+   * // Get a form task by ID
+   * const formTask = await sdk.tasks.getById(<taskId>, <folderId>);
+   * 
+   * // Access form task properties
+   * console.log(formTask.formLayout);
+   * ```
+   */
   getById(id: number, options?: TaskGetByIdOptions, folderId?: number): Promise<TaskGetResponse>;
 
+  /**
+   * Creates a new task
+   * 
+   * @param options - The task to be created
+   * @param folderId - Required folder ID
+   * @returns Promise resolving to the created task
+   * {@link TaskCreateResponse}
+   * @example
+   * ```typescript
+   * import { TaskPriority } from '@uipath/uipath-typescript';
+   * const task = await sdk.tasks.create({
+   *   title: "My Task",
+   *   priority: TaskPriority.Medium
+   * }, <folderId>); // folderId is required
+   * ```
+   */
   create(options: TaskCreateOptions, folderId: number): Promise<TaskCreateResponse>;
 
+  /**
+   * Assigns tasks to users
+   * 
+   * @param options - Single task assignment or array of task assignments
+   * @param folderId - Optional folder ID
+   * @returns Promise resolving to array of task assignment results
+   * {@link TaskAssignmentResponse}
+   * @example
+   * ```typescript
+   * // Assign a single task to a user by ID
+   * const result = await sdk.tasks.assign({
+   *   taskId: <taskId>,
+   *   userId: <userId>
+   * });
+   * 
+   * // Assign a single task to a user by email
+   * const result = await sdk.tasks.assign({
+   *   taskId: <taskId>,
+   *   userNameOrEmail: "user@example.com"
+   * });
+   * 
+   * // Assign multiple tasks
+   * const result = await sdk.tasks.assign([
+   *   { taskId: <taskId1>, userId: <userId> },
+   *   { taskId: <taskId2>, userNameOrEmail: "user@example.com" }
+   * ]);
+   * ```
+   */
   assign(options: TaskAssignmentOptions | TaskAssignmentOptions[], folderId?: number): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
   
+  /**
+   * Reassigns tasks to new users
+   * 
+   * @param options - Single task assignment or array of task assignments
+   * @param folderId - Optional folder ID
+   * @returns Promise resolving to array of task assignment results
+   * {@link TaskAssignmentResponse}
+   * @example
+   * ```typescript
+   * // Reassign a single task to a user by ID
+   * const result = await sdk.tasks.reassign({
+   *   taskId: <taskId>,
+   *   userId: <userId>
+   * });
+   * 
+   * // Reassign a single task to a user by email
+   * const result = await sdk.tasks.reassign({
+   *   taskId: <taskId>,
+   *   userNameOrEmail: "user@example.com"
+   * });
+   * 
+   * // Reassign multiple tasks
+   * const result = await sdk.tasks.reassign([
+   *   { taskId: <taskId1>, userId: <userId> },
+   *   { taskId: <taskId2>, userNameOrEmail: "user@example.com" }
+   * ]);
+   * ```
+   */
   reassign(options: TaskAssignmentOptions | TaskAssignmentOptions[], folderId?: number): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
   
+  /**
+   * Unassigns tasks (removes current assignees)
+   * 
+   * @param taskId - Single task ID or array of task IDs to unassign
+   * @param folderId - Optional folder ID
+   * @returns Promise resolving to array of task assignment results
+   * {@link TaskAssignmentResponse}
+   * @example
+   * ```typescript
+   * // Unassign a single task
+   * const result = await sdk.tasks.unassign(<taskId>);
+   * 
+   * // Unassign multiple tasks
+   * const result = await sdk.tasks.unassign([<taskId1>, <taskId2>, <taskId3>]);
+   * ```
+   */
   unassign(taskId: number | number[], folderId?: number): Promise<OperationResponse<{ taskId: number }[] | TaskAssignmentResponse[]>>;
   
+  /**
+   * Completes a task with the specified type and data
+   * 
+   * @param taskType - The type of task (Form, App, or External)
+   * @param options - The completion options
+   * @param folderId - Required folder ID
+   * @returns Promise resolving to completion result
+   * {@link TaskCompletionOptions}
+   * @example
+   * ```typescript
+   * // Complete an app task
+   * await sdk.tasks.complete(TaskType.App, {
+   *   taskId: <taskId>,
+   *   data: {},
+   *   action: "submit"
+   * }, <folderId>); // folderId is required
+   * 
+   * // Complete an external task
+   * await sdk.tasks.complete(TaskType.External, {
+   *   taskId: <taskId>
+   * }, <folderId>); // folderId is required
+   * ```
+   */
   complete(
     taskType: TaskType,
     options: TaskCompletionOptions,
@@ -61,7 +216,17 @@ export interface TaskServiceModel {
    * 
    * @param folderId - The folder ID to get users from
    * @param options - Optional query and pagination parameters
-   * @returns Promise resolving to NonPaginatedResponse or a paginated result
+   * @returns Promise resolving to either an array of users NonPaginatedResponse<UserLoginInfo> or a PaginatedResponse<UserLoginInfo> when pagination options are used. 
+   * {@link UserLoginInfo}
+   * @example
+   * ```typescript
+   * // Get users from a folder
+   * const users = await sdk.tasks.getUsers(<folderId>);
+   * 
+   * // Access user properties
+   * console.log(users.items[0].name);
+   * console.log(users.items[0].emailAddress);
+   * ```
    */
   getUsers<T extends TaskGetUsersOptions = TaskGetUsersOptions>(
     folderId: number,

--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -106,7 +106,6 @@ export interface TaskServiceModel {
    * Assigns tasks to users
    * 
    * @param options - Single task assignment or array of task assignments
-   * @param folderId - Optional folder ID
    * @returns Promise resolving to array of task assignment results
    * {@link TaskAssignmentResponse}
    * @example
@@ -130,13 +129,12 @@ export interface TaskServiceModel {
    * ]);
    * ```
    */
-  assign(options: TaskAssignmentOptions | TaskAssignmentOptions[], folderId?: number): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
+  assign(options: TaskAssignmentOptions | TaskAssignmentOptions[]): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
   
   /**
    * Reassigns tasks to new users
    * 
    * @param options - Single task assignment or array of task assignments
-   * @param folderId - Optional folder ID
    * @returns Promise resolving to array of task assignment results
    * {@link TaskAssignmentResponse}
    * @example
@@ -160,13 +158,12 @@ export interface TaskServiceModel {
    * ]);
    * ```
    */
-  reassign(options: TaskAssignmentOptions | TaskAssignmentOptions[], folderId?: number): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
+  reassign(options: TaskAssignmentOptions | TaskAssignmentOptions[]): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
   
   /**
    * Unassigns tasks (removes current assignees)
    * 
    * @param taskId - Single task ID or array of task IDs to unassign
-   * @param folderId - Optional folder ID
    * @returns Promise resolving to array of task assignment results
    * {@link TaskAssignmentResponse}
    * @example
@@ -178,7 +175,7 @@ export interface TaskServiceModel {
    * const result = await sdk.tasks.unassign([<taskId1>, <taskId2>, <taskId3>]);
    * ```
    */
-  unassign(taskId: number | number[], folderId?: number): Promise<OperationResponse<{ taskId: number }[] | TaskAssignmentResponse[]>>;
+  unassign(taskId: number | number[]): Promise<OperationResponse<{ taskId: number }[] | TaskAssignmentResponse[]>>;
   
   /**
    * Completes a task with the specified type and data
@@ -294,7 +291,7 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
         userNameOrEmail: options.userNameOrEmail
       };
       
-      return service.assign(assignmentOptions, taskData.organizationUnitId);
+      return service.assign(assignmentOptions);
     },
     
     async reassign(options: TaskAssignOptions): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
@@ -306,13 +303,13 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
         userNameOrEmail: options.userNameOrEmail
       };
       
-      return service.reassign(assignmentOptions, taskData.organizationUnitId);
+      return service.reassign(assignmentOptions);
     },
 
     async unassign(): Promise<OperationResponse<{ taskId: number }[] | TaskAssignmentResponse[]>> {
       if (!taskData.id) throw new Error('Task ID is undefined');
       
-      return service.unassign(taskData.id, taskData.organizationUnitId);
+      return service.unassign(taskData.id);
     },
 
     async complete(options: TaskCompleteOptions): Promise<OperationResponse<TaskCompletionOptions>> {

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -122,10 +122,8 @@ export interface TaskBaseResponse {
   key: string;
   isDeleted: boolean;
   creationTime: string;
-  creatorUserId: number;
   id: number;
   action: string | null;
-  assignedToUserId: number | null;
   externalTag: string | null;
   lastAssignedTime: string | null;
   completionTime: string | null;
@@ -158,7 +156,7 @@ export interface RawTaskGetResponse extends TaskBaseResponse {
   taskSlaDetail: TaskSlaDetail | null;
   taskAssigneeName: string | null;
   lastModifierUserId: number | null;
-  assignedToUser?: UserLoginInfo;
+  assignedToUser: UserLoginInfo | null;
   creatorUser?: UserLoginInfo;
   lastModifierUser?: UserLoginInfo;
   taskAssignments?: TaskAssignment[];

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -275,7 +275,6 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * Assigns tasks to users
    * 
    * @param taskAssignments - Single task assignment or array of task assignments
-   * @param folderId - Optional folder ID
    * @returns Promise resolving to array of task assignment results
    * 
    * @example
@@ -306,9 +305,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * ```
    */
   @track('Tasks.Assign')
-  async assign(taskAssignments: TaskAssignmentOptions | TaskAssignmentOptions[], folderId?: number): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
-    const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
+  async assign(taskAssignments: TaskAssignmentOptions | TaskAssignmentOptions[]): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
     // Normalize input to array
     const assignmentArray = Array.isArray(taskAssignments) ? taskAssignments : [taskAssignments];
     
@@ -321,8 +318,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
     
     const response = await this.post<TaskAssignmentResponseCollection>(
       TASK_ENDPOINTS.ASSIGN_TASKS,
-      pascalOptions,
-      { headers }
+      pascalOptions
     );
     
     // Transform response from PascalCase to camelCase
@@ -336,7 +332,6 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * Reassigns tasks to new users
    * 
    * @param taskAssignments - Single task assignment or array of task assignments
-   * @param folderId - Optional folder ID
    * @returns Promise resolving to array of task assignment results
    * 
    * @example
@@ -367,9 +362,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * ```
    */
   @track('Tasks.Reassign')
-  async reassign(taskAssignments: TaskAssignmentOptions | TaskAssignmentOptions[], folderId?: number): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
-    const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
+  async reassign(taskAssignments: TaskAssignmentOptions | TaskAssignmentOptions[]): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
     // Normalize input to array
     const assignmentArray = Array.isArray(taskAssignments) ? taskAssignments : [taskAssignments];
     
@@ -382,8 +375,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
     
     const response = await this.post<TaskAssignmentResponseCollection>(
       TASK_ENDPOINTS.REASSIGN_TASKS,
-      pascalOptions,
-      { headers }
+      pascalOptions
     );
     
     // Transform response from PascalCase to camelCase
@@ -397,7 +389,6 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * Unassigns tasks (removes current assignees)
    * 
    * @param taskIds - Single task ID or array of task IDs to unassign
-   * @param folderId - Optional folder ID
    * @returns Promise resolving to array of task assignment results
    * 
    * @example
@@ -410,9 +401,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * ```
    */
   @track('Tasks.Unassign')
-  async unassign(taskIds: number | number[], folderId?: number): Promise<OperationResponse<{ taskId: number }[] | TaskAssignmentResponse[]>> {
-    const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
+  async unassign(taskIds: number | number[]): Promise<OperationResponse<{ taskId: number }[] | TaskAssignmentResponse[]>> {
     // Normalize input to array
     const taskIdArray = Array.isArray(taskIds) ? taskIds : [taskIds];
     
@@ -422,8 +411,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
     
     const response = await this.post<TaskAssignmentResponseCollection>(
       TASK_ENDPOINTS.UNASSIGN_TASKS,
-      options,
-      { headers }
+      options
     );
     
     // Transform response from PascalCase to camelCase

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -22,7 +22,7 @@ import {
 } from '../../models/action-center/tasks.models';
 import { OperationResponse } from '../../models/common/types';
 import { pascalToCamelCaseKeys, camelToPascalCaseKeys, transformData, applyDataTransforms, addPrefixToKeys } from '../../utils/transform';
-import { TaskStatusMap, TaskMap } from '../../models/action-center/tasks.constants';
+import { TaskStatusMap, TaskMap, DEFAULT_TASK_EXPAND } from '../../models/action-center/tasks.constants';
 import { createHeaders } from '../../utils/http/headers';
 import { FOLDER_ID } from '../../utils/constants/headers';
 import { TASK_ENDPOINTS } from '../../utils/constants/endpoints';
@@ -223,10 +223,11 @@ export class TaskService extends BaseService implements TaskServiceModel {
 
   /**
    * Gets a task by ID
+   * IMPORTANT: For form tasks, folderId must be provided.
    * 
    * @param id - The ID of the task to retrieve
    * @param options - Optional query parameters
-   * @param folderId - Optional folder ID
+   * @param folderId - Optional folder ID (REQUIRED for form tasks)
    * @returns Promise resolving to the task (form tasks will return form-specific data)
    * 
    * @example
@@ -240,9 +241,13 @@ export class TaskService extends BaseService implements TaskServiceModel {
   @track('Tasks.GetById')
   async getById(id: number, options: TaskGetByIdOptions = {}, folderId?: number): Promise<TaskGetResponse> {
     const headers = createHeaders({ [FOLDER_ID]: folderId });
+    
+    // Add default expand parameters
+    const modifiedOptions = this.addDefaultExpand(options);
+    
     // prefix all keys in options
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
+    const keysToPrefix = Object.keys(modifiedOptions);
+    const apiOptions = addPrefixToKeys(modifiedOptions, ODATA_PREFIX, keysToPrefix);
     const response = await this.get<TaskGetResponse>(
       TASK_ENDPOINTS.GET_BY_ID(id),
       { 
@@ -516,7 +521,9 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * @private
    */
   private processTaskParameters = (options: Record<string, any>, folderId?: number): Record<string, any> => {
-    const processedOptions = { ...options };
+    // Add default expand parameters
+    const processedOptions = this.addDefaultExpand(options);
+    
     if (folderId) {
       // Create or add to existing filter for folder-specific queries
       if (processedOptions.filter) {
@@ -526,5 +533,21 @@ export class TaskService extends BaseService implements TaskServiceModel {
       }
     }
     return processedOptions;
+  }
+
+  /**
+   * Adds default expand parameters to options
+   * @param options - The options object to add default expand to
+   * @returns Options with default expand parameters added
+   * @private
+   */
+  private addDefaultExpand<T extends Record<string, any>>(options: T): T {
+    const processedOptions: any = { ...options };
+    
+    processedOptions.expand = processedOptions.expand 
+      ? `${DEFAULT_TASK_EXPAND},${processedOptions.expand}`
+      : DEFAULT_TASK_EXPAND;
+    
+    return processedOptions as T;
   }
 } 


### PR DESCRIPTION
1. Added default expand fields(`AssignedToUser,CreatorUser,LastModifierUser`) to getAll() and getById() methods.
2. Added JSDoc comments with examples for all public methods. 
3. Remove optional folderId parameter from assign, reassign and unassign methods.