### PR TITLE
Add 'asTaskAdmin' flag in options for fetching tasks [PLT-90774]

### DIFF
--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -25,7 +25,7 @@ export interface TaskServiceModel {
   /**
    * Gets all tasks across folders with optional filtering
    * 
-   * @param options - Query options including optional folderId and pagination options
+   * @param options - Query options including optional folderId, asTaskAdmin flag and pagination options
    * @returns Promise resolving to either an array of tasks NonPaginatedResponse<TaskGetResponse> or a PaginatedResponse<TaskGetResponse> when pagination options are used.
    * {@link TaskGetResponse}
    *  @example
@@ -36,6 +36,18 @@ export interface TaskServiceModel {
    * // Get tasks within a specific folder
    * const tasks = await sdk.tasks.getAll({ 
    *   folderId: 123
+   * });
+   *
+   * // Get tasks with admin permissions
+   * // This fetches tasks across folders where the user has Task.View, Task.Edit and TaskAssignment.Create permissions
+   * const tasks = await sdk.tasks.getAll({
+   *   asTaskAdmin: true
+   * });
+   *
+   * // Get tasks without admin permissions (default)
+   * // This fetches tasks across folders where the user has Task.View and Task.Edit permissions
+   * const tasks = await sdk.tasks.getAll({
+   *   asTaskAdmin: false
    * });
    * 
    * // First page with pagination

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -225,6 +225,14 @@ export type TaskGetAllOptions = RequestOptions & PaginationOptions & {
    * Optional folder ID to filter tasks by folder
    */
   folderId?: number;
+  /**
+   * Optional flag to fetch tasks using admin permissions
+   * When true, fetches tasks across folders
+   * where the user has at least Task.View, Task.Edit and TaskAssignment.Create permissions
+   * When false or omitted, fetches tasks across folders
+   * where the user has at least Task.View and Task.Edit permissions
+   */
+  asTaskAdmin?: boolean;
 }
 
 /**

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -157,7 +157,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * - An array of tasks (when no pagination parameters are provided)
    * - A paginated result with navigation cursors (when any pagination parameter is provided)
    * 
-   * @param options - Query options including optional folderId and pagination options
+   * @param options - Query options including optional folderId, asTaskAdmin flag and pagination options
    * @returns Promise resolving to an array of tasks or paginated result
    * 
    * @example
@@ -168,6 +168,11 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * // Get tasks within a specific folder
    * const tasks = await sdk.tasks.getAll({ 
    *   folderId: 123
+   * });
+   *
+   * // Get tasks with admin permissions
+   * const tasks = await sdk.tasks.getAll({
+   *   asTaskAdmin: true
    * });
    * 
    * // First page with pagination
@@ -193,6 +198,11 @@ export class TaskService extends BaseService implements TaskServiceModel {
       ? PaginatedResponse<TaskGetResponse>
       : NonPaginatedResponse<TaskGetResponse>
   > {
+    // Determine which endpoint to use based on asTaskAdmin flag
+    const endpoint = options?.asTaskAdmin
+      ? TASK_ENDPOINTS.GET_TASKS_ACROSS_FOLDERS_ADMIN
+      : TASK_ENDPOINTS.GET_TASKS_ACROSS_FOLDERS;
+
     // Transformation function for tasks
     const transformTaskResponse = (task: any) => {
       const transformedTask = transformData(pascalToCamelCaseKeys(task) as TaskGetResponse, TaskMap);
@@ -204,7 +214,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
 
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
-      getEndpoint: () => TASK_ENDPOINTS.GET_TASKS_ACROSS_FOLDERS,
+      getEndpoint: () => endpoint,
       transformFn: transformTaskResponse,
       processParametersFn: this.processTaskParameters,
       excludeFromPrefix: ['event'], // Exclude 'event' key from ODATA prefix transformation

--- a/src/utils/constants/endpoints.ts
+++ b/src/utils/constants/endpoints.ts
@@ -46,7 +46,8 @@ export const MAESTRO_ENDPOINTS = {
 export const TASK_ENDPOINTS = {
   CREATE_GENERIC_TASK: `${ORCHESTRATOR_BASE}/tasks/GenericTasks/CreateTask`,
   GET_TASK_USERS: (folderId: number) => `${ORCHESTRATOR_BASE}/odata/Tasks/UiPath.Server.Configuration.OData.GetTaskUsers(organizationUnitId=${folderId})`,
-  GET_TASKS_ACROSS_FOLDERS: `${ORCHESTRATOR_BASE}/odata/Tasks/UiPath.Server.Configuration.OData.GetTasksAcrossFoldersForAdmin`,
+  GET_TASKS_ACROSS_FOLDERS: `${ORCHESTRATOR_BASE}/odata/Tasks/UiPath.Server.Configuration.OData.GetTasksAcrossFolders`,
+  GET_TASKS_ACROSS_FOLDERS_ADMIN: `${ORCHESTRATOR_BASE}/odata/Tasks/UiPath.Server.Configuration.OData.GetTasksAcrossFoldersForAdmin`,
   GET_BY_ID: (id: number) => `${ORCHESTRATOR_BASE}/odata/Tasks(${id})`,
   ASSIGN_TASKS: `${ORCHESTRATOR_BASE}/odata/Tasks/UiPath.Server.Configuration.OData.AssignTasks`,
   REASSIGN_TASKS: `${ORCHESTRATOR_BASE}/odata/Tasks/UiPath.Server.Configuration.OData.ReassignTasks`,

--- a/tests/unit/services/action-center/tasks.test.ts
+++ b/tests/unit/services/action-center/tasks.test.ts
@@ -767,6 +767,46 @@ describe('TaskService Unit Tests', () => {
       const processedNoFolder = capturedProcessParametersFn!(optionsNoFolder);
       expect(processedNoFolder.filter).toBeUndefined();
     });
+
+    it('should use admin endpoint when asTaskAdmin is true', async () => {
+      const mockTasks = createMockTasks(2);
+      const mockResponse = {
+        items: mockTasks,
+        totalCount: 2
+      };
+
+      // Mock PaginationHelpers.getAll and capture the getEndpoint function
+      let capturedEndpoint: string | undefined;
+      vi.mocked(PaginationHelpers.getAll).mockImplementation(async (config: any) => {
+        capturedEndpoint = config.getEndpoint();
+        return mockResponse;
+      });
+
+      await taskService.getAll({ asTaskAdmin: true });
+
+      // Verify the admin endpoint was used
+      expect(capturedEndpoint).toBe(TASK_ENDPOINTS.GET_TASKS_ACROSS_FOLDERS_ADMIN);
+    });
+
+    it('should use non-admin endpoint when asTaskAdmin is not provided', async () => {
+      const mockTasks = createMockTasks(2);
+      const mockResponse = {
+        items: mockTasks,
+        totalCount: 2
+      };
+
+      // Mock PaginationHelpers.getAll and capture the getEndpoint function
+      let capturedEndpoint: string | undefined;
+      vi.mocked(PaginationHelpers.getAll).mockImplementation(async (config: any) => {
+        capturedEndpoint = config.getEndpoint();
+        return mockResponse;
+      });
+
+      await taskService.getAll();
+
+      // Verify the non-admin endpoint was used (default behavior)
+      expect(capturedEndpoint).toBe(TASK_ENDPOINTS.GET_TASKS_ACROSS_FOLDERS);
+    });
   });
 
   describe('getUsers', () => {


### PR DESCRIPTION
Add `asAdmin` parameter to `tasks.getAll()`

Adds optional asAdmin parameter to `tasks.getAll()` to support fetching tasks with different permission levels.

**Changes**
New parameter: `asAdmin?: boolean` in TaskGetAllOptions
Endpoint selection:
```
asAdmin: true → Uses GetTasksAcrossFoldersForAdmin (fetches tasks from folders where the user has Task.View, Task.Edit and TaskAssignment.Create permissions)
asAdmin: false or omitted → Uses GetTasksAcrossFolders (fetches tasks from folders where the user has Task.View and Task.Edit permissions)
```

Tests: Added 2 new unit test cases covering these scenarios
**Usage**
```
// Admin permissions
const tasks = await sdk.tasks.getAll({ asAdmin: true });

// Normal permissions (default)
const tasks = await sdk.tasks.getAll();
```

Is this a breaking change? 
No. Existing code works without changes. We have just added an optional parameter.