### PR TITLE
feat: add API guide links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,3 +168,6 @@ nav:
   - FAQ: FAQ.md
   - How To Contribute: CONTRIBUTING.md
   - Release Policy: release-policy.md
+  - API Guide:
+      - Data Fabric: https://docs.uipath.com/data-service/automation-cloud/latest/api-guide/get-entity-endpoint
+      - Orchestrator: https://docs.uipath.com/orchestrator/automation-cloud/latest/api-guide/introduction


### PR DESCRIPTION
PLT-92717

Added doc links for Swagger. 
Maestro is missing and team has confirmed they'll review and get back for public facing API docs. [Slack thread](https://uipath-product.slack.com/archives/C074M703U8G/p1769768270701469)

<img width="1394" height="983" alt="image" src="https://github.com/user-attachments/assets/a07f4496-7af5-4f6a-b34a-adb185a7b9ed" />
<img width="1377" height="1016" alt="image" src="https://github.com/user-attachments/assets/63e0bb27-7f3b-49c0-ae85-18944ac8a852" />
