### PR TITLE
Move choiceset to SDK root level

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
           - Assets: api/interfaces/AssetServiceModel.md
           - Buckets: api/interfaces/BucketServiceModel.md
           - Entities: api/interfaces/EntityServiceModel.md
+          - Choice Sets: api/interfaces/ChoiceSetServiceModel.md
           - Maestro:
             - Processes: api/interfaces/MaestroProcessesServiceModel.md
             - Process Instances: api/interfaces/ProcessInstancesServiceModel.md

--- a/src/models/data-fabric/choicesets.models.ts
+++ b/src/models/data-fabric/choicesets.models.ts
@@ -19,7 +19,7 @@ export interface ChoiceSetServiceModel {
    * @example
    * ```typescript
    * // Get all choice sets
-   * const choiceSets = await sdk.entities.choicesets.getAll();
+   * const choiceSets = await sdk.choicesets.getAll();
    *
    * // Iterate through choice sets
    * choiceSets.forEach(choiceSet => {
@@ -54,12 +54,12 @@ export interface ChoiceSetServiceModel {
    * @example
    * ```typescript
    * // First, get the choice set ID using getAll()
-   * const choiceSets = await sdk.entities.choicesets.getAll();
+   * const choiceSets = await sdk.choicesets.getAll();
    * const expenseTypes = choiceSets.find(cs => cs.name === 'ExpenseTypes');
    * const choiceSetId = expenseTypes.id;
    *
    * // Get all values (non-paginated)
-   * const values = await sdk.entities.choicesets.getById(choiceSetId);
+   * const values = await sdk.choicesets.getById(choiceSetId);
    *
    * // Iterate through choice set values
    * for (const value of values.items) {
@@ -67,11 +67,11 @@ export interface ChoiceSetServiceModel {
    * }
    *
    * // First page with pagination
-   * const page1 = await sdk.entities.choicesets.getById(choiceSetId, { pageSize: 10 });
+   * const page1 = await sdk.choicesets.getById(choiceSetId, { pageSize: 10 });
    *
    * // Navigate using cursor
    * if (page1.hasNextPage) {
-   *   const page2 = await sdk.entities.choicesets.getById(choiceSetId, { cursor: page1.nextCursor });
+   *   const page2 = await sdk.choicesets.getById(choiceSetId, { cursor: page1.nextCursor });
    * }
    * ```
    */

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -75,7 +75,7 @@ export interface EntityServiceModel {
    * // If a field references a ChoiceSet, get the choiceSetId from records.fields
    * const choiceSetId = records.fields[0].referenceChoiceSet?.id;
    * if (choiceSetId) {
-   *   const choiceSetValues = await sdk.entities.choicesets.getById(choiceSetId);
+   *   const choiceSetValues = await sdk.choicesets.getById(choiceSetId);
    * }
    *
    * // Insert a single record

--- a/src/services/data-fabric/choicesets.ts
+++ b/src/services/data-fabric/choicesets.ts
@@ -30,7 +30,7 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
    * @example
    * ```typescript
    * // Get all choice sets
-   * const choiceSets = await sdk.entities.choicesets.getAll();
+   * const choiceSets = await sdk.choicesets.getAll();
    *
    * // Iterate through choice sets
    * choiceSets.forEach(choiceSet => {
@@ -66,12 +66,12 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
    * @example
    * ```typescript
    * // First, get the choice set ID using getAll()
-   * const choiceSets = await sdk.entities.choicesets.getAll();
+   * const choiceSets = await sdk.choicesets.getAll();
    * const expenseTypes = choiceSets.find(cs => cs.name === 'ExpenseTypes');
    * const choiceSetId = expenseTypes.id;
    *
    * // Get all values (non-paginated)
-   * const values = await sdk.entities.choicesets.getById(choiceSetId);
+   * const values = await sdk.choicesets.getById(choiceSetId);
    *
    * // Iterate through choice set values
    * for (const value of values.items) {
@@ -79,11 +79,11 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
    * }
    *
    * // First page with pagination
-   * const page1 = await sdk.entities.choicesets.getById(choiceSetId, { pageSize: 10 });
+   * const page1 = await sdk.choicesets.getById(choiceSetId, { pageSize: 10 });
    *
    * // Navigate using cursor
    * if (page1.hasNextPage) {
-   *   const page2 = await sdk.entities.choicesets.getById(choiceSetId, { cursor: page1.nextCursor });
+   *   const page2 = await sdk.choicesets.getById(choiceSetId, { cursor: page1.nextCursor });
    * }
    * ```
    */

--- a/src/uipath.ts
+++ b/src/uipath.ts
@@ -196,12 +196,7 @@ export class UiPath {
    * Access to Entity service
    */
   get entities() {
-    return Object.assign(this.getService(EntityService), {
-      /**
-       * Access to ChoiceSet service for managing choice sets
-       */
-      choicesets: this.getService(ChoiceSetService)
-    });
+    return this.getService(EntityService);
   }
 
   /**
@@ -237,6 +232,13 @@ export class UiPath {
    */
   get assets(): AssetService {
     return this.getService(AssetService);
+  }
+
+  /**
+   * Access to ChoiceSets service
+   */
+  get choicesets(): ChoiceSetService {
+    return this.getService(ChoiceSetService);
   }
 }
 


### PR DESCRIPTION
Before
```
const choiceSets = await sdk.entities.choicesets.getAll();
const values = await sdk.entities.choicesets.getById(choiceSetId);
```

After
```
const choiceSets = await sdk.choicesets.getAll();
const values = await sdk.choicesets.getById(choiceSetId);
```
Added choiceset in the root level in Docs
<img width="1782" height="794" alt="image" src="https://github.com/user-attachments/assets/00d9da56-56b9-400f-85f9-36fde09fcb38" />
