### PR TITLE
chore: add retry to publish npm step in publish sdk worfkflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,9 +57,14 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
-        run: |
-          echo "@uipath:registry=https://registry.npmjs.org" > .npmrc
-          npm publish --provenance --access public
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            echo "@uipath:registry=https://registry.npmjs.org" > .npmrc
+            npm publish --provenance --access public
 
       - name: Publish to GitHub Packages
         run: |


### PR DESCRIPTION
in one of recent run, npm publish failed with error: "package with this version already exists" which was false positive. but re-runing worked. 
Adding retry to npm publish step