### PR TITLE
fix: clear stale OAuth context from session storage - [PLT-98274]

### DIFF
--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../../src/core/auth/service', () => {
   AuthService.isInOAuthCallback = vi.fn(() => false);
   AuthService.getStoredOAuthContext = vi.fn(() => null);
   AuthService._mergeConfigWithContext = vi.fn((config: any) => config);
+  AuthService._clearStoredOAuthContext = vi.fn();
 
   return { AuthService };
 });

--- a/tests/unit/legacy/uipath-legacy.test.ts
+++ b/tests/unit/legacy/uipath-legacy.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../../src/core/auth/service', () => {
   AuthService.isInOAuthCallback = vi.fn(() => false);
   AuthService.getStoredOAuthContext = vi.fn(() => null);
   AuthService._mergeConfigWithContext = vi.fn((config: any) => config);
+  AuthService._clearStoredOAuthContext = vi.fn();
 
   return { AuthService };
 });


### PR DESCRIPTION
Issue:
 When a developer hits an OAuth error (e.g., scope mismatch or invalid redirect URI) from the identity, and fixes their config, and retries sdk.initialize(), the SDK silently uses the old stored values from session storage ( `uipath_sdk_oauth_context` and `uipath_sdk_code_verifier` ). and they have to manually clear session storage before trying again

Fix:

 - Only use stored OAuth context when completing an active callback (URL has ?code= parameter)
  - If no callback is in progress, clear any leftover `uipath_sdk_oauth_context` and `uipath_sdk_code_verifier` from session storage before proceeding
  - Fresh config from the developer always takes effect on re-initialization