### PR TITLE
fix: esbuilder unable to resolve nodejs module during build - [PLT-92503]

### DIFF
--- a/src/core/auth/service.ts
+++ b/src/core/auth/service.ts
@@ -232,12 +232,16 @@ export class AuthService extends BaseService {
       return this._base64URLEncode(array);
     } else {
       // In Node.js environment
+      try {
       const crypto = require('crypto');
       return crypto.randomBytes(32)
         .toString('base64')
         .replace(/\+/g, '-')
         .replace(/\//g, '_')
         .replace(/=/g, '');
+      } catch(e) {
+        throw new Error("crypto not available in browser")
+      }
     }
   }
 
@@ -252,6 +256,7 @@ export class AuthService extends BaseService {
       return this._base64URLEncode(new Uint8Array(hash));
     } else {
       // In Node.js environment
+      try {
       const crypto = require('crypto');
       return crypto.createHash('sha256')
         .update(codeVerifier)
@@ -259,6 +264,9 @@ export class AuthService extends BaseService {
         .replace(/\+/g, '-')
         .replace(/\//g, '_')
         .replace(/=/g, '');
+      } catch (e) {
+        throw new Error("crypto not available in browser")
+      }
     }
   }
 


### PR DESCRIPTION
project with esbuild bundler were failing with this issue while building:

```
X [ERROR] Could not resolve "crypto"

The package "crypto" wasn't found on the file system but is built into node. Are you trying to bundle for node?
```
even though we had browser check, runtime is fine. But esbuild is performing static analysis at build time and seeing the
  require('crypto') statement, even though it would never execute in a browser. hence added try catch.
  
 tested on https://github.com/UiPath/sdk-test-apps