### PR TITLE
chore: update gitignore and sample app env example - [PLT-97239]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ npm-debug.log*
 dist/
 docs/api/
 site/
+.uipath/

--- a/samples/process-app-v0/.env.example
+++ b/samples/process-app-v0/.env.example
@@ -4,10 +4,11 @@
 VITE_UIPATH_CLIENT_ID=your-oauth-client-id
 VITE_UIPATH_ORG_NAME=your-organization-name
 VITE_UIPATH_TENANT_NAME=your-tenant-name
-VITE_UIPATH_BASE_URL=https://cloud.uipath.com
-VITE_UIPATH_REDIRECT_URI=http://localhost:5173 # url where app is running
-VITE_UIPATH_SCOPE=OR.License OR.License.Read OR.License.Write OR.Settings OR.Settings.Read OR.Settings.Write OR.Robots OR.Robots.Read OR.Robots.Write OR.Machines OR.Machines.Read OR.Machines.Write OR.Execution OR.Execution.Read OR.Execution.Write OR.Assets OR.Assets.Read OR.Assets.Write OR.Queues OR.Queues.Read OR.Queues.Write OR.Jobs OR.Jobs.Read OR.Jobs.Write OR.Users OR.Users.Read OR.Users.Write OR.Administration OR.Administration.Read OR.Administration.Write OR.Audit OR.Audit.Read OR.Audit.Write OR.Webhooks OR.Webhooks.Read OR.Webhooks.Write OR.Monitoring OR.Monitoring.Read OR.Monitoring.Write OR.ML OR.ML.Read OR.ML.Write OR.Tasks OR.Tasks.Read OR.Tasks.Write OR.Analytics OR.Analytics.Read OR.Analytics.Write OR.Folders OR.Folders.Read OR.Folders.Write OR.BackgroundTasks OR.BackgroundTasks.Read OR.BackgroundTasks.Write OR.TestSets OR.TestSets.Read OR.TestSets.Write OR.TestSetExecutions OR.TestSetExecutions.Read OR.TestSetExecutions.Write OR.TestSetSchedules OR.TestSetSchedules.Read OR.TestSetSchedules.Write OR.TestDataQueues OR.TestDataQueues.Read OR.TestDataQueues.Write OR.Hypervisor OR.Hypervisor.Read OR.Hypervisor.Write OR.AutomationSolutions.Access PIMS DataFabric.Schema.Read DataFabric.Data.Read DataFabric.Data.Write
-
+VITE_UIPATH_BASE_URL=${UIPATH_BASE_URL} # url where app is running
+VITE_UIPATH_REDIRECT_URI=${UIPATH_REDIRECT_URI} # url where app is running
+VITE_UIPATH_SCOPE=VITE_UIPATH_SCOPE=PIMS DataFabric.Schema.Read DataFabric.Data.Read DataFabric.Data.Write OR.Execution.Read
+UIPATH_BASE_URL=https://cloud.uipath.com
+UIPATH_REDIRECT_URI=http://localhost:5173
 # Entity ID for attachments and data retrieval
 # Replace with your specific entity ID from Data Service to fetch any relevant data
 VITE_UIPATH_ENTITY_ID=your-entity-id-here

--- a/samples/process-app-v1/.env.example
+++ b/samples/process-app-v1/.env.example
@@ -4,10 +4,11 @@
 VITE_UIPATH_CLIENT_ID=your-oauth-client-id
 VITE_UIPATH_ORG_NAME=your-organization-name
 VITE_UIPATH_TENANT_NAME=your-tenant-name
-VITE_UIPATH_BASE_URL=https://cloud.uipath.com
-VITE_UIPATH_REDIRECT_URI=http://localhost:5173 # url where app is running
-VITE_UIPATH_SCOPE=OR.License OR.License.Read OR.License.Write OR.Settings OR.Settings.Read OR.Settings.Write OR.Robots OR.Robots.Read OR.Robots.Write OR.Machines OR.Machines.Read OR.Machines.Write OR.Execution OR.Execution.Read OR.Execution.Write OR.Assets OR.Assets.Read OR.Assets.Write OR.Queues OR.Queues.Read OR.Queues.Write OR.Jobs OR.Jobs.Read OR.Jobs.Write OR.Users OR.Users.Read OR.Users.Write OR.Administration OR.Administration.Read OR.Administration.Write OR.Audit OR.Audit.Read OR.Audit.Write OR.Webhooks OR.Webhooks.Read OR.Webhooks.Write OR.Monitoring OR.Monitoring.Read OR.Monitoring.Write OR.ML OR.ML.Read OR.ML.Write OR.Tasks OR.Tasks.Read OR.Tasks.Write OR.Analytics OR.Analytics.Read OR.Analytics.Write OR.Folders OR.Folders.Read OR.Folders.Write OR.BackgroundTasks OR.BackgroundTasks.Read OR.BackgroundTasks.Write OR.TestSets OR.TestSets.Read OR.TestSets.Write OR.TestSetExecutions OR.TestSetExecutions.Read OR.TestSetExecutions.Write OR.TestSetSchedules OR.TestSetSchedules.Read OR.TestSetSchedules.Write OR.TestDataQueues OR.TestDataQueues.Read OR.TestDataQueues.Write OR.Hypervisor OR.Hypervisor.Read OR.Hypervisor.Write OR.AutomationSolutions.Access PIMS DataFabric.Schema.Read DataFabric.Data.Read DataFabric.Data.Write
-
+VITE_UIPATH_BASE_URL=${UIPATH_BASE_URL} # url where app is running
+VITE_UIPATH_REDIRECT_URI=${UIPATH_REDIRECT_URI} # url where app is running
+VITE_UIPATH_SCOPE=VITE_UIPATH_SCOPE=PIMS DataFabric.Schema.Read DataFabric.Data.Read DataFabric.Data.Write OR.Execution.Read
+UIPATH_BASE_URL=https://cloud.uipath.com
+UIPATH_REDIRECT_URI=http://localhost:5173
 # Entity ID for attachments and data retrieval
 # Replace with your specific entity ID from Data Service to fetch any relevant data
 VITE_UIPATH_ENTITY_ID=your-entity-id-here


### PR DESCRIPTION
Update sample app env examples and gitignore

- Reference `UIPATH_BASE_URL` and `UIPATH_REDIRECT_URI` in the Vite-prefixed env variables (`VITE_UIPATH_BASE_URL`, `VITE_UIPATH_REDIRECT_URI`) so that they are automatically kept in sync when running uipath cli commands.
- Keep only relevant scopes in the sample app env examples.
- Add .uipath/ to root .gitignore.