### PR TITLE
feat(conversations): expose disconnect method for clean process exit

### DIFF
--- a/src/models/conversational-agent/conversations/conversations.models.ts
+++ b/src/models/conversational-agent/conversations/conversations.models.ts
@@ -364,6 +364,20 @@ export interface ConversationServiceModel {
    * @internal
    */
   onConnectionStatusChanged(handler: ConnectionStatusChangedHandler): () => void;
+
+  /**
+   * Closes the WebSocket connection and releases all session resources.
+   *
+   * In Node.js the WebSocket keeps the event loop alive until disconnected,
+   * so call this to allow the process to exit cleanly. In the browser the
+   * runtime handles socket cleanup on page unload, so this is effectively a no-op.
+   *
+   * @example
+   * ```typescript
+   * conversationalAgent.conversations.disconnect();
+   * ```
+   */
+  disconnect(): void;
 }
 
 /**

--- a/src/services/conversational-agent/conversations/conversations.ts
+++ b/src/services/conversational-agent/conversations/conversations.ts
@@ -471,6 +471,23 @@ export class ConversationService extends BaseService implements ConversationServ
     return this._sessionManager.onConnectionStatusChanged(handler);
   }
 
+  /**
+   * Closes the WebSocket connection and releases all session resources.
+   *
+   * In Node.js the WebSocket keeps the event loop alive until disconnected,
+   * so call this to allow the process to exit cleanly. In the browser the
+   * runtime handles socket cleanup on page unload, so this is effectively a no-op.
+   *
+   * @example
+   * ```typescript
+   * conversationalAgent.conversations.disconnect();
+   * ```
+   */
+  @track('ConversationalAgent.Conversations.Disconnect')
+  disconnect(): void {
+    this._sessionManager.disconnect();
+  }
+
   // ==================== Private Methods ====================
 
   private _getEvents(): ConversationEventHelperManager {

--- a/tests/unit/services/conversational-agent/conversations.test.ts
+++ b/tests/unit/services/conversational-agent/conversations.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/services/conversational-agent/conversations/session/session-manager',
     setLogLevel: vi.fn(),
     setEventDispatcher: vi.fn(),
     emitEvent: vi.fn(),
+    disconnect: vi.fn(),
   }))
 }));
 
@@ -650,6 +651,14 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
 
       expect(cleanup).toBeDefined();
       expect(typeof cleanup).toBe('function');
+    });
+
+    it('should call disconnect on the session manager', () => {
+      const sessionManager = (conversationalAgent.conversations as any)._sessionManager;
+
+      conversationalAgent.conversations.disconnect();
+
+      expect(sessionManager.disconnect).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Exposes `disconnect()` on `ConversationService`, delegating to the existing `SessionManager.disconnect()` method
- Without this, CLI consumers using `startSession`/`endSession` have no way to close the underlying WebSocket, causing the process to hang indefinitely due to socket.io reconnection timers keeping the event loop alive
- Bumps version from 1.2.1 → 1.3.0 (new public API surface)

## Test plan
- [x] Verified `cas chat` single-message mode exits cleanly (exit code 0) against the built binary
- [x] Verified interactive mode `/quit` exits cleanly (exit code 0)
- [x] Verified SIGINT exits cleanly (exit code 130)
- [x] All 64 cas-tool unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)