### PR TITLE
feat: start method on maestro process

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -62,6 +62,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `PIMS` |
 | `getIncidents()` | `PIMS` |
+| `start()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ## Maestro Process Instances
 

--- a/src/models/maestro/processes.models.ts
+++ b/src/models/maestro/processes.models.ts
@@ -5,6 +5,11 @@
 
 import { RawMaestroProcessGetAllResponse } from './processes.types';
 import { ProcessIncidentGetResponse } from './process-incidents.types';
+import {
+  ProcessStartRequest,
+  ProcessStartResponse,
+} from '../orchestrator/processes.types';
+import { RequestOptions } from '../common/types';
 
 /**
  * Service for managing UiPath Maestro Processes
@@ -66,6 +71,29 @@ export interface MaestroProcessesServiceModel {
    * ```
    */
   getIncidents(processKey: string, folderKey: string): Promise<ProcessIncidentGetResponse[]>;
+
+  /**
+   * Starts a Maestro process execution within a folder.
+   *
+   * @param request - Process start request body (provide either `processKey` or `processName`)
+   * @param folderKey - Required folder key
+   * @param options - Optional query parameters
+   * @returns Promise resolving to the created jobs
+   * {@link ProcessStartResponse}
+   * @example
+   * ```typescript
+   * // Start a process by process key
+   * const jobs = await maestroProcesses.start({
+   *   processKey: '<processKey>'
+   * }, '<folderKey>');
+   *
+   * // Start a process by name
+   * const jobs = await maestroProcesses.start({
+   *   processName: 'MyProcess'
+   * }, '<folderKey>');
+   * ```
+   */
+  start(request: ProcessStartRequest, folderKey: string, options?: RequestOptions): Promise<ProcessStartResponse[]>;
 }
 
 // Method interface that will be added to process objects

--- a/src/services/maestro/processes/processes.ts
+++ b/src/services/maestro/processes/processes.ts
@@ -9,6 +9,12 @@ import { track } from '../../../core/telemetry';
 import { createHeaders } from '../../../utils/http/headers';
 import { FOLDER_KEY } from '../../../utils/constants/headers';
 import { ProcessInstancesService } from './process-instances';
+import {
+  ProcessStartRequest,
+  ProcessStartResponse,
+} from '../../../models/orchestrator/processes.types';
+import { RequestOptions } from '../../../models/common/types';
+import { startProcessRequest } from '../../orchestrator/processes/helpers';
 
 /**
  * Service for interacting with Maestro Processes
@@ -77,4 +83,40 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
     // Fetch BPMN XML and add element name/type to each incident
     return BpmnHelpers.enrichIncidentsWithBpmnData(rawResponse.data || [], folderKey, this.processInstancesService);
   }
-} 
+
+  /**
+   * Starts a Maestro process execution within a folder
+   *
+   * @param request - Process start request body
+   * @param folderKey - Required folder key
+   * @param options - Optional query parameters
+   * @returns Promise resolving to the created jobs
+   *
+   * @example
+   * ```typescript
+   * import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
+   *
+   * const maestroProcesses = new MaestroProcesses(sdk);
+   *
+   * // Start a process by process key
+   * const jobs = await maestroProcesses.start({
+   *   processKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+   * }, "<folderKey>");
+   *
+   * // Start a process by name
+   * const jobs = await maestroProcesses.start({
+   *   processName: "MyProcess"
+   * }, "<folderKey>");
+   * ```
+   */
+  @track('MaestroProcesses.Start')
+  async start(request: ProcessStartRequest, folderKey: string, options: RequestOptions = {}
+  ): Promise<ProcessStartResponse[]> {
+    return startProcessRequest(
+      this.post.bind(this),
+      request,
+      createHeaders({ [FOLDER_KEY]: folderKey }),
+      options
+    );
+  }
+}

--- a/src/services/orchestrator/processes/helpers.ts
+++ b/src/services/orchestrator/processes/helpers.ts
@@ -1,0 +1,56 @@
+import type { ApiResponse } from '../../base';
+import type { RequestSpec } from '../../../models/common/request-spec';
+import {
+  ProcessStartRequest,
+  ProcessStartResponse,
+} from '../../../models/orchestrator/processes.types';
+import { ProcessMap } from '../../../models/orchestrator/processes.constants';
+import { CollectionResponse, RequestOptions } from '../../../models/common/types';
+import {
+  addPrefixToKeys,
+  pascalToCamelCaseKeys,
+  transformData,
+  transformRequest,
+} from '../../../utils/transform';
+import { ODATA_PREFIX } from '../../../utils/constants/common';
+import { PROCESS_ENDPOINTS } from '../../../utils/constants/endpoints';
+
+type Poster = <T>(path: string, body?: unknown, options?: RequestSpec) => Promise<ApiResponse<T>>;
+
+/**
+ * Shared implementation of the Orchestrator StartJobs request.
+ *
+ * Both `ProcessService.start` (orchestrator, folderId header) and
+ * `MaestroProcessesService.start` (maestro, folderKey header) delegate here.
+ * Callers are responsible for constructing the appropriate folder header.
+ */
+export async function startProcessRequest(
+  post: Poster,
+  request: ProcessStartRequest,
+  headers: Record<string, string>,
+  options: RequestOptions = {}
+): Promise<ProcessStartResponse[]> {
+  // Transform SDK field names to API field names (e.g., processKey → releaseKey)
+  const apiRequest = transformRequest(request, ProcessMap);
+
+  // Create the request object according to API spec
+  const requestBody = {
+    startInfo: apiRequest
+  };
+
+  // Prefix all query parameter keys with '$' for OData
+  const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, Object.keys(options));
+
+  const response = await post<CollectionResponse<ProcessStartResponse>>(
+    PROCESS_ENDPOINTS.START_PROCESS,
+    requestBody,
+    {
+      params: apiOptions,
+      headers
+    }
+  );
+
+  return response.data?.value.map(process =>
+    transformData(pascalToCamelCaseKeys(process) as ProcessStartResponse, ProcessMap)
+  );
+}

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -1,5 +1,5 @@
 import { BaseService } from '../../base';
-import { CollectionResponse, RequestOptions } from '../../../models/common/types';
+import { RequestOptions } from '../../../models/common/types';
 import {
   ProcessGetResponse,
   ProcessGetAllOptions,
@@ -8,12 +8,13 @@ import {
   ProcessGetByIdOptions
 } from '../../../models/orchestrator/processes.types';
 import { ProcessServiceModel } from '../../../models/orchestrator/processes.models';
-import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest } from '../../../utils/transform';
+import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
 import { ProcessMap } from '../../../models/orchestrator/processes.constants';
 import { FOLDER_ID } from '../../../utils/constants/headers';
 import { PROCESS_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, ODATA_PAGINATION, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
+import { startProcessRequest } from './helpers';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
@@ -124,34 +125,12 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
    */
   @track('Processes.Start')
   async start(request: ProcessStartRequest, folderId: number, options: RequestOptions = {}): Promise<ProcessStartResponse[]> {
-    const headers = createHeaders({ [FOLDER_ID]: folderId });
-
-    // Transform SDK field names to API field names (e.g., processKey → releaseKey)
-    const apiRequest = transformRequest(request, ProcessMap);
-
-    // Create the request object according to API spec
-    const requestBody = {
-      startInfo: apiRequest
-    };
-
-    // Prefix all query parameter keys with '$' for OData
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
-    const response = await this.post<CollectionResponse<ProcessStartResponse>>(
-      PROCESS_ENDPOINTS.START_PROCESS,
-      requestBody,
-      { 
-        params: apiOptions,
-        headers
-      }
+    return startProcessRequest(
+      this.post.bind(this),
+      request,
+      createHeaders({ [FOLDER_ID]: folderId }),
+      options
     );
-    
-    const transformedProcess = response.data?.value.map(process => 
-      transformData(pascalToCamelCaseKeys(process) as ProcessStartResponse, ProcessMap)
-    );
-
-    return transformedProcess;
   }
 
   /**

--- a/tests/integration/shared/maestro/processes.integration.test.ts
+++ b/tests/integration/shared/maestro/processes.integration.test.ts
@@ -134,6 +134,38 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe('start', () => {
+    it('should start a process and create a job using processKey', async () => {
+      const { maestroProcesses } = getServices();
+      const config = getTestConfig();
+
+      const processKey = config.orchestratorTestProcessKey;
+
+      expect(
+        processKey,
+        'ORCHESTRATOR_TEST_PROCESS_KEY must be configured to test process execution'
+      ).toBeDefined();
+      expect(config.folderId, 'INTEGRATION_TEST_FOLDER_ID must be configured').toBeDefined();
+
+      const result = await maestroProcesses.start(
+        {
+          processKey: processKey!,
+          inputArguments: JSON.stringify({
+            testRun: true,
+            timestamp: new Date().toISOString(),
+          }),
+        },
+        config.folderId!
+      );
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      if (result.length > 0) {
+        expect(result[0].id).toBeDefined();
+      }
+    });
+  });
+
   describe('Process metadata validation', () => {
     it('should have expected fields in process objects', async () => {
       const { maestroProcesses } = getServices();

--- a/tests/unit/services/maestro/processes.test.ts
+++ b/tests/unit/services/maestro/processes.test.ts
@@ -218,29 +218,6 @@ describe('MaestroProcessesService', () => {
       );
     });
 
-    it('should start process with options', async () => {
-      const mockJob = createMockProcessStartResponse();
-      const mockResponse = createMockProcessStartApiResponse([mockJob]);
-      mockApiClient.post.mockResolvedValue(mockResponse);
-
-      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
-      const options: RequestOptions = { expand: PROCESS_TEST_CONSTANTS.EXPAND_ROBOT };
-      await service.start(request, MAESTRO_TEST_CONSTANTS.FOLDER_KEY, options);
-
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        PROCESS_ENDPOINTS.START_PROCESS,
-        expect.any(Object),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            [FOLDER_KEY]: MAESTRO_TEST_CONSTANTS.FOLDER_KEY
-          }),
-          params: expect.objectContaining({
-            '$expand': PROCESS_TEST_CONSTANTS.EXPAND_ROBOT
-          })
-        })
-      );
-    });
-
     it('should handle multiple jobs returned from start', async () => {
       const mockJobs = [
         createMockProcessStartResponse(),

--- a/tests/unit/services/maestro/processes.test.ts
+++ b/tests/unit/services/maestro/processes.test.ts
@@ -1,16 +1,22 @@
 // ===== IMPORTS =====
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MaestroProcessesService } from '../../../../src/services/maestro/processes';
-import { MAESTRO_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import { MAESTRO_ENDPOINTS, PROCESS_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { ApiClient } from '../../../../src/core/http/api-client';
-import { 
+import {
   MAESTRO_TEST_CONSTANTS,
-  createMockProcess, 
+  createMockProcess,
   createMockProcessesApiResponse,
-  createMockError, 
-  TEST_CONSTANTS
+  createMockError,
+  TEST_CONSTANTS,
+  createMockProcessStartResponse,
+  createMockProcessStartApiResponse,
 } from '../../../utils/mocks';
+import { PROCESS_TEST_CONSTANTS } from '../../../utils/constants';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
+import { JobPriority, ProcessStartRequest } from '../../../../src/models/orchestrator/processes.types';
+import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+import { RequestOptions } from '../../../../src/models/common';
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -151,6 +157,116 @@ describe('MaestroProcessesService', () => {
 
       
       expect(result[0].name).toBe(MAESTRO_TEST_CONSTANTS.CUSTOM_PACKAGE_ID);
+    });
+  });
+
+  describe('start', () => {
+    it('should start process by processKey successfully with transformations applied', async () => {
+      const mockJob = createMockProcessStartResponse();
+      const mockResponse = createMockProcessStartApiResponse([mockJob]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      const result = await service.start(request, MAESTRO_TEST_CONSTANTS.FOLDER_KEY);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe(PROCESS_TEST_CONSTANTS.JOB_KEY);
+      expect(result[0].processName).toBe(PROCESS_TEST_CONSTANTS.PROCESS_NAME);
+      expect(result[0].state).toBe('Running');
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.START_PROCESS,
+        expect.objectContaining({
+          startInfo: expect.objectContaining({
+            releaseKey: PROCESS_TEST_CONSTANTS.PROCESS_KEY,
+            jobPriority: JobPriority.Normal,
+            inputArguments: PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST.inputArguments
+          })
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: MAESTRO_TEST_CONSTANTS.FOLDER_KEY
+          }),
+          params: expect.any(Object)
+        })
+      );
+    });
+
+    it('should start process by processName successfully with transformations applied', async () => {
+      const mockJob = createMockProcessStartResponse();
+      const mockResponse = createMockProcessStartApiResponse([mockJob]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST_WITH_NAME as ProcessStartRequest;
+      const result = await service.start(request, MAESTRO_TEST_CONSTANTS.FOLDER_KEY);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe(PROCESS_TEST_CONSTANTS.JOB_KEY);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.START_PROCESS,
+        expect.objectContaining({
+          startInfo: expect.objectContaining({
+            releaseName: PROCESS_TEST_CONSTANTS.PROCESS_NAME,
+            jobPriority: JobPriority.High,
+            inputArguments: PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST_WITH_NAME.inputArguments
+          })
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('should start process with options', async () => {
+      const mockJob = createMockProcessStartResponse();
+      const mockResponse = createMockProcessStartApiResponse([mockJob]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      const options: RequestOptions = { expand: PROCESS_TEST_CONSTANTS.EXPAND_ROBOT };
+      await service.start(request, MAESTRO_TEST_CONSTANTS.FOLDER_KEY, options);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.START_PROCESS,
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: MAESTRO_TEST_CONSTANTS.FOLDER_KEY
+          }),
+          params: expect.objectContaining({
+            '$expand': PROCESS_TEST_CONSTANTS.EXPAND_ROBOT
+          })
+        })
+      );
+    });
+
+    it('should handle multiple jobs returned from start', async () => {
+      const mockJobs = [
+        createMockProcessStartResponse(),
+        createMockProcessStartResponse({
+          key: PROCESS_TEST_CONSTANTS.JOB_KEY,
+          id: 2
+        })
+      ];
+      const mockResponse = createMockProcessStartApiResponse(mockJobs);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      const result = await service.start(request, MAESTRO_TEST_CONSTANTS.FOLDER_KEY);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(2);
+      expect(result[1].key).toBe(PROCESS_TEST_CONSTANTS.JOB_KEY);
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await expect(service.start(request, MAESTRO_TEST_CONSTANTS.FOLDER_KEY))
+        .rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 });


### PR DESCRIPTION
<details>
  <summary>Prompt used</summary>
1. Under maestro Processes I want to add a new method named start. It should internally call the same start logic done within Processes. One difference, instead of folderId: number as an argument, take folderKey: string
2. Orchestrator process start and Maestro process start both has same implementation with only headers being the difference. Is there a way to reduce code duplication across both methods
</details>

<details>
  <summary>Generated claude plan</summary>

# Plan: Deduplicate Orchestrator + Maestro `start` process logic

## Context

`ProcessService.start` (orchestrator) and `MaestroProcessesService.start` (maestro) currently contain near-identical implementations. The only meaningful difference is the folder header:

- Orchestrator: `X-UIPATH-OrganizationUnitId` (numeric `folderId`)
- Maestro: `X-UIPATH-FolderKey` (string `folderKey`)

Everything else — `transformRequest(request, ProcessMap)`, the `{ startInfo: ... }` body wrap, OData `$`-prefixing of options, the POST to `PROCESS_ENDPOINTS.START_PROCESS`, and the response transform pipeline (`pascalToCamelCaseKeys` + `transformData`) — is duplicated verbatim. Any future change (new transform field, response shape change, error handling tweak) must currently be made in two places.

The goal is to extract the shared body into one helper so both public methods become thin wrappers that only differ in their folder-header construction and `@track` label.

## Approach

Extract a free helper function `startProcessRequest()` that takes the work that's identical between the two services. Both `ProcessService.start` and `MaestroProcessesService.start` keep their public signatures and `@track` decorators; their bodies shrink to building the headers and delegating.

### Why a free function (and not a base class / static method)

`BaseService.post` is `protected`, so the helper cannot call it from outside the class hierarchy. The cleanest workaround — already used elsewhere in the codebase (`createPaginationServiceAccess` on `base.ts:90`) — is to have the calling service hand the helper a bound `post` callable. This avoids inheritance gymnastics, keeps `BaseService` free of domain-specific code, and preserves protected-method encapsulation.

### Helper signature

New file: `src/services/orchestrator/processes/helpers.ts` (orchestrator owns the underlying API).

```ts
import type { ApiResponse } from '../../base';
import type { RequestSpec } from '../../../models/common/request-spec';
import { ProcessStartRequest, ProcessStartResponse } from '../../../models/orchestrator/processes.types';
import { ProcessMap } from '../../../models/orchestrator/processes.constants';
import { CollectionResponse, RequestOptions } from '../../../models/common/types';
import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest } from '../../../utils/transform';
import { ODATA_PREFIX } from '../../../utils/constants/common';
import { PROCESS_ENDPOINTS } from '../../../utils/constants/endpoints';

type Poster = <T>(path: string, body?: unknown, options?: RequestSpec) => Promise<ApiResponse<T>>;

export async function startProcessRequest(
  post: Poster,
  request: ProcessStartRequest,
  headers: Record<string, string>,
  options: RequestOptions = {}
): Promise<ProcessStartResponse[]> {
  const apiRequest = transformRequest(request, ProcessMap);
  const requestBody = { startInfo: apiRequest };
  const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, Object.keys(options));

  const response = await post<CollectionResponse<ProcessStartResponse>>(
    PROCESS_ENDPOINTS.START_PROCESS,
    requestBody,
    { params: apiOptions, headers }
  );

  return response.data?.value.map(process =>
    transformData(pascalToCamelCaseKeys(process) as ProcessStartResponse, ProcessMap)
  );
}
```

### Caller shape

`src/services/orchestrator/processes/processes.ts` — `start()` becomes:

```ts
@track('Processes.Start')
async start(request: ProcessStartRequest, folderId: number, options: RequestOptions = {}): Promise<ProcessStartResponse[]> {
  return startProcessRequest(
    this.post.bind(this),
    request,
    createHeaders({ [FOLDER_ID]: folderId }),
    options
  );
}
```

`src/services/maestro/processes/processes.ts` — `start()` becomes:

```ts
@track('MaestroProcesses.Start')
async start(request: ProcessStartRequest, folderKey: string, options: RequestOptions = {}): Promise<ProcessStartResponse[]> {
  return startProcessRequest(
    this.post.bind(this),
    request,
    createHeaders({ [FOLDER_KEY]: folderKey }),
    options
  );
}
```

After the refactor, the maestro service can drop its now-unused imports of `transformRequest`, `pascalToCamelCaseKeys`, `transformData`, `addPrefixToKeys`, `ODATA_PREFIX`, `CollectionResponse`, `ProcessMap`, and `PROCESS_ENDPOINTS` (only `RequestOptions`, the response/request types, `FOLDER_KEY`, `createHeaders`, and the new helper remain). Same housekeeping for orchestrator.

## Files to modify

| File | Change |
|------|--------|
| `src/services/orchestrator/processes/helpers.ts` | **new** — exports `startProcessRequest` |
| `src/services/orchestrator/processes/processes.ts` | `start()` body delegates to helper; trim imports |
| `src/services/maestro/processes/processes.ts` | `start()` body delegates to helper; trim imports |

No model, endpoint, type, or test changes required — public signatures and behavior are unchanged.

## Verification

1. `npm run typecheck` — clean
2. `npm run lint` — 0 warnings/errors
3. `npm run test:unit` — all existing orchestrator + maestro start tests pass unchanged. The 11 maestro tests and 5 orchestrator start tests already exercise: processKey path, processName path, OData option `$` prefixing, multi-job response, and error propagation. No new tests needed because the public contract is identical.
4. `npm run build` — Rollup completes without import-resolution errors (the new `helpers.ts` is internal to its module and not exported from any subpath).

## Out of scope

- Renaming the helper or relocating it to a `shared/` directory — orchestrator owns the endpoint, so co-locating with orchestrator processes is correct.
- Touching `getById` / `getAll` — they don't share enough surface to justify deduplication.
- Adding integration tests for the helper directly — it has no public surface.


</details>
<details>
  <summary>Local Testing</summary>

Done on playground app
  

  
</details>