### PR TITLE
feat: add deleteRecordById method [PLT-95546]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -47,6 +47,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `insertRecordById()` / `insertRecord()` | `DataFabric.Data.Write` |
 | `insertRecordsById()` / `insertRecords()` | `DataFabric.Data.Write` |
 | `deleteRecordsById()` / `deleteRecords()` | `DataFabric.Data.Write` |
+| `deleteRecordById()` / `deleteRecord()` | `DataFabric.Data.Write` |
 | `updateRecordById()` / `updateRecord()` | `DataFabric.Data.Write` |
 | `updateRecordsById()` / `updateRecords()` | `DataFabric.Data.Write` |
 | `downloadAttachment()` | `DataFabric.Data.Read` |

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -333,7 +333,6 @@ export interface EntityServiceModel {
    */
   deleteRecordsById(id: string, recordIds: string[], options?: EntityDeleteRecordsOptions): Promise<EntityDeleteResponse>;
 
-
   /**
    * Deletes a single record from an entity by entity ID and record ID
    *
@@ -345,7 +344,11 @@ export interface EntityServiceModel {
    * @returns Promise resolving to void on success
    * @example
    * ```typescript
-   * await entities.deleteRecordById(<entityId>, <recordId>);
+   * import { Entities } from '@uipath/uipath-typescript/entities';
+   *
+   * const entities = new Entities(sdk);
+   *
+   * await entities.deleteRecordById("<entityId>", "<recordId>");
    * ```
    */
   deleteRecordById(entityId: string, recordId: string): Promise<void>;
@@ -657,6 +660,8 @@ export interface EntityMethods {
   /**
    * Delete data from this entity
    *
+   * Note: Records deleted using deleteRecords will not trigger Data Fabric trigger events. Use {@link deleteRecord} if you need trigger events to fire for the deleted record.
+   *
    * @param recordIds - Array of record UUIDs to delete
    * @param options - Delete options
    * @returns Promise resolving to delete response
@@ -861,7 +866,7 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
     async deleteRecord(recordId: string): Promise<void> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
       if (!recordId) throw new Error('Record ID is undefined');
-      await service.deleteRecordById(entityData.id, recordId);
+      return service.deleteRecordById(entityData.id, recordId);
     },
 
     async getAllRecords<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(options?: T): Promise<

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -9,6 +9,7 @@ import {
   EntityUpdateRecordOptions,
   EntityUpdateRecordResponse,
   EntityDeleteResponse,
+  EntityDeleteRecordResponse,
   EntityRecord,
   RawEntityGetResponse,
   EntityFileType,
@@ -333,6 +334,23 @@ export interface EntityServiceModel {
 
 
   /**
+   * Deletes a single record from an entity by entity ID and record ID
+   *
+   * Note: Data Fabric supports trigger events only on individual deletes, not on deleting multiple records.
+   * Use this method if you need trigger events to fire for the deleted record.
+   *
+   * @param entityId - UUID of the entity
+   * @param recordId - UUID of the record to delete
+   * @returns Promise resolving to {@link EntityDeleteRecordResponse}
+   * @example
+   * ```typescript
+   * const result = await entities.deleteRecordById(<entityId>, <recordId>);
+   * console.log(result.success); // true
+   * ```
+   */
+  deleteRecordById(entityId: string, recordId: string): Promise<EntityDeleteRecordResponse>;
+
+  /**
    * Queries entity records with filters, sorting, and SDK-managed pagination
    *
    * @param id - UUID of the entity
@@ -646,6 +664,17 @@ export interface EntityMethods {
   deleteRecords(recordIds: string[], options?: EntityDeleteRecordsOptions): Promise<EntityDeleteResponse>;
 
   /**
+   * Delete a single record from this entity
+   *
+   * Note: Data Fabric supports trigger events only on individual deletes, not on deleting multiple records.
+   * Use this method if you need trigger events to fire for the deleted record.
+   *
+   * @param recordId - UUID of the record to delete
+   * @returns Promise resolving to delete response
+   */
+  deleteRecord(recordId: string): Promise<EntityDeleteRecordResponse>;
+
+  /**
    * Get all records from this entity
    *
    * @param options - Query options
@@ -827,6 +856,13 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
     async deleteRecords(recordIds: string[], options?: EntityDeleteRecordsOptions): Promise<EntityDeleteResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
       return service.deleteRecordsById(entityData.id, recordIds, options);
+    },
+
+    async deleteRecord(recordId: string): Promise<EntityDeleteRecordResponse> {
+      if (!entityData.id) throw new Error('Entity ID is undefined');
+      if (!recordId) throw new Error('Record ID is undefined');
+
+      return service.deleteRecordById(entityData.id, recordId);
     },
 
     async getAllRecords<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(options?: T): Promise<

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -317,6 +317,8 @@ export interface EntityServiceModel {
   /**
    * Deletes data from an entity by entity ID
    *
+   * Note: Records deleted using deleteRecordsById will not trigger Data Fabric trigger events. Use {@link deleteRecordById} if you need trigger events to fire for the deleted record.
+   *
    * @param id - UUID of the entity
    * @param recordIds - Array of record UUIDs to delete
    * @param options - Delete options
@@ -861,7 +863,6 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
     async deleteRecord(recordId: string): Promise<EntityDeleteRecordResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
       if (!recordId) throw new Error('Record ID is undefined');
-
       return service.deleteRecordById(entityData.id, recordId);
     },
 

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -9,7 +9,6 @@ import {
   EntityUpdateRecordOptions,
   EntityUpdateRecordResponse,
   EntityDeleteResponse,
-  EntityDeleteRecordResponse,
   EntityRecord,
   RawEntityGetResponse,
   EntityFileType,
@@ -343,14 +342,13 @@ export interface EntityServiceModel {
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to delete
-   * @returns Promise resolving to {@link EntityDeleteRecordResponse}
+   * @returns Promise resolving to void on success
    * @example
    * ```typescript
-   * const result = await entities.deleteRecordById(<entityId>, <recordId>);
-   * console.log(result.success); // true
+   * await entities.deleteRecordById(<entityId>, <recordId>);
    * ```
    */
-  deleteRecordById(entityId: string, recordId: string): Promise<EntityDeleteRecordResponse>;
+  deleteRecordById(entityId: string, recordId: string): Promise<void>;
 
   /**
    * Queries entity records with filters, sorting, and SDK-managed pagination
@@ -672,9 +670,9 @@ export interface EntityMethods {
    * Use this method if you need trigger events to fire for the deleted record.
    *
    * @param recordId - UUID of the record to delete
-   * @returns Promise resolving to delete response
+   * @returns Promise resolving to void on success
    */
-  deleteRecord(recordId: string): Promise<EntityDeleteRecordResponse>;
+  deleteRecord(recordId: string): Promise<void>;
 
   /**
    * Get all records from this entity
@@ -860,10 +858,10 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
       return service.deleteRecordsById(entityData.id, recordIds, options);
     },
 
-    async deleteRecord(recordId: string): Promise<EntityDeleteRecordResponse> {
+    async deleteRecord(recordId: string): Promise<void> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
       if (!recordId) throw new Error('Record ID is undefined');
-      return service.deleteRecordById(entityData.id, recordId);
+      await service.deleteRecordById(entityData.id, recordId);
     },
 
     async getAllRecords<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(options?: T): Promise<

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -125,14 +125,6 @@ export interface EntityDeleteOptions {
  */
 export interface EntityDeleteRecordsOptions extends EntityDeleteOptions {}
 
-/**
- * Response from deleting a single record from an entity
- */
-export interface EntityDeleteRecordResponse {
-  /** Whether the record was successfully deleted */
-  success: boolean;
-}
-
 
 /**
  * Logical operator for combining query filter groups

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -125,6 +125,14 @@ export interface EntityDeleteOptions {
  */
 export interface EntityDeleteRecordsOptions extends EntityDeleteOptions {}
 
+/**
+ * Response from deleting a single record from an entity
+ */
+export interface EntityDeleteRecordResponse {
+  /** Whether the record was successfully deleted */
+  success: boolean;
+}
+
 
 /**
  * Logical operator for combining query filter groups

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -373,6 +373,8 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /**
    * Deletes data from an entity by entity ID
    *
+   * Note: Records deleted using deleteRecordsById will not trigger Data Fabric trigger events. Use {@link deleteRecordById} if you need trigger events to fire for the deleted record.
+   *
    * @param entityId - UUID of the entity
    * @param recordIds - Array of record UUIDs to delete
    * @param options - Delete options

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -17,6 +17,8 @@ import {
   EntityUpdateResponse,
   EntityDeleteRecordsOptions,
   EntityDeleteResponse,
+  EntityDeleteRecordOptions,
+  EntityDeleteRecordResponse,
   EntityRecord,
   RawEntityGetResponse,
   FieldMetaData,
@@ -405,6 +407,34 @@ export class EntityService extends BaseService implements EntityServiceModel {
     );
 
     return response.data;
+  }
+
+  /**
+   * Deletes a single record from an entity by entity ID and record ID
+   *
+   * @param entityId - UUID of the entity
+   * @param recordId - UUID of the record to delete
+   * @param options - Delete options
+   * @returns Promise resolving to delete response
+   *
+   * @example
+   * ```typescript
+   * import { Entities } from '@uipath/uipath-typescript/entities';
+   *
+   * const entities = new Entities(sdk);
+   *
+   * const result = await entities.deleteRecordById("<entityId>", "<recordId>");
+   * console.log(result.success); // true
+   * ```
+   */
+  @track('Entities.DeleteRecordById')
+  async deleteRecordById(entityId: string, recordId: string, _options: EntityDeleteRecordOptions = {}): Promise<EntityDeleteRecordResponse> {
+    const response = await this.post<boolean>(
+      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId),
+      recordId
+    );
+
+    return { success: response.data };
   }
 
   /**

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -429,9 +429,8 @@ export class EntityService extends BaseService implements EntityServiceModel {
    */
   @track('Entities.DeleteRecordById')
   async deleteRecordById(entityId: string, recordId: string, _options: EntityDeleteRecordOptions = {}): Promise<EntityDeleteRecordResponse> {
-    const response = await this.post<boolean>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId),
-      recordId
+    const response = await this.delete<boolean>(
+      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId, recordId)
     );
 
     return { success: response.data };

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -411,17 +411,15 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /**
    * Deletes a single record from an entity by entity ID and record ID
    *
+   * Note: Data Fabric supports trigger events only on individual deletes, not on deleting multiple records.
+   * Use this method if you need trigger events to fire for the deleted record.
+   *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to delete
-   * @returns Promise resolving to delete response
-   *
+   * @returns Promise resolving to {@link EntityDeleteRecordResponse}
    * @example
    * ```typescript
-   * import { Entities } from '@uipath/uipath-typescript/entities';
-   *
-   * const entities = new Entities(sdk);
-   *
-   * const result = await entities.deleteRecordById("<entityId>", "<recordId>");
+   * const result = await entities.deleteRecordById(<entityId>, <recordId>);
    * console.log(result.success); // true
    * ```
    */

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -17,7 +17,6 @@ import {
   EntityUpdateResponse,
   EntityDeleteRecordsOptions,
   EntityDeleteResponse,
-  EntityDeleteRecordResponse,
   EntityRecord,
   RawEntityGetResponse,
   FieldMetaData,
@@ -418,20 +417,17 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to delete
-   * @returns Promise resolving to {@link EntityDeleteRecordResponse}
+   * @returns Promise resolving to void on success
    * @example
    * ```typescript
-   * const result = await entities.deleteRecordById(<entityId>, <recordId>);
-   * console.log(result.success); // true
+   * await entities.deleteRecordById(<entityId>, <recordId>);
    * ```
    */
   @track('Entities.DeleteRecordById')
-  async deleteRecordById(entityId: string, recordId: string): Promise<EntityDeleteRecordResponse> {
-    const response = await this.delete<boolean>(
+  async deleteRecordById(entityId: string, recordId: string): Promise<void> {
+    await this.delete<boolean>(
       DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId, recordId)
     );
-
-    return { success: response.data };
   }
 
   /**

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -413,7 +413,6 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to delete
-   * @param options - Delete options
    * @returns Promise resolving to delete response
    *
    * @example

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -17,7 +17,6 @@ import {
   EntityUpdateResponse,
   EntityDeleteRecordsOptions,
   EntityDeleteResponse,
-  EntityDeleteRecordOptions,
   EntityDeleteRecordResponse,
   EntityRecord,
   RawEntityGetResponse,
@@ -428,7 +427,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * ```
    */
   @track('Entities.DeleteRecordById')
-  async deleteRecordById(entityId: string, recordId: string, _options: EntityDeleteRecordOptions = {}): Promise<EntityDeleteRecordResponse> {
+  async deleteRecordById(entityId: string, recordId: string): Promise<EntityDeleteRecordResponse> {
     const response = await this.delete<boolean>(
       DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId, recordId)
     );

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -420,12 +420,16 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * @returns Promise resolving to void on success
    * @example
    * ```typescript
-   * await entities.deleteRecordById(<entityId>, <recordId>);
+   * import { Entities } from '@uipath/uipath-typescript/entities';
+   *
+   * const entities = new Entities(sdk);
+   *
+   * await entities.deleteRecordById("<entityId>", "<recordId>");
    * ```
    */
   @track('Entities.DeleteRecordById')
   async deleteRecordById(entityId: string, recordId: string): Promise<void> {
-    await this.delete<boolean>(
+    await this.delete(
       DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId, recordId)
     );
   }

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -25,13 +25,13 @@ export const DATA_FABRIC_ENDPOINTS = {
     BATCH_INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert-batch`,
     UPDATE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update/${recordId}`,
     UPDATE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update-batch`,
+    DELETE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete/${recordId}`,
     DELETE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete-batch`,
     UPSERT: `${DATAFABRIC_BASE}/api/Entity`,
     DELETE: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
     UPDATE_METADATA: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}/metadata`,
     QUERY_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/query`,
     BULK_UPLOAD_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/bulk-upload`,
-    DELETE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete/${recordId}`,
     DOWNLOAD_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
     UPLOAD_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -31,6 +31,7 @@ export const DATA_FABRIC_ENDPOINTS = {
     UPDATE_METADATA: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}/metadata`,
     QUERY_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/query`,
     BULK_UPLOAD_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/bulk-upload`,
+    DELETE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete/${recordId}`,
     DOWNLOAD_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
     UPLOAD_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -989,9 +989,9 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const testData = await buildDummyRecord(entityMetadata);
       const inserted = await entities.insertRecordById(entityId, testData);
 
-      expect(inserted.id).toBeDefined();
+      expect(inserted.Id).toBeDefined();
 
-      const result = await entities.deleteRecordById(entityId, inserted.id);
+      const result = await entities.deleteRecordById(entityId, inserted.Id);
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
@@ -1030,9 +1030,9 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const testData = await buildDummyRecord(entity);
       const inserted = await entity.insertRecord(testData);
 
-      expect(inserted.id).toBeDefined();
+      expect(inserted.Id).toBeDefined();
 
-      const result = await entity.deleteRecord(inserted.id);
+      const result = await entity.deleteRecord(inserted.Id);
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -191,6 +191,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(typeof entity.insertRecords).toBe('function');
       expect(typeof entity.updateRecords).toBe('function');
       expect(typeof entity.deleteRecords).toBe('function');
+      expect(typeof entity.deleteRecord).toBe('function');
       expect(typeof entity.getAllRecords).toBe('function');
       expect(typeof entity.getRecord).toBe('function');
       expect(typeof entity.downloadAttachment).toBe('function');
@@ -260,6 +261,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(typeof result.insertRecords).toBe('function');
       expect(typeof result.updateRecords).toBe('function');
       expect(typeof result.deleteRecords).toBe('function');
+      expect(typeof result.deleteRecord).toBe('function');
       expect(typeof result.getAllRecords).toBe('function');
       expect(typeof result.getRecord).toBe('function');
       expect(typeof result.downloadAttachment).toBe('function');

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -994,10 +994,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       createdRecordIds.push(inserted.Id);
       registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
 
-      const result = await entities.deleteRecordById(entityId, inserted.Id);
-
-      expect(result).toBeDefined();
-      expect(result.success).toBe(true);
+      await entities.deleteRecordById(entityId, inserted.Id);
 
       const idx = createdRecordIds.indexOf(inserted.Id);
       if (idx !== -1) createdRecordIds.splice(idx, 1);
@@ -1040,10 +1037,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       createdRecordIds.push(inserted.Id);
       registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
 
-      const result = await entity.deleteRecord(inserted.Id);
-
-      expect(result).toBeDefined();
-      expect(result.success).toBe(true);
+      await entity.deleteRecord(inserted.Id);
 
       const idx = createdRecordIds.indexOf(inserted.Id);
       if (idx !== -1) createdRecordIds.splice(idx, 1);

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -998,6 +998,9 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
+
+      const idx = createdRecordIds.indexOf(inserted.Id);
+      if (idx !== -1) createdRecordIds.splice(idx, 1);
     });
 
     it('should throw for a non-existent record', async () => {
@@ -1041,6 +1044,9 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
+
+      const idx = createdRecordIds.indexOf(inserted.Id);
+      if (idx !== -1) createdRecordIds.splice(idx, 1);
     });
   });
 

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -745,6 +745,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const config = getTestConfig();
       const entityId = config.dataFabricTestEntityId || testEntityId;
+
       if (!entityId) {
         throw new Error('No entity ID available for testing. Set DATA_FABRIC_TEST_ENTITY_ID.');
       }
@@ -963,6 +964,76 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       const all = await entities.getAll();
       expect(all.find(e => e.id === entityId)).toBeUndefined();
+    });
+  });
+
+  // ─── Single Record Delete ─────────────────────────────────────────────────
+
+  describe('deleteRecordById (service-level)', () => {
+    it('should delete a single record using deleteRecordById', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+
+      if (!entityId) {
+        throw new Error('No entity ID available for testing. Set DATA_FABRIC_TEST_ENTITY_ID.');
+      }
+
+      if (entityMetadata?.id !== entityId) {
+        entityMetadata = await entities.getById(entityId);
+      }
+
+      const testData = await buildDummyRecord(entityMetadata);
+      const inserted = await entities.insertRecordById(entityId, testData);
+
+      expect(inserted.id).toBeDefined();
+
+      const result = await entities.deleteRecordById(entityId, inserted.id);
+
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+    });
+
+    it('should throw for a non-existent record', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+
+      await expect(
+        entities.deleteRecordById(entityId, '00000000-0000-0000-0000-000000000000')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('deleteRecord (entity-level method)', () => {
+    it('should delete a single record via entity.deleteRecord', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+
+      const entity = await entities.getById(entityId);
+      entityMetadata = entity;
+
+      const testData = await buildDummyRecord(entity);
+      const inserted = await entity.insertRecord(testData);
+
+      expect(inserted.id).toBeDefined();
+
+      const result = await entity.deleteRecord(inserted.id);
+
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
     });
   });
 

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -989,7 +989,10 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const testData = await buildDummyRecord(entityMetadata);
       const inserted = await entities.insertRecordById(entityId, testData);
 
+      expect(inserted).toBeDefined();
       expect(inserted.Id).toBeDefined();
+      createdRecordIds.push(inserted.Id);
+      registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
 
       const result = await entities.deleteRecordById(entityId, inserted.Id);
 
@@ -1025,12 +1028,14 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       }
 
       const entity = await entities.getById(entityId);
-      entityMetadata = entity;
 
       const testData = await buildDummyRecord(entity);
       const inserted = await entity.insertRecord(testData);
 
+      expect(inserted).toBeDefined();
       expect(inserted.Id).toBeDefined();
+      createdRecordIds.push(inserted.Id);
+      registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
 
       const result = await entity.deleteRecord(inserted.Id);
 

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -37,6 +37,7 @@ describe("Entity Models", () => {
       deleteRecordsById: vi.fn(),
       queryRecordsById: vi.fn(),
       importRecordsById: vi.fn(),
+      deleteRecordById: vi.fn(),
       downloadAttachment: vi.fn(),
       uploadAttachment: vi.fn(),
       deleteAttachment: vi.fn(),
@@ -488,6 +489,39 @@ describe("Entity Models", () => {
       });
     });
 
+    describe('entity.deleteRecord()', () => {
+      it('should call service.deleteRecordById with entity id and record id', async () => {
+        const entityData = createBasicEntity();
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        const mockResponse = { success: true };
+        mockService.deleteRecordById = vi.fn().mockResolvedValue(mockResponse);
+
+        const result = await entity.deleteRecord(ENTITY_TEST_CONSTANTS.RECORD_ID);
+
+        expect(mockService.deleteRecordById).toHaveBeenCalledWith(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID
+        );
+        expect(result).toEqual(mockResponse);
+        expect(result.success).toBe(true);
+      });
+
+      it('should throw error if entity id is undefined', async () => {
+        const entityData = createBasicEntity({ id: undefined as any });
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        await expect(entity.deleteRecord(ENTITY_TEST_CONSTANTS.RECORD_ID)).rejects.toThrow(ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_ENTITY_ID_UNDEFINED);
+      });
+
+      it('should throw error if record id is empty', async () => {
+        const entityData = createBasicEntity();
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        await expect(entity.deleteRecord('')).rejects.toThrow('Record ID is undefined');
+      });
+    });
+
     describe("entity.getAllRecords()", () => {
       it("should call entity.getAllRecords without options", async () => {
         const entityData = createBasicEntity();
@@ -765,6 +799,7 @@ describe("Entity Models", () => {
       expect(typeof entity.updateRecord).toBe("function");
       expect(typeof entity.updateRecords).toBe("function");
       expect(typeof entity.deleteRecords).toBe("function");
+      expect(typeof entity.deleteRecord).toBe("function");
       expect(typeof entity.getAllRecords).toBe("function");
       expect(typeof entity.getRecord).toBe("function");
       expect(typeof entity.downloadAttachment).toBe("function");
@@ -825,3 +860,4 @@ describe("Entity Models", () => {
     });
   });
 });
+

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -494,17 +494,14 @@ describe("Entity Models", () => {
         const entityData = createBasicEntity();
         const entity = createEntityWithMethods(entityData, mockService);
 
-        const mockResponse = { success: true };
-        mockService.deleteRecordById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.deleteRecordById = vi.fn().mockResolvedValue(undefined);
 
-        const result = await entity.deleteRecord(ENTITY_TEST_CONSTANTS.RECORD_ID);
+        await entity.deleteRecord(ENTITY_TEST_CONSTANTS.RECORD_ID);
 
         expect(mockService.deleteRecordById).toHaveBeenCalledWith(
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
           ENTITY_TEST_CONSTANTS.RECORD_ID
         );
-        expect(result).toEqual(mockResponse);
-        expect(result.success).toBe(true);
       });
 
       it('should throw error if entity id is undefined', async () => {

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -518,7 +518,7 @@ describe("Entity Models", () => {
         const entityData = createBasicEntity();
         const entity = createEntityWithMethods(entityData, mockService);
 
-        await expect(entity.deleteRecord('')).rejects.toThrow('Record ID is undefined');
+        await expect(entity.deleteRecord('')).rejects.toThrow(ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_RECORD_ID_UNDEFINED);
       });
     });
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -1136,13 +1136,11 @@ describe("EntityService Unit Tests", () => {
     it('should delete a single record successfully', async () => {
       mockApiClient.delete.mockResolvedValue(true);
 
-      const result = await entityService.deleteRecordById(
+      await entityService.deleteRecordById(
         ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ENTITY_TEST_CONSTANTS.RECORD_ID
       );
 
-      expect(result).toBeDefined();
-      expect(result.success).toBe(true);
       expect(mockApiClient.delete).toHaveBeenCalledWith(
         DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(
           ENTITY_TEST_CONSTANTS.ENTITY_ID,

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -120,6 +120,7 @@ describe("EntityService Unit Tests", () => {
       expect(typeof result.updateRecord).toBe("function");
       expect(typeof result.updateRecords).toBe("function");
       expect(typeof result.deleteRecords).toBe("function");
+      expect(typeof result.deleteRecord).toBe("function");
       expect(typeof result.getAllRecords).toBe("function");
     });
 
@@ -315,6 +316,7 @@ describe("EntityService Unit Tests", () => {
         expect(typeof entity.insertRecords).toBe("function");
         expect(typeof entity.updateRecords).toBe("function");
         expect(typeof entity.deleteRecords).toBe("function");
+        expect(typeof entity.deleteRecord).toBe("function");
         expect(typeof entity.getAllRecords).toBe("function");
       });
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -1130,6 +1130,37 @@ describe("EntityService Unit Tests", () => {
     });
   });
 
+  describe('deleteRecordById', () => {
+    it('should delete a single record successfully', async () => {
+      mockApiClient.delete.mockResolvedValue(true);
+
+      const result = await entityService.deleteRecordById(
+        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID
+      );
+
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID
+        ),
+        {}
+      );
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.delete.mockRejectedValue(error);
+
+      await expect(entityService.deleteRecordById(
+        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID
+      )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
   describe("downloadAttachment", () => {
     it("should download attachment successfully", async () => {
       const mockBlob = new Blob(["test content"], { type: "application/pdf" });


### PR DESCRIPTION
## Summary

- Adds `deleteRecordById(entityId, recordId)` service-level method to `EntityService` for single-record deletion via `DELETE /api/EntityService/entity/{entityId}/delete/{recordId}`
- Adds `deleteRecord(recordId)` entity-bound convenience method on `EntityMethods` for use after `getById()`
- Single-record deletion is distinct from batch (`deleteRecordsById`) because Data Fabric only fires trigger events on individual deletes


<img width="3024" height="1828" alt="image" src="https://github.com/user-attachments/assets/45a71828-6543-4061-bfee-0aefdff22e0b" />
