### PR TITLE
feat(data-fabric): add query method with joins, aggregates, and filters

### DIFF
--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -465,6 +465,13 @@ export interface EntityServiceModel {
   deleteAttachment(entityId: string, recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse>;
 
   /**
+   *
+   * @experimental
+   *
+   * /// warning
+    Preview: This method is experimental and may change or be removed in future releases.
+    ///
+   *
    * Queries an entity by name with support for joins, aggregates, filters, grouping, and sorting
    *
    * @param entityName - Name of the entity to query
@@ -626,6 +633,13 @@ export interface EntityMethods {
   deleteAttachment(recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse>;
 
   /**
+   *
+   * @experimental
+   *
+   * /// warning
+    Preview: This method is experimental and may change or be removed in future releases.
+    ///
+   *
    * Queries this entity with support for joins, aggregates, filters, grouping, and sorting
    *
    * @param options - Query options

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -21,7 +21,9 @@ import {
   EntityUpdateRecordsOptions,
   EntityDeleteRecordsOptions,
   EntityGetAllRecordsOptions,
-  EntityInsertRecordOptions
+  EntityInsertRecordOptions,
+  EntityQueryOptions,
+  EntityQueryResponse
 } from './entities.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination/types';
 
@@ -461,6 +463,53 @@ export interface EntityServiceModel {
    * ```
    */
   deleteAttachment(entityId: string, recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse>;
+
+  /**
+   * Queries an entity by name with support for joins, aggregates, filters, grouping, and sorting
+   *
+   * @param entityName - Name of the entity to query
+   * @param options - Query options including selectedFields, aggregates, joins, filterGroup, groupBy, sortOptions, start, limit
+   * @returns Promise resolving to query response with matching records
+   * {@link EntityQueryResponse}
+   * @example
+   * ```typescript
+   * import { Entities } from '@uipath/uipath-typescript/entities';
+   *
+   * const entities = new Entities(sdk);
+   *
+   * // Simple query with filters
+   * const result = await entities.query('Customer', {
+   *   selectedFields: ['name', 'email'],
+   *   filterGroup: {
+   *     logicalOperator: 0,
+   *     queryFilters: [{ fieldName: 'status', operator: '=', value: 'active' }]
+   *   },
+   *   limit: 50
+   * });
+   *
+   * // Cross-entity join query
+   * const joinResult = await entities.query('Orders', {
+   *   selectedFields: ['Orders.orderId', 'Customer.name'],
+   *   joins: [{
+   *     type: 'INNER',
+   *     entity: 'Customer',
+   *     on: { left: 'customerId', right: 'Id' }
+   *   }],
+   *   sortOptions: [{ fieldName: 'Orders.createdDate', isDescending: true }],
+   *   limit: 100
+   * });
+   *
+   * // Aggregate query
+   * const stats = await entities.query('Orders', {
+   *   aggregates: [
+   *     { function: 'COUNT', field: 'Id', alias: 'totalOrders' },
+   *     { function: 'SUM', field: 'amount', alias: 'totalAmount' }
+   *   ],
+   *   groupBy: ['status']
+   * });
+   * ```
+   */
+  query(entityName: string, options?: EntityQueryOptions): Promise<EntityQueryResponse>;
 }
 
 /**
@@ -577,6 +626,14 @@ export interface EntityMethods {
   deleteAttachment(recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse>;
 
   /**
+   * Queries this entity with support for joins, aggregates, filters, grouping, and sorting
+   *
+   * @param options - Query options
+   * @returns Promise resolving to query response with matching records
+   */
+  query(options?: EntityQueryOptions): Promise<EntityQueryResponse>;
+
+  /**
    * @deprecated Use {@link insertRecord} instead.
    * @hidden
    */
@@ -689,6 +746,12 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
       if (!entityData.id) throw new Error('Entity ID is undefined');
 
       return service.deleteAttachment(entityData.id, recordId, fieldName);
+    },
+
+    async query(options?: EntityQueryOptions): Promise<EntityQueryResponse> {
+      if (!entityData.name) throw new Error('Entity name is undefined');
+
+      return service.query(entityData.name, options);
     },
 
     async insert(data: Record<string, any>, options?: EntityInsertOptions): Promise<EntityInsertResponse> {

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -472,9 +472,9 @@ export interface EntityServiceModel {
     Preview: This method is experimental and may change or be removed in future releases.
     ///
    *
-   * Queries an entity by name with support for joins, aggregates, filters, grouping, and sorting
+   * Queries an entity by ID with support for joins, aggregates, filters, grouping, and sorting
    *
-   * @param entityName - Name of the entity to query
+   * @param entityId - UUID of the entity to query
    * @param options - Query options including selectedFields, aggregates, joins, filterGroup, groupBy, sortOptions, start, limit
    * @returns Promise resolving to query response with matching records
    * {@link EntityQueryResponse}
@@ -485,7 +485,7 @@ export interface EntityServiceModel {
    * const entities = new Entities(sdk);
    *
    * // Simple query with filters
-   * const result = await entities.query('Customer', {
+   * const result = await entities.query('<entityId>', {
    *   selectedFields: ['name', 'email'],
    *   filterGroup: {
    *     logicalOperator: 0,
@@ -495,7 +495,7 @@ export interface EntityServiceModel {
    * });
    *
    * // Cross-entity join query
-   * const joinResult = await entities.query('Orders', {
+   * const joinResult = await entities.query('<entityId>', {
    *   selectedFields: ['Orders.orderId', 'Customer.name'],
    *   joins: [{
    *     type: 'INNER',
@@ -507,7 +507,7 @@ export interface EntityServiceModel {
    * });
    *
    * // Aggregate query
-   * const stats = await entities.query('Orders', {
+   * const stats = await entities.query('<entityId>', {
    *   aggregates: [
    *     { function: 'COUNT', field: 'Id', alias: 'totalOrders' },
    *     { function: 'SUM', field: 'amount', alias: 'totalAmount' }
@@ -516,7 +516,7 @@ export interface EntityServiceModel {
    * });
    * ```
    */
-  query(entityName: string, options?: EntityQueryOptions): Promise<EntityQueryResponse>;
+  query(entityId: string, options?: EntityQueryOptions): Promise<EntityQueryResponse>;
 }
 
 /**
@@ -763,9 +763,9 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
     },
 
     async query(options?: EntityQueryOptions): Promise<EntityQueryResponse> {
-      if (!entityData.name) throw new Error('Entity name is undefined');
+      if (!entityData.id) throw new Error('Entity ID is undefined');
 
-      return service.query(entityData.name, options);
+      return service.query(entityData.id, options);
     },
 
     async insert(data: Record<string, any>, options?: EntityInsertOptions): Promise<EntityInsertResponse> {

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -192,6 +192,13 @@ export interface EntityUpdateResponse extends EntityOperationResponse {}
 export interface EntityDeleteResponse extends EntityOperationResponse {}
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * Aggregate function types for query operations
  */
 export enum QueryAggregateFunction {
@@ -203,6 +210,13 @@ export enum QueryAggregateFunction {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * Join types for cross-entity query operations
  */
 export enum QueryJoinType {
@@ -213,6 +227,13 @@ export enum QueryJoinType {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * Logical operators for combining query filters
  */
 export enum QueryLogicalOperator {
@@ -221,6 +242,13 @@ export enum QueryLogicalOperator {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * An aggregate operation in a query
  */
 export interface QueryAggregate {
@@ -233,6 +261,13 @@ export interface QueryAggregate {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * A join condition for cross-entity queries
  */
 export interface QueryJoinCondition {
@@ -243,6 +278,13 @@ export interface QueryJoinCondition {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * A join clause for cross-entity queries
  */
 export interface QueryJoin {
@@ -255,6 +297,13 @@ export interface QueryJoin {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * A single query filter condition
  */
 export interface QueryFilter {
@@ -267,6 +316,13 @@ export interface QueryFilter {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * A group of query filters combined with a logical operator
  */
 export interface QueryFilterGroup {
@@ -279,6 +335,13 @@ export interface QueryFilterGroup {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * Sort option for query results
  */
 export interface QuerySortOption {
@@ -289,6 +352,13 @@ export interface QuerySortOption {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * Options for querying an entity with joins, aggregates, and filters
  */
 export interface EntityQueryOptions {
@@ -311,6 +381,13 @@ export interface EntityQueryOptions {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+  Preview: This type is experimental and may change or be removed in future releases.
+  ///
+ *
  * Response from a query operation
  */
 export interface EntityQueryResponse {

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -362,15 +362,15 @@ export interface QuerySortOption {
  * Options for querying an entity with joins, aggregates, and filters
  */
 export interface EntityQueryOptions {
-  /** Fields to include in the result set */
+  /** Fields to include in the result set. Required when using aggregates — must include the groupBy fields. */
   selectedFields?: string[];
-  /** Aggregate operations to perform */
+  /** Aggregate operations to perform. Requires selectedFields to include the groupBy fields. */
   aggregates?: QueryAggregate[];
-  /** Cross-entity join clauses */
+  /** Cross-entity join clauses. Joined entity fields can be referenced as "entityName.fieldName" in selectedFields. */
   joins?: QueryJoin[];
   /** Filter conditions */
   filterGroup?: QueryFilterGroup;
-  /** Fields to group results by (used with aggregates) */
+  /** Fields to group results by (used with aggregates). These fields must also appear in selectedFields. */
   groupBy?: string[];
   /** Sort options for result ordering */
   sortOptions?: QuerySortOption[];
@@ -392,9 +392,9 @@ export interface EntityQueryOptions {
  */
 export interface EntityQueryResponse {
   /** Array of matching records */
-  records: Record<string, unknown>[];
+  value: Record<string, unknown>[];
   /** Total count of matching records (before pagination) */
-  totalCount?: number;
+  totalRecordCount?: number;
 }
 
 /**

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -309,7 +309,7 @@ export interface QueryJoin {
 export interface QueryFilter {
   /** Field name to filter on */
   fieldName: string;
-  /** Comparison operator (e.g. "=", "!=", ">", "<", ">=", "<=", "contains", "startswith", "endswith") */
+  /** Comparison operator: "=", "!=", ">", "<", ">=", "<=", "contains", "startswith", "endswith" (lowercase for string operators) */
   operator: string;
   /** Value to compare against */
   value: unknown;

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -192,6 +192,135 @@ export interface EntityUpdateResponse extends EntityOperationResponse {}
 export interface EntityDeleteResponse extends EntityOperationResponse {}
 
 /**
+ * Aggregate function types for query operations
+ */
+export enum QueryAggregateFunction {
+  COUNT = "COUNT",
+  SUM = "SUM",
+  AVG = "AVG",
+  MIN = "MIN",
+  MAX = "MAX",
+}
+
+/**
+ * Join types for cross-entity query operations
+ */
+export enum QueryJoinType {
+  INNER = "INNER",
+  LEFT = "LEFT",
+  RIGHT = "RIGHT",
+  FULL = "FULL",
+}
+
+/**
+ * Logical operators for combining query filters
+ */
+export enum QueryLogicalOperator {
+  AND = 0,
+  OR = 1,
+}
+
+/**
+ * An aggregate operation in a query
+ */
+export interface QueryAggregate {
+  /** Aggregate function to apply */
+  function: QueryAggregateFunction;
+  /** Field to aggregate on */
+  field: string;
+  /** Alias for the aggregated result */
+  alias: string;
+}
+
+/**
+ * A join condition for cross-entity queries
+ */
+export interface QueryJoinCondition {
+  /** Left side field name (from the primary entity) */
+  left: string;
+  /** Right side field name (from the joined entity) */
+  right: string;
+}
+
+/**
+ * A join clause for cross-entity queries
+ */
+export interface QueryJoin {
+  /** Type of join */
+  type: QueryJoinType;
+  /** Name of the entity to join */
+  entity: string;
+  /** Join condition specifying left and right field mappings */
+  on: QueryJoinCondition;
+}
+
+/**
+ * A single query filter condition
+ */
+export interface QueryFilter {
+  /** Field name to filter on */
+  fieldName: string;
+  /** Comparison operator (e.g. "=", "!=", ">", "<", ">=", "<=", "contains", "startswith", "endswith") */
+  operator: string;
+  /** Value to compare against */
+  value: unknown;
+}
+
+/**
+ * A group of query filters combined with a logical operator
+ */
+export interface QueryFilterGroup {
+  /** Logical operator to combine filters (0 = AND, 1 = OR) */
+  logicalOperator: QueryLogicalOperator;
+  /** Array of filter conditions */
+  queryFilters: QueryFilter[];
+  /** Nested filter groups for complex conditions */
+  queryFilterGroups?: QueryFilterGroup[];
+}
+
+/**
+ * Sort option for query results
+ */
+export interface QuerySortOption {
+  /** Field name to sort by */
+  fieldName: string;
+  /** Whether to sort in descending order (default: false) */
+  isDescending?: boolean;
+}
+
+/**
+ * Options for querying an entity with joins, aggregates, and filters
+ */
+export interface EntityQueryOptions {
+  /** Fields to include in the result set */
+  selectedFields?: string[];
+  /** Aggregate operations to perform */
+  aggregates?: QueryAggregate[];
+  /** Cross-entity join clauses */
+  joins?: QueryJoin[];
+  /** Filter conditions */
+  filterGroup?: QueryFilterGroup;
+  /** Fields to group results by (used with aggregates) */
+  groupBy?: string[];
+  /** Sort options for result ordering */
+  sortOptions?: QuerySortOption[];
+  /** Starting offset for pagination (default: 0) */
+  start?: number;
+  /** Maximum number of records to return (default: 100) */
+  limit?: number;
+}
+
+/**
+ * Response from a query operation
+ */
+export interface EntityQueryResponse {
+  /** Array of matching records */
+  records: Record<string, unknown>[];
+  /** Total count of matching records (before pagination) */
+  totalCount?: number;
+}
+
+/**
  * Entity type enum
  */
 export enum EntityType {

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -24,7 +24,9 @@ import {
   EntityFileType,
   EntityUploadAttachmentOptions,
   EntityUploadAttachmentResponse,
-  EntityDeleteAttachmentResponse
+  EntityDeleteAttachmentResponse,
+  EntityQueryOptions,
+  EntityQueryResponse
 } from '../../models/data-fabric/entities.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination/types';
 import { PaginationType } from '../../utils/pagination/internal-types';
@@ -572,6 +574,73 @@ export class EntityService extends BaseService implements EntityServiceModel {
     );
 
     return response.data;
+  }
+
+  /**
+   * Queries an entity by name with support for joins, aggregates, filters, grouping, and sorting
+   *
+   * @param entityName - Name of the entity to query
+   * @param options - Query options including selectedFields, aggregates, joins, filterGroup, groupBy, sortOptions, start, limit
+   * @returns Promise resolving to query response with matching records
+   *
+   * @example
+   * ```typescript
+   * import { Entities } from '@uipath/uipath-typescript/entities';
+   *
+   * const entities = new Entities(sdk);
+   *
+   * // Simple filtered query
+   * const result = await entities.query('Customer', {
+   *   selectedFields: ['name', 'email'],
+   *   filterGroup: {
+   *     logicalOperator: 0,
+   *     queryFilters: [{ fieldName: 'status', operator: '=', value: 'active' }]
+   *   },
+   *   limit: 50
+   * });
+   *
+   * // Cross-entity join query
+   * const joinResult = await entities.query('Orders', {
+   *   selectedFields: ['Orders.orderId', 'Customer.name'],
+   *   joins: [{
+   *     type: 'INNER',
+   *     entity: 'Customer',
+   *     on: { left: 'customerId', right: 'Id' }
+   *   }],
+   *   sortOptions: [{ fieldName: 'Orders.createdDate', isDescending: true }],
+   *   limit: 100
+   * });
+   *
+   * // Aggregate query with grouping
+   * const stats = await entities.query('Orders', {
+   *   aggregates: [
+   *     { function: 'COUNT', field: 'Id', alias: 'totalOrders' },
+   *     { function: 'SUM', field: 'amount', alias: 'totalAmount' }
+   *   ],
+   *   groupBy: ['status']
+   * });
+   * ```
+   */
+  @track('Entities.Query')
+  async query(entityName: string, options: EntityQueryOptions = {}): Promise<EntityQueryResponse> {
+    const body: Record<string, unknown> = {};
+
+    if (options.selectedFields) body.selectedFields = options.selectedFields;
+    if (options.aggregates) body.aggregates = options.aggregates;
+    if (options.joins) body.joins = options.joins;
+    if (options.filterGroup) body.filterGroup = options.filterGroup;
+    if (options.groupBy) body.groupBy = options.groupBy;
+    if (options.sortOptions) body.sortOptions = options.sortOptions;
+    if (options.start !== undefined) body.start = options.start;
+    if (options.limit !== undefined) body.limit = options.limit;
+
+    const response = await this.post<EntityQueryResponse>(
+      DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(entityName),
+      body
+    );
+
+    const camelResponse = pascalToCamelCaseKeys(response.data);
+    return camelResponse;
   }
 
     /**

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -584,9 +584,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
     Preview: This method is experimental and may change or be removed in future releases.
     ///
    *
-   * Queries an entity by name with support for joins, aggregates, filters, grouping, and sorting
+   * Queries an entity by ID with support for joins, aggregates, filters, grouping, and sorting
    *
-   * @param entityName - Name of the entity to query
+   * @param entityId - UUID of the entity to query
    * @param options - Query options including selectedFields, aggregates, joins, filterGroup, groupBy, sortOptions, start, limit
    * @returns Promise resolving to query response with matching records
    *
@@ -597,7 +597,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * const entities = new Entities(sdk);
    *
    * // Simple filtered query
-   * const result = await entities.query('Customer', {
+   * const result = await entities.query('<entityId>', {
    *   selectedFields: ['name', 'email'],
    *   filterGroup: {
    *     logicalOperator: 0,
@@ -607,7 +607,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * });
    *
    * // Cross-entity join query
-   * const joinResult = await entities.query('Orders', {
+   * const joinResult = await entities.query('<entityId>', {
    *   selectedFields: ['Orders.orderId', 'Customer.name'],
    *   joins: [{
    *     type: 'INNER',
@@ -619,7 +619,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * });
    *
    * // Aggregate query with grouping
-   * const stats = await entities.query('Orders', {
+   * const stats = await entities.query('<entityId>', {
    *   aggregates: [
    *     { function: 'COUNT', field: 'Id', alias: 'totalOrders' },
    *     { function: 'SUM', field: 'amount', alias: 'totalAmount' }
@@ -629,7 +629,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * ```
    */
   @track('Entities.Query')
-  async query(entityName: string, options: EntityQueryOptions = {}): Promise<EntityQueryResponse> {
+  async query(entityId: string, options: EntityQueryOptions = {}): Promise<EntityQueryResponse> {
     const body: Record<string, unknown> = {};
 
     if (options.selectedFields) body.selectedFields = options.selectedFields;
@@ -642,7 +642,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
     if (options.limit !== undefined) body.limit = options.limit;
 
     const response = await this.post<EntityQueryResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(entityName),
+      DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(entityId),
       body
     );
 

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -577,6 +577,13 @@ export class EntityService extends BaseService implements EntityServiceModel {
   }
 
   /**
+   *
+   * @experimental
+   *
+   * /// warning
+    Preview: This method is experimental and may change or be removed in future releases.
+    ///
+   *
    * Queries an entity by name with support for joins, aggregates, filters, grouping, and sorting
    *
    * @param entityName - Name of the entity to query

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -25,6 +25,7 @@ export const DATA_FABRIC_ENDPOINTS = {
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
     DELETE_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
+    QUERY: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/query`,
   },
   CHOICESETS: {
     GET_ALL: `${DATAFABRIC_BASE}/api/Entity/choiceset`,

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -25,7 +25,7 @@ export const DATA_FABRIC_ENDPOINTS = {
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
     DELETE_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
-    QUERY: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/query`,
+    QUERY: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/query`,
   },
   CHOICESETS: {
     GET_ALL: `${DATAFABRIC_BASE}/api/Entity/choiceset`,

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -596,7 +596,7 @@ describe('Entity Models', () => {
         const entityData = createBasicEntity();
         const entity = createEntityWithMethods(entityData, mockService);
 
-        const mockResponse = { records: [{ id: '1', name: 'John' }], totalCount: 1 };
+        const mockResponse = { value: [{ id: '1', name: 'John' }], totalRecordCount: 1 };
         mockService.query = vi.fn().mockResolvedValue(mockResponse);
 
         const options = {

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -592,7 +592,7 @@ describe('Entity Models', () => {
     });
 
     describe('entity.query()', () => {
-      it('should call query with entity name and options', async () => {
+      it('should call query with entity id and options', async () => {
         const entityData = createBasicEntity();
         const entity = createEntityWithMethods(entityData, mockService);
 
@@ -607,21 +607,21 @@ describe('Entity Models', () => {
         const result = await entity.query(options);
 
         expect(mockService.query).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
           options
         );
         expect(result).toEqual(mockResponse);
       });
 
-      it('should throw error if entity name is undefined', async () => {
-        const entityData = createBasicEntity({ name: undefined as any });
+      it('should throw error if entity id is undefined', async () => {
+        const entityData = createBasicEntity({ id: undefined as any });
         const entity = createEntityWithMethods(entityData, mockService);
 
         mockService.query = vi.fn();
 
         await expect(
           entity.query({ limit: 10 })
-        ).rejects.toThrow(ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_ENTITY_NAME_UNDEFINED);
+        ).rejects.toThrow(ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_ENTITY_ID_UNDEFINED);
       });
     });
   });

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -590,6 +590,40 @@ describe('Entity Models', () => {
         ).rejects.toThrow(ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_ENTITY_ID_UNDEFINED);
       });
     });
+
+    describe('entity.query()', () => {
+      it('should call query with entity name and options', async () => {
+        const entityData = createBasicEntity();
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        const mockResponse = { records: [{ id: '1', name: 'John' }], totalCount: 1 };
+        mockService.query = vi.fn().mockResolvedValue(mockResponse);
+
+        const options = {
+          selectedFields: ['name', 'email'],
+          limit: 10
+        };
+
+        const result = await entity.query(options);
+
+        expect(mockService.query).toHaveBeenCalledWith(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          options
+        );
+        expect(result).toEqual(mockResponse);
+      });
+
+      it('should throw error if entity name is undefined', async () => {
+        const entityData = createBasicEntity({ name: undefined as any });
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        mockService.query = vi.fn();
+
+        await expect(
+          entity.query({ limit: 10 })
+        ).rejects.toThrow(ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_ENTITY_NAME_UNDEFINED);
+      });
+    });
   });
 
   describe('Entity data and methods are combined correctly', () => {
@@ -617,6 +651,7 @@ describe('Entity Models', () => {
       expect(typeof entity.getAllRecords).toBe('function');
       expect(typeof entity.getRecord).toBe('function');
       expect(typeof entity.downloadAttachment).toBe('function');
+      expect(typeof entity.query).toBe('function');
     });
   });
 });

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -28,6 +28,11 @@ import type {
   EntityRecord,
   EntityGetAllRecordsOptions
 } from '../../../../src/models/data-fabric/entities.types';
+import {
+  QueryLogicalOperator,
+  QueryJoinType,
+  QueryAggregateFunction
+} from '../../../../src/models/data-fabric/entities.types';
 import { ENTITY_TEST_CONSTANTS } from '../../../utils/constants/entities';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
 import { DATA_FABRIC_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
@@ -1015,6 +1020,134 @@ describe('EntityService Unit Tests', () => {
       )).rejects.toThrow(
         TEST_CONSTANTS.ERROR_MESSAGE
       );
+    });
+  });
+
+  describe('query', () => {
+    it('should query an entity by name with default options', async () => {
+      const mockResponse = {
+        data: {
+          Records: [
+            { Id: ENTITY_TEST_CONSTANTS.RECORD_ID, Name: 'John Doe' },
+            { Id: ENTITY_TEST_CONSTANTS.RECORD_ID_2, Name: 'Jane Smith' }
+          ],
+          TotalCount: 2
+        }
+      };
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const result = await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_NAME);
+
+      expect(result).toBeDefined();
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_NAME),
+        {},
+        {}
+      );
+    });
+
+    it('should query with selectedFields and filters', async () => {
+      const mockResponse = {
+        data: {
+          Records: [{ Id: ENTITY_TEST_CONSTANTS.RECORD_ID, Name: 'John Doe' }],
+          TotalCount: 1
+        }
+      };
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const options = {
+        selectedFields: ['name', 'email'],
+        filterGroup: {
+          logicalOperator: QueryLogicalOperator.AND,
+          queryFilters: [{ fieldName: 'name', operator: '=', value: 'John Doe' }]
+        },
+        limit: 50
+      };
+
+      await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_NAME, options);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_NAME),
+        expect.objectContaining({
+          selectedFields: ['name', 'email'],
+          filterGroup: options.filterGroup,
+          limit: 50
+        }),
+        {}
+      );
+    });
+
+    it('should query with joins', async () => {
+      const mockResponse = {
+        data: {
+          Records: [{ orderId: '1', customerName: 'John' }],
+          TotalCount: 1
+        }
+      };
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const options = {
+        selectedFields: ['Orders.orderId', 'Customer.name'],
+        joins: [{
+          type: QueryJoinType.INNER,
+          entity: 'Customer',
+          on: { left: 'customerId', right: 'Id' }
+        }],
+        sortOptions: [{ fieldName: 'Orders.createdDate', isDescending: true }],
+        start: 0,
+        limit: 100
+      };
+
+      await entityService.query('Orders', options);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY('Orders'),
+        expect.objectContaining({
+          selectedFields: options.selectedFields,
+          joins: options.joins,
+          sortOptions: options.sortOptions,
+          start: 0,
+          limit: 100
+        }),
+        {}
+      );
+    });
+
+    it('should query with aggregates and groupBy', async () => {
+      const mockResponse = {
+        data: {
+          Records: [{ status: 'active', totalOrders: 42 }],
+          TotalCount: 1
+        }
+      };
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const options = {
+        aggregates: [
+          { function: QueryAggregateFunction.COUNT, field: 'Id', alias: 'totalOrders' }
+        ],
+        groupBy: ['status']
+      };
+
+      await entityService.query('Orders', options);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY('Orders'),
+        expect.objectContaining({
+          aggregates: options.aggregates,
+          groupBy: ['status']
+        }),
+        {}
+      );
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(entityService.query(
+        ENTITY_TEST_CONSTANTS.ENTITY_NAME
+      )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -1024,7 +1024,7 @@ describe('EntityService Unit Tests', () => {
   });
 
   describe('query', () => {
-    it('should query an entity by name with default options', async () => {
+    it('should query an entity by ID with default options', async () => {
       const mockResponse = {
         data: {
           Records: [
@@ -1036,11 +1036,11 @@ describe('EntityService Unit Tests', () => {
       };
       mockApiClient.post.mockResolvedValue(mockResponse);
 
-      const result = await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_NAME);
+      const result = await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_ID);
 
       expect(result).toBeDefined();
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_NAME),
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_ID),
         {},
         {}
       );
@@ -1064,10 +1064,10 @@ describe('EntityService Unit Tests', () => {
         limit: 50
       };
 
-      await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_NAME, options);
+      await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_ID, options);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_NAME),
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_ID),
         expect.objectContaining({
           selectedFields: ['name', 'email'],
           filterGroup: options.filterGroup,
@@ -1098,10 +1098,10 @@ describe('EntityService Unit Tests', () => {
         limit: 100
       };
 
-      await entityService.query('Orders', options);
+      await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_ID, options);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY('Orders'),
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_ID),
         expect.objectContaining({
           selectedFields: options.selectedFields,
           joins: options.joins,
@@ -1129,10 +1129,10 @@ describe('EntityService Unit Tests', () => {
         groupBy: ['status']
       };
 
-      await entityService.query('Orders', options);
+      await entityService.query(ENTITY_TEST_CONSTANTS.ENTITY_ID, options);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY('Orders'),
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY(ENTITY_TEST_CONSTANTS.ENTITY_ID),
         expect.objectContaining({
           aggregates: options.aggregates,
           groupBy: ['status']
@@ -1146,7 +1146,7 @@ describe('EntityService Unit Tests', () => {
       mockApiClient.post.mockRejectedValue(error);
 
       await expect(entityService.query(
-        ENTITY_TEST_CONSTANTS.ENTITY_NAME
+        ENTITY_TEST_CONSTANTS.ENTITY_ID
       )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });


### PR DESCRIPTION
Add `query()` method to EntityService supporting cross-entity joins, aggregates, filters, grouping, and sorting via POST /api/EntityService/{EntityName}/query.

Changes:
- Add QUERY endpoint to DATA_FABRIC_ENDPOINTS
- Add query types: QueryAggregate, QueryJoin, QueryFilter, QueryFilterGroup, QuerySortOption, EntityQueryOptions, EntityQueryResponse
- Add query enums: QueryAggregateFunction, QueryJoinType, QueryLogicalOperator
- Add query() to EntityServiceModel interface and EntityService implementation
- Add bound query() to EntityMethods and createEntityMethods factory
- Add unit tests for service and model layers