### PR TITLE
updates to case-instance methods

### DIFF
--- a/src/models/maestro/case-instances.types.ts
+++ b/src/models/maestro/case-instances.types.ts
@@ -198,6 +198,7 @@ export interface CaseGetStageResponse {
   sla?: StageSLA;
   status: string;
   tasks: StageTask[][];
+  stageType?: string;
 }
 
 /**

--- a/src/services/maestro/case-instances.ts
+++ b/src/services/maestro/case-instances.ts
@@ -495,7 +495,8 @@ export class CaseInstancesService extends BaseService implements CaseInstancesSe
       name: node.data?.label || CASE_STAGE_CONSTANTS.UNDEFINED_VALUE,
       sla: node.data?.sla ? transformData(node.data.sla, StageSLAMap) : undefined,
       status: execution?.status || CASE_STAGE_CONSTANTS.NOT_STARTED_STATUS,
-      tasks: this.processTasks(node, executionMap, bindingsMap)
+      tasks: this.processTasks(node, executionMap, bindingsMap),
+      ...(node.type && { stageType: node.type })
     };
 
     return stage;
@@ -530,6 +531,7 @@ export class CaseInstancesService extends BaseService implements CaseInstancesSe
     // Prepare the enhanced options with proper typing
     const enhancedOptions: T = {
       ...options,
+      asTaskAdmin: true,
       filter,
       expand
     } as T;

--- a/src/utils/constants/endpoints.ts
+++ b/src/utils/constants/endpoints.ts
@@ -36,7 +36,7 @@ export const MAESTRO_ENDPOINTS = {
   },
   CASES: {
     GET_CASE_JSON: (instanceId: string) => `${PIMS_BASE}/api/v1/cases/${instanceId}/case-json`,
-    GET_ELEMENT_EXECUTIONS: (instanceId: string) => `${PIMS_BASE}/api/v1alpha1/element-executions/case-instances/${instanceId}`,
+    GET_ELEMENT_EXECUTIONS: (instanceId: string) => `${PIMS_BASE}/api/v1/element-executions/case-instances/${instanceId}`,
   },
 } as const;
 
@@ -56,6 +56,7 @@ export const TASK_ENDPOINTS = {
   COMPLETE_APP_TASK: `${ORCHESTRATOR_BASE}/tasks/AppTasks/CompleteAppTask`,
   COMPLETE_GENERIC_TASK: `${ORCHESTRATOR_BASE}/tasks/GenericTasks/CompleteTask`,
   GET_TASK_FORM_BY_ID: `${ORCHESTRATOR_BASE}/forms/TaskForms/GetTaskFormById`,
+  GET_APP_TASK_BY_ID: `${ORCHESTRATOR_BASE}/tasks/AppTasks/GetAppTaskById`,
 } as const;
 
 /**


### PR DESCRIPTION
- Added a private method for retrieving app tasks by ID.
- Updated `CaseGetStageResponse` to include `stageType` property.
- Updated `element-executions` endpoint from `v1alpha1` to `v1`
- Passed `asTaskAdmin: true` for `CaseInstances.GetActionTasks`