### PR TITLE
docs: add Attachments scopes to Jobs.getOutput()

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -15,7 +15,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `OR.Jobs` or `OR.Jobs.Read` |
 | `getById()` | `OR.Jobs` or `OR.Jobs.Read` |
-| `getOutput()` | `OR.Jobs` or `OR.Jobs.Read` |
+| `getOutput()` | `OR.Jobs` or `OR.Jobs.Read`, `OR.Folders` or `OR.Folders.Read` |
 
 ## Attachments
 


### PR DESCRIPTION
## Summary
- `Jobs.getOutput()` internally calls `Attachments.getById()` for blob downloads
- Added `OR.Folders` / `OR.Folders.Read` scopes to the `getOutput()` row in oauth-scopes docs so users know the full scope requirements

## Test plan
- [ ] Verify oauth-scopes.md renders correctly on docs site