### PR TITLE
fix: Traces scope in conversational agents sample

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -85,7 +85,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 
 To use the full Conversational Agent functionality (discover agents, manage conversations, stream real-time responses via WebSocket sessions, and retrieve history), your external app needs the following combined scopes:
 
-`OR.Execution` · `OR.Folders` · `OR.Jobs` · `ConversationalAgents` · `Traces.API`
+`OR.Execution` · `OR.Folders` · `OR.Jobs` · `ConversationalAgents` · `Traces.Api`
 
 /// note
 The `ConversationalAgents` scope is required for real-time WebSocket sessions (`startSession()`). Without it, REST API calls for agents and conversations will work, but the socket connection will fail.
@@ -116,7 +116,7 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 |--------|-------------|
 | `getAll()` | `OR.Execution` or `OR.Execution.Read`, `OR.Jobs` or `OR.Jobs.Read` |
 | `getById()` | `OR.Execution` or `OR.Execution.Read`, `OR.Jobs` or `OR.Jobs.Read` |
-| `createFeedback()` | `OR.Execution`, `OR.Jobs`, `Traces.API` |
+| `createFeedback()` | `OR.Execution`, `OR.Jobs`, `Traces.Api` |
 
 ### Messages
 

--- a/samples/conversational-agent-app/.env.example
+++ b/samples/conversational-agent-app/.env.example
@@ -6,6 +6,6 @@ VITE_UIPATH_ORG_NAME=your-organization-name
 VITE_UIPATH_TENANT_NAME=your-tenant-name
 VITE_UIPATH_BASE_URL=${UIPATH_BASE_URL} # url where app is running
 VITE_UIPATH_REDIRECT_URI=${UIPATH_REDIRECT_URI} # url where app is running
-VITE_UIPATH_SCOPE=OR.Execution OR.Folders OR.Jobs ConversationalAgents Traces.API
+VITE_UIPATH_SCOPE=OR.Execution OR.Folders OR.Jobs ConversationalAgents Traces.Api
 UIPATH_BASE_URL=https://cloud.uipath.com
 UIPATH_REDIRECT_URI=http://localhost:5173

--- a/samples/conversational-agent-app/README.md
+++ b/samples/conversational-agent-app/README.md
@@ -24,7 +24,7 @@ npm install @uipath/uipath-typescript
 3. Configure:
    - **Name**: Your app name (e.g., "Conversational Agent App")
    - **Redirect URI**: `http://localhost:5173/callback` (for development)
-   - **Scopes**: `OR.Execution`, `OR.Folders`, `OR.Jobs`, `ConversationalAgents`, `Traces.API`
+   - **Scopes**: `OR.Execution`, `OR.Folders`, `OR.Jobs`, `ConversationalAgents`, `Traces.Api`
 
 4. Save and copy the **Client ID**
 
@@ -42,7 +42,7 @@ npm install @uipath/uipath-typescript
    VITE_UIPATH_BASE_URL=https://cloud.uipath.com
    VITE_UIPATH_CLIENT_ID=your-oauth-client-id
    VITE_UIPATH_REDIRECT_URI=http://localhost:5173/callback
-   VITE_UIPATH_SCOPE=OR.Execution OR.Folders OR.Jobs ConversationalAgents Traces.API
+   VITE_UIPATH_SCOPE=OR.Execution OR.Folders OR.Jobs ConversationalAgents Traces.Api
    VITE_UIPATH_ORG_NAME=your-organization-name
    VITE_UIPATH_TENANT_NAME=your-tenant-name
    ```


### PR DESCRIPTION
scope should be `Traces.Api` instead of `Traces.API`