### PR TITLE
Update TaskAssignmentOptions [PLT-90793]

### DIFF
--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -303,25 +303,21 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
   return {
     async assign(options: TaskAssignOptions): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
       if (!taskData.id) throw new Error('Task ID is undefined');
-      
-      const assignmentOptions: TaskAssignmentOptions = {
-        taskId: taskData.id,
-        userId: options.userId || 0, // Will be handled by userNameOrEmail if userId is not provided, 0 is considered as invalid user id
-        userNameOrEmail: options.userNameOrEmail
-      };
-      
+
+      const assignmentOptions: TaskAssignmentOptions = 'userId' in options && options.userId !== undefined
+        ? { taskId: taskData.id, userId: options.userId }
+        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail! };
+
       return service.assign(assignmentOptions);
     },
     
     async reassign(options: TaskAssignOptions): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
       if (!taskData.id) throw new Error('Task ID is undefined');
-      
-      const assignmentOptions: TaskAssignmentOptions = {
-        taskId: taskData.id,
-        userId: options.userId || 0, // Will be handled by userNameOrEmail if userId is not provided, 0 is considered as invalid user id
-        userNameOrEmail: options.userNameOrEmail
-      };
-      
+
+      const assignmentOptions: TaskAssignmentOptions = 'userId' in options && options.userId !== undefined
+        ? { taskId: taskData.id, userId: options.userId }
+        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail! };
+
       return service.reassign(assignmentOptions);
     },
 

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -175,11 +175,22 @@ export interface RawTaskGetResponse extends TaskBaseResponse {
   data?: Record<string, unknown> | null;
 }
 
-export interface TaskAssignmentOptions {
+/**
+ * Options for task assignment operations when called from a task instance
+ * Requires either userId or userNameOrEmail, but not both
+ */
+export type TaskAssignOptions =
+  | { userId: number; userNameOrEmail?: never }
+  | { userId?: never; userNameOrEmail: string };
+
+/**
+ * Options for task assignment operations when called from the service
+ * Extends TaskAssignOptions with the required taskId field
+ */
+export type TaskAssignmentOptions = {
   taskId: number;
-  userId: number;
-  userNameOrEmail?: string;
-}
+} & TaskAssignOptions;
+
 export interface TasksUnassignOptions {
   taskIds: number[];
 }
@@ -196,14 +207,6 @@ export interface TaskCompletionOptions {
   data?: any;
   action?: string;
 }
-
-/**
- * Options for task assignment operations in the Task class
- * At least one identification parameter is required
- */
-export type TaskAssignOptions = 
-  | { userId: number; userNameOrEmail?: string}
-  | { userId?: number; userNameOrEmail: string};
 
 /**
  * Options for completing a task


### PR DESCRIPTION
Bug fix 
Issue : Providing user-id was required when assigning tasks.
Fix : user id is now optional when assigning tasks. We could either assign through user-id or through user-email.
