### PR TITLE
feat(jobs): add Jobs.resume method [PLT-102121]

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -56,6 +56,7 @@ jobs:
           echo "data_fabric_test_choiceset_id=${{ secrets.UIPATH_DATA_FABRIC_TEST_CHOICESET_ID_DEV || secrets.UIPATH_DATA_FABRIC_TEST_CHOICESET_ID }}" >> $GITHUB_OUTPUT
           echo "data_fabric_test_attachment_field=${{ secrets.UIPATH_DATA_FABRIC_TEST_ATTACHMENT_FIELD_DEV || secrets.UIPATH_DATA_FABRIC_TEST_ATTACHMENT_FIELD }}" >> $GITHUB_OUTPUT
           echo "orchestrator_attachment_id=${{ secrets.UIPATH_ORCHESTRATOR_ATTACHMENT_ID_DEV || secrets.UIPATH_ORCHESTRATOR_ATTACHMENT_ID }}" >> $GITHUB_OUTPUT
+          echo "jobs_test_folder_id=${{ secrets.UIPATH_JOBS_TEST_FOLDER_ID_DEV || secrets.UIPATH_JOBS_TEST_FOLDER_ID }}" >> $GITHUB_OUTPUT
 
       - name: Create Integration Test Configuration
         if: github.base_ref == 'main'
@@ -75,6 +76,7 @@ jobs:
           DATA_FABRIC_TEST_ATTACHMENT_FIELD=${{ steps.config.outputs.data_fabric_test_attachment_field }}
           ORCHESTRATOR_TEST_PROCESS_KEY=${{ steps.config.outputs.orchestrator_test_process_key }}
           ORCHESTRATOR_ATTACHMENT_ID=${{ steps.config.outputs.orchestrator_attachment_id }}
+          JOBS_TEST_FOLDER_ID=${{ steps.config.outputs.jobs_test_folder_id }}
           EOF
 
       - name: Run Integration Tests

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -15,6 +15,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `OR.Jobs` or `OR.Jobs.Read` |
 | `getOutput()` | `OR.Jobs` or `OR.Jobs.Read` |
+| `resume()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ## Attachments
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -17,6 +17,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getById()` | `OR.Jobs` or `OR.Jobs.Read` |
 | `getOutput()` | `OR.Jobs` or `OR.Jobs.Read`, `OR.Folders` or `OR.Folders.Read` |
 | `stop()` | `OR.Jobs` |
+| `resume()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ## Attachments
 

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -1,5 +1,6 @@
-import { JobGetAllOptions, RawJobGetResponse } from './jobs.types';
+import { JobGetAllOptions, JobResumeOptions, RawJobGetResponse } from './jobs.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
+import { OperationResponse } from '../common/types';
 
 // Combined type for job data with methods
 export type JobGetResponse = RawJobGetResponse & JobMethods;
@@ -100,6 +101,35 @@ export interface JobServiceModel {
    * ```
    */
   getOutput(jobKey: string, folderId: number): Promise<Record<string, unknown> | null>;
+
+  /**
+   * Resumes a suspended job.
+   *
+   * Sends a resume request to a job that is currently in the `Suspended` state.
+   * The job transitions to `Resumed` and continues execution. Optionally pass
+   * input arguments to provide data for the resumed workflow.
+   *
+   * @param jobKey - The unique key (GUID) of the suspended job to resume
+   * @param folderId - The folder ID where the job resides
+   * @param options - Optional parameters including input arguments
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   *
+   * @example
+   * ```typescript
+   * // Resume a suspended job
+   * const result = await jobs.resume(<jobKey>, <folderId>);
+   * console.log(result.data.state); // 'Resumed'
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Resume with input arguments
+   * const result = await jobs.resume(<jobKey>, <folderId>, {
+   *   inputArguments: JSON.stringify({ approved: true })
+   * });
+   * ```
+   */
+  resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -127,6 +157,14 @@ export interface JobMethods {
    * ```
    */
   getOutput(): Promise<Record<string, unknown> | null>;
+
+  /**
+   * Resumes this suspended job.
+   *
+   * @param options - Optional parameters including input arguments
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   */
+  resume(options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -142,6 +180,11 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.getOutput(jobData.key, jobData.folderId);
+    },
+    async resume(options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>> {
+      if (!jobData.key) throw new Error('Job key is undefined');
+      if (!jobData.folderId) throw new Error('Job folderId is undefined');
+      return service.resume(jobData.key, jobData.folderId, options);
     },
   };
 }

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -1,6 +1,5 @@
 import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions, JobResumeOptions } from './jobs.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
-import { OperationResponse } from '../common/types';
 
 /** Combined response type for job data with bound methods. */
 export type JobGetResponse = RawJobGetResponse & JobMethods;
@@ -175,24 +174,23 @@ export interface JobServiceModel {
    * @param jobKey - The unique key (GUID) of the suspended job to resume
    * @param folderId - The folder ID where the job resides
    * @param options - Optional parameters including input arguments
-   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   * @returns Promise that resolves when the job is resumed successfully, or rejects on failure
    *
    * @example
    * ```typescript
    * // Resume a suspended job
-   * const result = await jobs.resume(<jobKey>, <folderId>);
-   * console.log(result.data.state); // 'Resumed'
+   * await jobs.resume(<jobKey>, <folderId>);
    * ```
    *
    * @example
    * ```typescript
    * // Resume with input arguments
-   * const result = await jobs.resume(<jobKey>, <folderId>, {
+   * await jobs.resume(<jobKey>, <folderId>, {
    *   inputArguments: JSON.stringify({ approved: true })
    * });
    * ```
    */
-  resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
+  resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<void>;
 }
 
 /**
@@ -245,9 +243,9 @@ export interface JobMethods {
    * Resumes this suspended job.
    *
    * @param options - Optional parameters including input arguments
-   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   * @returns Promise that resolves when the job is resumed successfully, or rejects on failure
    */
-  resume(options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
+  resume(options?: JobResumeOptions): Promise<void>;
 }
 
 /**
@@ -269,7 +267,7 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.stop([jobData.key], jobData.folderId, options);
     },
-    async resume(options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>> {
+    async resume(options?: JobResumeOptions): Promise<void> {
       if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.resume(jobData.key, jobData.folderId, options);

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -1,5 +1,6 @@
-import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions } from './jobs.types';
+import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions, JobResumeOptions } from './jobs.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
+import { OperationResponse } from '../common/types';
 
 /** Combined response type for job data with bound methods. */
 export type JobGetResponse = RawJobGetResponse & JobMethods;
@@ -163,6 +164,35 @@ export interface JobServiceModel {
     folderId: number,
     options?: JobStopOptions
   ): Promise<void>;
+
+  /**
+   * Resumes a suspended job.
+   *
+   * Sends a resume request to a job that is currently in the `Suspended` state.
+   * The job transitions to `Resumed` and continues execution. Optionally pass
+   * input arguments to provide data for the resumed workflow.
+   *
+   * @param jobKey - The unique key (GUID) of the suspended job to resume
+   * @param folderId - The folder ID where the job resides
+   * @param options - Optional parameters including input arguments
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   *
+   * @example
+   * ```typescript
+   * // Resume a suspended job
+   * const result = await jobs.resume(<jobKey>, <folderId>);
+   * console.log(result.data.state); // 'Resumed'
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Resume with input arguments
+   * const result = await jobs.resume(<jobKey>, <folderId>, {
+   *   inputArguments: JSON.stringify({ approved: true })
+   * });
+   * ```
+   */
+  resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -210,6 +240,14 @@ export interface JobMethods {
    * ```
    */
   stop(options?: JobStopOptions): Promise<void>;
+
+  /**
+   * Resumes this suspended job.
+   *
+   * @param options - Optional parameters including input arguments
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   */
+  resume(options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -230,6 +268,11 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.stop([jobData.key], jobData.folderId, options);
+    },
+    async resume(options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>> {
+      if (!jobData.key) throw new Error('Job key is undefined');
+      if (!jobData.folderId) throw new Error('Job folderId is undefined');
+      return service.resume(jobData.key, jobData.folderId, options);
     },
   };
 }

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -168,7 +168,7 @@ export interface JobServiceModel {
    * Resumes a suspended job.
    *
    * Sends a resume request to a job that is currently in the `Suspended` state.
-   * The job transitions to `Resumed` and continues execution. Optionally pass
+   * The job transitions to `Resumed` and then to `Running` as it continues execution. Optionally pass
    * input arguments to provide data for the resumed workflow.
    *
    * @param jobKey - The unique key (GUID) of the suspended job to resume

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -186,7 +186,7 @@ export interface JobServiceModel {
    * ```typescript
    * // Resume with input arguments
    * await jobs.resume(<jobKey>, <folderId>, {
-   *   inputArguments: JSON.stringify({ approved: true })
+   *   inputArguments: { approved: true }
    * });
    * ```
    */

--- a/src/models/orchestrator/jobs.types.ts
+++ b/src/models/orchestrator/jobs.types.ts
@@ -157,6 +157,14 @@ export interface RawJobGetResponse extends FolderProperties {
 }
 
 /**
+ * Options for resuming a suspended job
+ */
+export interface JobResumeOptions {
+  /** Input arguments as a JSON string to pass to the resumed job */
+  inputArguments?: string;
+}
+
+/**
  * Options for getting all jobs
  */
 export type JobGetAllOptions = RequestOptions & PaginationOptions & {

--- a/src/models/orchestrator/jobs.types.ts
+++ b/src/models/orchestrator/jobs.types.ts
@@ -162,9 +162,9 @@ export interface RawJobGetResponse extends FolderProperties {
  * Options for resuming a suspended job
  */
 export interface JobResumeOptions {
-  /** Input arguments to pass to the resumed job (will be stringified automatically) */
+  /** Input arguments to pass to the resumed job */
   inputArguments?: Record<string, unknown>;
-  /** Fast Process Scenario properties (e.g., debug metadata, serverless runtime config). Will be stringified automatically. */
+  /** Fast Process Scenario properties (e.g., debug metadata, serverless runtime config) */
   fpsProperties?: Record<string, unknown>;
 }
 

--- a/src/models/orchestrator/jobs.types.ts
+++ b/src/models/orchestrator/jobs.types.ts
@@ -159,6 +159,14 @@ export interface RawJobGetResponse extends FolderProperties {
 }
 
 /**
+ * Options for resuming a suspended job
+ */
+export interface JobResumeOptions {
+  /** Input arguments as a JSON string to pass to the resumed job */
+  inputArguments?: string;
+}
+
+/**
  * Options for getting all jobs
  */
 export type JobGetAllOptions = RequestOptions & PaginationOptions & {

--- a/src/models/orchestrator/jobs.types.ts
+++ b/src/models/orchestrator/jobs.types.ts
@@ -162,10 +162,10 @@ export interface RawJobGetResponse extends FolderProperties {
  * Options for resuming a suspended job
  */
 export interface JobResumeOptions {
-  /** Input arguments as a JSON string to pass to the resumed job */
-  inputArguments?: string;
-  /** Fast Process Scenario properties as a JSON string (e.g., debug metadata, serverless runtime config) */
-  fpsProperties?: string;
+  /** Input arguments to pass to the resumed job (will be stringified automatically) */
+  inputArguments?: Record<string, unknown>;
+  /** Fast Process Scenario properties (e.g., debug metadata, serverless runtime config). Will be stringified automatically. */
+  fpsProperties?: Record<string, unknown>;
 }
 
 /**

--- a/src/models/orchestrator/jobs.types.ts
+++ b/src/models/orchestrator/jobs.types.ts
@@ -164,8 +164,6 @@ export interface RawJobGetResponse extends FolderProperties {
 export interface JobResumeOptions {
   /** Input arguments to pass to the resumed job */
   inputArguments?: Record<string, unknown>;
-  /** Fast Process Scenario properties (e.g., debug metadata, serverless runtime config) */
-  fpsProperties?: Record<string, unknown>;
 }
 
 /**

--- a/src/models/orchestrator/jobs.types.ts
+++ b/src/models/orchestrator/jobs.types.ts
@@ -164,6 +164,8 @@ export interface RawJobGetResponse extends FolderProperties {
 export interface JobResumeOptions {
   /** Input arguments as a JSON string to pass to the resumed job */
   inputArguments?: string;
+  /** Fast Process Scenario properties as a JSON string (e.g., debug metadata, serverless runtime config) */
+  fpsProperties?: string;
 }
 
 /**

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -266,7 +266,7 @@ export class JobService extends FolderScopedService implements JobServiceModel {
    * Resumes a suspended job.
    *
    * Sends a resume request to a job that is currently in the `Suspended` state.
-   * The job transitions to `Resumed` and continues execution. Optionally pass
+   * The job transitions to `Resumed` and then to `Running` as it continues execution. Optionally pass
    * input arguments to provide data for the resumed workflow.
    *
    * @param jobKey - The unique key (GUID) of the suspended job to resume
@@ -306,7 +306,7 @@ export class JobService extends FolderScopedService implements JobServiceModel {
     }
 
     if (options?.fpsProperties) {
-      body.FpsProperties = JSON.stringify(options.fpsProperties);
+      body.fpsProperties = JSON.stringify(options.fpsProperties);
     }
 
     await this.post(

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -1,5 +1,5 @@
 import { FolderScopedService } from '../../folder-scoped';
-import { RawJobGetResponse, JobGetAllOptions } from '../../../models/orchestrator/jobs.types';
+import { RawJobGetResponse, JobGetAllOptions, JobResumeOptions } from '../../../models/orchestrator/jobs.types';
 import { RawJobOutputFields } from '../../../models/orchestrator/jobs.internal-types';
 import { JobServiceModel, JobGetResponse, createJobWithMethods } from '../../../models/orchestrator/jobs.models';
 import { pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
@@ -7,6 +7,7 @@ import { JOB_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PAGINATION, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
 import { JobMap } from '../../../models/orchestrator/jobs.constants';
 import { AttachmentService } from '../attachments/attachments';
+import { OperationResponse } from '../../../models/common/types';
 import { ValidationError, ServerError } from '../../../core/errors';
 import { ErrorFactory } from '../../../core/errors/error-factory';
 import { errorResponseParser } from '../../../core/errors/parser';
@@ -158,6 +159,56 @@ export class JobService extends FolderScopedService implements JobServiceModel {
     }
 
     return null;
+  }
+
+  /**
+   * Resumes a suspended job.
+   *
+   * Sends a resume request to a job that is currently in the `Suspended` state.
+   * The job transitions to `Resumed` and continues execution. Optionally pass
+   * input arguments to provide data for the resumed workflow.
+   *
+   * @param jobKey - The unique key (GUID) of the suspended job to resume
+   * @param folderId - The folder ID where the job resides
+   * @param options - Optional parameters including input arguments
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   *
+   * @example
+   * ```typescript
+   * // Resume a suspended job
+   * const result = await jobs.resume(<jobKey>, <folderId>);
+   * console.log(result.data.state); // 'Resumed'
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Resume with input arguments
+   * const result = await jobs.resume(<jobKey>, <folderId>, {
+   *   inputArguments: JSON.stringify({ approved: true })
+   * });
+   * ```
+   */
+  @track('Jobs.Resume')
+  async resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>> {
+    if (!jobKey) {
+      throw new ValidationError({ message: 'jobKey is required for resume' });
+    }
+
+    const headers = createHeaders({ [FOLDER_ID]: folderId });
+    const body: Record<string, unknown> = { jobKey };
+
+    if (options?.inputArguments) {
+      body.inputArguments = options.inputArguments;
+    }
+
+    const response = await this.post<Record<string, unknown>>(
+      JOB_ENDPOINTS.RESUME,
+      body,
+      { headers }
+    );
+
+    const rawJob = transformData(pascalToCamelCaseKeys(response.data) as RawJobGetResponse, JobMap);
+    return { success: true, data: createJobWithMethods(rawJob, this) };
   }
 
   /**

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -305,10 +305,6 @@ export class JobService extends FolderScopedService implements JobServiceModel {
       body.inputArguments = JSON.stringify(options.inputArguments);
     }
 
-    if (options?.fpsProperties) {
-      body.fpsProperties = JSON.stringify(options.fpsProperties);
-    }
-
     await this.post(
       JOB_ENDPOINTS.RESUME,
       body,

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -1,11 +1,12 @@
 import { FolderScopedService } from '../../folder-scoped';
-import { RawJobGetResponse, JobGetAllOptions, JobGetByIdOptions, JobStopOptions } from '../../../models/orchestrator/jobs.types';
+import { RawJobGetResponse, JobGetAllOptions, JobGetByIdOptions, JobStopOptions, JobResumeOptions } from '../../../models/orchestrator/jobs.types';
 import { JobServiceModel, JobGetResponse, createJobWithMethods } from '../../../models/orchestrator/jobs.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
 import { JOB_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PAGINATION, ODATA_OFFSET_PARAMS, ODATA_PREFIX } from '../../../utils/constants/common';
 import { JobMap, JOB_KEY_RESOLUTION_CHUNK_SIZE } from '../../../models/orchestrator/jobs.constants';
 import { AttachmentService } from '../attachments/attachments';
+import { OperationResponse } from '../../../models/common/types';
 import { ValidationError, ServerError } from '../../../core/errors';
 import { ErrorFactory } from '../../../core/errors/error-factory';
 import { errorResponseParser } from '../../../core/errors/parser';
@@ -260,6 +261,56 @@ export class JobService extends FolderScopedService implements JobServiceModel {
     const jobIds = await this.resolveJobKeys(jobKeys, folderId);
 
     await this.stopJobsByIds(jobIds, strategy, headers);
+  }
+
+  /**
+   * Resumes a suspended job.
+   *
+   * Sends a resume request to a job that is currently in the `Suspended` state.
+   * The job transitions to `Resumed` and continues execution. Optionally pass
+   * input arguments to provide data for the resumed workflow.
+   *
+   * @param jobKey - The unique key (GUID) of the suspended job to resume
+   * @param folderId - The folder ID where the job resides
+   * @param options - Optional parameters including input arguments
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   *
+   * @example
+   * ```typescript
+   * // Resume a suspended job
+   * const result = await jobs.resume(<jobKey>, <folderId>);
+   * console.log(result.data.state); // 'Resumed'
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Resume with input arguments
+   * const result = await jobs.resume(<jobKey>, <folderId>, {
+   *   inputArguments: JSON.stringify({ approved: true })
+   * });
+   * ```
+   */
+  @track('Jobs.Resume')
+  async resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>> {
+    if (!jobKey) {
+      throw new ValidationError({ message: 'jobKey is required for resume' });
+    }
+
+    const headers = createHeaders({ [FOLDER_ID]: folderId });
+    const body: Record<string, unknown> = { jobKey };
+
+    if (options?.inputArguments) {
+      body.inputArguments = options.inputArguments;
+    }
+
+    const response = await this.post<Record<string, unknown>>(
+      JOB_ENDPOINTS.RESUME,
+      body,
+      { headers }
+    );
+
+    const rawJob = transformData(pascalToCamelCaseKeys(response.data) as RawJobGetResponse, JobMap);
+    return { success: true, data: createJobWithMethods(rawJob, this) };
   }
 
   /**

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -6,7 +6,6 @@ import { JOB_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PAGINATION, ODATA_OFFSET_PARAMS, ODATA_PREFIX } from '../../../utils/constants/common';
 import { JobMap, JOB_KEY_RESOLUTION_CHUNK_SIZE } from '../../../models/orchestrator/jobs.constants';
 import { AttachmentService } from '../attachments/attachments';
-import { OperationResponse } from '../../../models/common/types';
 import { ValidationError, ServerError } from '../../../core/errors';
 import { ErrorFactory } from '../../../core/errors/error-factory';
 import { errorResponseParser } from '../../../core/errors/parser';
@@ -273,25 +272,24 @@ export class JobService extends FolderScopedService implements JobServiceModel {
    * @param jobKey - The unique key (GUID) of the suspended job to resume
    * @param folderId - The folder ID where the job resides
    * @param options - Optional parameters including input arguments
-   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
+   * @returns Promise that resolves when the job is resumed successfully, or rejects on failure
    *
    * @example
    * ```typescript
    * // Resume a suspended job
-   * const result = await jobs.resume(<jobKey>, <folderId>);
-   * console.log(result.data.state); // 'Resumed'
+   * await jobs.resume(<jobKey>, <folderId>);
    * ```
    *
    * @example
    * ```typescript
    * // Resume with input arguments
-   * const result = await jobs.resume(<jobKey>, <folderId>, {
+   * await jobs.resume(<jobKey>, <folderId>, {
    *   inputArguments: JSON.stringify({ approved: true })
    * });
    * ```
    */
   @track('Jobs.Resume')
-  async resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>> {
+  async resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<void> {
     if (!jobKey) {
       throw new ValidationError({ message: 'jobKey is required for resume' });
     }
@@ -303,14 +301,15 @@ export class JobService extends FolderScopedService implements JobServiceModel {
       body.inputArguments = options.inputArguments;
     }
 
-    const response = await this.post<Record<string, unknown>>(
+    if (options?.fpsProperties) {
+      body.FpsProperties = options.fpsProperties;
+    }
+
+    await this.post(
       JOB_ENDPOINTS.RESUME,
       body,
       { headers }
     );
-
-    const rawJob = transformData(pascalToCamelCaseKeys(response.data) as RawJobGetResponse, JobMap);
-    return { success: true, data: createJobWithMethods(rawJob, this) };
   }
 
   /**

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -284,7 +284,7 @@ export class JobService extends FolderScopedService implements JobServiceModel {
    * ```typescript
    * // Resume with input arguments
    * await jobs.resume(<jobKey>, <folderId>, {
-   *   inputArguments: JSON.stringify({ approved: true })
+   *   inputArguments: { approved: true }
    * });
    * ```
    */
@@ -294,15 +294,19 @@ export class JobService extends FolderScopedService implements JobServiceModel {
       throw new ValidationError({ message: 'jobKey is required for resume' });
     }
 
+    if (!folderId) {
+      throw new ValidationError({ message: 'folderId is required for resume' });
+    }
+
     const headers = createHeaders({ [FOLDER_ID]: folderId });
     const body: Record<string, unknown> = { jobKey };
 
     if (options?.inputArguments) {
-      body.inputArguments = options.inputArguments;
+      body.inputArguments = JSON.stringify(options.inputArguments);
     }
 
     if (options?.fpsProperties) {
-      body.FpsProperties = options.fpsProperties;
+      body.FpsProperties = JSON.stringify(options.fpsProperties);
     }
 
     await this.post(

--- a/src/utils/constants/endpoints/orchestrator.ts
+++ b/src/utils/constants/endpoints/orchestrator.ts
@@ -61,6 +61,7 @@ export const JOB_ENDPOINTS = {
   GET_ALL: `${ORCHESTRATOR_BASE}/odata/Jobs`,
   GET_BY_KEY: (identifier: string) => `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.GetByKey(identifier=${identifier})`,
   STOP: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.StopJobs`,
+  RESUME: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.ResumeJob`,
 } as const;
 
 /**

--- a/src/utils/constants/endpoints/orchestrator.ts
+++ b/src/utils/constants/endpoints/orchestrator.ts
@@ -60,6 +60,7 @@ export const QUEUE_ENDPOINTS = {
 export const JOB_ENDPOINTS = {
   GET_ALL: `${ORCHESTRATOR_BASE}/odata/Jobs`,
   GET_BY_KEY: (identifier: string) => `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.GetByKey(identifier=${identifier})`,
+  RESUME: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.ResumeJob`,
 } as const;
 
 /**

--- a/tests/.env.integration.example
+++ b/tests/.env.integration.example
@@ -49,5 +49,9 @@ DATA_FABRIC_TEST_ENTITY_ID=
 DATA_FABRIC_TEST_CHOICESET_ID=
 DATA_FABRIC_TEST_ATTACHMENT_FIELD=
 
+# Jobs test folder ID (folder containing jobs for resume/suspend tests)
+# Falls back to INTEGRATION_TEST_FOLDER_ID if not set
+JOBS_TEST_FOLDER_ID=
+
 # Orchestrator attachment ID (UUID) for attachment getById tests
 ORCHESTRATOR_ATTACHMENT_ID=

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -18,6 +18,7 @@ export interface IntegrationConfig {
   dataFabricTestChoiceSetId?: string;
   dataFabricTestAttachmentField?: string;
   orchestratorAttachmentId?: string;
+  jobsTestFolderId?: string;
 }
 
 function isValidUrl(value: string): boolean {
@@ -67,6 +68,7 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     dataFabricTestChoiceSetId: typeof rawConfig.dataFabricTestChoiceSetId === 'string' ? rawConfig.dataFabricTestChoiceSetId : undefined,
     dataFabricTestAttachmentField: typeof rawConfig.dataFabricTestAttachmentField === 'string' ? rawConfig.dataFabricTestAttachmentField : undefined,
     orchestratorAttachmentId: typeof rawConfig.orchestratorAttachmentId === 'string' ? rawConfig.orchestratorAttachmentId : undefined,
+    jobsTestFolderId: typeof rawConfig.jobsTestFolderId === 'string' ? rawConfig.jobsTestFolderId : undefined,
   };
 }
 
@@ -100,6 +102,7 @@ export function loadIntegrationConfig(): IntegrationConfig {
     dataFabricTestChoiceSetId: process.env.DATA_FABRIC_TEST_CHOICESET_ID || undefined,
     dataFabricTestAttachmentField: process.env.DATA_FABRIC_TEST_ATTACHMENT_FIELD || undefined,
     orchestratorAttachmentId: process.env.ORCHESTRATOR_ATTACHMENT_ID || undefined,
+    jobsTestFolderId: process.env.JOBS_TEST_FOLDER_ID || undefined,
   };
 
   cachedConfig = validateConfig(rawConfig);

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -91,6 +91,35 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe('resume', () => {
+    it('should resume a suspended job', async () => {
+      const { jobs, folderId } = getJobsService();
+
+      if (!folderId) {
+        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for resume tests.');
+      }
+
+      // Find a suspended job
+      const result = await jobs.getAll({
+        folderId,
+        pageSize: 1,
+        filter: "State eq 'Suspended'",
+      });
+
+      if (result.items.length === 0) {
+        throw new Error('No suspended jobs found in the test environment to test resume.');
+      }
+
+      const job = result.items[0];
+      const resumed = await jobs.resume(job.key, folderId);
+
+      expect(resumed.success).toBe(true);
+      expect(resumed.data).toBeDefined();
+      expect(resumed.data.key).toBe(job.key);
+      expect(resumed.data.state).toBeDefined();
+    });
+  });
+
   describe('Job structure validation', () => {
     it('should have expected fields in job objects', async () => {
       const { jobs, folderId } = getJobsService();

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -223,15 +223,22 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
 
   describe('resume', () => {
     it('should resume a suspended job', async () => {
-      const { jobs, folderId } = getJobsService();
+      const { jobs } = getJobsService();
+      const config = getTestConfig();
 
-      if (!folderId) {
-        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for resume tests.');
+      const resumeFolderId = config.jobsTestFolderId
+        ? Number(config.jobsTestFolderId)
+        : config.folderId
+          ? Number(config.folderId)
+          : undefined;
+
+      if (!resumeFolderId) {
+        throw new Error('JOBS_TEST_FOLDER_ID or INTEGRATION_TEST_FOLDER_ID is required for resume tests.');
       }
 
       // Find a suspended job
       const result = await jobs.getAll({
-        folderId,
+        folderId: resumeFolderId,
         pageSize: 1,
         filter: "State eq 'Suspended'",
       });
@@ -241,7 +248,7 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
       }
 
       const job = result.items[0];
-      await jobs.resume(job.key, folderId);
+      await jobs.resume(job.key, resumeFolderId);
     });
   });
 

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -241,12 +241,7 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
       }
 
       const job = result.items[0];
-      const resumed = await jobs.resume(job.key, folderId);
-
-      expect(resumed.success).toBe(true);
-      expect(resumed.data).toBeDefined();
-      expect(resumed.data.key).toBe(job.key);
-      expect(resumed.data.state).toBeDefined();
+      await jobs.resume(job.key, folderId);
     });
   });
 

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -240,7 +240,7 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
       const result = await jobs.getAll({
         folderId: resumeFolderId,
         pageSize: 1,
-        filter: "State eq 'Suspended'",
+        filter: "state eq 'Suspended'",
       });
 
       if (result.items.length === 0) {

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -221,6 +221,35 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe('resume', () => {
+    it('should resume a suspended job', async () => {
+      const { jobs, folderId } = getJobsService();
+
+      if (!folderId) {
+        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for resume tests.');
+      }
+
+      // Find a suspended job
+      const result = await jobs.getAll({
+        folderId,
+        pageSize: 1,
+        filter: "State eq 'Suspended'",
+      });
+
+      if (result.items.length === 0) {
+        throw new Error('No suspended jobs found in the test environment to test resume.');
+      }
+
+      const job = result.items[0];
+      const resumed = await jobs.resume(job.key, folderId);
+
+      expect(resumed.success).toBe(true);
+      expect(resumed.data).toBeDefined();
+      expect(resumed.data.key).toBe(job.key);
+      expect(resumed.data.state).toBeDefined();
+    });
+  });
+
   describe('Job structure validation', () => {
     it('should have expected fields in job objects', async () => {
       const { jobs, folderId } = getJobsService();

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -15,6 +15,7 @@ describe('Job Models', () => {
     mockService = {
       getAll: vi.fn(),
       getOutput: vi.fn(),
+      resume: vi.fn(),
     } as any;
   });
 
@@ -61,6 +62,51 @@ describe('Job Models', () => {
         const job = createJobWithMethods(mockJobData, mockService);
 
         await expect(job.getOutput()).rejects.toThrow('Job folderId is undefined');
+      });
+    });
+
+    describe('job.resume()', () => {
+      it('should call service.resume with the job key and folderId', async () => {
+        const mockJobData = createBasicJob();
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        const mockResult = { success: true, data: job };
+        vi.mocked(mockService.resume).mockResolvedValue(mockResult);
+
+        const result = await job.resume();
+
+        expect(mockService.resume).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, undefined);
+        expect(result).toEqual(mockResult);
+      });
+
+      it('should pass options to service.resume', async () => {
+        const mockJobData = createBasicJob();
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        const mockResult = { success: true, data: job };
+        vi.mocked(mockService.resume).mockResolvedValue(mockResult);
+
+        await job.resume({ inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS });
+
+        expect(mockService.resume).toHaveBeenCalledWith(
+          JOB_TEST_CONSTANTS.JOB_KEY,
+          TEST_CONSTANTS.FOLDER_ID,
+          { inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS }
+        );
+      });
+
+      it('should throw when job key is undefined', async () => {
+        const mockJobData = createBasicJob({ key: '' as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.resume()).rejects.toThrow('Job key is undefined');
+      });
+
+      it('should throw when job folderId is undefined', async () => {
+        const mockJobData = createBasicJob({ folderId: undefined as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.resume()).rejects.toThrow('Job folderId is undefined');
       });
     });
   });

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -18,6 +18,7 @@ describe('Job Models', () => {
       getById: vi.fn(),
       getOutput: vi.fn(),
       stop: vi.fn(),
+      resume: vi.fn(),
     } as any;
   });
 
@@ -113,6 +114,51 @@ describe('Job Models', () => {
         const job = createJobWithMethods(mockJobData, mockService);
 
         await expect(job.stop()).rejects.toThrow('Job folderId is undefined');
+      });
+    });
+
+    describe('job.resume()', () => {
+      it('should call service.resume with the job key and folderId', async () => {
+        const mockJobData = createBasicJob();
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        const mockResult = { success: true, data: job };
+        vi.mocked(mockService.resume).mockResolvedValue(mockResult);
+
+        const result = await job.resume();
+
+        expect(mockService.resume).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, undefined);
+        expect(result).toEqual(mockResult);
+      });
+
+      it('should pass options to service.resume', async () => {
+        const mockJobData = createBasicJob();
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        const mockResult = { success: true, data: job };
+        vi.mocked(mockService.resume).mockResolvedValue(mockResult);
+
+        await job.resume({ inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS });
+
+        expect(mockService.resume).toHaveBeenCalledWith(
+          JOB_TEST_CONSTANTS.JOB_KEY,
+          TEST_CONSTANTS.FOLDER_ID,
+          { inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS }
+        );
+      });
+
+      it('should throw when job key is undefined', async () => {
+        const mockJobData = createBasicJob({ key: '' as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.resume()).rejects.toThrow('Job key is undefined');
+      });
+
+      it('should throw when job folderId is undefined', async () => {
+        const mockJobData = createBasicJob({ folderId: undefined as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.resume()).rejects.toThrow('Job folderId is undefined');
       });
     });
   });

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -122,21 +122,18 @@ describe('Job Models', () => {
         const mockJobData = createBasicJob();
         const job = createJobWithMethods(mockJobData, mockService);
 
-        const mockResult = { success: true, data: job };
-        vi.mocked(mockService.resume).mockResolvedValue(mockResult);
+        vi.mocked(mockService.resume).mockResolvedValue(undefined);
 
-        const result = await job.resume();
+        await job.resume();
 
         expect(mockService.resume).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, undefined);
-        expect(result).toEqual(mockResult);
       });
 
       it('should pass options to service.resume', async () => {
         const mockJobData = createBasicJob();
         const job = createJobWithMethods(mockJobData, mockService);
 
-        const mockResult = { success: true, data: job };
-        vi.mocked(mockService.resume).mockResolvedValue(mockResult);
+        vi.mocked(mockService.resume).mockResolvedValue(undefined);
 
         await job.resume({ inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS });
 

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -672,6 +672,23 @@ describe('JobService Unit Tests', () => {
       );
     });
 
+    it('should pass fpsProperties when provided', async () => {
+      mockApiClient.post.mockResolvedValueOnce(undefined);
+
+      await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, {
+        fpsProperties: '{"debug.master":"true"}',
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.RESUME,
+        {
+          jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
+          FpsProperties: '{"debug.master":"true"}',
+        },
+        expect.any(Object)
+      );
+    });
+
     it('should throw validation error when jobKey is missing', async () => {
       await expect(
         jobService.resume('', TEST_CONSTANTS.FOLDER_ID)

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -655,28 +655,28 @@ describe('JobService Unit Tests', () => {
       );
     });
 
-    it('should pass input arguments when provided', async () => {
+    it('should stringify and pass input arguments when provided', async () => {
       mockApiClient.post.mockResolvedValueOnce(undefined);
 
       await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, {
-        inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS,
+        inputArguments: { approved: true },
       });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         JOB_ENDPOINTS.RESUME,
         {
           jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
-          inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS,
+          inputArguments: '{"approved":true}',
         },
         expect.any(Object)
       );
     });
 
-    it('should pass fpsProperties when provided', async () => {
+    it('should stringify and pass fpsProperties when provided', async () => {
       mockApiClient.post.mockResolvedValueOnce(undefined);
 
       await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, {
-        fpsProperties: '{"debug.master":"true"}',
+        fpsProperties: { 'debug.master': 'true' },
       });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
@@ -693,6 +693,12 @@ describe('JobService Unit Tests', () => {
       await expect(
         jobService.resume('', TEST_CONSTANTS.FOLDER_ID)
       ).rejects.toThrow('jobKey is required for resume');
+    });
+
+    it('should throw validation error when folderId is missing', async () => {
+      await expect(
+        jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, 0)
+      ).rejects.toThrow('folderId is required for resume');
     });
 
     it('should handle API errors', async () => {

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -400,4 +400,70 @@ describe('JobService Unit Tests', () => {
       );
     });
   });
+
+  describe('resume', () => {
+    it('should resume a suspended job and return transformed response', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Resumed' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.RESUME,
+        { jobKey: JOB_TEST_CONSTANTS.JOB_KEY },
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-UIPATH-OrganizationUnitId': String(TEST_CONSTANTS.FOLDER_ID),
+          }),
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
+    });
+
+    it('should pass input arguments when provided', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Resumed' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, {
+        inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS,
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.RESUME,
+        {
+          jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
+          inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS,
+        },
+        expect.any(Object)
+      );
+    });
+
+    it('should attach bound methods to the returned job', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Resumed' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(typeof result.data.getOutput).toBe('function');
+      expect(typeof result.data.resume).toBe('function');
+    });
+
+    it('should throw validation error when jobKey is missing', async () => {
+      await expect(
+        jobService.resume('', TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow('jobKey is required for resume');
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(JOB_TEST_CONSTANTS.ERROR_JOB_RESUME_FAILED);
+      mockApiClient.post.mockRejectedValueOnce(error);
+
+      await expect(
+        jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_RESUME_FAILED);
+    });
+  });
 });

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -637,4 +637,70 @@ describe('JobService Unit Tests', () => {
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
+
+  describe('resume', () => {
+    it('should resume a suspended job and return transformed response', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Resumed' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.RESUME,
+        { jobKey: JOB_TEST_CONSTANTS.JOB_KEY },
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-UIPATH-OrganizationUnitId': String(TEST_CONSTANTS.FOLDER_ID),
+          }),
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
+    });
+
+    it('should pass input arguments when provided', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Resumed' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, {
+        inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS,
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.RESUME,
+        {
+          jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
+          inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS,
+        },
+        expect.any(Object)
+      );
+    });
+
+    it('should attach bound methods to the returned job', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Resumed' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(typeof result.data.getOutput).toBe('function');
+      expect(typeof result.data.resume).toBe('function');
+    });
+
+    it('should throw validation error when jobKey is missing', async () => {
+      await expect(
+        jobService.resume('', TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow('jobKey is required for resume');
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(JOB_TEST_CONSTANTS.ERROR_JOB_RESUME_FAILED);
+      mockApiClient.post.mockRejectedValueOnce(error);
+
+      await expect(
+        jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_RESUME_FAILED);
+    });
+  });
 });

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -672,23 +672,6 @@ describe('JobService Unit Tests', () => {
       );
     });
 
-    it('should stringify and pass fpsProperties when provided', async () => {
-      mockApiClient.post.mockResolvedValueOnce(undefined);
-
-      await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, {
-        fpsProperties: { 'debug.master': 'true' },
-      });
-
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        JOB_ENDPOINTS.RESUME,
-        {
-          jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
-          fpsProperties: '{"debug.master":"true"}',
-        },
-        expect.any(Object)
-      );
-    });
-
     it('should throw validation error when jobKey is missing', async () => {
       await expect(
         jobService.resume('', TEST_CONSTANTS.FOLDER_ID)

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -639,11 +639,10 @@ describe('JobService Unit Tests', () => {
   });
 
   describe('resume', () => {
-    it('should resume a suspended job and return transformed response', async () => {
-      const mockRawJob = createMockRawJob({ State: 'Resumed' });
-      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+    it('should resume a suspended job', async () => {
+      mockApiClient.post.mockResolvedValueOnce(undefined);
 
-      const result = await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
+      await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         JOB_ENDPOINTS.RESUME,
@@ -654,15 +653,10 @@ describe('JobService Unit Tests', () => {
           }),
         })
       );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toBeDefined();
-      expect(result.data.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
     });
 
     it('should pass input arguments when provided', async () => {
-      const mockRawJob = createMockRawJob({ State: 'Resumed' });
-      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+      mockApiClient.post.mockResolvedValueOnce(undefined);
 
       await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID, {
         inputArguments: JOB_TEST_CONSTANTS.INPUT_ARGUMENTS,
@@ -676,16 +670,6 @@ describe('JobService Unit Tests', () => {
         },
         expect.any(Object)
       );
-    });
-
-    it('should attach bound methods to the returned job', async () => {
-      const mockRawJob = createMockRawJob({ State: 'Resumed' });
-      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
-
-      const result = await jobService.resume(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
-
-      expect(typeof result.data.getOutput).toBe('function');
-      expect(typeof result.data.resume).toBe('function');
     });
 
     it('should throw validation error when jobKey is missing', async () => {

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -683,7 +683,7 @@ describe('JobService Unit Tests', () => {
         JOB_ENDPOINTS.RESUME,
         {
           jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
-          FpsProperties: '{"debug.master":"true"}',
+          fpsProperties: '{"debug.master":"true"}',
         },
         expect.any(Object)
       );

--- a/tests/utils/constants/jobs.ts
+++ b/tests/utils/constants/jobs.ts
@@ -30,7 +30,7 @@ export const JOB_TEST_CONSTANTS = {
   PARSED_BLOB_OUTPUT: { largeResult: 'data from blob' },
 
   // Resume
-  INPUT_ARGUMENTS: '{"approved": true}',
+  INPUT_ARGUMENTS: { approved: true },
 
   // Error Messages
   ERROR_JOB_NOT_FOUND: 'Job not found',

--- a/tests/utils/constants/jobs.ts
+++ b/tests/utils/constants/jobs.ts
@@ -29,8 +29,11 @@ export const JOB_TEST_CONSTANTS = {
   BLOB_CONTENT: '{"largeResult": "data from blob"}',
   PARSED_BLOB_OUTPUT: { largeResult: 'data from blob' },
 
+  // Resume
+  INPUT_ARGUMENTS: '{"approved": true}',
+
   // Error Messages
   ERROR_JOB_NOT_FOUND: 'Job not found',
   ERROR_JOBS_NOT_FOUND_FOR_KEYS: 'Jobs not found for keys',
-
+  ERROR_JOB_RESUME_FAILED: 'Job resume failed',
 } as const;

--- a/tests/utils/constants/jobs.ts
+++ b/tests/utils/constants/jobs.ts
@@ -27,6 +27,10 @@ export const JOB_TEST_CONSTANTS = {
   BLOB_CONTENT: '{"largeResult": "data from blob"}',
   PARSED_BLOB_OUTPUT: { largeResult: 'data from blob' },
 
+  // Resume
+  INPUT_ARGUMENTS: '{"approved": true}',
+
   // Error Messages
   ERROR_JOB_NOT_FOUND: 'Job not found',
+  ERROR_JOB_RESUME_FAILED: 'Job resume failed',
 } as const;


### PR DESCRIPTION
## Method Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `jobs.resume()` | `resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<void>` |
| Bound | `job.resume()` | `resume(options?: JobResumeOptions): Promise<void>` |

## Endpoint Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `resume()` | POST | `/odata/Jobs/UiPath.Server.Configuration.OData.ResumeJob` | `OR.Jobs` or `OR.Jobs.Write` |

- Extends `FolderScopedService` — sets `X-UIPATH-OrganizationUnitId` header
- Accepts optional `inputArguments` (stringified as JSON in the request body)
- Validates `jobKey` and `folderId` with `ValidationError`

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { Jobs } from '@uipath/uipath-typescript/jobs';

const sdk = new UiPath(config);
await sdk.initialize();
const jobs = new Jobs(sdk);

// Resume a suspended job
await jobs.resume(<jobKey>, <folderId>);

// Resume with input arguments
await jobs.resume(<jobKey>, <folderId>, {
  inputArguments: { approved: true }
});
```

## API Response vs SDK Response

### Transform pipeline
No response transform — `resume()` returns `void`.

### Request transform
- `inputArguments` object is `JSON.stringify()`-ed before sending to the API

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/orchestrator.ts` |
| Types | `src/models/orchestrator/jobs.types.ts` |
| Models | `src/models/orchestrator/jobs.models.ts` |
| Service | `src/services/orchestrator/jobs/jobs.ts` |
| CI | `.github/workflows/pr-checks.yml` |
| Unit tests | `tests/unit/services/orchestrator/jobs.test.ts` (5 tests) |
| Model tests | `tests/unit/models/orchestrator/jobs.test.ts` (4 tests) |
| Integration tests | `tests/integration/shared/orchestrator/jobs.integration.test.ts` (1 test) |
| Test utils | `tests/utils/constants/jobs.ts` |
| Test config | `tests/integration/config/test-config.ts`, `tests/.env.integration.example` |
| Docs | `docs/oauth-scopes.md` |

Refs PLT-102121