### PR TITLE
feat: get user details from token

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -151,6 +151,7 @@ useEffect(() => {
 - `sdk.isInOAuthCallback()` - Check if processing OAuth redirect
 - `sdk.completeOAuth()` - Manually complete OAuth (advanced use)
 - `sdk.getToken()` - Get the logged-in user's access token
+- `sdk.getTokenIdentity()` - Get identity claims (email, firstName, lastName, preferredUsername, name) decoded from the current JWT access token
 - `sdk.logout()` - Logout and clear all authentication state (requires re-initialization to authenticate again)
 - `sdk.updateToken()` - Inject a refreshed token into the SDK instance (useful for backend services managing token lifecycle)
 

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -31,3 +31,14 @@ export interface OAuthContext {
   tenantName: string;
   scope: string;
 }
+
+/**
+ * Identity claims decoded from the current JWT access token.
+ */
+export interface TokenIdentity {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  preferredUsername?: string;
+  name?: string;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,7 +45,7 @@
 
 export { UiPath } from './uipath';
 export type { UiPathSDKConfig } from './config/sdk-config';
-export type { TokenInfo } from './auth/types';
+export type { TokenInfo, TokenIdentity } from './auth/types';
 export * from './errors';
 
 // Pagination (common across all services)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,7 +9,7 @@
  */
 
 import type { BaseConfig } from './config/sdk-config';
-import type { TokenInfo } from './auth/types';
+import type { TokenInfo, TokenIdentity } from './auth/types';
 
 export interface IUiPath {
   /** Read-only configuration for the SDK instance */
@@ -46,6 +46,13 @@ export interface IUiPath {
    * Get the current authentication token
    */
   getToken(): string | undefined;
+
+  /**
+   * Retrieves identity claims (email, firstName, lastName, preferredUsername, name)
+   * of the currently authenticated user by decoding the JWT access token.
+   * Does not work with PAT tokens.
+   */
+  getTokenIdentity(): TokenIdentity;
 
   /**
    * Logout from the SDK, clearing all authentication state.

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -1,7 +1,7 @@
 import { UiPathConfig } from './config/config';
 import { ExecutionContext } from './context/execution';
 import { AuthService } from './auth/service';
-import { TokenInfo } from './auth/types';
+import { TokenInfo, TokenIdentity } from './auth/types';
 import { UiPathSDKConfig, PartialUiPathConfig, BaseConfig, hasOAuthConfig, hasSecretConfig } from './config/sdk-config';
 import { validateConfig, normalizeBaseUrl, isCompleteConfig } from './config/config-utils';
 import { telemetryClient, trackEvent } from './telemetry';
@@ -9,6 +9,8 @@ import { SDKInternalsRegistry } from './internals';
 import { loadFromMetaTags } from './config/runtime';
 import type { IUiPath } from './types';
 import { isInActionCenter } from '../utils/platform';
+import { decodeBase64 } from '../utils/encoding/base64';
+import { AuthenticationError, ValidationError } from './errors';
 
 /**
  * UiPath - Core SDK class for authentication and configuration management.
@@ -236,6 +238,65 @@ export class UiPath implements IUiPath {
    */
   public getToken(): string | undefined {
     return this.#authService?.getToken();
+  }
+
+  /**
+   * Retrieves identity claims of the currently authenticated user by decoding
+   * the JWT access token held in memory. Does not make an API call.
+   *
+   * Returns the following camelCase claims when present on the token:
+   * `email`, `firstName`, `lastName`, `preferredUsername`, `name`.
+   *
+   * @returns The {@link TokenIdentity} extracted from the JWT payload.
+   * @throws {@link AuthenticationError} If the user is not authenticated.
+   * @throws {@link ValidationError} If the token is malformed or its payload cannot be decoded.
+   *
+   * @example
+   * ```typescript
+   * const sdk = new UiPath({ ...config });
+   * await sdk.initialize();
+   *
+   * const identity = sdk.getTokenIdentity();
+   * console.log(identity.email, identity.name);
+   * ```
+   */
+  public getTokenIdentity(): TokenIdentity {
+    if (!this.isAuthenticated()) {
+      throw new AuthenticationError({
+        message: 'User is not authenticated. Call initialize() before getTokenIdentity().'
+      });
+    }
+
+    const token = this.getToken();
+    if (!token) {
+      throw new AuthenticationError({
+        message: 'User is not authenticated. Call initialize() before getTokenIdentity().'
+      });
+    }
+
+    const segments = token.split('.');
+    if (segments.length !== 3) {
+      throw new ValidationError({ message: 'Invalid JWT token format.' });
+    }
+
+    let claims: Record<string, unknown>;
+    try {
+      // Convert base64url to base64 and pad to a multiple of 4.
+      let payload = segments[1].replace(/-/g, '+').replace(/_/g, '/');
+      const paddingLength = (4 - (payload.length % 4)) % 4;
+      payload = payload + '='.repeat(paddingLength);
+      claims = JSON.parse(decodeBase64(payload));
+    } catch {
+      throw new ValidationError({ message: 'Failed to decode JWT token payload.' });
+    }
+
+    return {
+      email: claims.email as string | undefined,
+      firstName: claims.first_name as string | undefined,
+      lastName: claims.last_name as string | undefined,
+      preferredUsername: claims.preferred_username as string | undefined,
+      name: claims.name as string | undefined
+    };
   }
 
   /**

--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -443,6 +443,19 @@ describe('UiPath Core', () => {
       expect(() => sdk.getTokenIdentity()).toThrow(ValidationError);
     });
 
+    it('should throw ValidationError when token has more than 3 segments', () => {
+      mockAuthState.token = 'header.payload.sig.extra';
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(() => sdk.getTokenIdentity()).toThrow(ValidationError);
+    });
+
     it('should throw ValidationError when payload is not valid JSON', () => {
       const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
       const invalidPayload = Buffer.from('not-json-content').toString('base64url');

--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -3,13 +3,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UiPath } from '../../../src/core/uipath';
 import { UiPathConfig } from '../../../src/core/config/config';
 import { ExecutionContext } from '../../../src/core/context/execution';
+import { AuthenticationError, ValidationError } from '../../../src/core/errors';
 import { getConfig, getContext, getTokenManager, getPrivateSDK } from '../../utils/setup';
 import { TEST_CONSTANTS } from '../../utils/constants/common';
 
 // ===== MOCKING =====
+const mockAuthState = {
+  token: 'mock-access-token' as string | undefined,
+  hasValidToken: true
+};
+
 const mockTokenManager = {
-  getToken: () => 'mock-access-token',
-  hasValidToken: () => true
+  getToken: () => mockAuthState.token,
+  hasValidToken: () => mockAuthState.hasValidToken
 };
 
 const mockLogout = vi.fn();
@@ -17,8 +23,8 @@ const mockLogout = vi.fn();
 vi.mock('../../../src/core/auth/service', () => {
   const AuthService: any = vi.fn().mockImplementation(() => ({
     getTokenManager: () => mockTokenManager,
-    hasValidToken: () => true,
-    getToken: () => 'mock-access-token',
+    hasValidToken: () => mockAuthState.hasValidToken,
+    getToken: () => mockAuthState.token,
     authenticateWithSecret: vi.fn(),
     authenticate: vi.fn().mockResolvedValue(true),
     logout: mockLogout
@@ -33,6 +39,13 @@ vi.mock('../../../src/core/auth/service', () => {
 });
 
 vi.mock('../../../src/core/http/api-client');
+
+// ===== TEST HELPERS =====
+const createJwt = (payload: Record<string, unknown>): string => {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+};
 
 // ===== TEST SUITE =====
 describe('UiPath Core', () => {
@@ -349,6 +362,100 @@ describe('UiPath Core', () => {
 
       expect(mockLogout).toHaveBeenCalledOnce();
       expect(sdk.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('getTokenIdentity', () => {
+    beforeEach(() => {
+      mockAuthState.hasValidToken = true;
+      mockAuthState.token = 'mock-access-token';
+    });
+
+    it('should return all 5 mapped identity fields from JWT claims', () => {
+      mockAuthState.token = createJwt({
+        email: 'jane.doe@example.com',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        preferred_username: 'jane.doe',
+        name: 'Jane Doe'
+      });
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      const identity = sdk.getTokenIdentity();
+
+      expect(identity).toEqual({
+        email: 'jane.doe@example.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        preferredUsername: 'jane.doe',
+        name: 'Jane Doe'
+      });
+    });
+
+    it('should return undefined for missing claims', () => {
+      mockAuthState.token = createJwt({ email: 'only.email@example.com' });
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      const identity = sdk.getTokenIdentity();
+
+      expect(identity.email).toBe('only.email@example.com');
+      expect(identity.firstName).toBeUndefined();
+      expect(identity.lastName).toBeUndefined();
+      expect(identity.preferredUsername).toBeUndefined();
+      expect(identity.name).toBeUndefined();
+    });
+
+    it('should throw AuthenticationError when user is not authenticated', () => {
+      mockAuthState.hasValidToken = false;
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(() => sdk.getTokenIdentity()).toThrow(AuthenticationError);
+    });
+
+    it('should throw ValidationError when token has fewer than 3 segments', () => {
+      mockAuthState.token = 'not-a-jwt';
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(() => sdk.getTokenIdentity()).toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError when payload is not valid JSON', () => {
+      const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+      const invalidPayload = Buffer.from('not-json-content').toString('base64url');
+      mockAuthState.token = `${header}.${invalidPayload}.signature`;
+
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET
+      });
+
+      expect(() => sdk.getTokenIdentity()).toThrow(ValidationError);
     });
   });
 


### PR DESCRIPTION
<details>
  <summary>Prompt used</summary>
This is the Typescript SDK repo. We want to add a util method to into src/core/uipath.ts named getTokenIdentity()

The util method should be able to retrieve details of current logged in user from the jwt token stored. We already expose isAuthenticated method. Use that to validate if user has already been authenticated. If not authenticated throw an error. We already expose getToken() method to get the token. Use the same method internally to get the token, decode the jwt token. Response should be consisting of below 5 fields. 
email
first_name
last_name
preferred_username
name

Follow coding and naming conventions mentioned in repo.
</details>

<details>
  <summary>Generated claude plan</summary>

# Plan: Add `getTokenIdentity()` to UiPath core class

## Context

Consumers of the SDK currently have no first-class way to read identity claims (email, name, etc.) for the authenticated user. The only hook is `getToken()`, which returns the raw JWT string — forcing every app to pull in a JWT library and implement base64url decoding themselves. This util exposes the identity claims directly from the token already held in memory, so coded-apps (and any other SDK consumer) can render the current user without an extra round-trip or dependency.

The method is a local, read-only utility — no API call, just decode the JWT payload we already have.

## Design

### Method signature

```typescript
public getTokenIdentity(): TokenIdentity
```

Synchronous, no parameters. Mirrors the style of the existing `isAuthenticated()` / `getToken()` methods on [`src/core/uipath.ts`](src/core/uipath.ts) — plain public method, JSDoc block, no `@track` decorator (consistent with other UiPath core class methods — decorators are only used on service methods).

### Return type

New interface `TokenIdentity` added to [src/core/auth/types.ts](src/core/auth/types.ts) (existing home for `TokenInfo`, `AuthToken`, `OAuthContext` — no need for a new file):

```typescript
/**
 * Identity claims decoded from the current JWT access token.
 */
export interface TokenIdentity {
  email?: string;
  firstName?: string;
  lastName?: string;
  preferredUsername?: string;
  name?: string;
}
```

All fields optional — JWT claims are not guaranteed to be present, and marking them required would cause runtime `undefined` access. Raw JWT claims use snake_case (`first_name`, `last_name`, `preferred_username`) and are mapped to camelCase to match the rest of the SDK's public surface.

### Behavior

1. If `!this.isAuthenticated()` → throw `AuthenticationError` with message `'User is not authenticated. Call initialize() before getTokenIdentity().'`
2. Read `this.getToken()`. If undefined (defensive — shouldn't happen when `isAuthenticated()` is true, but possible with secret-auth empty-token path at [`src/core/uipath.ts:120`](src/core/uipath.ts#L120)) → throw `AuthenticationError`.
3. Split the JWT on `.` — must be 3 segments. Otherwise → throw `ValidationError` with message `'Invalid JWT token format.'`
4. Base64url-decode the payload segment (replace `-`→`+`, `_`→`/`, pad with `=` to multiple of 4), then `decodeBase64()` from [src/utils/encoding/base64.ts](src/utils/encoding/base64.ts) and `JSON.parse()`. Any failure in this chain → throw `ValidationError` with message `'Failed to decode JWT token payload.'`
5. Map the 5 snake_case claims to camelCase and return.

### Error type choices

- **Not authenticated** → `AuthenticationError` from [src/core/errors/authentication.ts](src/core/errors/authentication.ts). The error type is designed for "missing authentication" (see class JSDoc).
- **Malformed token / decode failure** → `ValidationError` from [src/core/errors/validation.ts](src/core/errors/validation.ts). Per `agent_docs/conventions.md` error-types section: `ValidationError` is for invalid data format (user-supplied input), `ServerError` is for failed parsing of *API response* data. A malformed JWT sitting in auth state is closer to invalid input than a server response issue. This is a judgment call; using `ServerError` here would also be defensible, but `ValidationError` matches the "invalid data format" description more directly.

### Files to modify

| File | Change |
|------|--------|
| [src/core/auth/types.ts](src/core/auth/types.ts) | Add `TokenIdentity` interface |
| [src/core/uipath.ts](src/core/uipath.ts) | Add `getTokenIdentity()` method after `getToken()` (line 239); add imports for `TokenIdentity`, `AuthenticationError`, `ValidationError`, `decodeBase64` |
| [src/core/index.ts](src/core/index.ts) | Add `export type { TokenIdentity }` alongside existing `TokenInfo` export (line 48) |

No changes needed to [src/index.ts](src/index.ts) — it doesn't explicitly re-export `TokenInfo` either, so `TokenIdentity` follows the same pattern (available via `@uipath/uipath-typescript/core`).

No changes to `package.json`, `rollup.config.js`, `mkdocs.yml` — this is a method on an existing class exported through an existing path, not a new service.

No `docs/oauth-scopes.md` entry — this method makes no API call, so no OAuth scope is required.

No `docs/pagination.md` entry — not a paginated method.

### Reused utilities

- `decodeBase64()` — [src/utils/encoding/base64.ts:33](src/utils/encoding/base64.ts#L33). Cross-platform (browser `atob` / Node `Buffer`).
- `AuthenticationError` — [src/core/errors/authentication.ts](src/core/errors/authentication.ts).
- `ValidationError` — [src/core/errors/validation.ts](src/core/errors/validation.ts).
- `isAuthenticated()` / `getToken()` — existing methods on `UiPath` class.

### JSDoc

Example to include in the method's JSDoc:

```typescript
const sdk = new UiPath({ /* ... */ });
await sdk.initialize();

const identity = sdk.getTokenIdentity();
console.log(identity.email, identity.name);
```

## Tests

Add a new `describe('getTokenIdentity')` block to [tests/unit/core/uipath.test.ts](tests/unit/core/uipath.test.ts). The existing test file already mocks `AuthService` with configurable `hasValidToken` and `getToken` — extend the mock so individual tests can override the returned token.

Cases to cover:
1. Returns all 5 mapped fields when JWT payload contains the claims (uses a fixture JWT assembled with base64url-encoded payload `{ email, first_name, last_name, preferred_username, name }`).
2. Returns fields as `undefined` when claims are missing from the payload.
3. Throws `AuthenticationError` when `isAuthenticated()` is false.
4. Throws `ValidationError` when token is not a valid JWT structure (e.g., `'not.a.jwt'` has 3 segments but the middle is not valid base64url JSON; also test 2-segment and 1-segment strings).
5. Throws `ValidationError` when payload base64 decodes but is not valid JSON.

Use `TEST_CONSTANTS` style; build the fixture JWT inline with a small helper in the test file (no new test util needed for a single use).

## Verification

```bash
npm run typecheck     # must be clean
npm run lint          # 0 errors
npm run test:unit     # all unit tests pass, new tests green
npm run build         # dist/ produced
```

Manual end-to-end check (optional, relies on a live auth setup):

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
const sdk = new UiPath({ /* oauth config */ });
await sdk.initialize();
console.log(sdk.getTokenIdentity());
```

Confirm the console output shows the 5 camelCase fields populated from the real token claims.

</details>
<details>
  <summary>Local Testing</summary>

<img width="2955" height="364" alt="image" src="https://github.com/user-attachments/assets/d54f8954-cd79-4838-8313-cfa511e7d80d" />
  

  
</details>