### PR TITLE
feat: inject W3C traceparent header for request correlation

### DIFF
--- a/src/core/http/api-client.ts
+++ b/src/core/http/api-client.ts
@@ -4,7 +4,7 @@ import { RequestSpec } from '../../models/common/request-spec';
 import { TokenManager } from '../auth/token-manager';
 import { errorResponseParser } from '../errors/parser';
 import { ErrorFactory } from '../errors/error-factory';
-import { CONTENT_TYPES, RESPONSE_TYPES } from '../../utils/constants/headers';
+import { CONTENT_TYPES, RESPONSE_TYPES, TRACEPARENT, UIPATH_TRACEPARENT_ID } from '../../utils/constants/headers';
 
 export interface ApiClientConfig {
   headers?: Record<string, string>;
@@ -64,8 +64,15 @@ export class ApiClient {
     if (isFormData) {
       delete defaultHeaders['Content-Type'];
     }
-    const headers = {
+
+    const traceId = crypto.randomUUID().replace(/-/g, '');
+    const spanId = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+    const traceparentValue = `00-${traceId}-${spanId}-01`;
+
+    const headers: Record<string, string> = {
       ...defaultHeaders,
+      [TRACEPARENT]: traceparentValue,
+      [UIPATH_TRACEPARENT_ID]: traceparentValue,
       ...options.headers
     };
 

--- a/src/utils/constants/headers.ts
+++ b/src/utils/constants/headers.ts
@@ -7,6 +7,8 @@ export const  CORRELATION_ID = 'X-UIPATH-Correlation-Id';
 export const  JOB_KEY = 'X-UIPATH-JobKey';
 export const  FOLDER_ID = 'X-UIPATH-OrganizationUnitId';
 export const  INSTANCE_ID = 'X-UIPATH-InstanceId';
+export const  TRACEPARENT = 'traceparent';
+export const  UIPATH_TRACEPARENT_ID = 'x-uipath-traceparent-id';
 
 /**
  * Content type constants for HTTP requests/responses

--- a/tests/unit/core/http/api-client.test.ts
+++ b/tests/unit/core/http/api-client.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ApiClient } from '../../../../src/core/http/api-client';
+import { TEST_CONSTANTS } from '../../../utils/constants/common';
+
+const TRACEPARENT_REGEX = /^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/;
+
+const mockTokenManager = {
+  getValidToken: vi.fn().mockResolvedValue(TEST_CONSTANTS.DEFAULT_ACCESS_TOKEN),
+};
+
+const mockConfig = {
+  baseUrl: TEST_CONSTANTS.BASE_URL,
+  orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+  tenantName: TEST_CONSTANTS.TENANT_ID,
+};
+
+const mockExecutionContext = {};
+
+let capturedHeaders: Record<string, string> = {};
+
+beforeEach(() => {
+  capturedHeaders = {};
+  global.fetch = vi.fn().mockImplementation((_url: string, options: any) => {
+    capturedHeaders = { ...options.headers };
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ result: 'ok' })),
+    });
+  });
+});
+
+function createClient(clientConfig = {}) {
+  return new ApiClient(
+    mockConfig as any,
+    mockExecutionContext as any,
+    mockTokenManager as any,
+    clientConfig,
+  );
+}
+
+describe('ApiClient traceparent', () => {
+  it('injects a traceparent header with correct W3C format', async () => {
+    const client = createClient();
+    await client.get('/test');
+
+    expect(capturedHeaders['traceparent']).toBeDefined();
+    expect(capturedHeaders['traceparent']).toMatch(TRACEPARENT_REGEX);
+  });
+
+  it('injects x-uipath-traceparent-id with same value as traceparent', async () => {
+    const client = createClient();
+    await client.get('/test');
+
+    expect(capturedHeaders['x-uipath-traceparent-id']).toBeDefined();
+    expect(capturedHeaders['x-uipath-traceparent-id']).toBe(capturedHeaders['traceparent']);
+  });
+
+  it('generates different traceId and spanId values', async () => {
+    const client = createClient();
+    await client.get('/test');
+
+    const parts = capturedHeaders['traceparent'].split('-');
+    const traceId = parts[1];
+    const spanId = parts[2];
+
+    expect(traceId).not.toBe(spanId.padEnd(32, '0'));
+    expect(traceId.slice(0, 16)).not.toBe(spanId);
+  });
+
+  it('generates unique traceparent per request', async () => {
+    const client = createClient();
+
+    await client.get('/test1');
+    const first = capturedHeaders['traceparent'];
+
+    await client.get('/test2');
+    const second = capturedHeaders['traceparent'];
+
+    expect(first).not.toBe(second);
+  });
+
+  it('allows caller to override traceparent via options.headers', async () => {
+    const client = createClient();
+    const custom = '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01';
+
+    await client.get('/test', { headers: { traceparent: custom } });
+
+    expect(capturedHeaders['traceparent']).toBe(custom);
+  });
+});


### PR DESCRIPTION
Injects a W3C `traceparent` header on every outgoing SDK API request, enabling end-to-end request correlation between CF Worker logs and App Insights.

**What it does:**
- Generates a unique `traceId` and `spanId` (independently random per W3C spec) for each request
- Sets the `traceparent` header in the format `00-{traceId}-{spanId}-01`
- Header is forwarded through the CF Worker to cloud.uipath.com, where App Insights automatically reads `traceId` as `operation_Id`

**Why:**
CF Worker logs and backend App Insights logs currently have no shared identifier. This makes it impossible to trace a single request across both systems when debugging.

Cf worker PR: https://github.com/UiPath/apps-dev-tools/pull/41