### PR TITLE
feat(cli): detect action app from remote manifest, add push validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm ci
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm ci
@@ -47,3 +47,6 @@ jobs:
 
       - name: Run CLI Tests
         run: npm run test:coverage --workspace=packages/cli
+
+      - name: Run Codedapp-Tool Tests
+        run: npm run test:coverage --workspace=packages/codedapp-tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci
@@ -37,10 +37,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run SDK Tests
         run: npm run test:coverage -- --run
+
+      - name: Run CLI Tests
+        run: npm run test:coverage --workspace=packages/cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,11 @@ on:
   pull_request:
     branches: [main, develop]
 
-permissions:
-  contents: read
-
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,10 +18,29 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Lint
         run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run SDK Tests
+        run: npm run test:coverage -- --run

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,8 +34,11 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Run Tests
+      - name: Run SDK Tests
         run: npm run test:coverage -- --run
+
+      - name: Run CLI Tests
+        run: npm run test:coverage --workspace=packages/cli
 
       - name: Build Project
         run: npm run build
@@ -84,7 +87,8 @@ jobs:
           echo "### Completed Checks:" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Dependencies installed successfully" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Typecheck passed" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ All tests passed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ SDK tests passed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ CLI tests passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Build completed successfully" >> $GITHUB_STEP_SUMMARY
           if [ "${{ github.base_ref }}" == "main" ]; then
             echo "- ✅ All integration tests passed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run CLI Tests
         run: npm run test:coverage --workspace=packages/cli
 
+      - name: Run Codedapp-Tool Tests
+        run: npm run test:coverage --workspace=packages/codedapp-tool
+
       - name: Build Project
         run: npm run build
 
@@ -89,6 +92,7 @@ jobs:
           echo "- ✅ Typecheck passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ SDK tests passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ CLI tests passed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Codedapp-Tool tests passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Build completed successfully" >> $GITHUB_STEP_SUMMARY
           if [ "${{ github.base_ref }}" == "main" ]; then
             echo "- ✅ All integration tests passed" >> $GITHUB_STEP_SUMMARY

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,138 +244,12 @@
             "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/compat-data": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-            "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/core": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-            "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.3",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.4",
-                "@babel/parser": "^7.28.4",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.4",
-                "@babel/types": "^7.28.4",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/generator": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-            "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.28.3",
-                "@babel/types": "^7.28.2",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.27.2",
-                "@babel/helper-validator-option": "^7.27.1",
-                "browserslist": "^4.24.0",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.28.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -400,30 +274,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helpers": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/parser": {
             "version": "7.28.4",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
@@ -440,279 +290,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-syntax-async-generators": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-bigint": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-class-properties": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.12.13"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-class-static-block": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-            "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-import-meta": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-json-strings": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-numeric-separator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-object-rest-spread": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-optional-chaining": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-private-property-in-object": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-top-level-await": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/template": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.2",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/traverse": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.3",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.4",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4",
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/types": {
             "version": "7.28.4",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
@@ -726,13 +303,6 @@
             "engines": {
                 "node": ">=6.9.0"
             }
-        },
-        "node_modules/@bcoe/v8-coverage": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.12",
@@ -1790,23 +1360,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "camelcase": "^5.3.1",
-                "find-up": "^4.1.0",
-                "get-package-type": "^0.1.0",
-                "js-yaml": "^3.13.1",
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1817,298 +1370,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@jest/console": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-            "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/core": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-            "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/reporters": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-changed-files": "^29.7.0",
-                "jest-config": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-resolve-dependencies": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@jest/environment": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-            "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-mock": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/expect": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-            "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "expect": "^29.7.0",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/expect-utils": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-            "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jest-get-type": "^29.6.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/fake-timers": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-            "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@types/node": "*",
-                "jest-message-util": "^29.7.0",
-                "jest-mock": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/globals": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-            "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "jest-mock": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/reporters": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-            "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "istanbul-lib-coverage": "^3.0.0",
-                "istanbul-lib-instrument": "^6.0.0",
-                "istanbul-lib-report": "^3.0.0",
-                "istanbul-lib-source-maps": "^4.0.0",
-                "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "slash": "^3.0.0",
-                "string-length": "^4.0.1",
-                "strip-ansi": "^6.0.0",
-                "v8-to-istanbul": "^9.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@jest/schemas": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/source-map": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-            "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.2.9"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-result": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-            "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "collect-v8-coverage": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-sequencer": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-            "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/transform": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-            "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/types": "^29.6.3",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "babel-plugin-istanbul": "^6.1.1",
-                "chalk": "^4.0.0",
-                "convert-source-map": "^2.0.0",
-                "fast-json-stable-stringify": "^2.1.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "pirates": "^4.0.4",
-                "slash": "^3.0.0",
-                "write-file-atomic": "^4.0.2"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2117,17 +1378,6 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
-        "node_modules/@jridgewell/remapping": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
@@ -2396,6 +1646,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -3215,83 +2466,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@sinonjs/commons": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
-        },
         "node_modules/@socket.io/component-emitter": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
             "license": "MIT"
-        },
-        "node_modules/@types/babel__core": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.20.7",
-                "@babel/types": "^7.20.7",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
-            }
-        },
-        "node_modules/@types/babel__generator": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__template": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__traverse": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.28.2"
-            }
         },
         "node_modules/@types/body-parser": {
             "version": "1.19.6",
@@ -3371,16 +2550,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/graceful-fs": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-            "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/hast": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -3406,44 +2575,6 @@
             "dependencies": {
                 "@types/through": "*",
                 "rxjs": "^7.2.0"
-            }
-        },
-        "node_modules/@types/istanbul-lib-coverage": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/istanbul-lib-report": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "*"
-            }
-        },
-        "node_modules/@types/istanbul-reports": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/istanbul-lib-report": "*"
-            }
-        },
-        "node_modules/@types/jest": {
-            "version": "29.5.14",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-            "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "expect": "^29.0.0",
-                "pretty-format": "^29.0.0"
             }
         },
         "node_modules/@types/jsonfile": {
@@ -3527,13 +2658,6 @@
                 "@types/send": "*"
             }
         },
-        "node_modules/@types/stack-utils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/through": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
@@ -3555,23 +2679,6 @@
             "version": "9.0.8",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
             "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/yargs": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@types/yargs-parser": {
-            "version": "21.0.3",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3885,6 +2992,7 @@
             "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/utils": "3.2.4",
                 "fflate": "^0.8.2",
@@ -3935,6 +3043,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4026,43 +3135,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/anymatch": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/anymatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4114,137 +3186,11 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
         },
-        "node_modules/babel-jest": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-            "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/transform": "^29.7.0",
-                "@types/babel__core": "^7.1.14",
-                "babel-plugin-istanbul": "^6.1.1",
-                "babel-preset-jest": "^29.6.3",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.8.0"
-            }
-        },
-        "node_modules/babel-plugin-istanbul": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-            "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@istanbuljs/load-nyc-config": "^1.0.0",
-                "@istanbuljs/schema": "^0.1.2",
-                "istanbul-lib-instrument": "^5.0.4",
-                "test-exclude": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@babel/core": "^7.12.3",
-                "@babel/parser": "^7.14.7",
-                "@istanbuljs/schema": "^0.1.2",
-                "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^6.3.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/babel-plugin-jest-hoist": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-            "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.3.3",
-                "@babel/types": "^7.3.3",
-                "@types/babel__core": "^7.1.14",
-                "@types/babel__traverse": "^7.0.6"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/babel-preset-current-node-syntax": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-            "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-bigint": "^7.8.3",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-import-attributes": "^7.24.7",
-                "@babel/plugin-syntax-import-meta": "^7.10.4",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0 || ^8.0.0-0"
-            }
-        },
-        "node_modules/babel-preset-jest": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-            "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-jest-hoist": "^29.6.3",
-                "babel-preset-current-node-syntax": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
-        },
-        "node_modules/baseline-browser-mapping": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
-            "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
-            }
         },
         "node_modules/body-parser": {
             "version": "2.2.0",
@@ -4277,88 +3223,11 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/browserslist": {
-            "version": "4.26.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.0.tgz",
-            "integrity": "sha512-P9go2WrP9FiPwLv3zqRD/Uoxo0RSHjzFCiQz7d4vbmwNqQFo9T9WCeP/Qn5EbcKQY6DBbkxEXNcpJOmncNrb7A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "baseline-browser-mapping": "^2.8.2",
-                "caniuse-lite": "^1.0.30001741",
-                "electron-to-chromium": "^1.5.218",
-                "node-releases": "^2.0.21",
-                "update-browserslist-db": "^1.1.3"
-            },
-            "bin": {
-                "browserslist": "cli.js"
-            },
-            "engines": {
-                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/bs-logger": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-json-stable-stringify": "2.x"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/bser": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "node-int64": "^0.4.0"
-            }
-        },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "license": "BSD-3-Clause"
-        },
-        "node_modules/buffer-from": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/builtin-modules": {
             "version": "3.3.0",
@@ -4446,37 +3315,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camelcase": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/caniuse-lite": {
-            "version": "1.0.30001741",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
-            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "CC-BY-4.0"
-        },
         "node_modules/chai": {
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -4511,16 +3349,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/char-regex": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/chardet": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
@@ -4536,29 +3364,6 @@
             "engines": {
                 "node": ">= 16"
             }
-        },
-        "node_modules/ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cjs-module-lexer": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/clean-stack": {
             "version": "3.0.1",
@@ -4622,39 +3427,6 @@
             "engines": {
                 "node": ">= 12"
             }
-        },
-        "node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">= 1.0.0",
-                "node": ">= 0.12.0"
-            }
-        },
-        "node_modules/collect-v8-coverage": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-            "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -4730,13 +3502,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/cookie": {
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -4760,28 +3525,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "license": "MIT"
-        },
-        "node_modules/create-jest": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-            "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "prompts": "^2.0.1"
-            },
-            "bin": {
-                "create-jest": "bin/create-jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -4820,21 +3563,6 @@
             },
             "peerDependenciesMeta": {
                 "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/dedent": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-            "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "babel-plugin-macros": "^3.1.0"
-            },
-            "peerDependenciesMeta": {
-                "babel-plugin-macros": {
                     "optional": true
                 }
             }
@@ -4924,26 +3652,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/detect-newline": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -5020,26 +3728,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/electron-to-chromium": {
-            "version": "1.5.218",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
-            "integrity": "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/emittery": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-            "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-            }
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5105,16 +3793,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/error-ex": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-define-property": {
@@ -5211,31 +3889,11 @@
                 "@esbuild/win32-x64": "0.25.12"
             }
         },
-        "node_modules/escalade": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "license": "MIT"
-        },
-        "node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/eslint": {
             "version": "8.57.1",
@@ -5244,6 +3902,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -5424,20 +4083,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/esquery": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -5500,56 +4145,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/exit": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/expect": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-            "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/expect-utils": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/expect-type": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -5565,6 +4160,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
             "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.0",
@@ -5649,16 +4245,6 @@
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fb-watchman": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-            "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bser": "2.1.1"
             }
         },
         "node_modules/fdir": {
@@ -5751,19 +4337,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/finalhandler": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -5779,20 +4352,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/flat-cache": {
@@ -5976,26 +4535,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/gensync": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
         "node_modules/get-east-asian-width": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
@@ -6052,19 +4591,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/glob": {
@@ -6155,28 +4681,6 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.5",
-                "neo-async": "^2.6.2",
-                "source-map": "^0.6.1",
-                "wordwrap": "^1.0.0"
-            },
-            "bin": {
-                "handlebars": "bin/handlebars"
-            },
-            "engines": {
-                "node": ">=0.4.7"
-            },
-            "optionalDependencies": {
-                "uglify-js": "^3.1.4"
-            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -6302,16 +4806,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -6364,26 +4858,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/import-local": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
-            "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pkg-dir": "^4.2.0",
-                "resolve-cwd": "^3.0.0"
-            },
-            "bin": {
-                "import-local-fixture": "fixtures/cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/imurmurhash": {
@@ -6467,13 +4941,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -6522,16 +4989,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-generator-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/is-glob": {
@@ -6599,16 +5056,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -6633,19 +5080,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "*"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-unicode-supported": {
@@ -6695,36 +5129,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/istanbul-lib-instrument": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-            "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@babel/core": "^7.23.9",
-                "@babel/parser": "^7.23.9",
-                "@istanbuljs/schema": "^0.1.3",
-                "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/istanbul-lib-report": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -6735,21 +5139,6 @@
                 "istanbul-lib-coverage": "^3.0.0",
                 "make-dir": "^4.0.0",
                 "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/istanbul-lib-source-maps": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-            "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^3.0.0",
-                "source-map": "^0.6.1"
             },
             "engines": {
                 "node": ">=10"
@@ -6802,660 +5191,18 @@
                 "node": ">=10"
             }
         },
-        "node_modules/jest": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-            "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "import-local": "^3.0.2",
-                "jest-cli": "^29.7.0"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-changed-files": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-            "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "execa": "^5.0.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-circus": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-            "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "co": "^4.6.0",
-                "dedent": "^1.0.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^29.7.0",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "pretty-format": "^29.7.0",
-                "pure-rand": "^6.0.0",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-cli": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-            "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "create-jest": "^29.7.0",
-                "exit": "^0.1.2",
-                "import-local": "^3.0.2",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "yargs": "^17.3.1"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-config": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-            "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/test-sequencer": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-jest": "^29.7.0",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "deepmerge": "^4.2.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-circus": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "parse-json": "^5.2.0",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-json-comments": "^3.1.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@types/node": "*",
-                "ts-node": ">=9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "ts-node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-diff": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-            "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^29.6.3",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-docblock": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-            "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "detect-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-each": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-            "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "jest-get-type": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-environment-node": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-            "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-mock": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-get-type": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-haste-map": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-            "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/graceful-fs": "^4.1.3",
-                "@types/node": "*",
-                "anymatch": "^3.0.3",
-                "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.2.9",
-                "jest-regex-util": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "walker": "^1.0.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "^2.3.2"
-            }
-        },
-        "node_modules/jest-leak-detector": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-            "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-            "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-message-util": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-            "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.6.3",
-                "@types/stack-utils": "^2.0.0",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-mock": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-            "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-pnp-resolver": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            },
-            "peerDependencies": {
-                "jest-resolve": "*"
-            },
-            "peerDependenciesMeta": {
-                "jest-resolve": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-regex-util": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-            "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-resolve": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-            "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "resolve": "^1.20.0",
-                "resolve.exports": "^2.0.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-resolve-dependencies": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-            "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jest-regex-util": "^29.6.3",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runner": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-            "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/environment": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "graceful-fs": "^4.2.9",
-                "jest-docblock": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-leak-detector": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-resolve": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "source-map-support": "0.5.13"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runtime": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-            "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/globals": "^29.7.0",
-                "@jest/source-map": "^29.6.3",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "cjs-module-lexer": "^1.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-mock": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-bom": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-snapshot": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-            "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@babel/generator": "^7.7.2",
-                "@babel/plugin-syntax-jsx": "^7.7.2",
-                "@babel/plugin-syntax-typescript": "^7.7.2",
-                "@babel/types": "^7.3.3",
-                "@jest/expect-utils": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-preset-current-node-syntax": "^1.0.0",
-                "chalk": "^4.0.0",
-                "expect": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^29.7.0",
-                "semver": "^7.5.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/jest-util": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "graceful-fs": "^4.2.9",
-                "picomatch": "^2.2.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-util/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/jest-validate": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-            "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "camelcase": "^6.2.0",
-                "chalk": "^4.0.0",
-                "jest-get-type": "^29.6.3",
-                "leven": "^3.1.0",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-validate/node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-watcher": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-            "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "jest-util": "^29.7.0",
-                "string-length": "^4.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-worker": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-util": "^29.7.0",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/jsesc": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=6"
-            }
+            "optional": true
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true,
             "license": "MIT"
         },
@@ -7472,19 +5219,6 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/jsonfile": {
             "version": "6.2.0",
@@ -7575,26 +5309,6 @@
                 "json-buffer": "3.0.1"
             }
         },
-        "node_modules/kleur": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/leven": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7630,13 +5344,6 @@
                 "url": "https://github.com/sponsors/antonk52"
             }
         },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/linkify-it": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -7645,19 +5352,6 @@
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
-            }
-        },
-        "node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/lodash.includes": {
@@ -7694,13 +5388,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "license": "MIT"
-        },
-        "node_modules/lodash.memoize": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
@@ -7763,16 +5450,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
         "node_modules/lunr": {
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -7829,23 +5506,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/makeerror": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-            "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tmpl": "1.0.5"
             }
         },
         "node_modules/markdown-it": {
@@ -7910,40 +5570,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -7963,16 +5589,6 @@
             },
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/mimic-function": {
@@ -7998,16 +5614,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
@@ -8080,13 +5686,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/neo-async": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/node-domexception": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -8123,30 +5722,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/node-fetch"
-            }
-        },
-        "node_modules/node-int64": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/node-releases": {
-            "version": "2.0.21",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
-            "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/npm": {
@@ -8334,19 +5909,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/npm/node_modules/@isaacs/cliui": {
@@ -10433,6 +7995,7 @@
             "version": "4.0.2",
             "inBundle": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -10705,22 +8268,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -10892,45 +8439,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/p-locate/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -10955,25 +8463,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parseurl": {
@@ -11094,29 +8583,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/pirates": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/postcss": {
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -11156,34 +8622,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/proc-log": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -11198,20 +8636,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
-        },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -11245,23 +8669,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/pure-rand": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-            "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/dubzzz"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fast-check"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.14.0",
@@ -11339,13 +8746,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -11367,16 +8767,6 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
         },
-        "node_modules/require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -11396,39 +8786,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/resolve-cwd": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/resolve.exports": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
-            "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/restore-cursor": {
@@ -11574,6 +8931,7 @@
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -11732,16 +9090,6 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
-        "node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/send": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
@@ -11893,13 +9241,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/sirv": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -11913,23 +9254,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/sisteransi": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/socket.io-client": {
@@ -11994,16 +9318,6 @@
                 }
             }
         },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -12012,37 +9326,6 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map-support": {
-            "version": "0.5.13",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/stack-utils": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/stackback": {
@@ -12094,20 +9377,6 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
-        },
-        "node_modules/string-length": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-            "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "char-regex": "^1.0.2",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -12163,26 +9432,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-bom": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/strip-json-comments": {
@@ -12242,21 +9491,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/test-exclude": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@istanbuljs/schema": "^0.1.2",
-                "glob": "^7.1.4",
-                "minimatch": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/text-table": {
@@ -12326,26 +9560,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/tmpl": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -12365,85 +9579,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/ts-jest": {
-            "version": "29.4.2",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.2.tgz",
-            "integrity": "sha512-pBNOkn4HtuLpNrXTMVRC9b642CBaDnKqWXny4OzuoULT9S7Kf8MMlaRe2veKax12rjf5WcpMBhVPbQurlWGNxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bs-logger": "^0.2.6",
-                "fast-json-stable-stringify": "^2.1.0",
-                "handlebars": "^4.7.8",
-                "json5": "^2.2.3",
-                "lodash.memoize": "^4.1.2",
-                "make-error": "^1.3.6",
-                "semver": "^7.7.2",
-                "type-fest": "^4.41.0",
-                "yargs-parser": "^21.1.1"
-            },
-            "bin": {
-                "ts-jest": "cli.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": ">=7.0.0-beta.0 <8",
-                "@jest/transform": "^29.0.0 || ^30.0.0",
-                "@jest/types": "^29.0.0 || ^30.0.0",
-                "babel-jest": "^29.0.0 || ^30.0.0",
-                "jest": "^29.0.0 || ^30.0.0",
-                "jest-util": "^29.0.0 || ^30.0.0",
-                "typescript": ">=4.3 <6"
-            },
-            "peerDependenciesMeta": {
-                "@babel/core": {
-                    "optional": true
-                },
-                "@jest/transform": {
-                    "optional": true
-                },
-                "@jest/types": {
-                    "optional": true
-                },
-                "babel-jest": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jest-util": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ts-jest/node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/ts-jest/node_modules/type-fest": {
-            "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -12461,16 +9596,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/type-detect": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/type-fest": {
@@ -12568,6 +9693,7 @@
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -12582,20 +9708,6 @@
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/uglify-js": {
-            "version": "3.19.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "bin": {
-                "uglifyjs": "bin/uglifyjs"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
         },
         "node_modules/undici-types": {
             "version": "6.21.0",
@@ -12619,37 +9731,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "escalade": "^3.2.0",
-                "picocolors": "^1.1.1"
-            },
-            "bin": {
-                "update-browserslist-db": "cli.js"
-            },
-            "peerDependencies": {
-                "browserslist": ">= 4.21.0"
             }
         },
         "node_modules/uri-js": {
@@ -12681,21 +9762,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/v8-to-istanbul": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.12",
-                "@types/istanbul-lib-coverage": "^2.0.1",
-                "convert-source-map": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.12.0"
-            }
-        },
         "node_modules/validate-npm-package-name": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -12720,6 +9786,7 @@
             "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -12818,6 +9885,7 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -12883,16 +9951,6 @@
                 "jsdom": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/walker": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-            "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "makeerror": "1.0.12"
             }
         },
         "node_modules/web-streams-polyfill": {
@@ -13007,20 +10065,6 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
         },
-        "node_modules/write-file-atomic": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
         "node_modules/ws": {
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
@@ -13080,23 +10124,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/y18n": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/yaml": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
@@ -13108,35 +10135,6 @@
             },
             "engines": {
                 "node": ">= 14.6"
-            }
-        },
-        "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/yarn": {
@@ -13183,6 +10181,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -13223,13 +10222,12 @@
                 "@oclif/test": "^4.0.9",
                 "@types/fs-extra": "^11.0.4",
                 "@types/inquirer": "^9.0.7",
-                "@types/jest": "^29.5.14",
                 "@types/node": "^20.11.19",
                 "@types/uuid": "^9.0.8",
+                "@vitest/coverage-v8": "^3.2.4",
                 "eslint": "^8.57.1",
-                "jest": "^29.7.0",
-                "ts-jest": "^29.4.0",
-                "typescript": "^5.3.3"
+                "typescript": "^5.3.3",
+                "vitest": "^3.2.4"
             },
             "engines": {
                 "node": ">=18.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,8 +22,9 @@
     "prebuild": "npm run clean",
     "build": "tsc && npm run copy-assets",
     "copy-assets": "cp -r src/assets dist/",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
@@ -56,12 +57,11 @@
     "@oclif/test": "^4.0.9",
     "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.7",
-    "@types/jest": "^29.5.14",
     "@types/node": "^20.11.19",
     "@types/uuid": "^9.0.8",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^8.57.1",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.4.0",
+    "vitest": "^3.2.4",
     "typescript": "^5.3.3"
   },
   "oclif": {

--- a/packages/cli/src/actions/deploy.ts
+++ b/packages/cli/src/actions/deploy.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import fetch from 'node-fetch';
 import type { EnvironmentConfig, AppConfig } from '../types/index.js';
 import { AppType } from '../types/action-app.js';

--- a/packages/cli/src/actions/pack.ts
+++ b/packages/cli/src/actions/pack.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import JSZip from 'jszip';
 import fetch from 'node-fetch';

--- a/packages/cli/src/actions/publish.ts
+++ b/packages/cli/src/actions/publish.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora, { type Ora } from 'ora';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 import type { EnvironmentConfig, AppConfig } from '../types/index.js';

--- a/packages/cli/src/actions/pull.ts
+++ b/packages/cli/src/actions/pull.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import * as path from 'path';
+import * as path from 'node:path';
 import { PUSH_METADATA_RELATIVE_PATH } from '../constants/api.js';
 import { AUTH_CONSTANTS, MESSAGES } from '../constants/index.js';
 import { PULL_OVERWRITE_LIST_MAX_DISPLAY } from '../constants/pull.js';

--- a/packages/cli/src/actions/push.ts
+++ b/packages/cli/src/actions/push.ts
@@ -1,15 +1,20 @@
 import chalk from 'chalk';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 import FormData from 'form-data';
 import { PUSH_METADATA_RELATIVE_PATH } from '../constants/api.js';
-import { AUTH_CONSTANTS, MESSAGES } from '../constants/index.js';
+import { ACTION_SCHEMA_CONSTANTS, AUTH_CONSTANTS, MESSAGES } from '../constants/index.js';
 import { getEnvironmentConfig } from '../utils/env-config.js';
 import { WebAppFileHandler } from '../core/webapp-file-handler/index.js';
+import { WEB_APP_MANIFEST_FILENAME, getRemoteFilesMap } from '../core/webapp-file-handler/structure.js';
+import * as api from '../core/webapp-file-handler/api.js';
 import { Preconditions } from '../core/preconditions.js';
+import { validatePushFiles } from '../utils/push-validation.js';
 import { cliTelemetryClient } from '../telemetry/index.js';
 import type { EnvironmentConfig } from '../types/index.js';
+import type { WebAppProjectConfig } from '../core/webapp-file-handler/index.js';
 
 export interface PushOptions {
   projectId?: string;
@@ -25,20 +30,31 @@ export interface PushOptions {
 async function createCodedAppProject(
   envConfig: EnvironmentConfig,
   appName: string,
+  isActionApp: boolean,
   logger: { log: (message: string) => void },
 ): Promise<string> {
   const url = `${envConfig.baseUrl}/${envConfig.orgId}/studio_/backend/api/Solution`;
 
+  const solutionResourceSubType = isActionApp ? 'CodedAction' : 'Coded';
+  const webAppManifest = JSON.stringify({
+    type: 'Coded',
+    solutionResourceSubType,
+    config: {
+      isCompiled: true,
+      isActionApp,
+    },
+  });
+
   const form = new FormData();
   form.append('createDefaultProjectCommand[expressionLanguage]', 'VisualBasic');
-  form.append('createDefaultProjectCommand[projectType]', 'WebApp');
+  form.append('createDefaultProjectCommand[projectType]', 'AppV2');
   form.append('createDefaultProjectCommand[triggerType]', 'Manual');
-  form.append('createDefaultProjectCommand[projectMode]', 'WebApp');
+  form.append('createDefaultProjectCommand[projectMode]', 'AppV2');
   form.append('createDefaultProjectCommand[isTenantLocked]', 'false');
   form.append('createDefaultProjectCommand[name]', appName);
   form.append('createDefaultProjectCommand[isApp]', 'false');
   form.append('createDefaultProjectCommand[context][expressionLanguage]', 'VB');
-  const webAppManifest = JSON.stringify({ type: 'App_ProCode', config: { isCompiled: true } });
+  form.append('createDefaultProjectCommand[context][projectSubType]', solutionResourceSubType);
   form.append(
     'createDefaultProjectCommand[context][serializedWebAppManifest]',
     webAppManifest,
@@ -120,11 +136,55 @@ export async function executePush(options: PushOptions): Promise<void> {
       message: 'Enter a name for the new Coded App:',
       default: 'App',
     }]);
-    projectId = await createCodedAppProject(envConfig, appName, logger);
+
+    const { appType } = await inquirer.prompt<{ appType: string }>([{
+      type: 'list',
+      name: 'appType',
+      message: 'Select app type:',
+      choices: ['Coded', 'CodedAction'],
+      default: 'Coded',
+    }]);
+
+    const isActionApp = appType === 'CodedAction';
+    if (isActionApp && !fs.existsSync(path.join(process.cwd(), ACTION_SCHEMA_CONSTANTS.ACTION_SCHEMA_FILENAME))) {
+      throw new Error(MESSAGES.ERRORS.ACTION_SCHEMA_REQUIRED);
+    }
+
+    projectId = await createCodedAppProject(envConfig, appName, isActionApp, logger);
   }
 
   const rootDir = process.cwd();
   const bundlePath = path.normalize(options.buildDir ?? 'dist').replace(/\\/g, '/');
+
+  // Check remote webAppManifest.json to determine if this is an Action app.
+  // If CodedAction, validate that action-schema.json exists locally.
+  const config: WebAppProjectConfig = {
+    projectId,
+    rootDir,
+    bundlePath,
+    manifestFile: PUSH_METADATA_RELATIVE_PATH,
+    envConfig,
+    logger,
+  };
+  const remoteStructure = await api.fetchRemoteStructure(config);
+  const remoteFiles = getRemoteFilesMap(remoteStructure);
+  const manifestFile = remoteFiles.get(WEB_APP_MANIFEST_FILENAME);
+  if (manifestFile) {
+    try {
+      const content = await api.downloadRemoteFile(config, manifestFile.id);
+      const manifest = JSON.parse(content.toString('utf8'));
+      if (manifest?.solutionResourceSubType === 'CodedAction') {
+        if (!fs.existsSync(path.join(rootDir, ACTION_SCHEMA_CONSTANTS.ACTION_SCHEMA_FILENAME))) {
+          throw new Error(MESSAGES.ERRORS.ACTION_SCHEMA_REQUIRED);
+        }
+      }
+    } catch (err) {
+      // Re-throw action-schema validation errors, ignore manifest parse errors
+      if (err instanceof Error && err.message === MESSAGES.ERRORS.ACTION_SCHEMA_REQUIRED) {
+        throw err;
+      }
+    }
+  }
 
   try {
     Preconditions.validate(rootDir, bundlePath);
@@ -134,14 +194,9 @@ export async function executePush(options: PushOptions): Promise<void> {
     );
   }
 
-  const handler = new WebAppFileHandler({
-    projectId,
-    rootDir,
-    bundlePath,
-    manifestFile: PUSH_METADATA_RELATIVE_PATH,
-    envConfig,
-    logger,
-  });
+  await validatePushFiles(rootDir, bundlePath, logger);
+
+  const handler = new WebAppFileHandler(config);
 
   await handler.push();
   await handler.importReferencedResources(options.ignoreResources ?? false);

--- a/packages/cli/src/actions/push.ts
+++ b/packages/cli/src/actions/push.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import * as path from 'path';
+import * as path from 'node:path';
 import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 import FormData from 'form-data';

--- a/packages/cli/src/auth/core/oidc.ts
+++ b/packages/cli/src/auth/core/oidc.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import fetch from 'node-fetch';
 import { AUTH_CONSTANTS } from '../../constants/auth.js';
 import { getAuthorizationBaseUrl, getTokenEndpointUrl, buildRedirectUri } from '../utils/url.js';

--- a/packages/cli/src/auth/core/oidc.ts
+++ b/packages/cli/src/auth/core/oidc.ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto';
+import crypto from 'crypto';
 import fetch from 'node-fetch';
 import { AUTH_CONSTANTS } from '../../constants/auth.js';
 import { getAuthorizationBaseUrl, getTokenEndpointUrl, buildRedirectUri } from '../utils/url.js';

--- a/packages/cli/src/auth/core/token-manager.ts
+++ b/packages/cli/src/auth/core/token-manager.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import path from 'path';
+import path from 'node:path';
 import { TokenResponse } from './oidc.js';
 import { SelectedTenant } from '../services/portal.js';
 import { AUTH_CONSTANTS } from '../../constants/auth.js';

--- a/packages/cli/src/auth/server/auth-server.ts
+++ b/packages/cli/src/auth/server/auth-server.ts
@@ -1,9 +1,8 @@
 import express, { Request, Response, NextFunction } from 'express';
-import path from 'path';
+import path, { dirname } from 'node:path';
 import fs from 'fs-extra';
-import { Server } from 'http';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { Server } from 'node:http';
+import { fileURLToPath } from 'node:url';
 import { TokenResponse } from '../core/oidc.js';
 import { getTokenEndpointUrl, buildRedirectUri } from '../utils/url.js';
 import { validateTokenExchangeRequest, validateTokenResponse } from '../utils/validation.js';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,9 +6,9 @@ import { MESSAGES } from './constants/messages.js';
 import { VERSION_CONSTANTS } from './constants/commands.js';
 import { cliTelemetryClient } from './telemetry/index.js';
 import chalk from 'chalk';
-import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/cli/src/constants/index.ts
+++ b/packages/cli/src/constants/index.ts
@@ -5,3 +5,4 @@ export * from './messages.js';
 export * from './commands.js';
 export * from './push.js';
 export * from './pull.js';
+export * from './push-validation.js';

--- a/packages/cli/src/constants/messages.ts
+++ b/packages/cli/src/constants/messages.ts
@@ -145,7 +145,12 @@ export const MESSAGES = {
     INVALID_PROPERTIES_OBJECT: 'Properties must be a valid object',
     MISSING_ACTION_SCHEMA_SECTION: 'Action schema must have inputs, outputs, inOuts, and outcomes sections',
     INVALID_ACTION_SCHEMA: 'Action schema validation failed:',
-    UNSUPPORTED_JSON_DATA_TYPE: 'Unsupported JSON data type:'
+    UNSUPPORTED_JSON_DATA_TYPE: 'Unsupported JSON data type:',
+
+    // Push file validation
+    PUSH_DISALLOWED_EXTENSIONS: 'Push blocked: files with disallowed extensions found. Only web-related file types are allowed.',
+    PUSH_FILE_TOO_LARGE: 'Push blocked: one or more files exceed the 10 MB size limit. Consider uploading large assets to cloud storage and referencing them in your code instead.',
+    PUSH_LARGE_FILES_DECLINED: 'Push cancelled by user.',
 
   },
   

--- a/packages/cli/src/constants/pull.ts
+++ b/packages/cli/src/constants/pull.ts
@@ -6,7 +6,7 @@
 export const PULL_WEB_APP_MANIFEST = 'webAppManifest.json';
 
 /** Required value in webAppManifest.json "type" field for pull to be allowed. */
-export const PULL_WEB_APP_MANIFEST_TYPE = 'App_ProCode';
+export const PULL_WEB_APP_MANIFEST_TYPE = 'Coded';
 
 /** Filename used as a project-root marker (e.g. for isProjectRootDirectory). */
 export const PACKAGE_JSON_FILENAME = 'package.json';

--- a/packages/cli/src/constants/push-validation.ts
+++ b/packages/cli/src/constants/push-validation.ts
@@ -1,0 +1,23 @@
+/** File extensions allowed for push. Lowercase, with leading dot. */
+export const ALLOWED_PUSH_EXTENSIONS = new Set([
+  // Web markup & styles
+  '.html', '.htm', '.css', '.scss', '.sass', '.less',
+  // JavaScript / TypeScript
+  '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.vue', '.svelte',
+  // Data & config
+  '.json', '.yaml', '.yml', '.xml', '.toml', '.graphql', '.gql', '.env', '.config',
+  // Images
+  '.svg', '.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp', '.avif',
+  // Fonts
+  '.woff', '.woff2', '.ttf', '.eot', '.otf',
+  // Maps & text
+  '.map', '.txt', '.md',
+  // Misc web
+  '.wasm', '.webmanifest', '.lock', '.LICENSE',
+]);
+
+/** Per-file soft warning threshold in bytes (2 MB). */
+export const PUSH_FILE_SIZE_WARN_BYTES = 2 * 1024 * 1024;
+
+/** Per-file hard block threshold in bytes (10 MB). */
+export const PUSH_FILE_SIZE_BLOCK_BYTES = 10 * 1024 * 1024;

--- a/packages/cli/src/core/preconditions.ts
+++ b/packages/cli/src/core/preconditions.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { MESSAGES } from '../constants/index.js';
 
 function buildDirErrorMessage(

--- a/packages/cli/src/core/webapp-file-handler/api.ts
+++ b/packages/cli/src/core/webapp-file-handler/api.ts
@@ -116,7 +116,7 @@ export async function fetchRemoteStructure(
     }
     const errText = await response.text().catch(() => '');
     trackApiFailure('fetchRemoteStructure', errText || response.statusText, response.status);
-    await handleHttpError(response, 'fetch remote structure');
+    throw new Error(`Failed to fetch remote structure: ${response.status} ${response.statusText}${errText ? `\n${errText}` : ''}`);
   }
   return (await response.json()) as ProjectStructure;
 }

--- a/packages/cli/src/core/webapp-file-handler/api.ts
+++ b/packages/cli/src/core/webapp-file-handler/api.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 import fetch from 'node-fetch';
 import FormData from 'form-data';
 import chalk from 'chalk';

--- a/packages/cli/src/core/webapp-file-handler/handler.ts
+++ b/packages/cli/src/core/webapp-file-handler/handler.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import chalk from 'chalk';
 import { MESSAGES } from '../../constants/index.js';
 import type {

--- a/packages/cli/src/core/webapp-file-handler/local-files.ts
+++ b/packages/cli/src/core/webapp-file-handler/local-files.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as crypto from 'crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import ignore, { type Ignore } from 'ignore';
 import type { LocalFile } from './types.js';
 import { isPathUnderBuildDir } from './pull-utils.js';

--- a/packages/cli/src/core/webapp-file-handler/local-files.ts
+++ b/packages/cli/src/core/webapp-file-handler/local-files.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as crypto from 'node:crypto';
+import * as crypto from 'crypto';
 import ignore, { type Ignore } from 'ignore';
 import type { LocalFile } from './types.js';
 import { isPathUnderBuildDir } from './pull-utils.js';

--- a/packages/cli/src/core/webapp-file-handler/metadata.ts
+++ b/packages/cli/src/core/webapp-file-handler/metadata.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import chalk from 'chalk';
 import { MESSAGES } from '../../constants/index.js';
 import { cliTelemetryClient } from '../../telemetry/index.js';

--- a/packages/cli/src/core/webapp-file-handler/pull-utils.ts
+++ b/packages/cli/src/core/webapp-file-handler/pull-utils.ts
@@ -2,8 +2,8 @@
  * Pull command: path and folder helpers. Shared logic for mapping remote paths to local
  * and building the folder set. No I/O except fs for overwrite check and mkdir.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { PUSH_METADATA_RELATIVE_PATH, PUSH_METADATA_FILENAME } from '../../constants/api.js';
 import { AUTH_CONSTANTS } from '../../constants/index.js';
 import { PULL_WEB_APP_MANIFEST, PACKAGE_JSON_FILENAME } from '../../constants/pull.js';

--- a/packages/cli/src/core/webapp-file-handler/pull-validation.ts
+++ b/packages/cli/src/core/webapp-file-handler/pull-validation.ts
@@ -1,6 +1,6 @@
 /**
  * Pull command: project type validation. Ensures remote is a supported Studio Web project
- * (webAppManifest.json with type "App_ProCode").
+ * (webAppManifest.json with type "Coded").
  */
 import { MESSAGES } from '../../constants/index.js';
 import { PULL_WEB_APP_MANIFEST, PULL_WEB_APP_MANIFEST_TYPE } from '../../constants/pull.js';
@@ -34,7 +34,7 @@ async function downloadAndParseRemoteJson(
 }
 
 /**
- * Validates project type by checking webAppManifest.json has "type": "App_ProCode".
+ * Validates project type by checking webAppManifest.json has "type": "Coded".
  * Throws Error if no manifest, parse failure, or key mismatch.
  * Assumes filesMap keys are remote paths as returned by getRemoteFilesMap.
  */

--- a/packages/cli/src/core/webapp-file-handler/push-plan.ts
+++ b/packages/cli/src/core/webapp-file-handler/push-plan.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 import chalk from 'chalk';
 import { PUSH_METADATA_FILENAME, PUSH_METADATA_RELATIVE_PATH } from '../../constants/api.js';
 import { MESSAGES } from '../../constants/index.js';

--- a/packages/cli/src/core/webapp-file-handler/resource-import.ts
+++ b/packages/cli/src/core/webapp-file-handler/resource-import.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import chalk from 'chalk';
 import { MESSAGES } from '../../constants/index.js';
 import type {

--- a/packages/cli/src/core/webapp-file-handler/run-pull.ts
+++ b/packages/cli/src/core/webapp-file-handler/run-pull.ts
@@ -2,8 +2,8 @@
  * Pull command: main orchestration. Validates target and project type, filters files
  * (source/ only, excludes buildDir), checks overwrite, recreates folders, downloads files with progress.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import chalk from 'chalk';
 import { MESSAGES } from '../../constants/index.js';
 import { PUSH_METADATA_RELATIVE_PATH, MAX_TELEMETRY_ERROR_LENGTH } from '../../constants/api.js';

--- a/packages/cli/src/telemetry/client.ts
+++ b/packages/cli/src/telemetry/client.ts
@@ -6,8 +6,8 @@ import { AzureMonitorLogExporter } from '@azure/monitor-opentelemetry-exporter';
 import { LoggerProvider, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
 import {
     CONNECTION_STRING,
     ENV_TELEMETRY_ENABLED,

--- a/packages/cli/src/utils/action-schema.ts
+++ b/packages/cli/src/utils/action-schema.ts
@@ -1,6 +1,6 @@
-import path from "path";
+import path from "node:path";
 import { v4 as uuidv4 } from 'uuid';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { z } from 'zod';
 import { JsonActionSchema, JsonActionSchemaValidator, JsonDataType, JsonFormatType, JsonSchemaProperty, ParsedActionPropertySchema, ParsedActionSchema, VbArgumentCollectionType, VbArgumentDataTypeNamespace, VBDataType } from "../types/index.js";
 import { ACTION_SCHEMA_CONSTANTS } from "../constants/index.js";

--- a/packages/cli/src/utils/env-config.ts
+++ b/packages/cli/src/utils/env-config.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import fsExtra from 'fs-extra';
 import { EnvironmentConfig } from '../types/index.js';
 import { MESSAGES } from '../constants/messages.js';

--- a/packages/cli/src/utils/push-validation.ts
+++ b/packages/cli/src/utils/push-validation.ts
@@ -1,0 +1,93 @@
+import * as path from 'node:path';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import {
+  ALLOWED_PUSH_EXTENSIONS,
+  PUSH_FILE_SIZE_WARN_BYTES,
+  PUSH_FILE_SIZE_BLOCK_BYTES,
+} from '../constants/push-validation.js';
+import { MESSAGES } from '../constants/messages.js';
+import { collectLocalFiles, collectSourceFiles } from '../core/webapp-file-handler/local-files.js';
+
+function formatSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+/**
+ * Validates all files that would be pushed (build + source).
+ *
+ * Checks:
+ * 1. Disallowed extensions → hard block
+ * 2. Files > 10 MB → hard block
+ * 3. Files > 2 MB → soft warning (prompt in TTY, block in non-TTY)
+ */
+export async function validatePushFiles(
+  rootDir: string,
+  bundlePath: string,
+  logger: { log: (message: string) => void },
+): Promise<void> {
+  const buildFiles = collectLocalFiles(rootDir, bundlePath);
+  const sourceFiles = collectSourceFiles(rootDir, bundlePath);
+  const allFiles = [...buildFiles, ...sourceFiles];
+
+  if (allFiles.length === 0) return;
+
+  // 1. Extension check
+  const disallowed = allFiles.filter((f) => {
+    const ext = path.extname(f.path).toLowerCase();
+    // Files without extension (e.g. LICENSE, Makefile) are allowed
+    if (!ext) return false;
+    return !ALLOWED_PUSH_EXTENSIONS.has(ext);
+  });
+
+  if (disallowed.length > 0) {
+    logger.log(chalk.red('\nFiles with disallowed extensions:'));
+    for (const f of disallowed) {
+      logger.log(chalk.red(`  • ${f.path}`));
+    }
+    logger.log('');
+    throw new Error(MESSAGES.ERRORS.PUSH_DISALLOWED_EXTENSIONS);
+  }
+
+  // 2. Hard block: files > 10 MB
+  const oversized = allFiles.filter((f) => f.content.length >= PUSH_FILE_SIZE_BLOCK_BYTES);
+
+  if (oversized.length > 0) {
+    logger.log(chalk.red('\nFiles exceeding 10 MB size limit:'));
+    for (const f of oversized) {
+      logger.log(chalk.red(`  • ${f.path} (${formatSize(f.content.length)})`));
+    }
+    logger.log('');
+    throw new Error(MESSAGES.ERRORS.PUSH_FILE_TOO_LARGE);
+  }
+
+  // 3. Soft warning: files > 2 MB
+  const large = allFiles.filter(
+    (f) => f.content.length >= PUSH_FILE_SIZE_WARN_BYTES && f.content.length < PUSH_FILE_SIZE_BLOCK_BYTES,
+  );
+
+  if (large.length > 0) {
+    logger.log(chalk.yellow('\nLarge files detected (> 2 MB):'));
+    for (const f of large) {
+      logger.log(chalk.yellow(`  • ${f.path} (${formatSize(f.content.length)})`));
+    }
+    logger.log(chalk.yellow('Consider uploading large assets to cloud storage instead.\n'));
+
+    if (!process.stdin.isTTY) {
+      throw new Error(MESSAGES.ERRORS.PUSH_LARGE_FILES_DECLINED);
+    }
+
+    const { proceed } = await inquirer.prompt<{ proceed: boolean }>([{
+      type: 'confirm',
+      name: 'proceed',
+      message: 'Some files exceed 2 MB. Continue with push?',
+      default: false,
+    }]);
+
+    if (!proceed) {
+      throw new Error(MESSAGES.ERRORS.PUSH_LARGE_FILES_DECLINED);
+    }
+  }
+}

--- a/packages/cli/tests/helpers/index.ts
+++ b/packages/cli/tests/helpers/index.ts
@@ -1,0 +1,56 @@
+import { vi } from 'vitest';
+import type { EnvironmentConfig } from '../../src/types/index.js';
+
+/**
+ * Shared mock factories and constants for CLI tests.
+ * Reduces duplication flagged by SonarQube across action test files.
+ */
+
+// ---------------------------------------------------------------------------
+// Common mock objects
+// ---------------------------------------------------------------------------
+
+export const createMockLogger = () => ({ log: vi.fn() });
+
+export function createMockEnvConfig(overrides: Partial<EnvironmentConfig> = {}): EnvironmentConfig {
+  return {
+    baseUrl: 'https://cloud.uipath.com',
+    orgId: 'org-id',
+    orgName: 'org',
+    tenantId: 'tenant-id',
+    tenantName: 'tenant',
+    folderKey: 'folder-key',
+    accessToken: 'token',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch response factory (used by publish, deploy tests)
+// ---------------------------------------------------------------------------
+
+export function createMockFetchResponse(options: {
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+  headers?: Record<string, string>;
+} = {}) {
+  const { ok = true, status = 200, json = {}, headers = {} } = options;
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(json),
+    headers: { get: vi.fn((key: string) => headers[key] ?? null) },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const REQUIRED_ENV_VARS = [
+  'UIPATH_BASE_URL',
+  'UIPATH_ORG_ID',
+  'UIPATH_TENANT_ID',
+  'UIPATH_ACCESS_TOKEN',
+] as const;

--- a/packages/cli/tests/setup.ts
+++ b/packages/cli/tests/setup.ts
@@ -1,0 +1,22 @@
+import { vi } from 'vitest';
+
+// Global mocks shared across all CLI test files.
+// Eliminates duplicated vi.hoisted() + vi.mock() boilerplate in each test.
+
+vi.mock('inquirer', () => ({ default: { prompt: vi.fn() } }));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    text: '',
+    isSpinning: false,
+  })),
+}));
+
+vi.mock('../src/telemetry/index.js', () => ({
+  cliTelemetryClient: { track: vi.fn() },
+}));

--- a/packages/cli/tests/unit/actions/auth.test.ts
+++ b/packages/cli/tests/unit/actions/auth.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../src/auth/core/token-manager.js', () => ({
+  loadTokens: vi.fn(),
+  clearTokens: vi.fn(),
+  isTokenExpired: vi.fn(),
+  saveTokensWithTenant: vi.fn(),
+}));
+
+vi.mock('../../../src/auth/core/oidc.js', () => ({
+  generatePKCEChallenge: vi.fn(),
+  getAuthorizationUrl: vi.fn(),
+  authenticateWithClientCredentials: vi.fn(),
+}));
+
+vi.mock('../../../src/auth/server/auth-server.js', () => ({
+  AuthServer: vi.fn().mockImplementation(() => ({
+    start: vi.fn().mockResolvedValue({ accessToken: 'test-token', expiresIn: 3600 }),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../src/auth/services/portal.js', () => ({
+  getTenantsAndOrganization: vi.fn(),
+  selectTenantInteractive: vi.fn(),
+}));
+
+vi.mock('../../../src/auth/services/folder.js', () => ({
+  selectFolderInteractive: vi.fn(),
+}));
+
+vi.mock('../../../src/auth/utils/port-checker.js', () => ({
+  isPortAvailable: vi.fn(),
+}));
+
+vi.mock('open', () => ({ default: vi.fn() }));
+
+import { executeAuth } from '../../../src/actions/auth.js';
+import { loadTokens, clearTokens, isTokenExpired } from '../../../src/auth/core/token-manager.js';
+import { authenticateWithClientCredentials } from '../../../src/auth/core/oidc.js';
+import { isPortAvailable } from '../../../src/auth/utils/port-checker.js';
+import inquirer from 'inquirer';
+
+describe('executeAuth', () => {
+  const mockLogger = { log: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('logout', () => {
+    it('should call clearTokens when logout option is true', async () => {
+      vi.mocked(clearTokens).mockResolvedValue(undefined);
+      await executeAuth({ logout: true, logger: mockLogger });
+      expect(clearTokens).toHaveBeenCalled();
+    });
+
+    it('should throw when clearTokens fails', async () => {
+      vi.mocked(clearTokens).mockRejectedValue(new Error('fs error'));
+      await expect(executeAuth({ logout: true, logger: mockLogger })).rejects.toThrow('fs error');
+    });
+  });
+
+  describe('client credentials', () => {
+    it('should authenticate with client credentials when both clientId and clientSecret provided', async () => {
+      vi.mocked(authenticateWithClientCredentials).mockResolvedValue({
+        accessToken: 'cc-token',
+        expiresIn: 3600,
+      } as any);
+
+      await executeAuth({ clientId: 'my-client', clientSecret: 'my-secret', logger: mockLogger });
+
+      expect(authenticateWithClientCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({ clientId: 'my-client', clientSecret: 'my-secret' })
+      );
+    });
+
+    it('should throw when client credentials auth fails', async () => {
+      vi.mocked(authenticateWithClientCredentials).mockRejectedValue(
+        new Error('Invalid credentials')
+      );
+
+      await expect(
+        executeAuth({ clientId: 'bad', clientSecret: 'bad', logger: mockLogger })
+      ).rejects.toThrow('Invalid credentials');
+    });
+  });
+
+  describe('existing auth check', () => {
+    it('should skip auth when already authenticated and user declines re-auth', async () => {
+      vi.mocked(loadTokens).mockResolvedValue({
+        accessToken: 'existing-token',
+        expiresAt: Date.now() + 60000,
+        domain: 'cloud',
+        organizationId: 'org',
+        organizationName: 'Test Org',
+        tenantName: 'tenant',
+      } as any);
+      vi.mocked(isTokenExpired).mockReturnValue(false);
+      vi.mocked(inquirer.prompt).mockResolvedValue({ reauth: false });
+
+      await executeAuth({ logger: mockLogger });
+
+      expect(loadTokens).toHaveBeenCalled();
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('Already authenticated')
+      );
+    });
+  });
+
+  describe('domain selection', () => {
+    it('should attempt PKCE flow with alpha domain when alpha option set', async () => {
+      vi.mocked(loadTokens).mockResolvedValue(null);
+      vi.mocked(isPortAvailable).mockResolvedValue(true);
+
+      await expect(
+        executeAuth({ alpha: true, force: true, logger: mockLogger })
+      ).rejects.toThrow();
+    });
+
+    it('should attempt PKCE flow with staging domain when staging option set', async () => {
+      vi.mocked(loadTokens).mockResolvedValue(null);
+      vi.mocked(isPortAvailable).mockResolvedValue(true);
+
+      await expect(
+        executeAuth({ staging: true, force: true, logger: mockLogger })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('port availability', () => {
+    it('should throw when no ports are available', async () => {
+      vi.mocked(loadTokens).mockResolvedValue(null);
+      vi.mocked(isPortAvailable).mockResolvedValue(false);
+
+      await expect(
+        executeAuth({ force: true, logger: mockLogger })
+      ).rejects.toThrow(/ports/i);
+    });
+  });
+});

--- a/packages/cli/tests/unit/actions/deploy.test.ts
+++ b/packages/cli/tests/unit/actions/deploy.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
+});
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+vi.mock('../../../src/utils/env-config.js', () => ({
+  getEnvironmentConfig: vi.fn(),
+  sanitizeAppName: vi.fn((name: string) => ({ sanitized: name, isModifiedd: false })),
+  atomicWriteFileSync: vi.fn(),
+}));
+
+import { createMockLogger, createMockEnvConfig, createMockFetchResponse } from '../../helpers/index.js';
+import { executeDeploy } from '../../../src/actions/deploy.js';
+import { getEnvironmentConfig } from '../../../src/utils/env-config.js';
+import fetch from 'node-fetch';
+
+describe('executeDeploy', () => {
+  const mockLogger = createMockLogger();
+  const mockEnvConfig = createMockEnvConfig();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
+  });
+
+  it('should throw when env config is missing', async () => {
+    vi.mocked(getEnvironmentConfig).mockReturnValue(null);
+
+    await expect(
+      executeDeploy({ name: 'my-app', logger: mockLogger })
+    ).rejects.toThrow('Missing required configuration');
+  });
+
+  it('should deploy a new app when not already deployed', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(createMockFetchResponse({ json: { value: [] } }) as any)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { value: [{ systemName: 'my-app-system', title: 'my-app', appVersion: '1.0.0', deployVersion: 1 }] },
+      }) as any)
+      .mockResolvedValueOnce(createMockFetchResponse({ json: { id: 'deploy-id-123' } }) as any);
+
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await executeDeploy({ name: 'my-app', logger: mockLogger });
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('should upgrade when app is already deployed', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { value: [{ id: 'app-id', title: 'my-app', systemName: 'my-app', semVersion: '1.0.0', deployVersion: 1 }] },
+      }) as any)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { value: [{ systemName: 'my-app', title: 'my-app', appVersion: '2.0.0', deployVersion: 2 }] },
+      }) as any)
+      .mockResolvedValueOnce(createMockFetchResponse() as any);
+
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await executeDeploy({ name: 'my-app', logger: mockLogger });
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenLastCalledWith(
+      expect.stringContaining('/apps/'),
+      expect.objectContaining({ method: 'PATCH' })
+    );
+  });
+
+  it('should throw when app not published yet', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(createMockFetchResponse({ json: { value: [] } }) as any)
+      .mockResolvedValueOnce(createMockFetchResponse({ json: { value: [] } }) as any);
+
+    await expect(
+      executeDeploy({ name: 'my-app', logger: mockLogger })
+    ).rejects.toThrow(/not been published/);
+  });
+
+  it('should throw when deployed app has no deploy version during upgrade', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { value: [{ id: 'app-id', title: 'my-app', systemName: 'my-app', semVersion: '1.0.0' }] },
+      }) as any)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { value: [{ systemName: 'my-app', title: 'my-app', appVersion: '2.0.0' }] },
+      }) as any);
+
+    await expect(
+      executeDeploy({ name: 'my-app', logger: mockLogger })
+    ).rejects.toThrow(/deploy version/i);
+  });
+});

--- a/packages/cli/tests/unit/actions/pack.test.ts
+++ b/packages/cli/tests/unit/actions/pack.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    statSync: vi.fn(),
+    readdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    copyFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/utils/env-config.js', () => ({
+  getEnvironmentConfig: vi.fn(),
+  sanitizeAppName: vi.fn((name: string) => ({ sanitized: name, isModifiedd: false })),
+}));
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({ isUnique: true }),
+    headers: { get: vi.fn() },
+  }),
+}));
+
+vi.mock('jszip', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    file: vi.fn(),
+    generateAsync: vi.fn().mockResolvedValue(Buffer.from('fake-nupkg')),
+  })),
+}));
+import { createMockLogger, createMockEnvConfig } from '../../helpers/index.js';
+import { executePack } from '../../../src/actions/pack.js';
+import { getEnvironmentConfig } from '../../../src/utils/env-config.js';
+import inquirer from 'inquirer';
+
+describe('executePack', () => {
+  const mockLogger = createMockLogger();
+  const mockEnvConfig = createMockEnvConfig();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
+  });
+
+  it('should throw when dist directory does not exist', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await expect(
+      executePack({ dist: './dist', name: 'test-app', logger: mockLogger })
+    ).rejects.toThrow(/Invalid dist directory/);
+  });
+
+  it('should throw when dist directory is empty', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+
+    await expect(
+      executePack({ dist: './dist', name: 'test-app', logger: mockLogger })
+    ).rejects.toThrow(/Invalid dist directory/);
+  });
+
+  it('should throw when env config is missing', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    vi.mocked(fs.readdirSync).mockReturnValue(['index.html'] as any);
+    vi.mocked(getEnvironmentConfig).mockReturnValue(null);
+
+    await expect(
+      executePack({ dist: './dist', name: 'test-app', logger: mockLogger })
+    ).rejects.toThrow('Missing required configuration');
+  });
+
+  it('should handle dry-run mode without creating files', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    vi.mocked(fs.readdirSync).mockReturnValue(['index.html'] as any);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+      clientId: '', scope: '', orgName: '', tenantName: '', baseUrl: '', redirectUri: '',
+    }));
+
+    await executePack({ dist: './dist', name: 'test-app', dryRun: true, logger: mockLogger });
+
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('Package Preview')
+    );
+  });
+
+  it('should throw when package name is required but not provided (non-TTY)', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    vi.mocked(fs.readdirSync).mockReturnValue(['index.html'] as any);
+    vi.mocked(inquirer.prompt).mockResolvedValue({ name: '' });
+
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+
+    try {
+      await expect(
+        executePack({ dist: './dist', logger: mockLogger })
+      ).rejects.toThrow(/Package name is required/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, writable: true });
+    }
+  });
+});

--- a/packages/cli/tests/unit/actions/publish.test.ts
+++ b/packages/cli/tests/unit/actions/publish.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(),
+    createReadStream: vi.fn(),
+  };
+});
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+vi.mock('form-data', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    append: vi.fn(),
+    getHeaders: vi.fn().mockReturnValue({}),
+  })),
+}));
+vi.mock('../../../src/utils/env-config.js', () => ({
+  getEnvironmentConfig: vi.fn(),
+  atomicWriteFileSync: vi.fn(),
+}));
+
+import { createMockLogger, createMockEnvConfig, createMockFetchResponse } from '../../helpers/index.js';
+import { executePublish } from '../../../src/actions/publish.js';
+import { getEnvironmentConfig } from '../../../src/utils/env-config.js';
+import fetch from 'node-fetch';
+
+describe('executePublish', () => {
+  const mockLogger = createMockLogger();
+  const mockEnvConfig = createMockEnvConfig();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
+  });
+
+  it('should throw when env config is missing', async () => {
+    vi.mocked(getEnvironmentConfig).mockReturnValue(null);
+
+    await expect(
+      executePublish({ logger: mockLogger })
+    ).rejects.toThrow('Missing required configuration');
+  });
+
+  it('should throw when .uipath dir not found', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await expect(
+      executePublish({ logger: mockLogger })
+    ).rejects.toThrow(/\.uipath directory not found/);
+  });
+
+  it('should throw when no nupkg files found', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+
+    await expect(
+      executePublish({ logger: mockLogger })
+    ).rejects.toThrow(/No .nupkg files found/);
+  });
+
+  it('should publish single package automatically', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue(['MyApp.1.0.0.nupkg'] as any);
+    vi.mocked(fs.createReadStream).mockReturnValue('stream' as any);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(createMockFetchResponse() as any)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { definition: { systemName: 'my-app-system' }, deployVersion: 1 },
+      }) as any);
+
+    await executePublish({ logger: mockLogger });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should select matching package by name', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue(['AppA.1.0.0.nupkg', 'AppB.2.0.0.nupkg'] as any);
+    vi.mocked(fs.createReadStream).mockReturnValue('stream' as any);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(createMockFetchResponse() as any)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { definition: { systemName: 'app-b' } },
+      }) as any);
+
+    await executePublish({ name: 'AppB', logger: mockLogger });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw when named package not found', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue(['AppA.1.0.0.nupkg'] as any);
+
+    await expect(
+      executePublish({ name: 'NonExistent', logger: mockLogger })
+    ).rejects.toThrow(/No package found matching name/);
+  });
+
+  it('should handle 409 conflict (package already exists)', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue(['MyApp.1.0.0.nupkg'] as any);
+    vi.mocked(fs.createReadStream).mockReturnValue('stream' as any);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        ok: false, status: 409, json: { errorCode: 1004, message: 'already exists' },
+      }) as any)
+      .mockResolvedValueOnce(createMockFetchResponse({
+        json: { definition: { systemName: 'my-app' } },
+      }) as any);
+
+    await executePublish({ logger: mockLogger });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cli/tests/unit/actions/pull.test.ts
+++ b/packages/cli/tests/unit/actions/pull.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../src/utils/env-config.js', () => ({
+  getEnvironmentConfig: vi.fn(),
+}));
+
+vi.mock('../../../src/core/webapp-file-handler/index.js', () => ({
+  runPull: vi.fn().mockResolvedValue(undefined),
+  isProjectRootDirectory: vi.fn().mockReturnValue(true),
+}));
+
+import { createMockLogger, createMockEnvConfig } from '../../helpers/index.js';
+import { executePull } from '../../../src/actions/pull.js';
+import { getEnvironmentConfig } from '../../../src/utils/env-config.js';
+import { runPull } from '../../../src/core/webapp-file-handler/index.js';
+
+describe('executePull', () => {
+  const mockLogger = createMockLogger();
+  const mockEnvConfig = createMockEnvConfig();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
+  });
+
+  afterEach(() => {
+    delete process.env.UIPATH_PROJECT_ID;
+  });
+
+  it('should pull successfully with project ID from options', async () => {
+    await executePull({ projectId: 'proj-123', logger: mockLogger });
+
+    expect(runPull).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'proj-123' }),
+      expect.any(Object)
+    );
+  });
+
+  it('should use project ID from env', async () => {
+    process.env.UIPATH_PROJECT_ID = 'env-proj';
+
+    await executePull({ logger: mockLogger });
+
+    expect(runPull).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'env-proj' }),
+      expect.any(Object)
+    );
+  });
+
+  it('should throw when no project ID available', async () => {
+    await expect(
+      executePull({ logger: mockLogger })
+    ).rejects.toThrow(/Project ID is required/);
+  });
+
+  it('should throw when env config is missing', async () => {
+    vi.mocked(getEnvironmentConfig).mockReturnValue(null);
+
+    await expect(
+      executePull({ projectId: 'proj', logger: mockLogger })
+    ).rejects.toThrow('Missing required configuration');
+  });
+
+  it('should pass overwrite option', async () => {
+    await executePull({ projectId: 'proj', overwrite: true, logger: mockLogger });
+
+    expect(runPull).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ overwrite: true })
+    );
+  });
+
+  it('should pass flag overrides to getEnvironmentConfig', async () => {
+    const overrides = {
+      baseUrl: 'https://staging.uipath.com',
+      orgId: 'custom-org',
+      tenantId: 'custom-tenant',
+      accessToken: 'custom-token',
+    };
+
+    await executePull({ projectId: 'proj', ...overrides, logger: mockLogger });
+
+    expect(getEnvironmentConfig).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Object),
+      expect.objectContaining(overrides)
+    );
+  });
+
+  it('should use target dir when specified', async () => {
+    await executePull({ projectId: 'proj', targetDir: './output', logger: mockLogger });
+
+    expect(runPull).toHaveBeenCalledWith(
+      expect.objectContaining({ rootDir: expect.stringContaining('output') }),
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/cli/tests/unit/actions/push.test.ts
+++ b/packages/cli/tests/unit/actions/push.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../src/utils/env-config.js', () => ({
+  getEnvironmentConfig: vi.fn(),
+}));
+
+vi.mock('../../../src/core/webapp-file-handler/index.js', () => ({
+  WebAppFileHandler: vi.fn().mockImplementation(() => ({
+    push: vi.fn().mockResolvedValue(undefined),
+    importReferencedResources: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('../../../src/core/preconditions.js', () => ({
+  Preconditions: { validate: vi.fn() },
+}));
+
+import { createMockLogger, createMockEnvConfig } from '../../helpers/index.js';
+import { executePush } from '../../../src/actions/push.js';
+import { getEnvironmentConfig } from '../../../src/utils/env-config.js';
+import { WebAppFileHandler } from '../../../src/core/webapp-file-handler/index.js';
+import { Preconditions } from '../../../src/core/preconditions.js';
+
+describe('executePush', () => {
+  const mockLogger = createMockLogger();
+  const mockEnvConfig = createMockEnvConfig();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
+    vi.mocked(Preconditions.validate).mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete process.env.UIPATH_PROJECT_ID;
+  });
+
+  it('should push successfully with project ID from options', async () => {
+    await executePush({ projectId: 'proj-123', logger: mockLogger });
+
+    expect(Preconditions.validate).toHaveBeenCalled();
+    expect(WebAppFileHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'proj-123' })
+    );
+  });
+
+  it('should use project ID from env when not in options', async () => {
+    process.env.UIPATH_PROJECT_ID = 'env-proj-456';
+
+    await executePush({ logger: mockLogger });
+
+    expect(WebAppFileHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'env-proj-456' })
+    );
+  });
+
+  it('should throw when env config is missing', async () => {
+    vi.mocked(getEnvironmentConfig).mockReturnValue(null);
+
+    await expect(
+      executePush({ projectId: 'proj', logger: mockLogger })
+    ).rejects.toThrow('Missing required configuration');
+  });
+
+  it('should throw when no project ID and non-TTY', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+
+    await expect(
+      executePush({ logger: mockLogger })
+    ).rejects.toThrow(/Project ID is required/);
+
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, writable: true });
+  });
+
+  it('should throw when Preconditions.validate fails', async () => {
+    vi.mocked(Preconditions.validate).mockImplementation(() => {
+      throw new Error('Build directory not found');
+    });
+
+    await expect(
+      executePush({ projectId: 'proj', logger: mockLogger })
+    ).rejects.toThrow('Build directory not found');
+  });
+
+  it('should use custom buildDir when provided', async () => {
+    await executePush({ projectId: 'proj-123', buildDir: 'build', logger: mockLogger });
+
+    expect(WebAppFileHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ bundlePath: 'build' })
+    );
+  });
+
+  it('should pass ignoreResources to handler', async () => {
+    const handler = {
+      push: vi.fn().mockResolvedValue(undefined),
+      importReferencedResources: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(WebAppFileHandler).mockImplementation(() => handler as any);
+
+    await executePush({ projectId: 'proj', ignoreResources: true, logger: mockLogger });
+
+    expect(handler.importReferencedResources).toHaveBeenCalledWith(true);
+  });
+
+  it('should pass flag overrides to getEnvironmentConfig', async () => {
+    const overrides = {
+      baseUrl: 'https://custom.uipath.com',
+      orgId: 'custom-org',
+      tenantId: 'custom-tenant',
+      accessToken: 'custom-token',
+    };
+
+    await executePush({ projectId: 'proj', ...overrides, logger: mockLogger });
+
+    expect(getEnvironmentConfig).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Object),
+      expect.objectContaining(overrides)
+    );
+  });
+});

--- a/packages/cli/tests/unit/actions/push.test.ts
+++ b/packages/cli/tests/unit/actions/push.test.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+  };
+});
 
 vi.mock('../../../src/utils/env-config.js', () => ({
   getEnvironmentConfig: vi.fn(),
@@ -11,8 +20,25 @@ vi.mock('../../../src/core/webapp-file-handler/index.js', () => ({
   })),
 }));
 
+vi.mock('../../../src/core/webapp-file-handler/api.js', () => ({
+  fetchRemoteStructure: vi.fn().mockResolvedValue({ files: [], folders: [] }),
+  downloadRemoteFile: vi.fn(),
+}));
+
+vi.mock('../../../src/core/webapp-file-handler/structure.js', async () => {
+  const actual = await vi.importActual('../../../src/core/webapp-file-handler/structure.js');
+  return {
+    ...actual,
+    getRemoteFilesMap: vi.fn().mockReturnValue(new Map()),
+  };
+});
+
 vi.mock('../../../src/core/preconditions.js', () => ({
   Preconditions: { validate: vi.fn() },
+}));
+
+vi.mock('../../../src/utils/push-validation.js', () => ({
+  validatePushFiles: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { createMockLogger, createMockEnvConfig } from '../../helpers/index.js';
@@ -20,6 +46,8 @@ import { executePush } from '../../../src/actions/push.js';
 import { getEnvironmentConfig } from '../../../src/utils/env-config.js';
 import { WebAppFileHandler } from '../../../src/core/webapp-file-handler/index.js';
 import { Preconditions } from '../../../src/core/preconditions.js';
+import * as api from '../../../src/core/webapp-file-handler/api.js';
+import { getRemoteFilesMap } from '../../../src/core/webapp-file-handler/structure.js';
 
 describe('executePush', () => {
   const mockLogger = createMockLogger();
@@ -29,6 +57,9 @@ describe('executePush', () => {
     vi.clearAllMocks();
     vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
     vi.mocked(Preconditions.validate).mockImplementation(() => {});
+    vi.mocked(api.fetchRemoteStructure).mockResolvedValue({ files: [], folders: [] } as any);
+    vi.mocked(getRemoteFilesMap).mockReturnValue(new Map());
+    vi.mocked(fs.existsSync).mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -118,5 +149,55 @@ describe('executePush', () => {
       expect.any(Object),
       expect.objectContaining(overrides)
     );
+  });
+
+  describe('action app detection from remote webAppManifest.json', () => {
+    const manifestFileEntry = { id: 'manifest-file-id', name: 'webAppManifest.json' };
+
+    it('should throw when remote manifest is CodedAction but action-schema.json is missing locally', async () => {
+      const remoteFilesMap = new Map([['webAppManifest.json', manifestFileEntry]]);
+      vi.mocked(getRemoteFilesMap).mockReturnValue(remoteFilesMap as any);
+      vi.mocked(api.downloadRemoteFile).mockResolvedValue(
+        Buffer.from(JSON.stringify({ type: 'Coded', solutionResourceSubType: 'CodedAction' }))
+      );
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      await expect(
+        executePush({ projectId: 'proj', logger: mockLogger })
+      ).rejects.toThrow(/action-schema/i);
+    });
+
+    it('should succeed when remote manifest is CodedAction and action-schema.json exists', async () => {
+      const remoteFilesMap = new Map([['webAppManifest.json', manifestFileEntry]]);
+      vi.mocked(getRemoteFilesMap).mockReturnValue(remoteFilesMap as any);
+      vi.mocked(api.downloadRemoteFile).mockResolvedValue(
+        Buffer.from(JSON.stringify({ type: 'Coded', solutionResourceSubType: 'CodedAction' }))
+      );
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      await executePush({ projectId: 'proj', logger: mockLogger });
+
+      expect(WebAppFileHandler).toHaveBeenCalled();
+    });
+
+    it('should not require action-schema.json when remote manifest is Coded', async () => {
+      const remoteFilesMap = new Map([['webAppManifest.json', manifestFileEntry]]);
+      vi.mocked(getRemoteFilesMap).mockReturnValue(remoteFilesMap as any);
+      vi.mocked(api.downloadRemoteFile).mockResolvedValue(
+        Buffer.from(JSON.stringify({ type: 'Coded', solutionResourceSubType: 'Coded' }))
+      );
+
+      await executePush({ projectId: 'proj', logger: mockLogger });
+
+      expect(WebAppFileHandler).toHaveBeenCalled();
+    });
+
+    it('should not require action-schema.json when no remote manifest exists', async () => {
+      vi.mocked(getRemoteFilesMap).mockReturnValue(new Map());
+
+      await executePush({ projectId: 'proj', logger: mockLogger });
+
+      expect(WebAppFileHandler).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/tests/unit/core/preconditions.test.ts
+++ b/packages/cli/tests/unit/core/preconditions.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import { Preconditions } from '../../../src/core/preconditions.js';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    statSync: vi.fn(),
+  };
+});
+
+describe('Preconditions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('validate', () => {
+    it('should pass when build dir exists and is a directory', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+      expect(() => Preconditions.validate('/project', 'dist')).not.toThrow();
+    });
+
+    it('should throw when build dir does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      expect(() => Preconditions.validate('/project', 'dist')).toThrow(
+        /Build directory not found/
+      );
+    });
+
+    it('should throw when path is not a directory', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false } as fs.Stats);
+
+      expect(() => Preconditions.validate('/project', 'dist')).toThrow(
+        /not a directory/
+      );
+    });
+
+    it('should use default bundlePath of dist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+      Preconditions.validate('/project');
+      expect(fs.existsSync).toHaveBeenCalledWith(expect.stringContaining('dist'));
+    });
+
+    it('should include remediation steps in error message', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      expect(() => Preconditions.validate('/project', 'dist')).toThrow(/Steps:/);
+      expect(() => Preconditions.validate('/project', 'dist')).toThrow(/npm run build/);
+    });
+  });
+});

--- a/packages/cli/tests/unit/utils/api.test.ts
+++ b/packages/cli/tests/unit/utils/api.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { createHeaders, buildAppUrl } from '../../../src/utils/api.js';
+
+describe('api utils', () => {
+  describe('createHeaders', () => {
+    it('should include Content-Type by default', () => {
+      const headers = createHeaders();
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should use custom content type', () => {
+      const headers = createHeaders({ contentType: 'text/plain' });
+      expect(headers['Content-Type']).toBe('text/plain');
+    });
+
+    it('should add Authorization header when bearerToken provided', () => {
+      const headers = createHeaders({ bearerToken: 'my-token' });
+      expect(headers['Authorization']).toBe('Bearer my-token');
+    });
+
+    it('should not add Authorization when no token', () => {
+      expect(createHeaders()['Authorization']).toBeUndefined();
+    });
+
+    it('should add tenant ID header', () => {
+      const headers = createHeaders({ tenantId: 'tenant-123' });
+      expect(headers['x-uipath-internal-tenantid']).toBe('tenant-123');
+    });
+
+    it('should add folder key header', () => {
+      const headers = createHeaders({ folderKey: 'folder-abc' });
+      expect(headers['x-uipath-folderkey']).toBe('folder-abc');
+    });
+
+    it('should merge additional headers', () => {
+      const headers = createHeaders({ additionalHeaders: { 'X-Custom': 'value' } });
+      expect(headers['X-Custom']).toBe('value');
+    });
+
+    it('should include all options together', () => {
+      const headers = createHeaders({
+        bearerToken: 'token',
+        tenantId: 'tenant',
+        folderKey: 'folder',
+        additionalHeaders: { Accept: 'application/json' },
+      });
+      expect(headers['Authorization']).toBe('Bearer token');
+      expect(headers['x-uipath-internal-tenantid']).toBe('tenant');
+      expect(headers['x-uipath-folderkey']).toBe('folder');
+      expect(headers['Accept']).toBe('application/json');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+  });
+
+  describe('buildAppUrl', () => {
+    it.each([
+      ['https://cloud.uipath.com', 'cloud'],
+      ['https://staging.uipath.com', 'staging'],
+      ['https://alpha.uipath.com', 'alpha'],
+      ['https://cloud.uipath.com/', 'cloud'],
+      ['https://custom.example.com', 'cloud'],
+    ])('should build URL for %s', (baseUrl, expectedEnv) => {
+      const url = buildAppUrl(baseUrl, 'my-org', 'my-app');
+      expect(url).toBe(`https://my-org.${expectedEnv}.uipath.host/my-app`);
+    });
+  });
+});

--- a/packages/cli/tests/unit/utils/env-config.test.ts
+++ b/packages/cli/tests/unit/utils/env-config.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getEnvironmentConfig, sanitizeAppName, validateEnvironment, isValidAppName, atomicWriteFileSync } from '../../../src/utils/env-config.js';
+import { createMockLogger, REQUIRED_ENV_VARS } from '../../helpers/index.js';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
+});
+
+describe('env-config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe('sanitizeAppName', () => {
+    it.each([
+      ['my-app', 'my-app', false, 'already valid'],
+      ['MyApp', 'myapp', true, 'uppercase'],
+      ['my_app', 'my-app', true, 'underscores'],
+      ['my@app!name', 'myappname', true, 'invalid characters'],
+      ['my---app', 'my-app', true, 'multiple hyphens'],
+      ['-my-app-', 'my-app', true, 'leading/trailing hyphens'],
+      ['', '', false, 'empty string'],
+      ['@#$%', '', true, 'only invalid chars'],
+    ])('should handle %s (%s)', (input, expected, modified) => {
+      const result = sanitizeAppName(input);
+      expect(result.sanitized).toBe(expected);
+      expect(result.isModifiedd).toBe(modified);
+    });
+  });
+
+  describe('isValidAppName', () => {
+    it.each([
+      ['my-app', true],
+      ['app123', true],
+      ['a', true],
+      ['MyApp', false],
+      ['my@app', false],
+      ['my app', false],
+    ])('should return %s for "%s"', (name, expected) => {
+      expect(isValidAppName(name)).toBe(expected);
+    });
+  });
+
+  describe('getEnvironmentConfig', () => {
+    const mockLogger = createMockLogger();
+
+    it('should return config when all required vars are present via flags', () => {
+      const flags = {
+        baseUrl: 'https://cloud.uipath.com',
+        orgId: 'org-123',
+        tenantId: 'tenant-456',
+        accessToken: 'token-789',
+      };
+
+      const result = getEnvironmentConfig([...REQUIRED_ENV_VARS], mockLogger, flags);
+
+      expect(result).not.toBeNull();
+      expect(result!.baseUrl).toBe(flags.baseUrl);
+      expect(result!.orgId).toBe(flags.orgId);
+      expect(result!.tenantId).toBe(flags.tenantId);
+      expect(result!.accessToken).toBe(flags.accessToken);
+    });
+
+    it('should return config from environment variables', () => {
+      process.env.UIPATH_BASE_URL = 'https://staging.uipath.com';
+      process.env.UIPATH_ORG_ID = 'env-org';
+      process.env.UIPATH_TENANT_ID = 'env-tenant';
+      process.env.UIPATH_ACCESS_TOKEN = 'env-token';
+
+      const result = getEnvironmentConfig([...REQUIRED_ENV_VARS], mockLogger, {});
+
+      expect(result).not.toBeNull();
+      expect(result!.orgId).toBe('env-org');
+    });
+
+    it('should prefer flags over env vars', () => {
+      process.env.UIPATH_ORG_ID = 'env-org';
+
+      const result = getEnvironmentConfig([...REQUIRED_ENV_VARS], mockLogger, {
+        baseUrl: 'https://cloud.uipath.com',
+        orgId: 'flag-org',
+        tenantId: 'tenant',
+        accessToken: 'token',
+      });
+
+      expect(result!.orgId).toBe('flag-org');
+    });
+
+    it('should return null when required vars are missing', () => {
+      const result = getEnvironmentConfig([...REQUIRED_ENV_VARS], mockLogger, {});
+      expect(result).toBeNull();
+    });
+
+    it('should use default base URL when not provided', () => {
+      const result = getEnvironmentConfig([...REQUIRED_ENV_VARS], mockLogger, {
+        orgId: 'org-123',
+        tenantId: 'tenant-456',
+        accessToken: 'token-789',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.baseUrl).toBe('https://cloud.uipath.com');
+    });
+
+    it('should add https protocol when missing', () => {
+      const result = getEnvironmentConfig([...REQUIRED_ENV_VARS], mockLogger, {
+        baseUrl: 'cloud.uipath.com',
+        orgId: 'org',
+        tenantId: 'tenant',
+        accessToken: 'token',
+      });
+
+      expect(result!.baseUrl).toBe('https://cloud.uipath.com');
+    });
+
+    it('should resolve alt env var names (UIPATH_URL for UIPATH_BASE_URL)', () => {
+      process.env.UIPATH_URL = 'https://alt.uipath.com';
+      process.env.UIPATH_ORG_ID = 'org';
+      process.env.UIPATH_TENANT_ID = 'tenant';
+      process.env.UIPATH_ACCESS_TOKEN = 'token';
+
+      const result = getEnvironmentConfig([...REQUIRED_ENV_VARS], mockLogger, {});
+
+      expect(result).not.toBeNull();
+      expect(result!.baseUrl).toBe('https://alt.uipath.com');
+    });
+  });
+
+  describe('validateEnvironment', () => {
+    const mockLogger = createMockLogger();
+
+    it('should return isValid true when all vars present', () => {
+      const result = validateEnvironment([...REQUIRED_ENV_VARS], mockLogger, {
+        baseUrl: 'https://cloud.uipath.com',
+        orgId: 'org',
+        tenantId: 'tenant',
+        accessToken: 'token',
+      });
+
+      expect(result.isValid).toBe(true);
+      expect(result.config).toBeDefined();
+    });
+
+    it('should return isValid false with missing vars list', () => {
+      const result = validateEnvironment([...REQUIRED_ENV_VARS], mockLogger, {});
+
+      expect(result.isValid).toBe(false);
+      expect(result.missingVars!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('atomicWriteFileSync', () => {
+    it('should write string content to temp file then rename', () => {
+      atomicWriteFileSync('./test-output/test.json', 'hello');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('.tmp'), 'hello');
+      expect(fs.renameSync).toHaveBeenCalled();
+    });
+
+    it('should stringify object content', () => {
+      atomicWriteFileSync('./test-output/test.json', { key: 'value' });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('.tmp'),
+        JSON.stringify({ key: 'value' }, null, 2)
+      );
+    });
+  });
+});

--- a/packages/cli/tests/unit/utils/error-handler.test.ts
+++ b/packages/cli/tests/unit/utils/error-handler.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createHttpErrorMessage, handleHttpError } from '../../../src/utils/error-handler.js';
+
+function makeMockResponse(status: number, text: string = ''): any {
+  return {
+    status,
+    text: vi.fn().mockResolvedValue(text),
+  };
+}
+
+describe('error-handler', () => {
+  describe('createHttpErrorMessage', () => {
+    it('should include user-friendly message for 401', async () => {
+      const msg = await createHttpErrorMessage(makeMockResponse(401));
+      expect(msg).toContain('Authentication failed');
+    });
+
+    it('should include context for 403', async () => {
+      const msg = await createHttpErrorMessage(makeMockResponse(403), 'app deployment');
+      expect(msg).toContain('app deployment');
+    });
+
+    it('should include API response text when present', async () => {
+      const msg = await createHttpErrorMessage(makeMockResponse(500, 'Internal Server Error'));
+      expect(msg).toContain('Internal Server Error');
+    });
+
+    it('should show no details message for empty response', async () => {
+      const msg = await createHttpErrorMessage(makeMockResponse(500, ''));
+      expect(msg).toContain('No additional error details');
+    });
+
+    it('should handle 404', async () => {
+      const msg = await createHttpErrorMessage(makeMockResponse(404));
+      expect(msg).toContain('not found');
+    });
+
+    it('should handle 429 rate limit', async () => {
+      const msg = await createHttpErrorMessage(makeMockResponse(429));
+      expect(msg).toContain('Rate limit');
+    });
+
+    it('should handle 502/503/504 service unavailable', async () => {
+      for (const status of [502, 503, 504]) {
+        const msg = await createHttpErrorMessage(makeMockResponse(status));
+        expect(msg).toContain('unavailable');
+      }
+    });
+
+    it('should handle unknown status codes', async () => {
+      const msg = await createHttpErrorMessage(makeMockResponse(418));
+      expect(msg).toContain('418');
+    });
+  });
+
+  describe('handleHttpError', () => {
+    it('should throw an error with the message', async () => {
+      await expect(
+        handleHttpError(makeMockResponse(401))
+      ).rejects.toThrow('Authentication failed');
+    });
+  });
+});

--- a/packages/cli/tests/unit/utils/push-validation.test.ts
+++ b/packages/cli/tests/unit/utils/push-validation.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import inquirer from 'inquirer';
+
+vi.mock('../../../src/core/webapp-file-handler/local-files.js', () => ({
+  collectLocalFiles: vi.fn().mockReturnValue([]),
+  collectSourceFiles: vi.fn().mockReturnValue([]),
+}));
+
+import { validatePushFiles } from '../../../src/utils/push-validation.js';
+import { collectLocalFiles, collectSourceFiles } from '../../../src/core/webapp-file-handler/local-files.js';
+import { createMockLogger } from '../../helpers/index.js';
+
+function makeFile(filePath: string, sizeBytes: number) {
+  return {
+    path: filePath,
+    absPath: `/project/${filePath}`,
+    hash: 'abc123',
+    content: Buffer.alloc(sizeBytes),
+  };
+}
+
+describe('validatePushFiles', () => {
+  const mockLogger = createMockLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(collectLocalFiles).mockReturnValue([]);
+    vi.mocked(collectSourceFiles).mockReturnValue([]);
+  });
+
+  it('should pass when all files have allowed extensions and are small', async () => {
+    vi.mocked(collectLocalFiles).mockReturnValue([
+      makeFile('dist/index.html', 100),
+      makeFile('dist/app.js', 500),
+      makeFile('dist/style.css', 200),
+    ]);
+
+    await expect(validatePushFiles('/project', 'dist', mockLogger)).resolves.toBeUndefined();
+  });
+
+  it('should pass with no files', async () => {
+    await expect(validatePushFiles('/project', 'dist', mockLogger)).resolves.toBeUndefined();
+  });
+
+  it('should allow files without extensions', async () => {
+    vi.mocked(collectSourceFiles).mockReturnValue([
+      makeFile('LICENSE', 100),
+      makeFile('Makefile', 50),
+    ]);
+
+    await expect(validatePushFiles('/project', 'dist', mockLogger)).resolves.toBeUndefined();
+  });
+
+  describe('extension validation', () => {
+    it('should block disallowed extensions', async () => {
+      vi.mocked(collectLocalFiles).mockReturnValue([
+        makeFile('dist/index.html', 100),
+        makeFile('dist/video.mp4', 1000),
+      ]);
+
+      await expect(
+        validatePushFiles('/project', 'dist', mockLogger)
+      ).rejects.toThrow(/disallowed extensions/);
+    });
+
+    it('should block executable files', async () => {
+      vi.mocked(collectSourceFiles).mockReturnValue([
+        makeFile('tools/helper.exe', 500),
+      ]);
+
+      await expect(
+        validatePushFiles('/project', 'dist', mockLogger)
+      ).rejects.toThrow(/disallowed extensions/);
+    });
+
+    it('should block archive files', async () => {
+      vi.mocked(collectSourceFiles).mockReturnValue([
+        makeFile('assets/bundle.zip', 500),
+      ]);
+
+      await expect(
+        validatePushFiles('/project', 'dist', mockLogger)
+      ).rejects.toThrow(/disallowed extensions/);
+    });
+
+    it('should check both build and source files', async () => {
+      vi.mocked(collectLocalFiles).mockReturnValue([
+        makeFile('dist/index.html', 100),
+      ]);
+      vi.mocked(collectSourceFiles).mockReturnValue([
+        makeFile('src/data.dll', 100),
+      ]);
+
+      await expect(
+        validatePushFiles('/project', 'dist', mockLogger)
+      ).rejects.toThrow(/disallowed extensions/);
+    });
+  });
+
+  describe('file size validation', () => {
+    const SIZE_3MB = 3 * 1024 * 1024;
+    const SIZE_11MB = 11 * 1024 * 1024;
+
+    it('should hard block files over 10 MB', async () => {
+      vi.mocked(collectLocalFiles).mockReturnValue([
+        makeFile('dist/huge-image.png', SIZE_11MB),
+      ]);
+
+      await expect(
+        validatePushFiles('/project', 'dist', mockLogger)
+      ).rejects.toThrow(/10 MB size limit/);
+    });
+
+    it('should prompt for files between 2-10 MB and proceed if accepted', async () => {
+      vi.mocked(collectLocalFiles).mockReturnValue([
+        makeFile('dist/large-font.woff2', SIZE_3MB),
+      ]);
+
+      const originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true });
+
+      vi.mocked(inquirer.prompt).mockResolvedValue({ proceed: true });
+
+      try {
+        await expect(validatePushFiles('/project', 'dist', mockLogger)).resolves.toBeUndefined();
+        expect(inquirer.prompt).toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, writable: true });
+      }
+    });
+
+    it('should prompt for files between 2-10 MB and block if declined', async () => {
+      vi.mocked(collectLocalFiles).mockReturnValue([
+        makeFile('dist/large-font.woff2', SIZE_3MB),
+      ]);
+
+      const originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true });
+
+      vi.mocked(inquirer.prompt).mockResolvedValue({ proceed: false });
+
+      try {
+        await expect(
+          validatePushFiles('/project', 'dist', mockLogger)
+        ).rejects.toThrow(/cancelled/i);
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, writable: true });
+      }
+    });
+
+    it('should hard block large files in non-TTY mode', async () => {
+      vi.mocked(collectLocalFiles).mockReturnValue([
+        makeFile('dist/large-font.woff2', SIZE_3MB),
+      ]);
+
+      const originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+
+      try {
+        await expect(
+          validatePushFiles('/project', 'dist', mockLogger)
+        ).rejects.toThrow(/cancelled/i);
+        expect(inquirer.prompt).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, writable: true });
+      }
+    });
+
+    it('should check extension before size (extension error takes precedence)', async () => {
+      vi.mocked(collectLocalFiles).mockReturnValue([
+        makeFile('dist/video.mp4', SIZE_11MB),
+      ]);
+
+      await expect(
+        validatePushFiles('/project', 'dist', mockLogger)
+      ).rejects.toThrow(/disallowed extensions/);
+    });
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['tests/setup.ts'],
+    include: ['tests/unit/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'tests/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*',
+      ],
+    },
+  },
+});


### PR DESCRIPTION
- Detect action app by reading remote webAppManifest.json
- Add Coded/CodedAction type selection for new project creation
- Add push file validation: extension whitelist + size limits
- Update createCodedAppProject to support action app type
- Change manifest type from App_ProCode to Coded
- Add codedapp-tool test step to CI workflows