### PR TITLE
Add typecheck to CI pipeline

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run Tests
         run: npm run test:coverage -- --run
 
@@ -45,6 +48,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Completed Checks:" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Dependencies installed successfully" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Typecheck passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ All tests passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Build completed successfully" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
         "clean": "rimraf dist && rimraf node_modules && rimraf package-lock.json",
         "docs:api": "typedoc && npm run docs:post-process",
         "docs:post-process": "mkdir -p docs/api/interfaces/entity && echo '---\ntitle: Entities\n---\n' | cat - docs/api/interfaces/EntityServiceModel.md > docs/api/interfaces/entity/index.md && rm docs/api/interfaces/EntityServiceModel.md",
+        "typecheck": "tsc --noEmit",
         "test": "vitest",
         "test:unit": "vitest tests/unit",
         "test:watch": "vitest --watch",


### PR DESCRIPTION
## Summary
Add TypeScript type checking as an explicit step in the PR checks workflow. This catches type errors earlier in the CI pipeline and ensures code quality before tests and build.

## Changes
- Added `typecheck` npm script using `tsc --noEmit`
- Added typecheck step to PR checks workflow before test execution
- Updated CI summary to reflect typecheck status

🤖 Generated with Claude Code