### PR TITLE
feat(users): add orchestrator users service and token identity helpers

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -147,6 +147,8 @@ useEffect(() => {
 - `sdk.isAuthenticated()` - Check if user has valid token
 - `sdk.isInOAuthCallback()` - Check if processing OAuth redirect
 - `sdk.completeOAuth()` - Manually complete OAuth (advanced use)
+- `sdk.getTokenClaims()` - Decode current token claims locally (no API call)
+- `sdk.getTokenIdentity()` - Get normalized identity from claims locally (no API call)
 
 ---
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -96,6 +96,14 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getAll()` | `OR.Queues` or `OR.Queues.Read` |
 | `getById()` | `OR.Queues` or `OR.Queues.Read` |
 
+## Users
+
+| Method | OAuth Scope |
+|--------|-------------|
+| `getAll()` | `OR.Users` or `OR.Users.Read` |
+| `getById()` | `OR.Users` or `OR.Users.Read` |
+| `getCurrent()` | `OR.Users` or `OR.Users.Read` |
+
 ## Tasks
 
 | Method | OAuth Scope |

--- a/package.json
+++ b/package.json
@@ -76,6 +76,16 @@
                 "default": "./dist/queues/index.cjs"
             }
         },
+        "./users": {
+            "import": {
+                "types": "./dist/users/index.d.ts",
+                "default": "./dist/users/index.mjs"
+            },
+            "require": {
+                "types": "./dist/users/index.d.ts",
+                "default": "./dist/users/index.cjs"
+            }
+        },
         "./buckets": {
             "import": {
                 "types": "./dist/buckets/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,60 +119,20 @@ const configs = [
 
 // Service-level entry points for modular imports
 const serviceEntries = [
-  {
-    name: 'core',
-    input: 'src/core/index.ts',
-    output: 'core/index'
-  },
-  {
-    name: 'entities',
-    input: 'src/services/data-fabric/index.ts',
-    output: 'entities/index'
-  },
-  {
-    name: 'tasks',
-    input: 'src/services/action-center/index.ts',
-    output: 'tasks/index'
-  },
-  {
-    name: 'assets',
-    input: 'src/services/orchestrator/assets/index.ts',
-    output: 'assets/index'
-  },
-  {
-    name: 'queues',
-    input: 'src/services/orchestrator/queues/index.ts',
-    output: 'queues/index'
-  },
-  {
-    name: 'users',
-    input: 'src/services/orchestrator/users/index.ts',
-    output: 'users/index'
-  },
-  {
-    name: 'buckets',
-    input: 'src/services/orchestrator/buckets/index.ts',
-    output: 'buckets/index'
-  },
-  {
-    name: 'processes',
-    input: 'src/services/orchestrator/processes/index.ts',
-    output: 'processes/index'
-  },
-  {
-    name: 'cases',
-    input: 'src/services/maestro/cases/index.ts',
-    output: 'cases/index'
-  },
-  {
-    name: 'maestro-processes',
-    input: 'src/services/maestro/processes/index.ts',
-    output: 'maestro-processes/index'
-  }
+  ['core', 'src/core/index.ts', 'core/index'],
+  ['entities', 'src/services/data-fabric/index.ts', 'entities/index'],
+  ['tasks', 'src/services/action-center/index.ts', 'tasks/index'],
+  ['assets', 'src/services/orchestrator/assets/index.ts', 'assets/index'],
+  ['queues', 'src/services/orchestrator/queues/index.ts', 'queues/index'],
+  ['users', 'src/services/orchestrator/users/index.ts', 'users/index'],
+  ['buckets', 'src/services/orchestrator/buckets/index.ts', 'buckets/index'],
+  ['processes', 'src/services/orchestrator/processes/index.ts', 'processes/index'],
+  ['cases', 'src/services/maestro/cases/index.ts', 'cases/index'],
+  ['maestro-processes', 'src/services/maestro/processes/index.ts', 'maestro-processes/index']
 ];
 
 // Generate ESM, CJS, and DTS builds for each service entry
-serviceEntries.forEach(({ name, input, output }) => {
+serviceEntries.forEach(([name, input, output]) => {
   // ESM bundle
   configs.push({
     input,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -145,6 +145,11 @@ const serviceEntries = [
     output: 'queues/index'
   },
   {
+    name: 'users',
+    input: 'src/services/orchestrator/users/index.ts',
+    output: 'users/index'
+  },
+  {
     name: 'buckets',
     input: 'src/services/orchestrator/buckets/index.ts',
     output: 'buckets/index'

--- a/src/core/auth/claimReader.ts
+++ b/src/core/auth/claimReader.ts
@@ -1,0 +1,94 @@
+import type { TokenClaims } from './types';
+
+/**
+ * A utility class to read and normalize claims from a parsed JWT payload.
+ * Provides getters that handle fallback aliases for standard identity properties.
+ */
+export class ClaimReader {
+    private readonly claims: TokenClaims;
+
+    constructor(claims: TokenClaims) {
+        this.claims = claims;
+    }
+
+    /**
+     * Reads the user ID claim.
+     * Priority: 'sub' -> 'user_id' -> 'uid'
+     */
+    getUserId(): string | undefined {
+        return this.getFirstStringClaim(['sub', 'user_id', 'uid']);
+    }
+
+    /**
+     * Reads the username claim.
+     * Priority: 'preferred_username' -> 'upn' -> 'unique_name'
+     */
+    getUsername(): string | undefined {
+        return this.getFirstStringClaim(['preferred_username', 'upn', 'unique_name']);
+    }
+
+    /**
+     * Reads the user's email address claim.
+     */
+    getEmail(): string | undefined {
+        return this.getFirstStringClaim(['email']);
+    }
+
+    /**
+     * Reads the full name claim.
+     */
+    getName(): string | undefined {
+        return this.getFirstStringClaim(['name']);
+    }
+
+    /**
+     * Reads the given (first) name claim.
+     */
+    getGivenName(): string | undefined {
+        return this.getFirstStringClaim(['given_name']);
+    }
+
+    /**
+     * Reads the family (last) name claim.
+     */
+    getFamilyName(): string | undefined {
+        return this.getFirstStringClaim(['family_name']);
+    }
+
+    /**
+     * Reads the tenant name claim.
+     * Priority: 'tenantName' -> 'tenant'
+     */
+    getTenantName(): string | undefined {
+        return this.getFirstStringClaim(['tenantName', 'tenant']);
+    }
+
+    /**
+     * Reads the organization name claim.
+     * Priority: 'orgName' -> 'org'
+     */
+    getOrgName(): string | undefined {
+        return this.getFirstStringClaim(['orgName', 'org']);
+    }
+
+    /**
+     * Returns the raw claims object exactly as decoded.
+     */
+    getRawClaims(): TokenClaims {
+        return this.claims;
+    }
+
+    /**
+     * Helper to find the first non-empty string claim matching the given keys.
+     */
+    private getFirstStringClaim(keys: string[]): string | undefined {
+        for (const key of keys) {
+            const value = this.claims[key];
+            if (typeof value === 'string' && value.length > 0) {
+                return value;
+            }
+        }
+
+        return undefined;
+    }
+}

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -31,3 +31,23 @@ export interface OAuthContext {
   tenantName: string;
   scope: string;
 }
+
+/**
+ * OAuth/JWT token claims map.
+ */
+export type TokenClaims = Record<string, unknown>;
+
+/**
+ * Normalized identity extracted from token claims.
+ */
+export interface TokenIdentity {
+  userId?: string;
+  username?: string;
+  email?: string;
+  name?: string;
+  givenName?: string;
+  familyName?: string;
+  tenantName?: string;
+  orgName?: string;
+  rawClaims: TokenClaims;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,6 +45,7 @@
 
 export { UiPath } from './uipath';
 export type { UiPathSDKConfig } from './config/sdk-config';
+export type { TokenClaims, TokenIdentity } from './auth/types';
 export * from './errors';
 
 // Pagination (common across all services)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,6 +9,7 @@
  */
 
 import type { BaseConfig } from './config/sdk-config';
+import type { TokenClaims, TokenIdentity } from './auth/types';
 
 export interface IUiPath {
   /** Read-only configuration for the SDK instance */
@@ -45,4 +46,16 @@ export interface IUiPath {
    * Get the current authentication token
    */
   getToken(): string | undefined;
+
+  /**
+   * Get decoded claims from the current OAuth token.
+   * Returns undefined if token is missing or malformed.
+   */
+  getTokenClaims(): TokenClaims | undefined;
+
+  /**
+   * Get normalized identity derived from the current OAuth token claims.
+   * Returns undefined if token is missing or malformed.
+   */
+  getTokenIdentity(): TokenIdentity | undefined;
 }

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -6,6 +6,7 @@ import { validateConfig, normalizeBaseUrl } from './config/config-utils';
 import { telemetryClient, trackEvent } from './telemetry';
 import { SDKInternalsRegistry } from './internals';
 import type { IUiPath } from './types';
+import type { TokenClaims, TokenIdentity } from './auth/types';
 
 /**
  * UiPath - Core SDK class for authentication and configuration management.
@@ -182,6 +183,98 @@ export class UiPath implements IUiPath {
    */
   public getToken(): string | undefined {
     return this.#authService.getToken();
+  }
+
+  /**
+   * Get decoded claims from the current JWT token.
+   * Returns undefined if token is missing or malformed.
+   */
+  public getTokenClaims(): TokenClaims | undefined {
+    const token = this.getToken();
+    if (!token) {
+      return undefined;
+    }
+
+    return this.decodeJwtClaims(token);
+  }
+
+  /**
+   * Get normalized identity from token claims.
+   * Returns undefined if token is missing or malformed.
+   */
+  public getTokenIdentity(): TokenIdentity | undefined {
+    const claims = this.getTokenClaims();
+    if (!claims) {
+      return undefined;
+    }
+
+    return {
+      userId: this.getFirstStringClaim(claims, ['sub', 'user_id', 'uid']),
+      username: this.getFirstStringClaim(claims, ['preferred_username', 'upn', 'unique_name']),
+      email: this.getFirstStringClaim(claims, ['email']),
+      name: this.getFirstStringClaim(claims, ['name']),
+      givenName: this.getFirstStringClaim(claims, ['given_name']),
+      familyName: this.getFirstStringClaim(claims, ['family_name']),
+      tenantName: this.getFirstStringClaim(claims, ['tenantName', 'tenant']),
+      orgName: this.getFirstStringClaim(claims, ['orgName', 'org']),
+      rawClaims: claims
+    };
+  }
+
+  private decodeJwtClaims(token: string): TokenClaims | undefined {
+    const parts = token.split('.');
+    if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+      return undefined;
+    }
+
+    try {
+      const payload = this.base64UrlDecode(parts[1]);
+      const parsed = JSON.parse(payload);
+
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return undefined;
+      }
+
+      return parsed as TokenClaims;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private base64UrlDecode(value: string): string {
+    const base64 = value
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(value.length / 4) * 4, '=');
+
+    if (typeof atob === 'function') {
+      try {
+        return decodeURIComponent(
+          Array.from(atob(base64))
+            .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`)
+            .join('')
+        );
+      } catch {
+        return atob(base64);
+      }
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(base64, 'base64').toString('utf-8');
+    }
+
+    throw new Error('No base64 decoder available');
+  }
+
+  private getFirstStringClaim(claims: TokenClaims, keys: string[]): string | undefined {
+    for (const key of keys) {
+      const value = claims[key];
+      if (typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+    }
+
+    return undefined;
   }
 
 }

--- a/src/models/orchestrator/index.ts
+++ b/src/models/orchestrator/index.ts
@@ -10,3 +10,5 @@ export * from './processes.types';
 export * from './processes.models';
 export * from './queues.types';
 export * from './queues.models';
+export * from './users.types';
+export * from './users.models';

--- a/src/models/orchestrator/users.constants.ts
+++ b/src/models/orchestrator/users.constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Maps fields for User entities to ensure consistent naming.
+ */
+export const UserMap: { [key: string]: string } = {
+  creationTime: 'createdTime',
+};

--- a/src/models/orchestrator/users.models.ts
+++ b/src/models/orchestrator/users.models.ts
@@ -10,20 +10,47 @@ import { HasPaginationOptions, NonPaginatedResponse, PaginatedResponse } from '.
 export interface UserServiceModel {
   /**
    * Gets users with optional OData filtering and pagination.
+   *
+   * @example
+   * ```typescript
+   * const result = await sdk.users.getAll({
+   *   filter: "userName eq 'jane.doe'",
+   *   pageSize: 10
+   * });
+   * console.log(result.items[0].emailAddress);
+   * ```
    */
   getAll<T extends UserGetAllOptions = UserGetAllOptions>(options?: T): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<UserGetResponse>
-      : NonPaginatedResponse<UserGetResponse>
+    ? PaginatedResponse<UserGetResponse>
+    : NonPaginatedResponse<UserGetResponse>
   >;
 
   /**
    * Gets a single user by ID.
+   *
+   * @example
+   * ```typescript
+   * const user = await sdk.users.getById(321, {
+   *   select: 'id,userName,emailAddress'
+   * });
+   * console.log(user.userName);
+   * ```
    */
   getById(id: number, options?: UserGetByIdOptions): Promise<UserGetResponse>;
 
   /**
    * Gets the currently authenticated user from Orchestrator.
+   *
+   * @example
+   * ```typescript
+   * const currentUser = await sdk.users.getCurrent({
+   *   select: 'id,userName'
+   * });
+   * if (currentUser) {
+   *   console.log(`Hello, ${currentUser.userName}`);
+   * }
+   * ```
    */
   getCurrent(options?: UserGetCurrentOptions): Promise<UserGetResponse | undefined>;
 }

--- a/src/models/orchestrator/users.models.ts
+++ b/src/models/orchestrator/users.models.ts
@@ -11,6 +11,9 @@ export interface UserServiceModel {
   /**
    * Gets users with optional OData filtering and pagination.
    *
+   * @param options Optional OData and pagination options
+   * @returns List response or paginated response based on provided options
+   *
    * @example
    * ```typescript
    * const result = await sdk.users.getAll({
@@ -29,6 +32,10 @@ export interface UserServiceModel {
   /**
    * Gets a single user by ID.
    *
+   * @param id User identifier
+   * @param options Optional OData options
+   * @returns User details for the requested ID
+   *
    * @example
    * ```typescript
    * const user = await sdk.users.getById(321, {
@@ -41,6 +48,9 @@ export interface UserServiceModel {
 
   /**
    * Gets the currently authenticated user from Orchestrator.
+   *
+   * @param options Optional OData options
+   * @returns Current user details, or `undefined` when no content is returned
    *
    * @example
    * ```typescript

--- a/src/models/orchestrator/users.models.ts
+++ b/src/models/orchestrator/users.models.ts
@@ -1,0 +1,29 @@
+import { UserGetAllOptions, UserGetByIdOptions, UserGetCurrentOptions, UserGetResponse } from './users.types';
+import { HasPaginationOptions, NonPaginatedResponse, PaginatedResponse } from '../../utils/pagination';
+
+/**
+ * Service for managing UiPath users from Orchestrator.
+ *
+ * User methods in this service call Orchestrator APIs and therefore require
+ * corresponding OAuth scopes (for example OR.Users / OR.Users.Read).
+ */
+export interface UserServiceModel {
+  /**
+   * Gets users with optional OData filtering and pagination.
+   */
+  getAll<T extends UserGetAllOptions = UserGetAllOptions>(options?: T): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<UserGetResponse>
+      : NonPaginatedResponse<UserGetResponse>
+  >;
+
+  /**
+   * Gets a single user by ID.
+   */
+  getById(id: number, options?: UserGetByIdOptions): Promise<UserGetResponse>;
+
+  /**
+   * Gets the currently authenticated user from Orchestrator.
+   */
+  getCurrent(options?: UserGetCurrentOptions): Promise<UserGetResponse | undefined>;
+}

--- a/src/models/orchestrator/users.types.ts
+++ b/src/models/orchestrator/users.types.ts
@@ -1,0 +1,67 @@
+import { BaseOptions, RequestOptions } from '../common/types';
+import { PaginationOptions } from '../../utils/pagination';
+
+/**
+ * Interface for user role response details.
+ */
+export type UserRoleType = 'Mixed' | 'Tenant' | 'Folder';
+
+export interface UserRoleInfo {
+  userId?: number;
+  roleId?: number;
+  userName?: string;
+  roleName?: string;
+  roleType?: UserRoleType;
+  id?: number;
+}
+
+/**
+ * Interface for user response.
+ */
+export interface UserGetResponse {
+  id: number;
+  key?: string;
+  name?: string;
+  surname?: string;
+  userName?: string;
+  domain?: string;
+  directoryIdentifier?: string;
+  fullName?: string;
+  emailAddress?: string;
+  lastLoginTime?: string | null;
+  isActive?: boolean;
+  createdTime?: string;
+  authenticationSource?: string;
+  password?: string;
+  isExternalLicensed?: boolean;
+  userRoles?: UserRoleInfo[];
+  rolesList?: string[];
+  loginProviders?: string[];
+  tenantId?: number;
+  tenancyName?: string;
+  tenantDisplayName?: string;
+  tenantKey?: string;
+  type?: string;
+  provisionType?: string;
+  licenseType?: string;
+  mayHaveUserSession?: boolean;
+  mayHaveRobotSession?: boolean;
+  mayHaveUnattendedSession?: boolean;
+  mayHavePersonalWorkspace?: boolean;
+  restrictToPersonalWorkspace?: boolean;
+}
+
+/**
+ * Options for getting users.
+ */
+export type UserGetAllOptions = RequestOptions & PaginationOptions;
+
+/**
+ * Options for getting a single user by ID.
+ */
+export type UserGetByIdOptions = BaseOptions;
+
+/**
+ * Options for getting current user.
+ */
+export type UserGetCurrentOptions = BaseOptions;

--- a/src/models/orchestrator/users.types.ts
+++ b/src/models/orchestrator/users.types.ts
@@ -2,9 +2,13 @@ import { BaseOptions, RequestOptions } from '../common/types';
 import { PaginationOptions } from '../../utils/pagination';
 
 /**
- * Interface for user role response details.
+ * Enum for user role response details.
  */
-export type UserRoleType = 'Mixed' | 'Tenant' | 'Folder';
+export enum UserRoleType {
+  Mixed = 'Mixed',
+  Tenant = 'Tenant',
+  Folder = 'Folder'
+}
 
 export interface UserRoleInfo {
   userId?: number;
@@ -17,6 +21,18 @@ export interface UserRoleInfo {
 
 /**
  * Interface for user response.
+ *
+ * @example
+ * ```typescript
+ * const user: UserGetResponse = {
+ *   id: 321,
+ *   userName: 'jane.doe',
+ *   emailAddress: 'jane.doe@uipath.com',
+ *   isActive: true,
+ *   createdTime: '2024-01-01T09:00:00Z',
+ *   type: 'DirectoryUser'
+ * };
+ * ```
  */
 export interface UserGetResponse {
   id: number;
@@ -32,7 +48,6 @@ export interface UserGetResponse {
   isActive?: boolean;
   createdTime?: string;
   authenticationSource?: string;
-  password?: string;
   isExternalLicensed?: boolean;
   userRoles?: UserRoleInfo[];
   rolesList?: string[];

--- a/src/services/orchestrator/index.ts
+++ b/src/services/orchestrator/index.ts
@@ -2,3 +2,4 @@ export * from './assets';
 export * from './buckets';
 export * from './processes';
 export * from './queues';
+export * from './users';

--- a/src/services/orchestrator/users/index.ts
+++ b/src/services/orchestrator/users/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Users Module
+ *
+ * Provides access to UiPath Orchestrator user APIs.
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { Users } from '@uipath/uipath-typescript/users';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * const users = new Users(sdk);
+ * const currentUser = await users.getCurrent();
+ * ```
+ *
+ * @module
+ */
+
+export { UserService as Users, UserService } from './users';
+
+export * from '../../../models/orchestrator/users.types';
+export * from '../../../models/orchestrator/users.models';

--- a/src/services/orchestrator/users/users.ts
+++ b/src/services/orchestrator/users/users.ts
@@ -1,0 +1,97 @@
+import { BaseService } from '../../base';
+import type { IUiPath } from '../../../core/types';
+import { UserServiceModel } from '../../../models/orchestrator/users.models';
+import { UserGetAllOptions, UserGetByIdOptions, UserGetCurrentOptions, UserGetResponse } from '../../../models/orchestrator/users.types';
+import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
+import { USERS_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { ODATA_OFFSET_PARAMS, ODATA_PAGINATION, ODATA_PREFIX } from '../../../utils/constants/common';
+import { HasPaginationOptions, NonPaginatedResponse, PaginatedResponse } from '../../../utils/pagination';
+import { PaginationHelpers } from '../../../utils/pagination/helpers';
+import { PaginationType } from '../../../utils/pagination/internal-types';
+import { UserMap } from '../../../models/orchestrator/users.constants';
+import { track } from '../../../core/telemetry';
+
+/**
+ * Service for interacting with UiPath Orchestrator Users API.
+ */
+export class UserService extends BaseService implements UserServiceModel {
+  /**
+   * Creates an instance of the Users service.
+   *
+   * @param instance - UiPath SDK instance providing authentication and configuration
+   */
+  constructor(instance: IUiPath) {
+    super(instance);
+  }
+
+  /**
+   * Gets users with optional filtering and pagination.
+   */
+  @track('Users.GetAll')
+  async getAll<T extends UserGetAllOptions = UserGetAllOptions>(
+    options?: T
+  ): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<UserGetResponse>
+      : NonPaginatedResponse<UserGetResponse>
+  > {
+    const transformUserResponse = (user: any) =>
+      transformData(pascalToCamelCaseKeys(user) as UserGetResponse, UserMap);
+
+    return PaginationHelpers.getAll({
+      serviceAccess: this.createPaginationServiceAccess(),
+      getEndpoint: () => USERS_ENDPOINTS.GET_ALL,
+      transformFn: transformUserResponse,
+      pagination: {
+        paginationType: PaginationType.OFFSET,
+        itemsField: ODATA_PAGINATION.ITEMS_FIELD,
+        totalCountField: ODATA_PAGINATION.TOTAL_COUNT_FIELD,
+        paginationParams: {
+          pageSizeParam: ODATA_OFFSET_PARAMS.PAGE_SIZE_PARAM,
+          offsetParam: ODATA_OFFSET_PARAMS.OFFSET_PARAM,
+          countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM
+        }
+      }
+    }, options) as any;
+  }
+
+  /**
+   * Gets a single user by ID.
+   */
+  @track('Users.GetById')
+  async getById(id: number, options: UserGetByIdOptions = {}): Promise<UserGetResponse> {
+    const keysToPrefix = Object.keys(options);
+    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
+
+    const response = await this.get<UserGetResponse>(
+      USERS_ENDPOINTS.GET_BY_ID(id),
+      {
+        params: apiOptions
+      }
+    );
+
+    return transformData(pascalToCamelCaseKeys(response.data) as UserGetResponse, UserMap);
+  }
+
+  /**
+   * Gets the current user from Orchestrator.
+   */
+  @track('Users.GetCurrent')
+  async getCurrent(options: UserGetCurrentOptions = {}): Promise<UserGetResponse | undefined> {
+    const keysToPrefix = Object.keys(options);
+    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
+
+    const response = await this.get<UserGetResponse | undefined>(
+      USERS_ENDPOINTS.GET_CURRENT,
+      {
+        params: apiOptions
+      }
+    );
+
+    if (!response.data) {
+      return undefined;
+    }
+
+    return transformData(pascalToCamelCaseKeys(response.data) as UserGetResponse, UserMap);
+  }
+}

--- a/src/uipath.ts
+++ b/src/uipath.ts
@@ -11,7 +11,8 @@ import {
   ProcessService,
   BucketService,
   QueueService,
-  AssetService
+  AssetService,
+  UserService
 } from './services';
 import { UiPathSDKConfig } from './core/config/sdk-config';
 
@@ -135,6 +136,13 @@ export class UiPath extends UiPathCore {
    */
   get assets(): AssetService {
     return this.getService(AssetService);
+  }
+
+  /**
+   * Access to Orchestrator Users service
+   */
+  get users(): UserService {
+    return this.getService(UserService);
   }
 }
 

--- a/src/uipath.ts
+++ b/src/uipath.ts
@@ -11,7 +11,8 @@ import {
   ProcessService,
   BucketService,
   QueueService,
-  AssetService
+  AssetService,
+  UserService
 } from './services';
 import { UiPathSDKConfig } from './core/config/sdk-config';
 
@@ -139,6 +140,13 @@ export class UiPath extends UiPathCore {
    */
   get assets(): AssetService {
     return this.getService(AssetService);
+  }
+
+  /**
+   * Access to Orchestrator Users service
+   */
+  get users(): UserService {
+    return this.getService(UserService);
   }
 }
 

--- a/src/utils/auth/jwtUtils.ts
+++ b/src/utils/auth/jwtUtils.ts
@@ -1,0 +1,47 @@
+import type { TokenClaims } from '../../core/auth/types';
+
+/**
+ * Safely decodes a base64url encoded string using Buffer.
+ * Targetting Node 20+ so standard Buffer usage is preferred over atob.
+ *
+ * @param value The base64url encoded string
+ * @returns The decoded utf-8 string
+ */
+export function base64UrlDecode(value: string): string {
+    const base64 = value
+        .replace(/-/g, '+')
+        .replace(/_/g, '/')
+        .padEnd(Math.ceil(value.length / 4) * 4, '=');
+
+    return Buffer.from(base64, 'base64').toString('utf-8');
+}
+
+/**
+ * Parses a JWT token and returns its claims payload.
+ *
+ * @param token The raw JWT string
+ * @returns The parsed TokenClaims object, or undefined if the token is invalid or missing
+ */
+export function parseJwtToken(token: string | undefined): TokenClaims | undefined {
+    if (!token) {
+        return undefined;
+    }
+
+    const parts = token.split('.');
+    if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+        return undefined;
+    }
+
+    try {
+        const payload = base64UrlDecode(parts[1]);
+        const parsed = JSON.parse(payload);
+
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return undefined;
+        }
+
+        return parsed as TokenClaims;
+    } catch {
+        return undefined;
+    }
+}

--- a/src/utils/constants/endpoints.ts
+++ b/src/utils/constants/endpoints.ts
@@ -129,3 +129,12 @@ export const ASSET_ENDPOINTS = {
   GET_ALL: `${ORCHESTRATOR_BASE}/odata/Assets/UiPath.Server.Configuration.OData.GetAssetsAcrossFolders`,
   GET_BY_ID: (id: number) => `${ORCHESTRATOR_BASE}/odata/Assets(${id})`,
 } as const;
+
+/**
+ * Orchestrator User Service Endpoints
+ */
+export const USERS_ENDPOINTS = {
+  GET_ALL: `${ORCHESTRATOR_BASE}/odata/Users`,
+  GET_BY_ID: (id: number) => `${ORCHESTRATOR_BASE}/odata/Users(${id})`,
+  GET_CURRENT: `${ORCHESTRATOR_BASE}/odata/Users/UiPath.Server.Configuration.OData.GetCurrentUser`,
+} as const;

--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -7,8 +7,10 @@ import { getConfig, getContext, getTokenManager, getPrivateSDK } from '../../uti
 import { TEST_CONSTANTS } from '../../utils/constants/common';
 
 // ===== MOCKING =====
+let mockAccessToken: string | undefined = 'mock-access-token';
+
 const mockTokenManager = {
-  getToken: () => 'mock-access-token',
+  getToken: () => mockAccessToken,
   hasValidToken: () => true
 };
 
@@ -16,7 +18,7 @@ vi.mock('../../../src/core/auth/service', () => {
   const AuthService: any = vi.fn().mockImplementation(() => ({
     getTokenManager: () => mockTokenManager,
     hasValidToken: () => true,
-    getToken: () => 'mock-access-token',
+    getToken: () => mockAccessToken,
     authenticateWithSecret: vi.fn(),
     authenticate: vi.fn().mockResolvedValue(true)
   }));
@@ -32,6 +34,10 @@ vi.mock('../../../src/core/http/api-client');
 
 // ===== TEST SUITE =====
 describe('UiPath Core', () => {
+  beforeEach(() => {
+    mockAccessToken = 'mock-access-token';
+  });
+
   describe('Constructor', () => {
     it('should create instance with secret-based auth config', () => {
       const sdk = new UiPath({
@@ -308,6 +314,161 @@ describe('UiPath Core', () => {
 
       expect(secretSdk.isInitialized()).toBe(true);
       expect(oauthSdk.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('Token Claims Helpers', () => {
+    const createJwt = (payload: Record<string, unknown>): string => {
+      const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+      const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+      return `${header}.${body}.signature`;
+    };
+
+    it('should return decoded token claims for valid JWT', () => {
+      mockAccessToken = createJwt({
+        sub: 'abc-123',
+        preferred_username: 'jane.doe',
+        email: 'jane.doe@uipath.com'
+      });
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      const claims = sdk.getTokenClaims();
+
+      expect(claims).toBeDefined();
+      expect(claims?.sub).toBe('abc-123');
+      expect(claims?.preferred_username).toBe('jane.doe');
+      expect(claims?.email).toBe('jane.doe@uipath.com');
+    });
+
+    it('should return undefined claims when token is missing', () => {
+      mockAccessToken = undefined;
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(sdk.getTokenClaims()).toBeUndefined();
+    });
+
+    it('should return undefined claims for malformed token payload', () => {
+      mockAccessToken = 'a.b.c';
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(sdk.getTokenClaims()).toBeUndefined();
+    });
+
+    it('should return undefined claims for token with missing JWT signature segment', () => {
+      mockAccessToken = 'a.b';
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(sdk.getTokenClaims()).toBeUndefined();
+    });
+
+    it('should return undefined claims for token with empty JWT segment', () => {
+      mockAccessToken = 'a..c';
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(sdk.getTokenClaims()).toBeUndefined();
+    });
+
+    it('should return normalized token identity with OIDC claim precedence', () => {
+      mockAccessToken = createJwt({
+        sub: 'oidc-subject',
+        preferred_username: 'oidc.username',
+        upn: 'fallback-upn',
+        email: 'identity@uipath.com',
+        name: 'OIDC Name',
+        given_name: 'OIDC',
+        family_name: 'User',
+        tenant: 'tenant-fallback',
+        org: 'org-fallback',
+        tenantName: 'tenant-primary',
+        orgName: 'org-primary'
+      });
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      const identity = sdk.getTokenIdentity();
+
+      expect(identity).toBeDefined();
+      expect(identity?.userId).toBe('oidc-subject');
+      expect(identity?.username).toBe('oidc.username');
+      expect(identity?.email).toBe('identity@uipath.com');
+      expect(identity?.name).toBe('OIDC Name');
+      expect(identity?.givenName).toBe('OIDC');
+      expect(identity?.familyName).toBe('User');
+      expect(identity?.tenantName).toBe('tenant-primary');
+      expect(identity?.orgName).toBe('org-primary');
+      expect(identity?.rawClaims).toBeDefined();
+    });
+
+    it('should use alias fallback claims when OIDC claims are absent', () => {
+      mockAccessToken = createJwt({
+        user_id: 'alias-id',
+        unique_name: 'alias-username',
+        tenant: 'alias-tenant',
+        org: 'alias-org'
+      });
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      const identity = sdk.getTokenIdentity();
+
+      expect(identity).toBeDefined();
+      expect(identity?.userId).toBe('alias-id');
+      expect(identity?.username).toBe('alias-username');
+      expect(identity?.tenantName).toBe('alias-tenant');
+      expect(identity?.orgName).toBe('alias-org');
+    });
+
+    it('should return undefined identity when token cannot be decoded', () => {
+      mockAccessToken = 'not-a-jwt';
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(sdk.getTokenIdentity()).toBeUndefined();
     });
   });
 

--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -357,24 +357,12 @@ describe('UiPath Core', () => {
       expect(sdk.getTokenClaims()).toBeUndefined();
     });
 
-    it('should return undefined claims for malformed token payload', () => {
-      mockAccessToken = 'a.b.c';
-
-      const sdk = createSecretSdk();
-
-      expect(sdk.getTokenClaims()).toBeUndefined();
-    });
-
-    it('should return undefined claims for token with missing JWT signature segment', () => {
-      mockAccessToken = 'a.b';
-
-      const sdk = createSecretSdk();
-
-      expect(sdk.getTokenClaims()).toBeUndefined();
-    });
-
-    it('should return undefined claims for token with empty JWT segment', () => {
-      mockAccessToken = 'a..c';
+    it.each([
+      ['malformed token payload', 'a.b.c'],
+      ['token with missing JWT signature segment', 'a.b'],
+      ['token with empty JWT segment', 'a..c']
+    ])('should return undefined claims for %s', (_description, malformedToken) => {
+      mockAccessToken = malformedToken;
 
       const sdk = createSecretSdk();
 

--- a/tests/unit/services/orchestrator/index.ts
+++ b/tests/unit/services/orchestrator/index.ts
@@ -6,3 +6,4 @@ export * from './buckets.test';
 export * from './processes.test';
 export * from './assets.test';
 export * from './queues.test';
+export * from './users.test';

--- a/tests/unit/services/orchestrator/users.test.ts
+++ b/tests/unit/services/orchestrator/users.test.ts
@@ -25,6 +25,18 @@ describe('UserService Unit Tests', () => {
   let userService: UserService;
   let mockApiClient: any;
 
+  const expectGetCalledWithODataParams = (
+    endpoint: string,
+    params: Record<string, unknown>
+  ) => {
+    expect(mockApiClient.get).toHaveBeenCalledWith(
+      endpoint,
+      expect.objectContaining({
+        params: expect.objectContaining(params)
+      })
+    );
+  };
+
   beforeEach(() => {
     const { instance } = createServiceTestDependencies();
     mockApiClient = createMockApiClient();
@@ -69,15 +81,12 @@ describe('UserService Unit Tests', () => {
       };
 
       await userService.getById(USER_TEST_CONSTANTS.USER_ID, options);
-
-      expect(mockApiClient.get).toHaveBeenCalledWith(
+      expectGetCalledWithODataParams(
         USERS_ENDPOINTS.GET_BY_ID(USER_TEST_CONSTANTS.USER_ID),
-        expect.objectContaining({
-          params: expect.objectContaining({
-            '$select': USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS,
-            '$expand': USER_TEST_CONSTANTS.ODATA_EXPAND_FIELDS
-          })
-        })
+        {
+          '$select': USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS,
+          '$expand': USER_TEST_CONSTANTS.ODATA_EXPAND_FIELDS
+        }
       );
     });
 
@@ -104,15 +113,9 @@ describe('UserService Unit Tests', () => {
       expect(result).toBeDefined();
       expect(result?.id).toBe(USER_TEST_CONSTANTS.USER_ID);
       expect(result?.userName).toBe(USER_TEST_CONSTANTS.USERNAME);
-
-      expect(mockApiClient.get).toHaveBeenCalledWith(
-        USERS_ENDPOINTS.GET_CURRENT,
-        expect.objectContaining({
-          params: expect.objectContaining({
-            '$select': USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS
-          })
-        })
-      );
+      expectGetCalledWithODataParams(USERS_ENDPOINTS.GET_CURRENT, {
+        '$select': USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS
+      });
     });
 
     it('should return undefined when API returns no content', async () => {

--- a/tests/unit/services/orchestrator/users.test.ts
+++ b/tests/unit/services/orchestrator/users.test.ts
@@ -1,0 +1,184 @@
+// ===== IMPORTS =====
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserService } from '../../../../src/services/orchestrator/users';
+import { ApiClient } from '../../../../src/core/http/api-client';
+import { PaginationHelpers } from '../../../../src/utils/pagination/helpers';
+import { createMockApiClient, createServiceTestDependencies } from '../../../utils/setup';
+import { createMockError } from '../../../utils/mocks/core';
+import { createMockRawUser, createMockTransformedUserCollection } from '../../../utils/mocks/users';
+import { USER_TEST_CONSTANTS } from '../../../utils/constants/users';
+import { TEST_CONSTANTS } from '../../../utils/constants/common';
+import { USERS_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import { UserGetAllOptions, UserGetByIdOptions, UserGetCurrentOptions } from '../../../../src/models/orchestrator/users.types';
+
+// ===== MOCKING =====
+vi.mock('../../../../src/core/http/api-client');
+
+const mocks = vi.hoisted(() => {
+  return import('../../../utils/mocks/core');
+});
+
+vi.mock('../../../../src/utils/pagination/helpers', async () => (await mocks).mockPaginationHelpers);
+
+// ===== TEST SUITE =====
+describe('UserService Unit Tests', () => {
+  let userService: UserService;
+  let mockApiClient: any;
+
+  beforeEach(() => {
+    const { instance } = createServiceTestDependencies();
+    mockApiClient = createMockApiClient();
+
+    vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+    vi.mocked(PaginationHelpers.getAll).mockReset();
+
+    userService = new UserService(instance);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getById', () => {
+    it('should get user by ID successfully and map fields', async () => {
+      const mockUser = createMockRawUser();
+      mockApiClient.get.mockResolvedValue(mockUser);
+
+      const result = await userService.getById(USER_TEST_CONSTANTS.USER_ID);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(USER_TEST_CONSTANTS.USER_ID);
+      expect(result.userName).toBe(USER_TEST_CONSTANTS.USERNAME);
+      expect(result.emailAddress).toBe(USER_TEST_CONSTANTS.USER_EMAIL);
+      expect(result.createdTime).toBe(USER_TEST_CONSTANTS.CREATED_TIME);
+      expect((result as any).creationTime).toBeUndefined();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        USERS_ENDPOINTS.GET_BY_ID(USER_TEST_CONSTANTS.USER_ID),
+        expect.any(Object)
+      );
+    });
+
+    it('should get user with OData options', async () => {
+      const mockUser = createMockRawUser();
+      mockApiClient.get.mockResolvedValue(mockUser);
+
+      const options: UserGetByIdOptions = {
+        select: USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS,
+        expand: USER_TEST_CONSTANTS.ODATA_EXPAND_FIELDS
+      };
+
+      await userService.getById(USER_TEST_CONSTANTS.USER_ID, options);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        USERS_ENDPOINTS.GET_BY_ID(USER_TEST_CONSTANTS.USER_ID),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS,
+            '$expand': USER_TEST_CONSTANTS.ODATA_EXPAND_FIELDS
+          })
+        })
+      );
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(USER_TEST_CONSTANTS.ERROR_USER_NOT_FOUND);
+      mockApiClient.get.mockRejectedValue(error);
+
+      await expect(userService.getById(USER_TEST_CONSTANTS.USER_ID))
+        .rejects.toThrow(USER_TEST_CONSTANTS.ERROR_USER_NOT_FOUND);
+    });
+  });
+
+  describe('getCurrent', () => {
+    it('should return current user when API has data', async () => {
+      const mockUser = createMockRawUser();
+      mockApiClient.get.mockResolvedValue(mockUser);
+
+      const options: UserGetCurrentOptions = {
+        select: USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS
+      };
+
+      const result = await userService.getCurrent(options);
+
+      expect(result).toBeDefined();
+      expect(result?.id).toBe(USER_TEST_CONSTANTS.USER_ID);
+      expect(result?.userName).toBe(USER_TEST_CONSTANTS.USERNAME);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        USERS_ENDPOINTS.GET_CURRENT,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': USER_TEST_CONSTANTS.ODATA_SELECT_FIELDS
+          })
+        })
+      );
+    });
+
+    it('should return undefined when API returns no content', async () => {
+      mockApiClient.get.mockResolvedValue(undefined);
+
+      const result = await userService.getCurrent();
+
+      expect(result).toBeUndefined();
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        USERS_ENDPOINTS.GET_CURRENT,
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all users without pagination options', async () => {
+      const mockResponse = createMockTransformedUserCollection();
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const result = await userService.getAll();
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          getEndpoint: expect.toSatisfy((fn: Function) => fn() === USERS_ENDPOINTS.GET_ALL),
+          transformFn: expect.any(Function),
+          pagination: expect.any(Object)
+        }),
+        undefined
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should return paginated users when pagination options provided', async () => {
+      const mockResponse = createMockTransformedUserCollection(100, {
+        totalCount: 100,
+        hasNextPage: true,
+        nextCursor: TEST_CONSTANTS.NEXT_CURSOR,
+        previousCursor: null,
+        currentPage: 1,
+        totalPages: 10
+      });
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const options: UserGetAllOptions = {
+        pageSize: TEST_CONSTANTS.PAGE_SIZE
+      };
+
+      const result = await userService.getAll(options) as any;
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          pageSize: TEST_CONSTANTS.PAGE_SIZE
+        })
+      );
+      expect(result).toEqual(mockResponse);
+      expect(result.hasNextPage).toBe(true);
+      expect(result.nextCursor).toBe(TEST_CONSTANTS.NEXT_CURSOR);
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
+
+      await expect(userService.getAll()).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+});

--- a/tests/unit/services/orchestrator/users.test.ts
+++ b/tests/unit/services/orchestrator/users.test.ts
@@ -166,12 +166,11 @@ describe('UserService Unit Tests', () => {
 
       const result = await userService.getAll(options) as any;
 
-      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
-        expect.any(Object),
-        expect.objectContaining({
-          pageSize: TEST_CONSTANTS.PAGE_SIZE
-        })
-      );
+      expect(PaginationHelpers.getAll).toHaveBeenCalledTimes(1);
+      const getAllCalls = vi.mocked(PaginationHelpers.getAll).mock.calls;
+      const [paginationConfig, paginationOptions] = getAllCalls[0];
+      expect(paginationConfig.getEndpoint()).toBe(USERS_ENDPOINTS.GET_ALL);
+      expect(paginationOptions?.pageSize).toBe(TEST_CONSTANTS.PAGE_SIZE);
       expect(result).toEqual(mockResponse);
       expect(result.hasNextPage).toBe(true);
       expect(result.nextCursor).toBe(TEST_CONSTANTS.NEXT_CURSOR);

--- a/tests/utils/constants/index.ts
+++ b/tests/utils/constants/index.ts
@@ -11,5 +11,6 @@ export * from './buckets';
 export * from './processes';
 export * from './assets';
 export * from './queues';
+export * from './users';
 export * from './pagination';
 

--- a/tests/utils/constants/users.ts
+++ b/tests/utils/constants/users.ts
@@ -1,0 +1,16 @@
+/**
+ * User service test constants.
+ */
+export const USER_TEST_CONSTANTS = {
+  USER_ID: 321,
+  USER_NAME: 'Jane',
+  USER_SURNAME: 'Doe',
+  USER_FULL_NAME: 'Jane Doe',
+  USERNAME: 'jane.doe',
+  USER_EMAIL: 'jane.doe@uipath.com',
+  USER_KEY: '12345678-1234-1234-1234-123456789abc',
+  CREATED_TIME: '2024-01-01T09:00:00Z',
+  ERROR_USER_NOT_FOUND: 'User not found',
+  ODATA_SELECT_FIELDS: 'id,userName,emailAddress',
+  ODATA_EXPAND_FIELDS: 'UserRoles'
+} as const;

--- a/tests/utils/mocks/index.ts
+++ b/tests/utils/mocks/index.ts
@@ -15,6 +15,7 @@ export * from './buckets';
 export * from './processes';
 export * from './assets';
 export * from './queues';
+export * from './users';
 export * from './pagination';
 
 // Re-export constants for convenience

--- a/tests/utils/mocks/users.ts
+++ b/tests/utils/mocks/users.ts
@@ -1,0 +1,62 @@
+/**
+ * User service mock utilities.
+ */
+import { UserGetResponse } from '../../../src/models/orchestrator/users.types';
+import { createMockBaseResponse, createMockCollection } from './core';
+import { USER_TEST_CONSTANTS } from '../constants/users';
+
+export const createMockRawUser = (overrides: Partial<any> = {}): any => {
+  return createMockBaseResponse({
+    Id: USER_TEST_CONSTANTS.USER_ID,
+    Name: USER_TEST_CONSTANTS.USER_NAME,
+    Surname: USER_TEST_CONSTANTS.USER_SURNAME,
+    FullName: USER_TEST_CONSTANTS.USER_FULL_NAME,
+    UserName: USER_TEST_CONSTANTS.USERNAME,
+    EmailAddress: USER_TEST_CONSTANTS.USER_EMAIL,
+    IsActive: true,
+    CreationTime: USER_TEST_CONSTANTS.CREATED_TIME,
+    Key: USER_TEST_CONSTANTS.USER_KEY
+  }, overrides);
+};
+
+export const createBasicUser = (overrides: Partial<UserGetResponse> = {}): UserGetResponse => {
+  return createMockBaseResponse({
+    id: USER_TEST_CONSTANTS.USER_ID,
+    name: USER_TEST_CONSTANTS.USER_NAME,
+    surname: USER_TEST_CONSTANTS.USER_SURNAME,
+    fullName: USER_TEST_CONSTANTS.USER_FULL_NAME,
+    userName: USER_TEST_CONSTANTS.USERNAME,
+    emailAddress: USER_TEST_CONSTANTS.USER_EMAIL,
+    isActive: true,
+    createdTime: USER_TEST_CONSTANTS.CREATED_TIME,
+    key: USER_TEST_CONSTANTS.USER_KEY
+  }, overrides);
+};
+
+export const createMockTransformedUserCollection = (
+  count: number = 1,
+  options?: {
+    totalCount?: number;
+    hasNextPage?: boolean;
+    nextCursor?: string;
+    previousCursor?: string | null;
+    currentPage?: number;
+    totalPages?: number;
+  }
+): any => {
+  const items = createMockCollection(count, (index) => createBasicUser({
+    id: USER_TEST_CONSTANTS.USER_ID + index,
+    userName: `${USER_TEST_CONSTANTS.USERNAME}${index + 1}`,
+    emailAddress: `user${index + 1}@uipath.com`
+  }));
+
+  return createMockBaseResponse({
+    items,
+    totalCount: options?.totalCount || count,
+    ...(options?.hasNextPage !== undefined && { hasNextPage: options.hasNextPage }),
+    ...(options?.nextCursor && { nextCursor: options.nextCursor }),
+    ...(options?.previousCursor !== undefined && { previousCursor: options.previousCursor }),
+    ...(options?.currentPage !== undefined && { currentPage: options.currentPage }),
+    ...(options?.totalPages !== undefined && { totalPages: options.totalPages })
+  });
+};

--- a/tests/utils/mocks/users.ts
+++ b/tests/utils/mocks/users.ts
@@ -64,13 +64,26 @@ export const createMockTransformedUserCollection = (
     emailAddress: `user${index + 1}@uipath.com`
   }));
 
-  return createMockBaseResponse({
+  const response = createMockBaseResponse({
     items,
-    totalCount: options?.totalCount || count,
-    ...(options?.hasNextPage !== undefined && { hasNextPage: options.hasNextPage }),
-    ...(options?.nextCursor && { nextCursor: options.nextCursor }),
-    ...(options?.previousCursor !== undefined && { previousCursor: options.previousCursor }),
-    ...(options?.currentPage !== undefined && { currentPage: options.currentPage }),
-    ...(options?.totalPages !== undefined && { totalPages: options.totalPages })
+    totalCount: options?.totalCount ?? count
   });
+
+  if (options?.hasNextPage !== undefined) {
+    response.hasNextPage = options.hasNextPage;
+  }
+  if (options?.nextCursor) {
+    response.nextCursor = options.nextCursor;
+  }
+  if (options?.previousCursor !== undefined) {
+    response.previousCursor = options.previousCursor;
+  }
+  if (options?.currentPage !== undefined) {
+    response.currentPage = options.currentPage;
+  }
+  if (options?.totalPages !== undefined) {
+    response.totalPages = options.totalPages;
+  }
+
+  return response;
 };

--- a/tests/utils/mocks/users.ts
+++ b/tests/utils/mocks/users.ts
@@ -5,32 +5,46 @@ import { UserGetResponse } from '../../../src/models/orchestrator/users.types';
 import { createMockBaseResponse, createMockCollection } from './core';
 import { USER_TEST_CONSTANTS } from '../constants/users';
 
-export const createMockRawUser = (overrides: Partial<any> = {}): any => {
-  return createMockBaseResponse({
-    Id: USER_TEST_CONSTANTS.USER_ID,
-    Name: USER_TEST_CONSTANTS.USER_NAME,
-    Surname: USER_TEST_CONSTANTS.USER_SURNAME,
-    FullName: USER_TEST_CONSTANTS.USER_FULL_NAME,
-    UserName: USER_TEST_CONSTANTS.USERNAME,
-    EmailAddress: USER_TEST_CONSTANTS.USER_EMAIL,
-    IsActive: true,
-    CreationTime: USER_TEST_CONSTANTS.CREATED_TIME,
-    Key: USER_TEST_CONSTANTS.USER_KEY
-  }, overrides);
+const BASE_USER: UserGetResponse = {
+  id: USER_TEST_CONSTANTS.USER_ID,
+  name: USER_TEST_CONSTANTS.USER_NAME,
+  surname: USER_TEST_CONSTANTS.USER_SURNAME,
+  fullName: USER_TEST_CONSTANTS.USER_FULL_NAME,
+  userName: USER_TEST_CONSTANTS.USERNAME,
+  emailAddress: USER_TEST_CONSTANTS.USER_EMAIL,
+  isActive: true,
+  createdTime: USER_TEST_CONSTANTS.CREATED_TIME,
+  key: USER_TEST_CONSTANTS.USER_KEY
+};
+
+const RAW_USER_FIELDS: Array<[keyof UserGetResponse, string]> = [
+  ['id', 'Id'],
+  ['name', 'Name'],
+  ['surname', 'Surname'],
+  ['fullName', 'FullName'],
+  ['userName', 'UserName'],
+  ['emailAddress', 'EmailAddress'],
+  ['isActive', 'IsActive'],
+  ['createdTime', 'CreationTime'],
+  ['key', 'Key']
+];
+
+const toRawUser = (user: UserGetResponse): Record<string, unknown> => {
+  return RAW_USER_FIELDS.reduce((result, [sourceKey, targetKey]) => {
+    const value = user[sourceKey];
+    if (value !== undefined) {
+      result[targetKey] = value;
+    }
+    return result;
+  }, {} as Record<string, unknown>);
+};
+
+export const createMockRawUser = (overrides: Record<string, unknown> = {}): Record<string, unknown> => {
+  return createMockBaseResponse(toRawUser(BASE_USER), overrides);
 };
 
 export const createBasicUser = (overrides: Partial<UserGetResponse> = {}): UserGetResponse => {
-  return createMockBaseResponse({
-    id: USER_TEST_CONSTANTS.USER_ID,
-    name: USER_TEST_CONSTANTS.USER_NAME,
-    surname: USER_TEST_CONSTANTS.USER_SURNAME,
-    fullName: USER_TEST_CONSTANTS.USER_FULL_NAME,
-    userName: USER_TEST_CONSTANTS.USERNAME,
-    emailAddress: USER_TEST_CONSTANTS.USER_EMAIL,
-    isActive: true,
-    createdTime: USER_TEST_CONSTANTS.CREATED_TIME,
-    key: USER_TEST_CONSTANTS.USER_KEY
-  }, overrides);
+  return createMockBaseResponse(BASE_USER, overrides);
 };
 
 export const createMockTransformedUserCollection = (


### PR DESCRIPTION
## Summary
This PR introduces two clearly separated user capabilities in the TypeScript SDK:

1. **Authoritative Orchestrator users API** under `sdk.users`:
   - `getAll(options?)`
   - `getById(id, options?)`
   - `getCurrent(options?)`
2. **Local token-derived identity helpers** on core `UiPath`:
   - `getTokenClaims()`
   - `getTokenIdentity()`

The change preserves source clarity (`users.*` = API-backed, `getToken*` = local token decode), adds modular packaging for `@uipath/uipath-typescript/users`, and includes unit test coverage and build verification.

## Why
- Enable first-class Users read operations from Orchestrator.
- Eliminate app-level JWT parsing boilerplate for common identity usage.
- Prevent ambiguity between API-authoritative user objects and token-derived identity.

## Scope
- Read-only Users surface only (`getAll/getById/getCurrent`)
- No Users write endpoints in this PR
- No auth flow mutation and no HTTP calls in token helper methods

## Breaking Changes
- None.

## OAuth Scopes
- Users service methods require `OR.Users` or `OR.Users.Read`.
- Token helper methods (`getTokenClaims/getTokenIdentity`) perform local decode only and do not require Users scopes.

## Method-Level Details

### Users.getAll
- Method added: `sdk.users.getAll(options?)`
- Endpoint called: `USERS_ENDPOINTS.GET_ALL`
- Resolved endpoint path: `orchestrator_/odata/Users`

#### Example Usage
```ts
import { UiPath } from '@uipath/uipath-typescript';

const sdk = new UiPath(config);
await sdk.initialize();

const result = await sdk.users.getAll({
  filter: "userName eq 'jane.doe'",
  pageSize: 10
});
```

#### API Response (Raw)
```json
{
  "value": [
    {
      "Id": 321,
      "UserName": "jane.doe",
      "EmailAddress": "jane.doe@uipath.com",
      "CreationTime": "2024-01-01T09:00:00Z"
    }
  ],
  "@odata.count": 1
}
```

#### SDK Response (Mapped)
```json
{
  "items": [
    {
      "id": 321,
      "userName": "jane.doe",
      "emailAddress": "jane.doe@uipath.com",
      "createdTime": "2024-01-01T09:00:00Z"
    }
  ],
  "totalCount": 1
}
```

### Users.getById
- Method added: `sdk.users.getById(id, options?)`
- Endpoint called: `USERS_ENDPOINTS.GET_BY_ID(id)`
- Resolved endpoint path: `orchestrator_/odata/Users({id})`

#### Example Usage
```ts
const user = await sdk.users.getById(321, {
  select: 'id,userName,emailAddress'
});
```

#### API Response (Raw)
```json
{
  "Id": 321,
  "UserName": "jane.doe",
  "EmailAddress": "jane.doe@uipath.com",
  "CreationTime": "2024-01-01T09:00:00Z"
}
```

#### SDK Response (Mapped)
```json
{
  "id": 321,
  "userName": "jane.doe",
  "emailAddress": "jane.doe@uipath.com",
  "createdTime": "2024-01-01T09:00:00Z"
}
```

### Users.getCurrent
- Method added: `sdk.users.getCurrent(options?)`
- Endpoint called: `USERS_ENDPOINTS.GET_CURRENT`
- Resolved endpoint path: `orchestrator_/odata/Users/UiPath.Server.Configuration.OData.GetCurrentUser`

#### Example Usage
```ts
const currentUser = await sdk.users.getCurrent({
  select: 'id,userName,emailAddress'
});
```

#### API Response (Raw)
```json
{
  "Id": 321,
  "UserName": "jane.doe",
  "EmailAddress": "jane.doe@uipath.com",
  "CreationTime": "2024-01-01T09:00:00Z"
}
```

#### SDK Response (Mapped)
```json
{
  "id": 321,
  "userName": "jane.doe",
  "emailAddress": "jane.doe@uipath.com",
  "createdTime": "2024-01-01T09:00:00Z"
}
```

Notes:
- If endpoint returns HTTP 204, `getCurrent()` returns `undefined` (no throw).

### UiPath.getTokenClaims
- Method added: `sdk.getTokenClaims()`
- Endpoint called: `N/A (local JWT decode)`

#### Example Usage
```ts
const claims = sdk.getTokenClaims();
```

#### API Response (Raw)
```json
{
  "N/A": "No API call"
}
```

#### SDK Response (Mapped)
```json
{
  "sub": "oidc-subject",
  "preferred_username": "jane.doe",
  "email": "jane.doe@uipath.com"
}
```

### UiPath.getTokenIdentity
- Method added: `sdk.getTokenIdentity()`
- Endpoint called: `N/A (local JWT decode)`

#### Example Usage
```ts
const identity = sdk.getTokenIdentity();
```

#### API Response (Raw)
```json
{
  "N/A": "No API call"
}
```

#### SDK Response (Mapped)
```json
{
  "userId": "oidc-subject",
  "username": "jane.doe",
  "email": "jane.doe@uipath.com",
  "name": "Jane Doe",
  "givenName": "Jane",
  "familyName": "Doe",
  "tenantName": "my-tenant",
  "orgName": "my-org",
  "rawClaims": {
    "sub": "oidc-subject",
    "preferred_username": "jane.doe",
    "email": "jane.doe@uipath.com"
  }
}
```

Notes:
- Identity precedence is OIDC-first with alias fallback.
- Invalid/missing/malformed token returns `undefined`.

## Testing
Executed:

- `npm test -- tests/unit/services/orchestrator/users.test.ts --run`
- `npm test -- tests/unit/core/uipath.test.ts --run`
- `npm test -- tests/unit/services/orchestrator --run`
- `npm run build`

Results:
- Users unit tests: passed
- Core token helper tests: passed
- Orchestrator unit suite: passed
- Build: passed

## Files of Interest
- `src/services/orchestrator/users/users.ts`
- `src/services/orchestrator/users/index.ts`
- `src/models/orchestrator/users.types.ts`
- `src/models/orchestrator/users.models.ts`
- `src/models/orchestrator/users.constants.ts`
- `src/core/uipath.ts`
- `src/core/types.ts`
- `src/core/auth/types.ts`
- `src/uipath.ts`
- `src/utils/constants/endpoints.ts`
- `package.json`
- `rollup.config.js`
- `tests/unit/services/orchestrator/users.test.ts`
- `tests/unit/core/uipath.test.ts`
