### PR TITLE
fix: enable Claude code review bot to approve clean PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -137,15 +137,15 @@ jobs:
               this run, and (b) any threads you unresolved this run. Do not list
               issues you skipped via the dedupe gate.
 
-            STEP 6 — Approve or stay silent.
+            STEP 6 — Post approval message or stay silent.
             After the review completes:
               • If you posted NO new inline comments and unresolved NO threads
-                (i.e., the PR is clean) → approve the PR using:
-                  gh pr review ${{ github.event.pull_request.number }} --approve --body "No issues found. Checked for bugs and CLAUDE.md compliance."
-              • If you DID post inline comments or unresolve threads → do NOT approve.
+                (i.e., the PR is clean) → post an approval comment using:
+                  gh pr comment ${{ github.event.pull_request.number }} --body "✅ No issues found. Checked for bugs and CLAUDE.md compliance."
+              • If you DID post inline comments or unresolve threads → do NOT post an approval comment.
 
             Now run the plugin:
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
           use_sticky_comment: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api graphql:*),Bash(gh api:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api graphql:*),Bash(gh api:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -137,8 +137,15 @@ jobs:
               this run, and (b) any threads you unresolved this run. Do not list
               issues you skipped via the dedupe gate.
 
+            STEP 6 — Approve or stay silent.
+            After the review completes:
+              • If you posted NO new inline comments and unresolved NO threads
+                (i.e., the PR is clean) → approve the PR using:
+                  gh pr review ${{ github.event.pull_request.number }} --approve --body "No issues found. Checked for bugs and CLAUDE.md compliance."
+              • If you DID post inline comments or unresolve threads → do NOT approve.
+
             Now run the plugin:
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
           use_sticky_comment: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api graphql:*),Bash(gh api:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api graphql:*),Bash(gh api:*),Bash(gh pr review:*)"


### PR DESCRIPTION
## Summary
- Adds Step 6 to the review workflow prompt instructing Claude to `gh pr review --approve` when no issues are found
- Adds `Bash(gh pr review:*)` to the allowed tools list so the bot can execute the approval command
- Previously, the bot only ever left `COMMENTED` reviews (79 across 20 PRs) and never approved

## Test plan
- [x] Tested on [ninja-shreyash/cherrypick-test#22](https://github.com/ninja-shreyash/cherrypick-test/pull/22) — bot approved a clean PR with state `APPROVED`
- [ ] Verify existing comment behavior is unaffected on a PR with real issues

🤖 Generated with [Claude Code](https://claude.ai/code)