### PR TITLE
Bumb CLI version to 1.0.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
             ],
             "dependencies": {
                 "@opentelemetry/sdk-logs": "^0.204.0",
-                "axios": "^1.12.0",
-                "zod": "^4.2.1"
+                "axios": "^1.12.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^25.0.0",
@@ -34,6 +33,9 @@
                 "typedoc-plugin-markdown": "^4.8.1",
                 "typescript": "^5.3.3",
                 "vitest": "^3.2.4"
+            },
+            "peerDependencies": {
+                "zod": "^4.2.1"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -12861,7 +12863,7 @@
         },
         "packages/cli": {
             "name": "@uipath/uipath-ts-cli",
-            "version": "1.0.0-beta.5",
+            "version": "1.0.0-beta.6",
             "dependencies": {
                 "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
                 "@oclif/core": "^4.0.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/uipath-ts-cli",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "UiPath CLI tool for authentication, packaging, publishing, and deployment",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
1. Bumb CLI version to `1.0.0-beta.6`
2. Move `zod` to peerDependencies. We had made this change in `package.json` earlier but did not update the `package-lock.json` file