### PR TITLE
Update comments and map organizationUnitId to folderId

### DIFF
--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -116,6 +116,13 @@ export interface TaskServiceModel {
    *   userId: <userId>
    * });
    * 
+   * or
+   * 
+   * const task = await sdk.tasks.getById(<taskId>);
+   * const result = await task.assign({
+   *   userId: <userId>
+   * });
+   * 
    * // Assign a single task to a user by email
    * const result = await sdk.tasks.assign({
    *   taskId: <taskId>,
@@ -145,6 +152,13 @@ export interface TaskServiceModel {
    *   userId: <userId>
    * });
    * 
+   * or
+   * 
+   * const task = await sdk.tasks.getById(<taskId>);
+   * const result = await task.reassign({
+   *   userId: <userId>
+   * });
+   * 
    * // Reassign a single task to a user by email
    * const result = await sdk.tasks.reassign({
    *   taskId: <taskId>,
@@ -170,6 +184,11 @@ export interface TaskServiceModel {
    * ```typescript
    * // Unassign a single task
    * const result = await sdk.tasks.unassign(<taskId>);
+   * 
+   * or
+   * 
+   * const task = await sdk.tasks.getById(<taskId>);
+   * const result = await task.unassign();
    * 
    * // Unassign multiple tasks
    * const result = await sdk.tasks.unassign([<taskId1>, <taskId2>, <taskId3>]);
@@ -314,7 +333,7 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
 
     async complete(options: TaskCompleteOptions): Promise<OperationResponse<TaskCompletionOptions>> {
       if (!taskData.id) throw new Error('Task ID is undefined');
-      const folderId = taskData.organizationUnitId;
+      const folderId = taskData.folderId;
       if (!folderId) throw new Error('Folder ID is required');
       
       return service.complete(

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -118,7 +118,7 @@ export interface TaskBaseResponse {
   title: string;
   type: TaskType;
   priority: TaskPriority;
-  organizationUnitId: number;
+  folderId: number;
   key: string;
   isDeleted: boolean;
   creationTime: string;

--- a/src/models/maestro/case-instances.models.ts
+++ b/src/models/maestro/case-instances.models.ts
@@ -91,32 +91,23 @@ export interface CaseInstancesServiceModel {
    *   <folderKey>
    * );
    * 
-   * if (result.success) {
-   *   console.log(`Instance ${result.data.instanceId} now has status: ${result.data.status}`);
-   * }
+   * or
    * 
-   * // Close with a comment
-   * const result = await sdk.maestro.cases.instances.close(
+   * const instance = await sdk.maestro.cases.instances.getById(
    *   <instanceId>,
-   *   <folderKey>,
-   *   { comment: <comment> }
+   *   <folderKey>
    * );
+   * const result = await instance.close();
    * 
-   * // Close multiple faulted instances
-   * const instances = await sdk.maestro.cases.instances.getAll({
-   *   latestRunStatus: "Faulted"
+   * console.log(`Closed: ${result.success}`);
+   *
+   * // Close with a comment
+   * const result = await instance.close({
+   *   comment: 'Closing due to invalid input data'
    * });
-   * 
-   * for (const instance of instances.items) {
-   *   const result = await sdk.maestro.cases.instances.close(
-   *     instance.instanceId,
-   *     instance.folderKey,
-   *     { comment: <comment> }
-   *   );
-   *   
-   *   if (result.success) {
-   *     console.log(`Closed instance: ${result.data.instanceId}`);
-   *   }
+   *
+   * if (result.success) {
+   *   console.log(`Instance ${result.data.instanceId} status: ${result.data.status}`);
    * }
    * ```
    */

--- a/src/models/maestro/process-instances.models.ts
+++ b/src/models/maestro/process-instances.models.ts
@@ -148,32 +148,23 @@ export interface ProcessInstancesServiceModel {
    *   <folderKey>
    * );
    * 
-   * if (result.success) {
-   *   console.log(`Instance ${result.data.instanceId} now has status: ${result.data.status}`);
-   * }
+   * or
    * 
-   * // Cancel with a comment
-   * const result = await sdk.maestro.processes.instances.cancel(
+   * const instance = await sdk.maestro.processes.instances.getById(
    *   <instanceId>,
-   *   <folderKey>,
-   *   { comment: <comment> }
+   *   <folderKey>
    * );
+   * const result = await instance.cancel();
    * 
-   * // Cancel multiple faulted instances
-   * const instances = await sdk.maestro.processes.instances.getAll({
-   *   latestRunStatus: "Faulted"
+   * console.log(`Cancelled: ${result.success}`);
+   *
+   * // Cancel with a comment
+   * const result = await instance.cancel({
+   *   comment: 'Cancelling due to invalid input data'
    * });
-   * 
-   * for (const instance of instances.items) {
-   *   const result = await sdk.maestro.processes.instances.cancel(
-   *     instance.instanceId,
-   *     instance.folderKey,
-   *     { comment: <comment> }
-   *   );
-   *   
-   *   if (result.success) {
-   *     console.log(`Cancelled instance: ${result.data.instanceId}`);
-   *   }
+   *
+   * if (result.success) {
+   *   console.log(`Instance ${result.data.instanceId} status: ${result.data.status}`);
    * }
    * ```
    */

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -262,7 +262,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
     // Check if this is a form task and get form-specific data if it is
     if (transformedTask.type === TaskType.Form) {
       const formOptions: TaskGetFormOptions = { expandOnFormLayout: true };
-      return this.getFormTaskById(id, folderId || transformedTask.organizationUnitId, formOptions);
+      return this.getFormTaskById(id, folderId || transformedTask.folderId, formOptions);
     }
     
     return createTaskWithMethods(


### PR DESCRIPTION
1. update comments for cancel and close methods
2. We had mapped organizationUnitId to folderId but it was still being used at some places.