### PR TITLE
docs: make type references clickable in documentation

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -264,6 +264,38 @@ video {
     border-color: rgba(255,255,255,0.4);
 }
 
+/* TypeDoc signature blockquotes */
+.md-typeset blockquote {
+    background-color: var(--md-code-bg-color);
+    border-left: none;
+    border-radius: 0.1rem;
+    padding: 0.9em 1.2em;
+    font-family: var(--md-code-font-family);
+    font-size: 0.85em;
+    line-height: 1.5;
+    color: var(--md-code-fg-color);
+    overflow-x: auto;
+}
+
+.md-typeset blockquote p {
+    margin: 0;
+}
+
+.md-typeset blockquote code {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    font-size: inherit;
+    color: inherit;
+    box-shadow: none;
+}
+
+.md-typeset blockquote a,
+.md-typeset blockquote a:hover {
+    text-decoration: none;
+    color: var(--md-typeset-a-color);
+}
+
 /* Center Mermaid diagrams */
 .mermaid {
     text-align: center;

--- a/typedoc.json
+++ b/typedoc.json
@@ -64,7 +64,7 @@
   "useHTMLEncodedBrackets": true,
   "sanitizeComments": false,
   "formatWithPrettier": false,
-  "useCodeBlocks": true,
+  "useCodeBlocks": false,
   "expandObjects": true,
   "expandParameters": true,
   "hideBreadcrumbs": true,


### PR DESCRIPTION
Markdown doesn't support clickable links inside code blocks.

With `useCodeBlocks: false`, TypeDoc renders signatures as blockquotes with inline markdown links, making every referenced type a clickable link. The custom CSS ensures these blockquotes look visually identical to real code blocks.


Before


https://github.com/user-attachments/assets/0aa67909-4630-40eb-8e7a-567e6cca25b8



After

https://github.com/user-attachments/assets/7ce1397c-9525-4bf9-8dda-7a848a6c9014

