### PR TITLE
chore: add .env to gitignore in sample app

### DIFF
--- a/samples/process-app/.gitignore
+++ b/samples/process-app/.gitignore
@@ -24,3 +24,4 @@ dist
 *.njsproj
 *.sln
 *.sw?
+*.env


### PR DESCRIPTION
in our repo, in sample app, we only have pushed .env.example . But in gitignore we should add .env such that users  using our sample app wont push the env to git