### PR TITLE
fix: migrate npm publish to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm ci
@@ -51,13 +50,25 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish to GitHub Packages
-        run: npm publish --registry=https://npm.pkg.github.com
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup registry for npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+
+      - name: Setup registry for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Summary
         run: |
@@ -69,8 +80,8 @@ jobs:
           echo "### Completed Steps:" >> $GITHUB_STEP_SUMMARY
           echo "- Updated telemetry constants" >> $GITHUB_STEP_SUMMARY
           echo "- Built TypeScript package" >> $GITHUB_STEP_SUMMARY
-          echo "- Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
           echo "- Published to npm registry (public access, with provenance)" >> $GITHUB_STEP_SUMMARY
+          echo "- Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Package Details:" >> $GITHUB_STEP_SUMMARY
           echo "- **Package:** @uipath/uipath-typescript" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
npm [revoked all classic tokens](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/). This PR migrates to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/), eliminating the need for any stored npm tokens.

- Added `id-token: write` permission ( required for GitHub Actions to generate the OIDC token npm uses for auth )

- Upgraded Node from 18 to 24 ( trusted publishing requires npm CLI 11.5.1+, which ships with Node 24 natively )

- Added `--provenance` to npm publish ( signs the package with a verifiable link back to this repo and workflow )

- Removed Configure Git step ( nothing in the workflow does git commits )

- Removed npm pack step ( npm publish packs internally, artifact wasn't being used )

- Fixed Generate Summary ( replaced undefined `$NEW_VERSION` / `$CURRENT_VERSION` vars with actual version from package.json