### PR TITLE
Task events service for coded escalation apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3570,6 +3570,10 @@
                 "node": ">=20.0.0"
             }
         },
+        "node_modules/@uipath/coded-action-apps": {
+            "resolved": "packages/coded-action-apps",
+            "link": true
+        },
         "node_modules/@uipath/uipath-ts-cli": {
             "resolved": "packages/cli",
             "link": true
@@ -13181,6 +13185,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "packages/coded-action-apps": {
+            "name": "@uipath/coded-action-apps",
+            "version": "1.0.0-beta.0",
+            "devDependencies": {
+                "oxlint": "^1.43.0",
+                "rimraf": "^6.0.1",
+                "typescript": "^5.3.3"
             }
         }
     }

--- a/packages/coded-action-apps/.oxlintrc.json
+++ b/packages/coded-action-apps/.oxlintrc.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "categories": {
+        "correctness": "deny",
+        "suspicious": "deny"
+    },
+    "rules": {
+        "typescript/no-extraneous-class": "off",
+        "oxc/no-async-endpoint-handlers": "off",
+        "eslint/preserve-caught-error": "off",
+        "unicorn/no-array-sort": "off"
+    },
+    "ignorePatterns": [
+        "dist",
+        "node_modules",
+        "docs",
+        "coverage",
+        "build",
+        "site"
+    ]
+}

--- a/packages/coded-action-apps/README.md
+++ b/packages/coded-action-apps/README.md
@@ -1,0 +1,184 @@
+# @uipath/coded-action-apps
+
+An SDK enabling coded apps to be the UI for tasks within UiPath Action Center. SDK handles bi-directional communication between the coded app and UiPath Action Center host using window.postMessage events.
+
+## Installation
+
+```bash
+npm install @uipath/coded-action-apps
+```
+
+## Overview
+
+Action Center renders a coded action app within an iframe. @uipath/coded-action-apps provides service CodedActionAppsService which offers below capabilities:
+
+- **Receive** - `getTask()` - On app load, UiPath Action Center provides the task details.
+- **Notify** - `setTaskData()` - Notify Action Center when task data changes (e.g. to enable the Save button).
+- **Complete** - `completeTask()` - Completes the task when user clicks on submit buttons (e.g. 'Approve' or 'Reject' buttons)
+- **Display** - `showMessage()` - Displays toast messages inside Action Center.
+
+## Usage
+
+### Initialise the service
+
+```ts
+import { CodedActionAppsService } from '@uipath/coded-action-apps';
+
+const service = new CodedActionAppsService();
+```
+
+The class is also exported under the alias `CodedActionApps` for convenience:
+
+```ts
+import { CodedActionApps } from '@uipath/coded-action-apps';
+
+const service = new CodedActionApps();
+```
+
+---
+
+### Get task details from Action Center
+
+Call this once when the app loads. It sends an `AC.init` event to Action Center and waits for the task data to be posted back. (**Recommended**: Do not call it more than once in your app)
+
+```ts
+const taskData = await service.getTask();
+
+console.log(taskData.taskId);     // number
+console.log(taskData.title);      // string
+console.log(taskData.status);     // TaskStatus enum
+console.log(taskData.isReadOnly); // boolean
+console.log(taskData.data);       // the task's form data
+console.log(taskData.folderId);   // number
+console.log(taskData.folderName); // string
+console.log(taskData.theme);      // Theme enum — the UI theme Action Center is currently using
+```
+
+> **Note:** This call will reject with an error if Action Center does not respond within 3 seconds, or if the parent origin is not trusted.
+
+---
+
+### Notify Action Center of data changes
+
+Call this whenever the user modifies the task form data. Action Center uses this signal to enable its Save button.
+
+```ts
+service.setTaskData({ field: 'updatedValue' });
+```
+
+---
+
+### Complete a task
+
+Call this when the user submits the form to mark the task as complete. Provide the action taken (e.g. `"Approve"` or `"Reject"`) and the final data payload. The call returns a `Promise<TaskCompleteResponse>` that resolves once Action Center confirms the completion.
+
+```ts
+const result = await service.completeTask('Approve', { approved: true, notes: 'Looks good' });
+
+if (!result.success) {
+  console.error(result.errorMessage);
+}
+```
+
+> **Note:** Only one `completeTask` call may be in flight at a time. Calling it again before the previous call resolves will throw an error: `"A completeTask call is already in progress"`.
+
+---
+
+### Display a message in Action Center
+
+Show a toast notification inside Action Center using one of the four severity levels.
+
+```ts
+import { MessageSeverity } from '@uipath/coded-action-apps';
+
+service.showMessage('Validation successful', MessageSeverity.Success);
+service.showMessage('Validation failed', MessageSeverity.Error);
+service.showMessage('Please review the details', MessageSeverity.Warning);
+service.showMessage('User information', MessageSeverity.Info);
+```
+
+---
+
+## API Reference
+
+### `CodedActionAppsService`
+
+| Method | Description |
+|---|---|
+| `getTask()` | Returns a `Promise<Task>` with the current task's metadata and form data. |
+| `setTaskData(data)` | Sends updated data to Action Center to signal that the form has changed. |
+| `completeTask(actionTaken, data)` | Marks the task as complete with the given action label and final data. Returns `Promise<TaskCompleteResponse>`. Throws if a call is already in progress. |
+| `showMessage(msg, type)` | Displays a toast message in Action Center with the given severity. |
+
+---
+
+### `Task`
+
+```ts
+type Task = {
+  taskId: number;
+  title: string;
+  status: TaskStatus;
+  isReadOnly: boolean;
+  action: string | null;
+  data: unknown;
+  folderId: number;
+  folderName: string;
+  theme: Theme;
+};
+```
+
+---
+
+### `TaskStatus`
+
+```ts
+enum TaskStatus {
+  Unassigned = 'Unassigned',
+  Pending    = 'Pending',
+  Completed  = 'Completed',
+}
+```
+
+---
+
+### `Theme`
+
+The UI theme that Action Center is currently using, passed to the coded action app on load via `getTask`. Apply this to your app's styling so it matches the Action Center host.
+
+```ts
+enum Theme {
+  AutoTheme         = 'autoTheme',
+  Light             = 'light',
+  Dark              = 'dark',
+  LightHighContrast = 'light-hc',
+  DarkHighContrast  = 'dark-hc',
+}
+```
+
+---
+
+### `TaskCompleteResponse`
+
+Returned by `completeTask` when Action Center responds.
+
+```ts
+type TaskCompleteResponse = {
+  success: boolean;
+  errorCode: number | null;
+  errorMessage: string | null;
+};
+```
+
+---
+
+### `MessageSeverity`
+
+```ts
+enum MessageSeverity {
+  Info    = 'info',
+  Success = 'success',
+  Warning = 'warning',
+  Error   = 'error',
+}
+```

--- a/packages/coded-action-apps/package.json
+++ b/packages/coded-action-apps/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@uipath/coded-action-apps",
+  "version": "1.0.0-beta.0",
+  "description": "UiPath package to be used for viewing coded action apps in Action Center",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "prebuild": "npm run clean",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint"
+  },
+  "devDependencies": {
+    "oxlint": "^1.43.0",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.3.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UiPath/uipath-typescript.git",
+    "directory": "packages/coded-action-apps"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/coded-action-apps/src/coded-action-apps-service.ts
+++ b/packages/coded-action-apps/src/coded-action-apps-service.ts
@@ -1,0 +1,181 @@
+import {
+  Task,
+  MessageSeverity,
+  TaskCompleteResponse,
+} from './types';
+import { CodedActionAppsServiceModel } from './coded-action-apps.models';
+import { ActionCenterEventNames, ActionCenterEventResponsePayload } from './types.internal';
+
+const INIT_TIMEOUT = 3000;
+
+/**
+ * Service for bi-directional communication between coded action apps and Action Center
+ */
+export class CodedActionAppsService implements CodedActionAppsServiceModel {
+  private readonly parentOrigin = new URLSearchParams(window.location.search).get('basedomain');
+  private isCompletingTask = false;
+
+  /**
+   * Notifies Action Center that the task data has been changed by the user.
+   * This is needed to enable the save button in Action Center when the task data has changed
+   *
+   * @param data - The updated data payload to send to Action Center.
+   */
+  setTaskData(data: unknown): void {
+    this.sendMessageToParent(ActionCenterEventNames.DATACHANGED, data);
+  }
+
+  /**
+   * Marks the current task as complete in Action Center.
+   * Sends the final action and associated data to Action Center,
+   * signalling that the user has finished interacting with the task.
+   *
+   * @param actionTaken - A string identifying the action the user performed (e.g. `"Approve"`, `"Reject"`).
+   * @param data - The final data payload to submit alongside the completion event.
+   * 
+   * @returns A promise that resolves with a {@link TaskCompleteResponse} object
+   *   containing success and error message if any.
+   * @throws {Error} If called from an untrusted origin.
+   * @throws {Error} If a completeTask call is already in progress.
+   */
+  completeTask(actionTaken: string, data: unknown): Promise<TaskCompleteResponse> {
+    if (this.isCompletingTask) {
+      throw new Error('A completeTask call is already in progress');
+    }
+    this.isCompletingTask = true;
+
+    const content = { data, action: actionTaken };
+
+    return new Promise<TaskCompleteResponse>((resolve, reject) => {
+      if (!this.isValidOrigin(this.parentOrigin)) {
+        this.isCompletingTask = false;
+        reject(new Error('Discarding event from invalid origin'));
+        return;
+      }
+
+      const messageListener = (event: MessageEvent<ActionCenterEventResponsePayload>) => {
+        if (event.origin !== this.parentOrigin) return;
+        if (event.data?.eventType !== ActionCenterEventNames.COMPLETERESPONSE) return;
+
+        this.cleanup(messageListener);
+        this.isCompletingTask = false;
+        resolve(event.data?.content as TaskCompleteResponse);
+      };
+
+      window.addEventListener('message', messageListener);
+      this.sendMessageToParent(ActionCenterEventNames.COMPLETE, content);
+    });
+  }
+
+  /**
+   * Displays a toast message inside Action Center.
+   *
+   * @param msg - The message text to display.
+   * @param type - The severity/style of the message (`info`, `success`, `warning`, or `error`).
+   */
+  showMessage(msg: string, type: MessageSeverity): void {
+    const content = {
+      msg,
+      type,
+    }
+    this.sendMessageToParent(ActionCenterEventNames.DISPLAYMESSAGE, content);
+  }
+
+  /**
+   * Fetches the current opened task's details from Action Center.
+   *
+   * @returns A promise that resolves with a {@link Task} object
+   *   containing task metadata and data.
+   * @throws {Error} If called from an untrusted origin.
+   * @throws {Error} If Action Center does not respond within the allotted timeout.
+   */
+  getTask(): Promise<Task> {
+    return new Promise((resolve, reject) => {
+      if (!this.isValidOrigin(this.parentOrigin)) {
+        reject(new Error('Discarding event from invalid origin'));
+        return;
+      }
+
+      const messageListener = (event: MessageEvent<ActionCenterEventResponsePayload>) => {
+        if (event.origin !== this.parentOrigin) return;
+        if (event.data?.eventType !== ActionCenterEventNames.LOADAPP) return;
+
+        clearTimeout(timer);
+
+        this.cleanup(messageListener);
+        resolve(event.data?.content as Task);
+      };
+
+      const timer = setTimeout(() => {
+        this.cleanup(messageListener);
+        reject(new Error('Timeout: Task data not received from Action Center'));
+      }, INIT_TIMEOUT);
+
+      window.addEventListener('message', messageListener);
+      this.sendMessageToParent(ActionCenterEventNames.INIT);
+    });
+  }
+
+  /** 
+   * Removes the message event listener once a response is received or the timeout fires,
+   * preventing memory leaks and duplicate handler invocations.
+   */
+  private cleanup(messageListener: (event: MessageEvent<ActionCenterEventResponsePayload>) => void): void {
+    window.removeEventListener('message', messageListener);
+  }
+
+  /** 
+   * Posts a structured message to the parent (Action Center) frame.
+   * Skips the call if the parent origin is not trusted.
+   * On serialisation errors, forwards an error event which displays an error toast in Action Center
+   *
+   * @param eventType - The {@link ActionCenterEventNames} event identifier to send.
+   * @param content - Optional payload to include with the event.
+   */
+  private sendMessageToParent(eventType: string, content?: unknown): void {
+    if (window.parent && this.isValidOrigin(this.parentOrigin)) {
+      try {
+        window.parent.postMessage(
+          { eventType, content },
+          this.parentOrigin!,
+        );
+      } catch (error) {
+        window.parent.postMessage(
+          {
+            eventType: ActionCenterEventNames.ERROR,
+            content: {
+              errorData: error,
+            }
+          },
+          this.parentOrigin!
+        );
+      }
+    }
+  }
+
+  /** 
+   * Validates that the given origin is a known UiPath environment or a local development server,
+   * guarding against cross-origin message spoofing.
+   *
+   * @param origin - The origin string to validate, sourced from the `basedomain` query parameter.
+   * @returns `true` if the origin is trusted, `false` otherwise.
+   */
+  private isValidOrigin(origin: string | null): boolean {
+    const ALLOWED_ORIGINS = ['https://alpha.uipath.com', 'https://staging.uipath.com', 'https://cloud.uipath.com'];
+
+    if (!origin) {
+      return false;
+    }
+
+    if (ALLOWED_ORIGINS.includes(origin)) {
+      return true;
+    }
+
+    try {
+      const url = new URL(origin);
+      return url.hostname === 'localhost';
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/coded-action-apps/src/coded-action-apps.models.ts
+++ b/packages/coded-action-apps/src/coded-action-apps.models.ts
@@ -1,0 +1,48 @@
+import { Task, MessageSeverity, TaskCompleteResponse } from './types';
+
+/**
+ * Service for bi-directional communication between coded action apps and Action Center
+ */
+export interface CodedActionAppsServiceModel {
+
+  /**
+   * Notifies Action Center that the task data has been changed by the user.
+   * This is needed to enable the save button in Action Center when the task data has changed
+   *
+   * @param data - The updated data payload to send to Action Center.
+   */
+  setTaskData(data: unknown): void;
+
+  /**
+   * Marks the current task as complete in Action Center.
+   * Sends the final action and associated data to Action Center,
+   * signalling that the user has finished interacting with the task.
+   *
+   * @param actionTaken - A string identifying the action the user performed (e.g. `"Approve"`, `"Reject"`).
+   * @param data - The final data payload to submit alongside the completion event.
+   * 
+   * @returns A promise that resolves with a {@link TaskCompleteResponse} object
+   *   containing success and error message if any.
+   * @throws {Error} If called from an untrusted origin.
+   * @throws {Error} If a completeTask call is already in progress.
+   */
+  completeTask(actionTaken: string, data: unknown): Promise<TaskCompleteResponse>;
+
+  /**
+   * Displays a toast message inside Action Center.
+   *
+   * @param msg - The message text to display.
+   * @param type - The severity/style of the message (`info`, `success`, `warning`, or `error`).
+   */
+  showMessage(msg: string, type: MessageSeverity): void;
+
+  /**
+   * Fetches the current opened task's details from Action Center.
+   *
+   * @returns A promise that resolves with a {@link Task} object
+   *   containing task metadata and data.
+   * @throws {Error} If called from an untrusted origin.
+   * @throws {Error} If Action Center does not respond within the allotted timeout.
+   */
+  getTask(): Promise<Task>;
+}

--- a/packages/coded-action-apps/src/index.ts
+++ b/packages/coded-action-apps/src/index.ts
@@ -1,0 +1,3 @@
+export { CodedActionAppsService as CodedActionApps, CodedActionAppsService} from './coded-action-apps-service';
+export * from './coded-action-apps.models';
+export * from './types';

--- a/packages/coded-action-apps/src/types.internal.ts
+++ b/packages/coded-action-apps/src/types.internal.ts
@@ -1,0 +1,16 @@
+import { Task, TaskCompleteResponse } from "./types";
+
+export enum ActionCenterEventNames {
+  INIT = 'AC.init',
+  COMPLETE = 'AC.complete',
+  DATACHANGED = 'AC.dataChanged',
+  LOADAPP = 'AC.loadApp',
+  ERROR = 'AC.error',
+  DISPLAYMESSAGE = 'AC.displayMessage',
+  COMPLETERESPONSE = 'AC.completeResponse',
+}
+
+export type ActionCenterEventResponsePayload = {
+  eventType: ActionCenterEventNames;
+  content: Task | TaskCompleteResponse;
+};

--- a/packages/coded-action-apps/src/types.ts
+++ b/packages/coded-action-apps/src/types.ts
@@ -1,0 +1,55 @@
+/** Severity level for toast messages displayed in Action Center. */
+export enum MessageSeverity {
+  Info = 'info',
+  Error = 'error',
+  Success = 'success',
+  Warning = 'warning',
+}
+
+/** Represents the status of a task in Action Center. */
+export enum TaskStatus {
+  Unassigned = 'Unassigned',
+  Pending = 'Pending',
+  Completed = 'Completed'
+}
+
+/** Details of task opened in Action Center. */
+export type Task = {
+  /** Unique identifier of the task. */
+  taskId: number;
+  /** Display title of the task. */
+  title: string;
+  /** Current status of the task. */
+  status: TaskStatus;
+  /** Whether the task is in read-only mode for the current user. Disable editing if this is true */
+  isReadOnly: boolean;
+  /** The action that was taken to complete the task, or `null` if not yet completed. */
+  action: string | null;
+  /** Data of the task. */
+  data: unknown;
+  /** ID of the folder the task belongs to. */
+  folderId: number;
+  /** Display name of the folder the task belongs to. */
+  folderName: string;
+  /** UI theme that Action Center is currently using. */
+  theme: Theme;
+};
+
+/** UI theme applied to Action Center, passed to the coded action app on load. */
+export enum Theme {
+  AutoTheme = 'autoTheme',
+  Light = 'light',
+  Dark = 'dark',
+  LightHighContrast = 'light-hc',
+  DarkHighContrast = 'dark-hc',
+}
+
+/** Response returned by Action Center after a task completion attempt. This type is used by coded-action-apps package */
+export type TaskCompleteResponse = {
+  /** Whether the task was completed successfully. */
+  success: boolean,
+  /** Error code returned on failure, null when successful */
+  errorCode: number | null,
+  /** Human-readable error message returned on failure, null when successful. */
+  errorMessage: string | null,
+}

--- a/packages/coded-action-apps/tsconfig.json
+++ b/packages/coded-action-apps/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/core/auth/action-center-token-manager.ts
+++ b/src/core/auth/action-center-token-manager.ts
@@ -1,0 +1,110 @@
+import { ActionCenterEventNames, ActionCenterEventResponsePayload } from '../../models/action-center/tasks.internal-types';
+import { TokenInfo } from './types';
+import { AuthenticationError, HttpStatus } from '../errors';
+import { Config } from '../config/config';
+
+const AUTHENTICATION_TIMEOUT = 8000;
+
+export class ActionCenterTokenManager {
+  private readonly parentOrigin = new URLSearchParams(window.location.search).get('basedomain');
+  private refreshPromise: Promise<string> | null = null;
+
+  constructor(
+    private readonly config: Config,
+    private readonly onTokenRefreshed: (tokenInfo: TokenInfo) => void
+  ) {}
+
+  async refreshAccessToken(tokenInfo: TokenInfo): Promise<string> {
+    if (!this.isTokenExpired(tokenInfo)) {
+      return tokenInfo.token;
+    }
+
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = new Promise<string>((resolve, reject) => {
+      const content = {
+        clientId: this.config.clientId,
+        scope: this.config.scope,
+      }
+      this.sendMessageToParent(ActionCenterEventNames.REFRESHTOKEN, content);
+
+      const messageListener = (event: MessageEvent<ActionCenterEventResponsePayload>) => {
+        if (event.origin !== this.parentOrigin) return;
+        if (event.data?.eventType !== ActionCenterEventNames.TOKENREFRESHED) return;
+
+        clearTimeout(timer);
+
+        if (event.data?.content?.token) {
+          const { accessToken, expiresAt } = event.data.content.token;
+          this.onTokenRefreshed({ token: accessToken, type: 'secret', expiresAt });
+          resolve(accessToken);
+        } else {
+          reject(new AuthenticationError({
+            message: 'Failed to fetch access token',
+            statusCode: HttpStatus.UNAUTHORIZED,
+          }));
+        }
+
+        this.refreshPromise = null;
+        this.cleanup(messageListener);
+      };
+
+      const timer = setTimeout(() => {
+        reject(new AuthenticationError({
+          message: 'Failed to fetch access token',
+          statusCode: HttpStatus.UNAUTHORIZED,
+        }));
+
+        this.refreshPromise = null;
+        this.cleanup(messageListener);
+      }, AUTHENTICATION_TIMEOUT);
+
+      window.addEventListener('message', messageListener);
+    });
+
+    return this.refreshPromise;
+  }
+
+  private isTokenExpired(tokenInfo: TokenInfo): boolean {
+    if (!tokenInfo?.expiresAt) {
+      return true;
+    }
+
+    return new Date() >= tokenInfo.expiresAt;
+  }
+
+  private sendMessageToParent(eventType: string, content?: unknown): void {
+    if (window.parent && this.isValidOrigin(this.parentOrigin)) {
+      try {
+        window.parent.postMessage({ eventType, content }, this.parentOrigin!);
+      } catch (error) {
+        console.warn('Failed to send message to Action Center', JSON.stringify(error));
+      }
+    }
+  }
+
+  private cleanup(messageListener: (event: MessageEvent<ActionCenterEventResponsePayload>) => void): void {
+    window.removeEventListener('message', messageListener);
+  }
+
+  private isValidOrigin(origin: string | null): boolean {
+    const ALLOWED_ORIGINS = ['https://alpha.uipath.com', 'https://staging.uipath.com', 'https://cloud.uipath.com'];
+
+    if (!origin) {
+      return false;
+    }
+
+    if (ALLOWED_ORIGINS.includes(origin)) {
+      return true;
+    }
+
+    try {
+      const url = new URL(origin);
+      return url.hostname === 'localhost';
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/core/http/api-client.ts
+++ b/src/core/http/api-client.ts
@@ -46,16 +46,6 @@ export class ApiClient {
   private async getDefaultHeaders(): Promise<Record<string, string>> {
     // Get headers from execution context first
     const contextHeaders = this.executionContext.getHeaders();
-    
-    // If Authorization header is already set in context, use that
-    if (contextHeaders['Authorization']) {
-      return {
-        ...contextHeaders,
-        'Content-Type': CONTENT_TYPES.JSON,
-        ...this.defaultHeaders,
-        ...this.clientConfig.headers
-      };
-    }
 
     const token = await this.getValidToken();
 

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -6,6 +6,7 @@ import { validateConfig, normalizeBaseUrl } from './config/config-utils';
 import { telemetryClient, trackEvent } from './telemetry';
 import { SDKInternalsRegistry } from './internals';
 import type { IUiPath } from './types';
+import { isInActionCenter } from '../utils/platform';
 
 /**
  * UiPath - Core SDK class for authentication and configuration management.
@@ -91,9 +92,11 @@ export class UiPath implements IUiPath {
     // Track SDK initialization
     trackEvent('Sdk.Auth');
 
-    // Auto-initialize for secret-based auth
-    if (hasSecretAuth) {
-      this.#authService.authenticateWithSecret(config.secret);
+    /** Auto-initialize for secret-based auth
+     * When viewed in Action Center, initialize tokenInfo with empty token. When an sdk call is made Action Center passes the token to sdk.
+     */
+    if (hasSecretAuth || isInActionCenter) {
+      this.#authService.authenticateWithSecret(config.secret ?? '');
       this.#initialized = true;
     }
   }

--- a/src/models/action-center/tasks.internal-types.ts
+++ b/src/models/action-center/tasks.internal-types.ts
@@ -1,6 +1,25 @@
 import { CollectionResponse } from "../common/types";
 import { TaskAssignmentOptions, TaskAssignmentResponse } from "./tasks.types";
 
+export enum ActionCenterEventNames {
+  TOKENREFRESHED = 'AC.tokenRefreshed',
+  REFRESHTOKEN = 'AC.refreshToken',
+}
+
+export type TokenWithExpiry = {
+  accessToken: string,
+  expiresAt: Date,
+}
+
+export type ActionCenterTokenData = {
+  token: TokenWithExpiry,
+}
+
+export type ActionCenterEventResponsePayload = {
+  eventType: ActionCenterEventNames,
+  content: ActionCenterTokenData,
+}
+
 export interface TasksAssignOptions {
     taskAssignments: TaskAssignmentOptions[];
 }

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -6,3 +6,5 @@
  * Checks if code is running in a browser environment
  */
 export const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+
+export const isInActionCenter = isBrowser && window.self != window.top && window.location.href.includes('source=ActionCenter');


### PR DESCRIPTION
## Description
- Added new package coded-action-apps which developers will call using new CodedActionAppsService()
- This service handles bidirectional communication between Action Center and coded app loaded from 'host' domain.
- External client authentication is taken care of by Action Center. Token (including refresh) is sent to the app through an event.
- When an sdk api call is made, it checks the expiry time of current token which if not found (or less than current time) it requests for a token from Action Center, receives it and updates token along with expiry time in TokenManager.


https://github.com/user-attachments/assets/7c67088d-89b0-483c-9242-eda6b276ace2

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 