### PR TITLE
fix: isAuthenticated method to load from session storage - [PLT-95034]

### DIFF
--- a/src/core/auth/service.ts
+++ b/src/core/auth/service.ts
@@ -14,11 +14,15 @@ export class AuthService extends BaseService {
     // Check if we should use stored OAuth context instead of provided config
     const storedContext = AuthService.getStoredOAuthContext();
     const effectiveConfig = storedContext ? AuthService._mergeConfigWithContext(config, storedContext) : config;
-    
+
     const isOAuth = hasOAuthConfig(effectiveConfig);
     const tokenManager = new TokenManager(executionContext, effectiveConfig, isOAuth);
     super(effectiveConfig, executionContext, tokenManager);
     this.tokenManager = tokenManager;
+
+    // Auto-load token from storage on initialization
+    // This ensures isAuthenticated() returns true after page refresh if a valid token exists
+    this.tokenManager.loadFromStorage();
   }
 
   /**


### PR DESCRIPTION
Problem:                                                            
  `isAuthenticated()` only checked in-memory tokens, returning false after page refresh even when a valid token existed in sessionStorage.         

 Fix:       
  Added `this.tokenManager.loadFromStorage()` call in the AuthService constructor to ensure tokens are loaded from storage immediately when the SDK is instantiated.           
 - Token is loaded once at construction, not on every `isAuthenticated()` call                                                  
 - `loadFromStorage()` already has guards for non-browser and non-OAuth contexts                                                      