### PR TITLE
feat(auth): add acr_values to OAuth authorization URL

### DIFF
--- a/src/core/auth/service.ts
+++ b/src/core/auth/service.ts
@@ -7,6 +7,8 @@ import { hasOAuthConfig } from '../config/sdk-config';
 import { isBrowser } from '../../utils/platform';
 import { IDENTITY_ENDPOINTS } from '../../utils/constants/endpoints';
 
+const GUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export class AuthService {
   private config: Config;
   private tokenManager: TokenManager;
@@ -329,7 +331,9 @@ export class AuthService {
     state?: string;
   }): string {
     const orgName = this.config.orgName;
-    
+    const isGuid = GUID_REGEX.test(orgName);
+    const acrValues = isGuid ? `tenant:${orgName}` : `tenantName:${orgName}`;
+
     const queryParams = new URLSearchParams({
       response_type: 'code',
       client_id: params.clientId,
@@ -340,7 +344,7 @@ export class AuthService {
       state: params.state || this.generateCodeVerifier().slice(0, 16)
     });
 
-    return `${this.config.baseUrl}/${orgName}/${IDENTITY_ENDPOINTS.AUTHORIZE}?${queryParams.toString()}`;
+    return `${this.config.baseUrl}/${IDENTITY_ENDPOINTS.AUTHORIZE}?${queryParams.toString()}&acr_values=${acrValues}`;
   }
 
   /**
@@ -352,8 +356,6 @@ export class AuthService {
     code: string;
     codeVerifier: string;
   }): Promise<AuthToken> {
-    const orgName = this.config.orgName;
-    
     const body = new URLSearchParams({
       grant_type: 'authorization_code',
       client_id: params.clientId,
@@ -362,7 +364,7 @@ export class AuthService {
       code_verifier: params.codeVerifier
     });
 
-    const response = await fetch(`${this.config.baseUrl}/${orgName}/${IDENTITY_ENDPOINTS.TOKEN}`, {
+    const response = await fetch(`${this.config.baseUrl}/${IDENTITY_ENDPOINTS.TOKEN}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'

--- a/tests/unit/core/auth/service.test.ts
+++ b/tests/unit/core/auth/service.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { AuthService } from '../../../../src/core/auth/service';
+import { ExecutionContext } from '../../../../src/core/context/execution';
+import { TEST_CONSTANTS } from '../../../utils/constants/common';
+import { IDENTITY_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+
+// Mock platform detection for Node test environment
+vi.mock('../../../../src/utils/platform', () => ({
+  isBrowser: false,
+  isInActionCenter: false
+}));
+
+describe('AuthService', () => {
+  const clientId = TEST_CONSTANTS.CLIENT_ID;
+  const redirectUri = TEST_CONSTANTS.REDIRECT_URI;
+  const codeChallenge = TEST_CONSTANTS.CODE_CHALLENGE;
+  const scope = TEST_CONSTANTS.OAUTH_SCOPE;
+
+  function createService(orgName: string) {
+    const config = {
+      baseUrl: TEST_CONSTANTS.BASE_URL,
+      orgName,
+      tenantName: TEST_CONSTANTS.TENANT_ID,
+      clientId,
+      redirectUri,
+      scope
+    };
+    return new AuthService(config, new ExecutionContext());
+  }
+
+  describe('getAuthorizationUrl', () => {
+    it('should build the correct authorize URL structure', () => {
+      const service = createService(TEST_CONSTANTS.ORGANIZATION_ID);
+      const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
+      expect(url.startsWith(TEST_CONSTANTS.BASE_URL)).toBe(true);
+      expect(url).toContain('connect/authorize');
+      expect(url).toContain('response_type=code');
+      expect(url).toContain('offline_access');
+    });
+
+    it('should include all required OAuth params alongside acr_values', () => {
+      const service = createService(TEST_CONSTANTS.ORGANIZATION_ID);
+      const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
+      const params = new URLSearchParams(url.split('?')[1]);
+      expect(params.get('response_type')).toBe('code');
+      expect(params.get('client_id')).toBe(clientId);
+      expect(params.get('redirect_uri')).toBe(redirectUri);
+      expect(params.get('code_challenge')).toBe(codeChallenge);
+      expect(params.get('code_challenge_method')).toBe('S256');
+      expect(params.get('scope')).toContain(scope);
+      expect(params.get('acr_values')).toBe(`tenantName:${TEST_CONSTANTS.ORGANIZATION_ID}`);
+    });
+
+    it('should set acr_values with tenant: prefix when orgName is a GUID', () => {
+      const service = createService(TEST_CONSTANTS.GUID_ORG_ID);
+      const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
+      const parsedUrl = new URL(url);
+      expect(parsedUrl.searchParams.get('acr_values')).toBe(`tenant:${TEST_CONSTANTS.GUID_ORG_ID}`);
+    });
+
+    it('should set acr_values with tenantName: prefix when orgName is a human-readable name', () => {
+      const service = createService(TEST_CONSTANTS.ORGANIZATION_ID);
+      const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
+      const parsedUrl = new URL(url);
+      expect(parsedUrl.searchParams.get('acr_values')).toBe(`tenantName:${TEST_CONSTANTS.ORGANIZATION_ID}`);
+    });
+
+    it('should set acr_values with tenantName: prefix for a GUID-like string with wrong segment length', () => {
+      const service = createService(TEST_CONSTANTS.INVALID_GUID_ORG_ID);
+      const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
+      const parsedUrl = new URL(url);
+      expect(parsedUrl.searchParams.get('acr_values')).toBe(`tenantName:${TEST_CONSTANTS.INVALID_GUID_ORG_ID}`);
+    });
+  });
+
+  describe('exchangeCode', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should call the token endpoint without orgName in the path', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ access_token: 'token', token_type: 'Bearer', expires_in: 360 }))
+      );
+      const service = createService(TEST_CONSTANTS.ORGANIZATION_ID);
+      await (service as any)._getAccessToken({
+        clientId,
+        redirectUri,
+        code: 'auth-code',
+        codeVerifier: 'code-verifier'
+      });
+      const calledUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(IDENTITY_ENDPOINTS.TOKEN);
+      expect(calledUrl).not.toContain(TEST_CONSTANTS.ORGANIZATION_ID);
+    });
+  });
+});

--- a/tests/utils/constants/common.ts
+++ b/tests/utils/constants/common.ts
@@ -36,5 +36,10 @@ export const TEST_CONSTANTS = {
   CLIENT_ID: 'test-client-id',
   CLIENT_SECRET: 'test-client-secret',
   ORGANIZATION_ID: 'test-org-id',
+  GUID_ORG_ID: '550e8400-e29b-41d4-a716-446655440000',
+  INVALID_GUID_ORG_ID: '550e840-e29b-41d4-a716-446655440000',
+  REDIRECT_URI: 'http://localhost:3000/callback',
+  CODE_CHALLENGE: 'test-code-challenge',
+  OAUTH_SCOPE: 'OR.Processes',
   TENANT_ID: 'test-tenant-id',
 } as const;


### PR DESCRIPTION
The acr_values is needed for identity as apart of the OIDC flow for partition information. It helps in sso silent login flows and ms entra authentication.

## Summary
- Adds `acr_values` parameter to the OAuth PKCE authorization URL
- Auto-detects whether `orgName` is a GUID or human-readable name:
  - GUID → `tenant:{orgName}`
  - Name → `tenantName:{orgName}`
- Ensures the identity provider resolves the correct tenant context during login
