### PR TITLE
Remove unused transformFn from EntityService unit tests

### DIFF
--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -304,7 +304,6 @@ describe('EntityService Unit Tests', () => {
         expect.objectContaining({
           serviceAccess: expect.any(Object),
           getEndpoint: expect.any(Function),
-          transformFn: expect.any(Function),
           pagination: expect.any(Object),
           excludeFromPrefix: ['expansionLevel']
         }),
@@ -340,7 +339,6 @@ describe('EntityService Unit Tests', () => {
         expect.objectContaining({
           serviceAccess: expect.any(Object),
           getEndpoint: expect.any(Function),
-          transformFn: expect.any(Function),
           pagination: expect.any(Object)
         }),
         expect.objectContaining({
@@ -375,7 +373,6 @@ describe('EntityService Unit Tests', () => {
         expect.objectContaining({
           serviceAccess: expect.any(Object),
           getEndpoint: expect.any(Function),
-          transformFn: expect.any(Function),
           pagination: expect.any(Object),
           excludeFromPrefix: ['expansionLevel']
         }),


### PR DESCRIPTION
Updated entity service unit tests to align with [PR #102](https://github.com/UiPath/uipath-typescript/pull/102) changes that removed the pascalToCamelCaseKeys transformation from getRecordsById method. 
Removed transformFn from PaginationHelpers.getAll assertions in three test cases.