### PR TITLE
Update TaskCompletionOptions [PLT-90841]

### DIFF
--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -1,7 +1,6 @@
 import type { 
   RawTaskCreateResponse,
   RawTaskGetResponse, 
-  TaskType,
   TaskAssignmentOptions,
   TaskAssignmentResponse,
   TaskCompletionOptions,
@@ -198,29 +197,29 @@ export interface TaskServiceModel {
   
   /**
    * Completes a task with the specified type and data
-   * 
-   * @param taskType - The type of task (Form, App, or External)
-   * @param options - The completion options
+   *
+   * @param options - The completion options including task type, taskId, data, and action
    * @param folderId - Required folder ID
    * @returns Promise resolving to completion result
-   * {@link TaskCompletionOptions}
+   * {@link TaskCompleteOptions}
    * @example
    * ```typescript
    * // Complete an app task
-   * await sdk.tasks.complete(TaskType.App, {
+   * await sdk.tasks.complete({
+   *   type: TaskType.App,
    *   taskId: <taskId>,
    *   data: {},
    *   action: "submit"
    * }, <folderId>); // folderId is required
-   * 
+   *
    * // Complete an external task
-   * await sdk.tasks.complete(TaskType.External, {
+   * await sdk.tasks.complete({
+   *   type: TaskType.External,
    *   taskId: <taskId>
    * }, <folderId>); // folderId is required
    * ```
    */
   complete(
-    taskType: TaskType,
     options: TaskCompletionOptions,
     folderId: number
   ): Promise<OperationResponse<TaskCompletionOptions>>;
@@ -333,12 +332,12 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
       if (!folderId) throw new Error('Folder ID is required');
       
       return service.complete(
-        options.type,
         {
+          type: options.type,
           taskId: taskData.id,
           data: options.data,
           action: options.action
-        },
+        } as TaskCompletionOptions,
         folderId
       );
     }

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -201,11 +201,6 @@ export interface TaskAssignmentResponse {
   errorCode?: number;
   errorMessage?: string;
   userNameOrEmail?: string;
-} 
-export interface TaskCompletionOptions {
-  taskId: number;
-  data?: any;
-  action?: string;
 }
 
 /**
@@ -213,7 +208,13 @@ export interface TaskCompletionOptions {
  */
 export type TaskCompleteOptions =
   | { type: TaskType.External; data?: any; action?: string }
-  | { type: Exclude<TaskType, TaskType.External>; data: any; action: string }; 
+  | { type: Exclude<TaskType, TaskType.External>; data: any; action: string };
+
+/**
+ * Options for completing a task when called from the service
+ * Extends TaskCompleteOptions with the required taskId field
+ */
+export type TaskCompletionOptions = TaskCompleteOptions & { taskId: number }; 
 
 /**
  * Options for getting tasks across folders

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -424,34 +424,35 @@ export class TaskService extends BaseService implements TaskServiceModel {
 
   /**
    * Completes a task with the specified type and data
-   * 
-   * @param completionType - The type of task (Form, App, or Generic)
-   * @param options - The completion options
+   *
+   * @param options - The completion options including task type, taskId, data, and action
    * @param folderId - Required folder ID
-   * @returns Promise resolving to void
-   * 
+   * @returns Promise resolving to completion result
+   *
    * @example
    * ```typescript
    * // Complete an app task
-   * await sdk.tasks.complete(TaskType.App, {
+   * await sdk.tasks.complete({
+   *   type: TaskType.App,
    *   taskId: 456,
    *   data: {},
    *   action: "submit"
    * }, 123); // folderId is required
    * 
    * // Complete an external task
-   * await sdk.tasks.complete(TaskType.ExternalTask, {
+   * await sdk.tasks.complete({
+   *   type: TaskType.External,
    *   taskId: 789
    * }, 123); // folderId is required
    * ```
    */
   @track('Tasks.Complete')
-  async complete(completionType: TaskType, options: TaskCompletionOptions, folderId: number): Promise<OperationResponse<TaskCompletionOptions>> {
+  async complete(options: TaskCompletionOptions, folderId: number): Promise<OperationResponse<TaskCompletionOptions>> {
     const headers = createHeaders({ [FOLDER_ID]: folderId });
     
     let endpoint: string;
-    
-    switch (completionType) {
+
+    switch (options.type) {
       case TaskType.Form:
         endpoint = TASK_ENDPOINTS.COMPLETE_FORM_TASK;
         break;


### PR DESCRIPTION
There is inconsistency in how options are passed to complete method when it is attached to a task object and otherwise. 

When attached to a task object - type is part of options object
```
task.complete({
        type: TaskType.App,
        data: {},
        action: ''
      });
```
 

When called independently - type is a separate option
```
sdk.actions.complete(TaskType.App, {
      data: {},
      action: '' }, FOLDER_ID)
}
```

Now in both cases we'll pass type in the options itself.
```
sdk.actions.complete({
      type : TaskType.App
      data: {},
      action: '' }, FOLDER_ID)
}
```

