### PR TITLE
ci: enhance claude code review and clean up enhance-claude-docs skill

### DIFF
--- a/.claude/skills/enhance-claude-docs/SKILL.md
+++ b/.claude/skills/enhance-claude-docs/SKILL.md
@@ -175,6 +175,16 @@ If actionable insights exist:
 5. For `agent_docs/architecture.md`, update tables or sections as appropriate.
 6. For `Agents.md`, update the quick reference or add new sections.
 
+### Content rules for doc edits
+
+The text written into the doc files must be self-contained guidance, not a changelog.
+
+- **Do not include source PR references** (`#327`, `Source: PR #184`, etc.) in the file content — they create permanent cross-link noise in the source PRs.
+- **Do not include @-mentions** (`@swati354`, `reviewer @maninder noted`) in the file content — handles don't belong in long-lived docs.
+- Rewrite each insight as a generalized rule/convention; don't quote the original comment verbatim.
+
+Provenance belongs in the PR body (Step 7) and the terminal output (Step 8) — not inside the docs.
+
 ---
 
 ## Step 7: Create or Update PR

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -127,9 +127,15 @@ jobs:
                    INSTEAD of posting a new comment.
                 4. Only post if STEP 3 says OK to post.
 
-              The same gate applies to the summary comment: when summarizing, do not
-              list issues whose threads you chose to skip or unresolve — summarize
-              only genuinely new findings and any threads you unresolved.
+              Top-level summary comment — POST ONLY IF the run produced an action.
+              An action means: (a) you posted at least one new inline comment, OR
+              (b) you unresolved at least one previously-resolved thread. If neither
+              happened, post NO summary comment at all — stay completely silent.
+              Do NOT post filler summaries like "No new issues" or "Nothing to report".
+
+              When you DO post a summary, list only: (a) the new findings you posted
+              this run, and (b) any threads you unresolved this run. Do not list
+              issues you skipped via the dedupe gate.
 
             Now run the plugin:
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,11 @@ on:
 
 jobs:
   claude-review:
+    # Opt-out: PR authors can apply the `skip-claude-review` label to suppress
+    # the bot on subsequent commits. Removing the label re-enables review on
+    # the next push.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-claude-review') }}
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -39,9 +44,95 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
-            Read CLAUDE.md at the repo root first — it references Agents.md and agent_docs/ which contain all project conventions, architecture, and rules. Follow every convention defined there during your review.
+            You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            STEP 1 — Fetch existing review threads and issue comments BEFORE reviewing.
+            Run this GraphQL query and read the results carefully:
+
+              gh api graphql -f query='
+                query($owner:String!,$repo:String!,$num:Int!){
+                  repository(owner:$owner,name:$repo){
+                    pullRequest(number:$num){
+                      reviewThreads(first:100){
+                        nodes{
+                          id
+                          isResolved
+                          path
+                          line
+                          comments(first:20){ nodes{ author{login} body }}
+                        }
+                      }
+                      comments(first:100){
+                        nodes{ author{login} body }
+                      }
+                    }
+                  }
+                }' \
+                -f owner=${{ github.repository_owner }} \
+                -f repo=${{ github.event.repository.name }} \
+                -F num=${{ github.event.pull_request.number }}
+
+            STEP 2 — Build a set of issues already covered by prior bot comments
+            (threads whose first comment is authored by a bot or this workflow's
+            identity). Treat each prior comment as "(path, line, topic)".
+
+            STEP 3 — Dedupe policy. For each issue you are about to raise, look for a
+            prior thread covering the same (path, line, topic):
+
+              • If an UNRESOLVED thread exists for this (path, line, topic) → SKIP.
+                Don't duplicate an open thread; the user will get to it.
+
+              • If a RESOLVED thread exists for this (path, line, topic), classify the
+                ORIGINAL comment:
+                  (a) Actionable ask (it requested the author to change something —
+                      e.g. "rename X", "use Y instead", "extract this", "add null check"):
+                      → Read the CURRENT code at that location.
+                          - If the requested change WAS made → SKIP (user fixed it).
+                          - If the requested change was NOT made → UNRESOLVE the
+                            original thread (do NOT post a new comment). Use:
+
+                              gh api graphql -f query='
+                                mutation($id:ID!){
+                                  unresolveReviewThread(input:{threadId:$id}){
+                                    thread{ id isResolved }
+                                  }
+                                }' -f id=<THREAD_ID>
+
+                            where <THREAD_ID> is the thread.id from STEP 1.
+                      → If thread replies show the author/maintainer explicitly
+                        disagreed or declined ("won't fix", "intentional", "ship it
+                        anyway") → SKIP regardless of code state. The decision was made.
+                  (b) Informational / nit / praise / question (not an ask for a change):
+                      → SKIP. Resolution means acknowledged; don't re-post and don't
+                        unresolve.
+
+              • If a prior comment raised a DIFFERENT topic on the same line → OK to post.
+              • New issues the prior review missed entirely → post normally.
+
+            STEP 4 — Read CLAUDE.md at the repo root first — it references Agents.md
+            and agent_docs/ which contain all project conventions, architecture, and
+            rules. Follow every convention defined there during your review.
+
+            STEP 5 — Run the review. The /code-review plugin below will analyze the PR
+            and propose inline comments. You MUST apply STEP 3 as a POSTING GATE on
+            every single comment the plugin wants to create — this includes comments
+            the plugin would post via mcp__github_inline_comment__create_inline_comment
+            or via `gh pr comment`. Concretely:
+
+              BEFORE every call to mcp__github_inline_comment__create_inline_comment:
+                1. Compute (path, line, topic) of the comment you are about to post.
+                2. Look it up in the dedupe set from STEP 1.
+                3. Apply STEP 3. If STEP 3 says SKIP → do NOT call the tool at all.
+                   If STEP 3 says UNRESOLVE → call the unresolveReviewThread mutation
+                   INSTEAD of posting a new comment.
+                4. Only post if STEP 3 says OK to post.
+
+              The same gate applies to the summary comment: when summarizing, do not
+              list issues whose threads you chose to skip or unresolve — summarize
+              only genuinely new findings and any threads you unresolved.
+
+            Now run the plugin:
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
           use_sticky_comment: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
-
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api graphql:*),Bash(gh api:*)"


### PR DESCRIPTION
## Why

Three pain points across our review/docs automation:

1. **Bombardment in `claude-code-review.yml`** — every push re-runs a full review with no awareness of prior comments, re-posting the same inline comments even after fixes/resolves/declines.
2. **No way to opt out** of the review workflow on WIP or trivial PRs.
3. **`enhance-claude-docs` skill bakes provenance into doc files** — `(Source: PR #184)` and `@swati354`-style references end up permanently inside `agent_docs/*.md` (see #360), creating cross-link noise and burning contributor handles into long-lived docs.

## What this PR does

### 1. Resolved-thread dedupe (`claude-code-review.yml`)

Fetches existing review threads via GraphQL before reviewing, then gates every inline-comment posting:

| Prior thread | Original was | Code now | Action |
|---|---|---|---|
| Unresolved | (any) | (any) | Skip |
| Resolved | Actionable ask | Fix applied | Skip |
| Resolved | Actionable ask | Fix NOT applied | **Unresolve** the thread (no new comment) |
| Resolved | Author replied "won't fix" / "intentional" | (any) | Skip |
| Resolved | Nit / FYI | (any) | Skip |

Decline detection reads thread reply text — no labels or syntax needed.

### 2. Opt-out label (`claude-code-review.yml`)

```yaml
if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-claude-review') }}
```

Apply `skip-claude-review` (label created in this repo) → workflow skipped on subsequent commits. Remove → re-enabled. Symmetric.

### 3. Silence summary on no-op runs (`claude-code-review.yml`)

The current workflow posts zero plugin summary comments on most PRs (e.g., 8 commits on #358 → 0 plugin summaries). Without explicit guidance, the new dedupe prompt would have started posting filler summaries like *"No new issues"* on runs where nothing actually happened.

STEP 5 of the prompt now gates the summary: post **only if** the run produced an action (a new inline comment or an unresolved thread). Otherwise stay silent. Preserves current "no chat on no-op" behavior while keeping audit value when state actually changed.

### 4. Content rules for `enhance-claude-docs` skill

Step 6 of `.claude/skills/enhance-claude-docs/SKILL.md` now forbids `#N` refs, `@username` mentions, and verbatim quoting **inside the doc files**. Provenance stays in the PR body and terminal output.

## Testing — review workflow

Validated end-to-end on `ninja-shreyash/cherrypick-test#20` across 8 scenarios. **All passed.**

| # | Scenario | Validates | Result |
|---|---|---|---|
| 1 | Baseline — open PR with 3 deliberate issues | Initial review posts findings | 3 inline threads at lines 3, 4, 8 ✅ |
| 2 | Idle re-run (empty commit) | No duplicate inline comments | Still 3 threads, 1 comment each ✅ |
| 3 | Resolve thread without fix → push | Bot unresolves the thread | Thread flipped resolved → unresolved, 0 new comments ✅ |
| 4 | Resolve + apply fix → push | Bot leaves it resolved | Stayed resolved (line 8 → 12 drift tracked correctly), 0 new comments ✅ |
| 5 | Reply "won't fix", resolve → push | Bot respects decline | Stayed resolved, 0 new comments ✅ |
| 6 | (Emergent) Bot finds new issue near existing thread | New finding on different topic posts; bot references existing thread | Posted on line 5 about a logic bug, body referenced line-4 thread ✅ |
| 7a | Add `skip-claude-review` label → push | Opt-out skips workflow | Run completed in 1s with status `skipped`, no compute ✅ |
| 7b | Remove label → push | Workflow resumes normally | Ran successfully, dedupe respected ✅ |
| **8** | **No-op push after silence-on-no-op clause added** | **Bot posts no filler summary** | **Same threads, comment count unchanged, 0 new summaries posted ✅** |

Across 4 follow-up pushes (scenarios 2–5), **zero duplicate inline comments were posted.** Scenario 8 confirms the silence-on-no-op clause from change #3 fully suppresses filler summaries — same conditions previously produced a `## Code Review — No New Issues` summary, now produces nothing.

**Test PR:** https://github.com/ninja-shreyash/cherrypick-test/pull/20

## Testing — docs skill change

Prompt-level change. Exercised by the next scheduled `claude-docs-update.yml` run (Mondays 9am UTC) or manual `workflow_dispatch`. Next run's docs PR should have no `#N` or `@username` strings inside modified `agent_docs/*.md` files.

## Risk

- CI / skill files only — no SDK code touched.
- Backward-compatible: PRs without the opt-out label behave as before, plus dedupe.
- If the GraphQL query fails, falls back to prior full-review behavior. Worst case = one run of duplicate comments, not a broken workflow.