### PR TITLE
chore: version bump sdk and coded-action-app pkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "workspaces": [
                 "packages/*"
@@ -13189,7 +13189,7 @@
         },
         "packages/coded-action-apps": {
             "name": "@uipath/uipath-ts-coded-action-apps",
-            "version": "1.0.0-beta.0",
+            "version": "1.0.0-beta.1",
             "devDependencies": {
                 "oxlint": "^1.43.0",
                 "rimraf": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/packages/coded-action-apps/package.json
+++ b/packages/coded-action-apps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/uipath-ts-coded-action-apps",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "UiPath package to be used for viewing coded action apps in Action Center",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
version bump sdk `1.1.2` and `coded-action-app` pkg to `1.0.0-beta.1`
