### PR TITLE
feat: export telemetry in core

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -49,3 +49,6 @@ export * from './errors';
 
 // Pagination (common across all services)
 export * from '../utils/pagination';
+
+// Export telemetry
+export * from './telemetry';


### PR DESCRIPTION
If user is using new `UiPath` instance from `core`, then the `telemetryClient` in legacy path wont work, so it needs to be exported in `core` also