### PR TITLE
feat(cas): agent inputs in conversations

### DIFF
--- a/src/models/conversational-agent/conversations/conversations.models.ts
+++ b/src/models/conversational-agent/conversations/conversations.models.ts
@@ -82,7 +82,7 @@ export interface ConversationServiceModel {
    * @param options - Optional settings for the conversation
    * @returns Promise resolving to {@link ConversationCreateResponse} with bound methods
    *
-   * @example
+   * @example Basic usage
    * ```typescript
    * const conversation = await conversationalAgent.conversations.create(
    *   agentId,
@@ -98,6 +98,19 @@ export interface ConversationServiceModel {
    *
    * // Delete the conversation
    * await conversation.delete();
+   * ```
+   *
+   * @example With agent input arguments
+   * ```typescript
+   * const conversation = await conversationalAgent.conversations.create(
+   *   agentId,
+   *   folderId,
+   *   {
+   *     agentInput: {
+   *       inline: { userId: 'user-123', language: 'en' }
+   *     }
+   *   }
+   * );
    * ```
    */
   create(agentId: number, folderId: number, options?: ConversationCreateOptions): Promise<ConversationCreateResponse>;

--- a/src/models/conversational-agent/conversations/conversations.types.ts
+++ b/src/models/conversational-agent/conversations/conversations.types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SortOrder, ConversationJobStartOverrides, RawConversationGetResponse } from './types/core.types';
+import type { AgentInput } from './types/common.types';
 import type { ConversationGetResponse } from './conversations.models';
 import type { PaginationOptions } from '@/utils/pagination/types';
 import type { LogLevel } from '@/core/websocket';
@@ -57,6 +58,8 @@ export interface ConversationCreateOptions {
   traceId?: string;
   /** Optional configuration for job start behavior */
   jobStartOverrides?: ConversationJobStartOverrides;
+  /** Input arguments for the agent */
+  agentInput?: AgentInput;
 }
 
 export interface ConversationUpdateOptions {
@@ -68,6 +71,8 @@ export interface ConversationUpdateOptions {
   jobKey?: string;
   /** Whether the conversation's job is running locally */
   isLocalJobExecution?: boolean;
+  /** Input arguments for the agent */
+  agentInput?: AgentInput;
 }
 
 export type ConversationGetAllOptions = PaginationOptions & {

--- a/src/models/conversational-agent/conversations/types/common.types.ts
+++ b/src/models/conversational-agent/conversations/types/common.types.ts
@@ -135,6 +135,12 @@ export interface ExternalValue {
 export type InlineOrExternalValue<T> = InlineValue<T> | ExternalValue;
 
 /**
+ * Input arguments passed to the agent on each exchange. Only inline values are currently supported by the API.
+ * Using the InlineOrExternalValue type to make future external value support easier.
+ */
+export type AgentInput = InlineOrExternalValue<JSONObject>;
+
+/**
  * Tool call input value type.
  */
 export type ToolCallInputValue = JSONObject;

--- a/src/models/conversational-agent/conversations/types/common.types.ts
+++ b/src/models/conversational-agent/conversations/types/common.types.ts
@@ -135,10 +135,11 @@ export interface ExternalValue {
 export type InlineOrExternalValue<T> = InlineValue<T> | ExternalValue;
 
 /**
- * Input arguments passed to the agent on each exchange. Only inline values are currently supported by the API.
- * Using the InlineOrExternalValue type to make future external value support easier.
+ * Input arguments passed in to the execution of the agent on each exchange. The input arguments are
+ * expected to match the input-schema defined in the Agent definition. Currently, only inline values
+ * are supported and the total serialized JSON payload must be less than 4,000 characters.
  */
-export type AgentInput = InlineOrExternalValue<JSONObject>;
+export type AgentInput = InlineValue<JSONObject>;
 
 /**
  * Tool call input value type.

--- a/src/models/conversational-agent/conversations/types/core.types.ts
+++ b/src/models/conversational-agent/conversations/types/core.types.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  AgentInput,
   CitationSource,
   InlineOrExternalValue,
   InterruptType,
@@ -383,5 +384,9 @@ export interface RawConversationGetResponse {
    * Whether the conversation's job is running locally.
    */
   isLocalJobExecution?: boolean;
+  /**
+   * Optional agent input arguments for the conversation.
+   */
+  agentInput?: AgentInput;
 }
 

--- a/tests/unit/services/conversational-agent/conversations.test.ts
+++ b/tests/unit/services/conversational-agent/conversations.test.ts
@@ -135,6 +135,32 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
       expect(result.exchanges).toBeDefined();
     });
 
+    it('should create a conversation with agentInput', async () => {
+      const agentInput = CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_INPUT;
+      const mockConversation = createMockRawConversation({ agentInput });
+      mockApiClient.post.mockResolvedValue(mockConversation);
+
+      const result = await conversationalAgent.conversations.create(
+        CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_ID,
+        TEST_CONSTANTS.FOLDER_ID,
+        { agentInput }
+      );
+
+      expect(result).toBeDefined();
+      expect(result.agentInput).toEqual(agentInput);
+
+      // Verify agentInput is passed through to the API unchanged
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        CONVERSATION_ENDPOINTS.CREATE,
+        expect.objectContaining({
+          agentReleaseId: CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_ID,
+          folderId: TEST_CONSTANTS.FOLDER_ID,
+          agentInput
+        }),
+        expect.any(Object)
+      );
+    });
+
     it('should handle API errors', async () => {
       const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
       mockApiClient.post.mockRejectedValue(error);
@@ -190,6 +216,18 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
       expect((result as any).agentReleaseId).toBeUndefined();
       expect((result as any).createdAt).toBeUndefined();
       expect((result as any).updatedAt).toBeUndefined();
+    });
+
+    it('should return agentInput from getById response', async () => {
+      const agentInput = CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_INPUT;
+      const mockConversation = createMockRawConversation({ agentInput });
+      mockApiClient.get.mockResolvedValue(mockConversation);
+
+      const result = await conversationalAgent.conversations.getById(
+        CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID
+      );
+
+      expect(result.agentInput).toEqual(agentInput);
     });
 
     it('should handle API errors', async () => {
@@ -330,6 +368,26 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
 
       expect(typeof result.update).toBe('function');
       expect(typeof result.delete).toBe('function');
+    });
+
+    it('should update a conversation with agentInput', async () => {
+      const agentInput = CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_INPUT;
+      const mockConversation = createMockRawConversation({ agentInput });
+      mockApiClient.patch.mockResolvedValue(mockConversation);
+
+      const result = await conversationalAgent.conversations.updateById(
+        CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID,
+        { agentInput }
+      );
+
+      expect(result).toBeDefined();
+      expect(result.agentInput).toEqual(agentInput);
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        CONVERSATION_ENDPOINTS.UPDATE(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID),
+        expect.objectContaining({ agentInput }),
+        expect.any(Object)
+      );
     });
 
     it('should handle API errors', async () => {

--- a/tests/unit/services/conversational-agent/conversations.test.ts
+++ b/tests/unit/services/conversational-agent/conversations.test.ts
@@ -167,6 +167,32 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
       expect(result.exchanges).toBeDefined();
     });
 
+    it('should create a conversation with agentInput', async () => {
+      const agentInput = CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_INPUT;
+      const mockConversation = createMockRawConversation({ agentInput });
+      mockApiClient.post.mockResolvedValue(mockConversation);
+
+      const result = await conversationalAgent.conversations.create(
+        CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_ID,
+        TEST_CONSTANTS.FOLDER_ID,
+        { agentInput }
+      );
+
+      expect(result).toBeDefined();
+      expect(result.agentInput).toEqual(agentInput);
+
+      // Verify agentInput is passed through to the API unchanged
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        CONVERSATION_ENDPOINTS.CREATE,
+        expect.objectContaining({
+          agentReleaseId: CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_ID,
+          folderId: TEST_CONSTANTS.FOLDER_ID,
+          agentInput
+        }),
+        expect.any(Object)
+      );
+    });
+
     it('should handle API errors', async () => {
       const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
       mockApiClient.post.mockRejectedValue(error);
@@ -222,6 +248,18 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
       expect((result as any).agentReleaseId).toBeUndefined();
       expect((result as any).createdAt).toBeUndefined();
       expect((result as any).updatedAt).toBeUndefined();
+    });
+
+    it('should return agentInput from getById response', async () => {
+      const agentInput = CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_INPUT;
+      const mockConversation = createMockRawConversation({ agentInput });
+      mockApiClient.get.mockResolvedValue(mockConversation);
+
+      const result = await conversationalAgent.conversations.getById(
+        CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID
+      );
+
+      expect(result.agentInput).toEqual(agentInput);
     });
 
     it('should handle API errors', async () => {
@@ -362,6 +400,26 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
 
       expect(typeof result.update).toBe('function');
       expect(typeof result.delete).toBe('function');
+    });
+
+    it('should update a conversation with agentInput', async () => {
+      const agentInput = CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_INPUT;
+      const mockConversation = createMockRawConversation({ agentInput });
+      mockApiClient.patch.mockResolvedValue(mockConversation);
+
+      const result = await conversationalAgent.conversations.updateById(
+        CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID,
+        { agentInput }
+      );
+
+      expect(result).toBeDefined();
+      expect(result.agentInput).toEqual(agentInput);
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        CONVERSATION_ENDPOINTS.UPDATE(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID),
+        expect.objectContaining({ agentInput }),
+        expect.any(Object)
+      );
     });
 
     it('should handle API errors', async () => {

--- a/tests/utils/constants/conversational-agent.ts
+++ b/tests/utils/constants/conversational-agent.ts
@@ -62,6 +62,9 @@ export const CONVERSATIONAL_AGENT_TEST_CONSTANTS = {
   FEATURE_FLAG_KEY: 'test-feature',
   FEATURE_FLAG_VALUE: true,
 
+  // Agent input
+  AGENT_INPUT: { inline: { userId: 'user-test-123', language: 'en' } },
+
   // Error messages
   ERROR_AGENT_NOT_FOUND: 'Agent not found',
   ERROR_CONVERSATION_NOT_FOUND: 'Conversation not found',


### PR DESCRIPTION
## Description
Conversational agents allow for agent inputs set by the user to be passed inline when conversations are created and updated. This change is to add support for this inline input feature, and to keep the implementation flexible for future external value support.