### PR TITLE
feat(jobs): add Jobs.restart method [PLT-102122]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -18,6 +18,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getOutput()` | `OR.Jobs` or `OR.Jobs.Read`, `OR.Folders` or `OR.Folders.Read` |
 | `stop()` | `OR.Jobs` |
 | `resume()` | `OR.Jobs` or `OR.Jobs.Write` |
+| `restart()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ## Attachments
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -18,7 +18,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getOutput()` | `OR.Jobs` or `OR.Jobs.Read`, `OR.Folders` or `OR.Folders.Read` |
 | `stop()` | `OR.Jobs` |
 | `resume()` | `OR.Jobs` or `OR.Jobs.Write` |
-| `restart()` | `OR.Jobs` or `OR.Jobs.Write` |
+| `restart()` | `OR.Jobs` |
 
 ## Attachments
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -16,6 +16,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getAll()` | `OR.Jobs` or `OR.Jobs.Read` |
 | `getOutput()` | `OR.Jobs` or `OR.Jobs.Read` |
 | `resume()` | `OR.Jobs` or `OR.Jobs.Write` |
+| `restart()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ## Attachments
 

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -1,5 +1,6 @@
 import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions, JobResumeOptions } from './jobs.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
+import { OperationResponse } from '../common/types';
 
 /** Combined response type for job data with bound methods. */
 export type JobGetResponse = RawJobGetResponse & JobMethods;
@@ -191,6 +192,27 @@ export interface JobServiceModel {
    * ```
    */
   resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<void>;
+
+  /**
+   * Restarts a completed or faulted job.
+   *
+   * Creates a new job execution from a previously completed, faulted, or stopped job.
+   * The new job is created with `Pending` state and uses the same process and input
+   * arguments as the original job.
+   *
+   * @param jobId - The numeric ID of the job to restart
+   * @param folderId - The folder ID where the job resides
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   *
+   * @example
+   * ```typescript
+   * // Restart a faulted job
+   * const result = await jobs.restart(<jobId>, <folderId>);
+   * console.log(result.data.state); // 'Pending'
+   * console.log(result.data.key);   // new job key
+   * ```
+   */
+  restart(jobId: number, folderId: number): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -246,6 +268,13 @@ export interface JobMethods {
    * @returns Promise that resolves when the job is resumed successfully, or rejects on failure
    */
   resume(options?: JobResumeOptions): Promise<void>;
+
+  /**
+   * Restarts this job, creating a new execution.
+   *
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   */
+  restart(): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -271,6 +300,11 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.resume(jobData.key, jobData.folderId, options);
+    },
+    async restart(): Promise<OperationResponse<JobGetResponse>> {
+      if (!jobData.id) throw new Error('Job id is undefined');
+      if (!jobData.folderId) throw new Error('Job folderId is undefined');
+      return service.restart(jobData.id, jobData.folderId);
     },
   };
 }

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -1,7 +1,6 @@
 import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions, JobResumeOptions } from './jobs.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
-
 /** Combined response type for job data with bound methods. */
 export type JobGetResponse = RawJobGetResponse & JobMethods;
 

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -200,19 +200,19 @@ export interface JobServiceModel {
    * The new job is created with `Pending` state and uses the same process and input
    * arguments as the original job.
    *
-   * @param jobId - The numeric ID of the job to restart
+   * @param jobKey - The unique key (GUID) of the job to restart
    * @param folderId - The folder ID where the job resides
    * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
    *
    * @example
    * ```typescript
    * // Restart a faulted job
-   * const result = await jobs.restart(<jobId>, <folderId>);
+   * const result = await jobs.restart(<jobKey>, <folderId>);
    * console.log(result.data.state); // 'Pending'
    * console.log(result.data.key);   // new job key
    * ```
    */
-  restart(jobId: number, folderId: number): Promise<OperationResponse<JobGetResponse>>;
+  restart(jobKey: string, folderId: number): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -302,9 +302,9 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       return service.resume(jobData.key, jobData.folderId, options);
     },
     async restart(): Promise<OperationResponse<JobGetResponse>> {
-      if (!jobData.id) throw new Error('Job id is undefined');
+      if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
-      return service.restart(jobData.id, jobData.folderId);
+      return service.restart(jobData.key, jobData.folderId);
     },
   };
 }

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -197,10 +197,10 @@ export interface JobServiceModel {
    * Restarts a job in a final state (Successful, Faulted, or Stopped).
    *
    * Creates a **new** job execution from a previously successful, faulted, or stopped job.
-   * The new job has its own unique `key` and `id`, starts in `Pending` state, and uses
+   * The new job has its own unique `key`, starts in `Pending` state, and uses
    * the same process and input arguments as the original job.
    *
-   * To monitor the new job's progress, poll with {@link JobServiceModel.getById | getById}
+   * To monitor the new job's progress, poll with {@link getById}
    * using the returned job's key until the state reaches a final value.
    *
    * @param jobKey - The unique key (GUID) of the job to restart
@@ -273,7 +273,7 @@ export interface JobMethods {
   resume(options?: JobResumeOptions): Promise<void>;
 
   /**
-   * Restarts this job, creating a new execution with a new key and ID.
+   * Restarts this job, creating a new execution with a new key.
    *
    * @returns Promise resolving to the new {@link JobGetResponse} with full job details
    */

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -194,9 +194,9 @@ export interface JobServiceModel {
   resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<void>;
 
   /**
-   * Restarts a completed or faulted job.
+   * Restarts a job in a final state (Successful, Faulted, or Stopped).
    *
-   * Creates a new job execution from a previously completed, faulted, or stopped job.
+   * Creates a new job execution from a previously successful, faulted, or stopped job.
    * The new job is created with `Pending` state and uses the same process and input
    * arguments as the original job.
    *

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -130,6 +130,27 @@ export interface JobServiceModel {
    * ```
    */
   resume(jobKey: string, folderId: number, options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
+
+  /**
+   * Restarts a completed or faulted job.
+   *
+   * Creates a new job execution from a previously completed, faulted, or stopped job.
+   * The new job is created with `Pending` state and uses the same process and input
+   * arguments as the original job.
+   *
+   * @param jobId - The numeric ID of the job to restart
+   * @param folderId - The folder ID where the job resides
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   *
+   * @example
+   * ```typescript
+   * // Restart a faulted job
+   * const result = await jobs.restart(<jobId>, <folderId>);
+   * console.log(result.data.state); // 'Pending'
+   * console.log(result.data.key);   // new job key
+   * ```
+   */
+  restart(jobId: number, folderId: number): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -165,6 +186,13 @@ export interface JobMethods {
    * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the resumed job details
    */
   resume(options?: JobResumeOptions): Promise<OperationResponse<JobGetResponse>>;
+
+  /**
+   * Restarts this job, creating a new execution.
+   *
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   */
+  restart(): Promise<OperationResponse<JobGetResponse>>;
 }
 
 /**
@@ -185,6 +213,11 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.resume(jobData.key, jobData.folderId, options);
+    },
+    async restart(): Promise<OperationResponse<JobGetResponse>> {
+      if (!jobData.id) throw new Error('Job id is undefined');
+      if (!jobData.folderId) throw new Error('Job folderId is undefined');
+      return service.restart(jobData.id, jobData.folderId);
     },
   };
 }

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -1,6 +1,6 @@
 import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions, JobResumeOptions } from './jobs.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
-import { OperationResponse } from '../common/types';
+
 
 /** Combined response type for job data with bound methods. */
 export type JobGetResponse = RawJobGetResponse & JobMethods;
@@ -196,23 +196,26 @@ export interface JobServiceModel {
   /**
    * Restarts a job in a final state (Successful, Faulted, or Stopped).
    *
-   * Creates a new job execution from a previously successful, faulted, or stopped job.
-   * The new job is created with `Pending` state and uses the same process and input
-   * arguments as the original job.
+   * Creates a **new** job execution from a previously successful, faulted, or stopped job.
+   * The new job has its own unique `key` and `id`, starts in `Pending` state, and uses
+   * the same process and input arguments as the original job.
+   *
+   * To monitor the new job's progress, poll with {@link JobServiceModel.getById | getById}
+   * using the returned job's key until the state reaches a final value.
    *
    * @param jobKey - The unique key (GUID) of the job to restart
    * @param folderId - The folder ID where the job resides
-   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   * @returns Promise resolving to the new {@link JobGetResponse} with full job details
    *
    * @example
    * ```typescript
    * // Restart a faulted job
-   * const result = await jobs.restart(<jobKey>, <folderId>);
-   * console.log(result.data.state); // 'Pending'
-   * console.log(result.data.key);   // new job key
+   * const newJob = await jobs.restart(<jobKey>, <folderId>);
+   * console.log(newJob.state); // 'Pending'
+   * console.log(newJob.key);   // new job key (different from original)
    * ```
    */
-  restart(jobKey: string, folderId: number): Promise<OperationResponse<JobGetResponse>>;
+  restart(jobKey: string, folderId: number): Promise<JobGetResponse>;
 }
 
 /**
@@ -270,11 +273,11 @@ export interface JobMethods {
   resume(options?: JobResumeOptions): Promise<void>;
 
   /**
-   * Restarts this job, creating a new execution.
+   * Restarts this job, creating a new execution with a new key and ID.
    *
-   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   * @returns Promise resolving to the new {@link JobGetResponse} with full job details
    */
-  restart(): Promise<OperationResponse<JobGetResponse>>;
+  restart(): Promise<JobGetResponse>;
 }
 
 /**
@@ -301,7 +304,7 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.resume(jobData.key, jobData.folderId, options);
     },
-    async restart(): Promise<OperationResponse<JobGetResponse>> {
+    async restart(): Promise<JobGetResponse> {
       if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.restart(jobData.key, jobData.folderId);

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -212,6 +212,43 @@ export class JobService extends FolderScopedService implements JobServiceModel {
   }
 
   /**
+   * Restarts a completed or faulted job.
+   *
+   * Creates a new job execution from a previously completed, faulted, or stopped job.
+   * The new job is created with `Pending` state and uses the same process and input
+   * arguments as the original job.
+   *
+   * @param jobId - The numeric ID of the job to restart
+   * @param folderId - The folder ID where the job resides
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   *
+   * @example
+   * ```typescript
+   * // Restart a faulted job
+   * const result = await jobs.restart(<jobId>, <folderId>);
+   * console.log(result.data.state); // 'Pending'
+   * console.log(result.data.key);   // new job key
+   * ```
+   */
+  @track('Jobs.Restart')
+  async restart(jobId: number, folderId: number): Promise<OperationResponse<JobGetResponse>> {
+    if (!jobId) {
+      throw new ValidationError({ message: 'jobId is required for restart' });
+    }
+
+    const headers = createHeaders({ [FOLDER_ID]: folderId });
+
+    const response = await this.post<Record<string, unknown>>(
+      JOB_ENDPOINTS.RESTART,
+      { jobId },
+      { headers }
+    );
+
+    const rawJob = transformData(pascalToCamelCaseKeys(response.data) as RawJobGetResponse, JobMap);
+    return { success: true, data: createJobWithMethods(rawJob, this) };
+  }
+
+  /**
    * Fetches a job by its Key (GUID) using the GetByKey endpoint.
    * Only selects fields needed for output extraction.
    */

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -327,21 +327,22 @@ export class JobService extends FolderScopedService implements JobServiceModel {
    * @example
    * ```typescript
    * // Restart a faulted job
-   * const result = await jobs.restart(<jobId>, <folderId>);
+   * const result = await jobs.restart(<jobKey>, <folderId>);
    * console.log(result.data.state); // 'Pending'
    * console.log(result.data.key);   // new job key
    * ```
    */
   @track('Jobs.Restart')
-  async restart(jobId: number, folderId: number): Promise<OperationResponse<JobGetResponse>> {
-    if (!jobId) {
-      throw new ValidationError({ message: 'jobId is required for restart' });
+  async restart(jobKey: string, folderId: number): Promise<OperationResponse<JobGetResponse>> {
+    if (!jobKey) {
+      throw new ValidationError({ message: 'jobKey is required for restart' });
     }
 
     if (!folderId) {
       throw new ValidationError({ message: 'folderId is required for restart' });
     }
 
+    const [jobId] = await this.resolveJobKeys([jobKey], folderId);
     const headers = createHeaders({ [FOLDER_ID]: folderId });
 
     const response = await this.post<Record<string, unknown>>(

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -338,6 +338,10 @@ export class JobService extends FolderScopedService implements JobServiceModel {
       throw new ValidationError({ message: 'jobId is required for restart' });
     }
 
+    if (!folderId) {
+      throw new ValidationError({ message: 'folderId is required for restart' });
+    }
+
     const headers = createHeaders({ [FOLDER_ID]: folderId });
 
     const response = await this.post<Record<string, unknown>>(

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -17,6 +17,7 @@ import { PaginationType } from '../../../utils/pagination/internal-types';
 import { track } from '../../../core/telemetry';
 import type { IUiPath } from '../../../core/types';
 import { StopStrategy } from '../../../models/orchestrator/processes.types';
+import { OperationResponse } from '../../../models/common/types';
 
 /**
  * Service for interacting with UiPath Orchestrator Jobs API
@@ -310,6 +311,43 @@ export class JobService extends FolderScopedService implements JobServiceModel {
       body,
       { headers }
     );
+  }
+
+  /**
+   * Restarts a completed or faulted job.
+   *
+   * Creates a new job execution from a previously completed, faulted, or stopped job.
+   * The new job is created with `Pending` state and uses the same process and input
+   * arguments as the original job.
+   *
+   * @param jobId - The numeric ID of the job to restart
+   * @param folderId - The folder ID where the job resides
+   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   *
+   * @example
+   * ```typescript
+   * // Restart a faulted job
+   * const result = await jobs.restart(<jobId>, <folderId>);
+   * console.log(result.data.state); // 'Pending'
+   * console.log(result.data.key);   // new job key
+   * ```
+   */
+  @track('Jobs.Restart')
+  async restart(jobId: number, folderId: number): Promise<OperationResponse<JobGetResponse>> {
+    if (!jobId) {
+      throw new ValidationError({ message: 'jobId is required for restart' });
+    }
+
+    const headers = createHeaders({ [FOLDER_ID]: folderId });
+
+    const response = await this.post<Record<string, unknown>>(
+      JOB_ENDPOINTS.RESTART,
+      { jobId },
+      { headers }
+    );
+
+    const rawJob = transformData(pascalToCamelCaseKeys(response.data) as RawJobGetResponse, JobMap);
+    return { success: true, data: createJobWithMethods(rawJob, this) };
   }
 
   /**

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -17,7 +17,6 @@ import { PaginationType } from '../../../utils/pagination/internal-types';
 import { track } from '../../../core/telemetry';
 import type { IUiPath } from '../../../core/types';
 import { StopStrategy } from '../../../models/orchestrator/processes.types';
-import { OperationResponse } from '../../../models/common/types';
 
 /**
  * Service for interacting with UiPath Orchestrator Jobs API
@@ -316,24 +315,27 @@ export class JobService extends FolderScopedService implements JobServiceModel {
   /**
    * Restarts a job in a final state (Successful, Faulted, or Stopped).
    *
-   * Creates a new job execution from a previously successful, faulted, or stopped job.
-   * The new job is created with `Pending` state and uses the same process and input
-   * arguments as the original job.
+   * Creates a **new** job execution from a previously successful, faulted, or stopped job.
+   * The new job has its own unique `key` and `id`, starts in `Pending` state, and uses
+   * the same process and input arguments as the original job.
+   *
+   * To monitor the new job's progress, poll with {@link JobServiceModel.getById | getById}
+   * using the returned job's key until the state reaches a final value.
    *
    * @param jobKey - The unique key (GUID) of the job to restart
    * @param folderId - The folder ID where the job resides
-   * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
+   * @returns Promise resolving to the new {@link JobGetResponse} with full job details
    *
    * @example
    * ```typescript
    * // Restart a faulted job
-   * const result = await jobs.restart(<jobKey>, <folderId>);
-   * console.log(result.data.state); // 'Pending'
-   * console.log(result.data.key);   // new job key
+   * const newJob = await jobs.restart(<jobKey>, <folderId>);
+   * console.log(newJob.state); // 'Pending'
+   * console.log(newJob.key);   // new job key (different from original)
    * ```
    */
   @track('Jobs.Restart')
-  async restart(jobKey: string, folderId: number): Promise<OperationResponse<JobGetResponse>> {
+  async restart(jobKey: string, folderId: number): Promise<JobGetResponse> {
     if (!jobKey) {
       throw new ValidationError({ message: 'jobKey is required for restart' });
     }
@@ -352,7 +354,7 @@ export class JobService extends FolderScopedService implements JobServiceModel {
     );
 
     const rawJob = transformData(pascalToCamelCaseKeys(response.data) as RawJobGetResponse, JobMap);
-    return { success: true, data: createJobWithMethods(rawJob, this) };
+    return createJobWithMethods(rawJob, this);
   }
 
   /**

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -314,13 +314,13 @@ export class JobService extends FolderScopedService implements JobServiceModel {
   }
 
   /**
-   * Restarts a completed or faulted job.
+   * Restarts a job in a final state (Successful, Faulted, or Stopped).
    *
-   * Creates a new job execution from a previously completed, faulted, or stopped job.
+   * Creates a new job execution from a previously successful, faulted, or stopped job.
    * The new job is created with `Pending` state and uses the same process and input
    * arguments as the original job.
    *
-   * @param jobId - The numeric ID of the job to restart
+   * @param jobKey - The unique key (GUID) of the job to restart
    * @param folderId - The folder ID where the job resides
    * @returns Promise resolving to an {@link OperationResponse}<{@link JobGetResponse}> with the new job details
    *

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -316,10 +316,10 @@ export class JobService extends FolderScopedService implements JobServiceModel {
    * Restarts a job in a final state (Successful, Faulted, or Stopped).
    *
    * Creates a **new** job execution from a previously successful, faulted, or stopped job.
-   * The new job has its own unique `key` and `id`, starts in `Pending` state, and uses
+   * The new job has its own unique `key`, starts in `Pending` state, and uses
    * the same process and input arguments as the original job.
    *
-   * To monitor the new job's progress, poll with {@link JobServiceModel.getById | getById}
+   * To monitor the new job's progress, poll with {@link getById}
    * using the returned job's key until the state reaches a final value.
    *
    * @param jobKey - The unique key (GUID) of the job to restart

--- a/src/utils/constants/endpoints/orchestrator.ts
+++ b/src/utils/constants/endpoints/orchestrator.ts
@@ -61,6 +61,7 @@ export const JOB_ENDPOINTS = {
   GET_ALL: `${ORCHESTRATOR_BASE}/odata/Jobs`,
   GET_BY_KEY: (identifier: string) => `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.GetByKey(identifier=${identifier})`,
   RESUME: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.ResumeJob`,
+  RESTART: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.RestartJob`,
 } as const;
 
 /**

--- a/src/utils/constants/endpoints/orchestrator.ts
+++ b/src/utils/constants/endpoints/orchestrator.ts
@@ -62,6 +62,7 @@ export const JOB_ENDPOINTS = {
   GET_BY_KEY: (identifier: string) => `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.GetByKey(identifier=${identifier})`,
   STOP: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.StopJobs`,
   RESUME: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.ResumeJob`,
+  RESTART: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.RestartJob`,
 } as const;
 
 /**

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -263,7 +263,7 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
       const result = await jobs.getAll({
         folderId,
         pageSize: 1,
-        filter: "State eq 'Faulted'",
+        filter: "state eq 'Faulted'",
       });
 
       if (result.items.length === 0) {
@@ -276,6 +276,37 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
       expect(restarted.success).toBe(true);
       expect(restarted.data).toBeDefined();
       expect(restarted.data.state).toBeDefined();
+    });
+
+    it('should apply transform pipeline correctly on restarted job', async () => {
+      const { jobs, folderId } = getJobsService();
+
+      if (!folderId) {
+        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for restart tests.');
+      }
+
+      const result = await jobs.getAll({
+        folderId,
+        pageSize: 1,
+        filter: "state eq 'Faulted'",
+      });
+
+      if (result.items.length === 0) {
+        throw new Error('No faulted jobs found in the test environment to test restart transform.');
+      }
+
+      const job = result.items[0];
+      const restarted = await jobs.restart(job.id, folderId);
+
+      // Verify transformed camelCase fields present with values
+      expect(restarted.data.createdTime).toBeDefined();
+      expect(restarted.data.processName).toBeDefined();
+      expect(restarted.data.folderId).toBeDefined();
+
+      // Verify original PascalCase API fields absent
+      expect((restarted.data as any).CreationTime).toBeUndefined();
+      expect((restarted.data as any).ReleaseName).toBeUndefined();
+      expect((restarted.data as any).OrganizationUnitId).toBeUndefined();
     });
   });
 

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -253,7 +253,7 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
   });
 
   describe('restart', () => {
-    it('should restart a faulted job', async () => {
+    it('should restart a faulted job with correct transform pipeline', async () => {
       const { jobs, folderId } = getJobsService();
 
       if (!folderId) {
@@ -271,32 +271,12 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
       }
 
       const job = result.items[0];
-      const restarted = await jobs.restart(job.id, folderId);
+      const restarted = await jobs.restart(job.key, folderId);
 
+      // Core restart assertions
       expect(restarted.success).toBe(true);
       expect(restarted.data).toBeDefined();
       expect(restarted.data.state).toBeDefined();
-    });
-
-    it('should apply transform pipeline correctly on restarted job', async () => {
-      const { jobs, folderId } = getJobsService();
-
-      if (!folderId) {
-        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for restart tests.');
-      }
-
-      const result = await jobs.getAll({
-        folderId,
-        pageSize: 1,
-        filter: "state eq 'Faulted'",
-      });
-
-      if (result.items.length === 0) {
-        throw new Error('No faulted jobs found in the test environment to test restart transform.');
-      }
-
-      const job = result.items[0];
-      const restarted = await jobs.restart(job.id, folderId);
 
       // Verify transformed camelCase fields present with values
       expect(restarted.data.createdTime).toBeDefined();

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -120,6 +120,33 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe('restart', () => {
+    it('should restart a faulted job', async () => {
+      const { jobs, folderId } = getJobsService();
+
+      if (!folderId) {
+        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for restart tests.');
+      }
+
+      const result = await jobs.getAll({
+        folderId,
+        pageSize: 1,
+        filter: "State eq 'Faulted'",
+      });
+
+      if (result.items.length === 0) {
+        throw new Error('No faulted jobs found in the test environment to test restart.');
+      }
+
+      const job = result.items[0];
+      const restarted = await jobs.restart(job.id, folderId);
+
+      expect(restarted.success).toBe(true);
+      expect(restarted.data).toBeDefined();
+      expect(restarted.data.state).toBeDefined();
+    });
+  });
+
   describe('Job structure validation', () => {
     it('should have expected fields in job objects', async () => {
       const { jobs, folderId } = getJobsService();

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -252,6 +252,33 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe('restart', () => {
+    it('should restart a faulted job', async () => {
+      const { jobs, folderId } = getJobsService();
+
+      if (!folderId) {
+        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for restart tests.');
+      }
+
+      const result = await jobs.getAll({
+        folderId,
+        pageSize: 1,
+        filter: "State eq 'Faulted'",
+      });
+
+      if (result.items.length === 0) {
+        throw new Error('No faulted jobs found in the test environment to test restart.');
+      }
+
+      const job = result.items[0];
+      const restarted = await jobs.restart(job.id, folderId);
+
+      expect(restarted.success).toBe(true);
+      expect(restarted.data).toBeDefined();
+      expect(restarted.data.state).toBeDefined();
+    });
+  });
+
   describe('Job structure validation', () => {
     it('should have expected fields in job objects', async () => {
       const { jobs, folderId } = getJobsService();

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import type { JobGetResponse } from '../../../../src/models/orchestrator/jobs.models';
 
 const modes: InitMode[] = ['v1'];
 
@@ -253,40 +254,44 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
   });
 
   describe('restart', () => {
-    it('should restart a faulted job with correct transform pipeline', async () => {
-      const { jobs, folderId } = getJobsService();
+    let restartResult!: JobGetResponse;
 
-      if (!folderId) {
+    beforeAll(async () => {
+      const { jobs: svc, folderId: fId } = getJobsService();
+
+      if (!fId) {
         throw new Error('INTEGRATION_TEST_FOLDER_ID is required for restart tests.');
       }
 
-      const result = await jobs.getAll({
-        folderId,
+      const result = await svc.getAll({
+        folderId: fId,
         pageSize: 1,
-        filter: "state eq 'Faulted'",
+        filter: "state eq 'Faulted' or state eq 'Successful' or state eq 'Stopped'",
       });
 
       if (result.items.length === 0) {
-        throw new Error('No faulted jobs found in the test environment to test restart.');
+        throw new Error('No restartable jobs (Faulted/Successful/Stopped) found in the test environment.');
       }
 
-      const job = result.items[0];
-      const restarted = await jobs.restart(job.key, folderId);
+      restartResult = await svc.restart(result.items[0].key, fId);
+    });
 
-      // Core restart assertions
-      expect(restarted.success).toBe(true);
-      expect(restarted.data).toBeDefined();
-      expect(restarted.data.state).toBeDefined();
+    it('should restart a job in a final state', () => {
+      expect(restartResult).toBeDefined();
+      expect(restartResult.state).toBeDefined();
+      expect(restartResult.key).toBeDefined();
+    });
 
+    it('should apply transform pipeline correctly on restarted job', () => {
       // Verify transformed camelCase fields present with values
-      expect(restarted.data.createdTime).toBeDefined();
-      expect(restarted.data.processName).toBeDefined();
-      expect(restarted.data.folderId).toBeDefined();
+      expect(restartResult.createdTime).toBeDefined();
+      expect(restartResult.processName).toBeDefined();
+      expect(restartResult.folderId).toBeDefined();
 
       // Verify original PascalCase API fields absent
-      expect((restarted.data as any).CreationTime).toBeUndefined();
-      expect((restarted.data as any).ReleaseName).toBeUndefined();
-      expect((restarted.data as any).OrganizationUnitId).toBeUndefined();
+      expect((restartResult as any).CreationTime).toBeUndefined();
+      expect((restartResult as any).ReleaseName).toBeUndefined();
+      expect((restartResult as any).OrganizationUnitId).toBeUndefined();
     });
   });
 

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -165,13 +165,12 @@ describe('Job Models', () => {
         const mockJobData = createBasicJob();
         const job = createJobWithMethods(mockJobData, mockService);
 
-        const mockResult = { success: true, data: job };
-        vi.mocked(mockService.restart).mockResolvedValue(mockResult);
+        vi.mocked(mockService.restart).mockResolvedValue(job);
 
         const result = await job.restart();
 
         expect(mockService.restart).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
-        expect(result).toEqual(mockResult);
+        expect(result).toEqual(job);
       });
 
       it('should throw when job key is undefined', async () => {

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -161,7 +161,7 @@ describe('Job Models', () => {
     });
 
     describe('job.restart()', () => {
-      it('should call service.restart with the job id and folderId', async () => {
+      it('should call service.restart with the job key and folderId', async () => {
         const mockJobData = createBasicJob();
         const job = createJobWithMethods(mockJobData, mockService);
 
@@ -170,15 +170,15 @@ describe('Job Models', () => {
 
         const result = await job.restart();
 
-        expect(mockService.restart).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+        expect(mockService.restart).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
         expect(result).toEqual(mockResult);
       });
 
-      it('should throw when job id is undefined', async () => {
-        const mockJobData = createBasicJob({ id: 0 as any });
+      it('should throw when job key is undefined', async () => {
+        const mockJobData = createBasicJob({ key: '' as any });
         const job = createJobWithMethods(mockJobData, mockService);
 
-        await expect(job.restart()).rejects.toThrow('Job id is undefined');
+        await expect(job.restart()).rejects.toThrow('Job key is undefined');
       });
 
       it('should throw when job folderId is undefined', async () => {

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -19,6 +19,7 @@ describe('Job Models', () => {
       getOutput: vi.fn(),
       stop: vi.fn(),
       resume: vi.fn(),
+      restart: vi.fn(),
     } as any;
   });
 
@@ -156,6 +157,35 @@ describe('Job Models', () => {
         const job = createJobWithMethods(mockJobData, mockService);
 
         await expect(job.resume()).rejects.toThrow('Job folderId is undefined');
+      });
+    });
+
+    describe('job.restart()', () => {
+      it('should call service.restart with the job id and folderId', async () => {
+        const mockJobData = createBasicJob();
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        const mockResult = { success: true, data: job };
+        vi.mocked(mockService.restart).mockResolvedValue(mockResult);
+
+        const result = await job.restart();
+
+        expect(mockService.restart).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+        expect(result).toEqual(mockResult);
+      });
+
+      it('should throw when job id is undefined', async () => {
+        const mockJobData = createBasicJob({ id: 0 as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.restart()).rejects.toThrow('Job id is undefined');
+      });
+
+      it('should throw when job folderId is undefined', async () => {
+        const mockJobData = createBasicJob({ folderId: undefined as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.restart()).rejects.toThrow('Job folderId is undefined');
       });
     });
   });

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -16,6 +16,7 @@ describe('Job Models', () => {
       getAll: vi.fn(),
       getOutput: vi.fn(),
       resume: vi.fn(),
+      restart: vi.fn(),
     } as any;
   });
 
@@ -107,6 +108,35 @@ describe('Job Models', () => {
         const job = createJobWithMethods(mockJobData, mockService);
 
         await expect(job.resume()).rejects.toThrow('Job folderId is undefined');
+      });
+    });
+
+    describe('job.restart()', () => {
+      it('should call service.restart with the job id and folderId', async () => {
+        const mockJobData = createBasicJob();
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        const mockResult = { success: true, data: job };
+        vi.mocked(mockService.restart).mockResolvedValue(mockResult);
+
+        const result = await job.restart();
+
+        expect(mockService.restart).toHaveBeenCalledWith(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+        expect(result).toEqual(mockResult);
+      });
+
+      it('should throw when job id is undefined', async () => {
+        const mockJobData = createBasicJob({ id: 0 as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.restart()).rejects.toThrow('Job id is undefined');
+      });
+
+      it('should throw when job folderId is undefined', async () => {
+        const mockJobData = createBasicJob({ folderId: undefined as any });
+        const job = createJobWithMethods(mockJobData, mockService);
+
+        await expect(job.restart()).rejects.toThrow('Job folderId is undefined');
       });
     });
   });

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -695,12 +695,29 @@ describe('JobService Unit Tests', () => {
   });
 
   describe('restart', () => {
-    it('should restart a job and return transformed response', async () => {
+    it('should resolve job key and restart with transformed response', async () => {
+      // Key resolution via getAll
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValueOnce({
+        items: [{ key: JOB_TEST_CONSTANTS.JOB_KEY, id: JOB_TEST_CONSTANTS.JOB_ID }],
+      });
+      // Restart API call
       const mockRawJob = createMockRawJob({ State: 'Pending' });
       mockApiClient.post.mockResolvedValueOnce(mockRawJob);
 
-      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
 
+      // Verify key resolution
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          folderId: TEST_CONSTANTS.FOLDER_ID,
+          filter: `key in ('${JOB_TEST_CONSTANTS.JOB_KEY}')`,
+          select: 'id,key',
+          pageSize: 1,
+        })
+      );
+
+      // Verify restart call with resolved numeric ID
       expect(mockApiClient.post).toHaveBeenCalledWith(
         JOB_ENDPOINTS.RESTART,
         { jobId: JOB_TEST_CONSTANTS.JOB_ID },
@@ -726,34 +743,40 @@ describe('JobService Unit Tests', () => {
     });
 
     it('should attach bound methods to the returned job', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValueOnce({
+        items: [{ key: JOB_TEST_CONSTANTS.JOB_KEY, id: JOB_TEST_CONSTANTS.JOB_ID }],
+      });
       const mockRawJob = createMockRawJob({ State: 'Pending' });
       mockApiClient.post.mockResolvedValueOnce(mockRawJob);
 
-      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
 
       expect(typeof result.data.getOutput).toBe('function');
       expect(typeof result.data.resume).toBe('function');
       expect(typeof result.data.restart).toBe('function');
     });
 
-    it('should throw validation error when jobId is missing', async () => {
+    it('should throw validation error when jobKey is missing', async () => {
       await expect(
-        jobService.restart(0, TEST_CONSTANTS.FOLDER_ID)
-      ).rejects.toThrow('jobId is required for restart');
+        jobService.restart('', TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow('jobKey is required for restart');
     });
 
     it('should throw validation error when folderId is missing', async () => {
       await expect(
-        jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, 0)
+        jobService.restart(JOB_TEST_CONSTANTS.JOB_KEY, 0)
       ).rejects.toThrow('folderId is required for restart');
     });
 
     it('should handle API errors', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValueOnce({
+        items: [{ key: JOB_TEST_CONSTANTS.JOB_KEY, id: JOB_TEST_CONSTANTS.JOB_ID }],
+      });
       const error = createMockError(JOB_TEST_CONSTANTS.ERROR_JOB_NOT_FOUND);
       mockApiClient.post.mockRejectedValueOnce(error);
 
       await expect(
-        jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID)
+        jobService.restart(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID)
       ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_NOT_FOUND);
     });
   });

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -693,4 +693,53 @@ describe('JobService Unit Tests', () => {
       ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_RESUME_FAILED);
     });
   });
+
+  describe('restart', () => {
+    it('should restart a job and return transformed response', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Pending' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.RESTART,
+        { jobId: JOB_TEST_CONSTANTS.JOB_ID },
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-UIPATH-OrganizationUnitId': String(TEST_CONSTANTS.FOLDER_ID),
+          }),
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
+    });
+
+    it('should attach bound methods to the returned job', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Pending' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(typeof result.data.getOutput).toBe('function');
+      expect(typeof result.data.resume).toBe('function');
+      expect(typeof result.data.restart).toBe('function');
+    });
+
+    it('should throw validation error when jobId is missing', async () => {
+      await expect(
+        jobService.restart(0, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow('jobId is required for restart');
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(JOB_TEST_CONSTANTS.ERROR_JOB_NOT_FOUND);
+      mockApiClient.post.mockRejectedValueOnce(error);
+
+      await expect(
+        jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_NOT_FOUND);
+    });
+  });
 });

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -466,4 +466,53 @@ describe('JobService Unit Tests', () => {
       ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_RESUME_FAILED);
     });
   });
+
+  describe('restart', () => {
+    it('should restart a job and return transformed response', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Pending' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.RESTART,
+        { jobId: JOB_TEST_CONSTANTS.JOB_ID },
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-UIPATH-OrganizationUnitId': String(TEST_CONSTANTS.FOLDER_ID),
+          }),
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
+    });
+
+    it('should attach bound methods to the returned job', async () => {
+      const mockRawJob = createMockRawJob({ State: 'Pending' });
+      mockApiClient.post.mockResolvedValueOnce(mockRawJob);
+
+      const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(typeof result.data.getOutput).toBe('function');
+      expect(typeof result.data.resume).toBe('function');
+      expect(typeof result.data.restart).toBe('function');
+    });
+
+    it('should throw validation error when jobId is missing', async () => {
+      await expect(
+        jobService.restart(0, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow('jobId is required for restart');
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(JOB_TEST_CONSTANTS.ERROR_JOB_NOT_FOUND);
+      mockApiClient.post.mockRejectedValueOnce(error);
+
+      await expect(
+        jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_NOT_FOUND);
+    });
+  });
 });

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -714,6 +714,15 @@ describe('JobService Unit Tests', () => {
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
       expect(result.data.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
+
+      // Verify transformed camelCase fields have expected values
+      expect(result.data.createdTime).toBe(JOB_TEST_CONSTANTS.CREATED_TIME);
+      expect(result.data.processName).toBe(JOB_TEST_CONSTANTS.PROCESS_NAME);
+
+      // Verify original PascalCase fields are absent
+      expect((result.data as any).CreationTime).toBeUndefined();
+      expect((result.data as any).ReleaseName).toBeUndefined();
+      expect((result.data as any).OrganizationUnitId).toBeUndefined();
     });
 
     it('should attach bound methods to the returned job', async () => {
@@ -731,6 +740,12 @@ describe('JobService Unit Tests', () => {
       await expect(
         jobService.restart(0, TEST_CONSTANTS.FOLDER_ID)
       ).rejects.toThrow('jobId is required for restart');
+    });
+
+    it('should throw validation error when folderId is missing', async () => {
+      await expect(
+        jobService.restart(JOB_TEST_CONSTANTS.JOB_ID, 0)
+      ).rejects.toThrow('folderId is required for restart');
     });
 
     it('should handle API errors', async () => {

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -728,18 +728,17 @@ describe('JobService Unit Tests', () => {
         })
       );
 
-      expect(result.success).toBe(true);
-      expect(result.data).toBeDefined();
-      expect(result.data.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
+      expect(result).toBeDefined();
+      expect(result.key).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
 
       // Verify transformed camelCase fields have expected values
-      expect(result.data.createdTime).toBe(JOB_TEST_CONSTANTS.CREATED_TIME);
-      expect(result.data.processName).toBe(JOB_TEST_CONSTANTS.PROCESS_NAME);
+      expect(result.createdTime).toBe(JOB_TEST_CONSTANTS.CREATED_TIME);
+      expect(result.processName).toBe(JOB_TEST_CONSTANTS.PROCESS_NAME);
 
       // Verify original PascalCase fields are absent
-      expect((result.data as any).CreationTime).toBeUndefined();
-      expect((result.data as any).ReleaseName).toBeUndefined();
-      expect((result.data as any).OrganizationUnitId).toBeUndefined();
+      expect((result as any).CreationTime).toBeUndefined();
+      expect((result as any).ReleaseName).toBeUndefined();
+      expect((result as any).OrganizationUnitId).toBeUndefined();
     });
 
     it('should attach bound methods to the returned job', async () => {
@@ -751,9 +750,10 @@ describe('JobService Unit Tests', () => {
 
       const result = await jobService.restart(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
 
-      expect(typeof result.data.getOutput).toBe('function');
-      expect(typeof result.data.resume).toBe('function');
-      expect(typeof result.data.restart).toBe('function');
+      expect(typeof result.getOutput).toBe('function');
+      expect(typeof result.stop).toBe('function');
+      expect(typeof result.resume).toBe('function');
+      expect(typeof result.restart).toBe('function');
     });
 
     it('should throw validation error when jobKey is missing', async () => {


### PR DESCRIPTION
## Method Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `jobs.restart()` | `restart(jobKey: string, folderId: number): Promise<JobGetResponse>` |
| Bound | `job.restart()` | `restart(): Promise<JobGetResponse>` |

## Endpoint Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `restart()` | POST | `/odata/Jobs/UiPath.Server.Configuration.OData.RestartJob` | `OR.Jobs` |
| _(key resolution)_ | GET | `/odata/Jobs` | `OR.Jobs` or `OR.Jobs.Read` |

- Extends `FolderScopedService` — sets `X-UIPATH-OrganizationUnitId` header
- Accepts `jobKey` (GUID) and resolves to numeric `jobId` internally via `resolveJobKeys()`, consistent with `stop()` and `resume()`
- Returns `JobGetResponse` directly (not wrapped in `OperationResponse`), consistent with `processes.start()`
- Creates a **new** job with its own `key` and `id` — original job remains unchanged

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { Jobs } from '@uipath/uipath-typescript/jobs';

const sdk = new UiPath(config);
await sdk.initialize();
const jobs = new Jobs(sdk);

// Restart a faulted job
const newJob = await jobs.restart(<jobKey>, <folderId>);
console.log(newJob.state); // 'Pending'
console.log(newJob.key);   // new job key (different from original)

// Restart via bound method
const job = await jobs.getById(<jobKey>, <folderId>);
const restarted = await job.restart();
```

## API Response vs SDK Response

### Transform pipeline
`pascalToCamelCaseKeys()` → `transformData(data, JobMap)` → `createJobWithMethods()`

### Field mapping
| API Response (PascalCase) | SDK Response (camelCase) | Change | Reason |
|---------------------------|--------------------------|--------|--------|
| `CreationTime` | `createdTime` | Case + Rename | Standard time convention |
| `ReleaseName` | `processName` | Case + Rename | User-facing terminology |
| `OrganizationUnitId` | `folderId` | Case + Rename | Standard folder convention |
| All other PascalCase fields | camelCase equivalents | Case only | `pascalToCamelCaseKeys()` |

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/orchestrator.ts` |
| Models | `src/models/orchestrator/jobs.models.ts` |
| Service | `src/services/orchestrator/jobs/jobs.ts` |
| Unit tests | `tests/unit/services/orchestrator/jobs.test.ts` (5 new tests) |
| Model tests | `tests/unit/models/orchestrator/jobs.test.ts` (3 new tests) |
| Integration tests | `tests/integration/shared/orchestrator/jobs.integration.test.ts` (2 new tests) |
| Docs | `docs/oauth-scopes.md` |

Refs PLT-102122

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*