### PR TITLE
fix: Added POST request param as part of Body same as non paginated r…

### DIFF
--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -169,7 +169,6 @@ export class BaseService {
       const existingBody = (options.body && typeof options.body === 'object') ? options.body as Record<string, unknown> : {};
       options.body = {
         ...existingBody,
-        ...options.params,
         ...requestParams
       };
     } else {

--- a/src/utils/pagination/helpers.ts
+++ b/src/utils/pagination/helpers.ts
@@ -185,13 +185,16 @@ export class PaginationHelpers {
     const endpoint = getEndpoint(folderId);
     const headers = folderId ? createHeaders({ [FOLDER_ID]: folderId }) : {};
 
+    const isPost = method?.toUpperCase() === HTTP_METHODS.POST.toUpperCase();
     const paginatedResponse = await serviceAccess.requestWithPagination<T>(
       method,
       endpoint,
       paginationParams,
       {
         headers,
-        params: additionalParams,
+        // POST: body
+        // GET: query params 
+        ...(isPost ? { body: additionalParams, params: {} } : { params: additionalParams }),
         pagination: {
           paginationType: options.paginationType || PaginationType.OFFSET,
           itemsField: options.itemsField || DEFAULT_ITEMS_FIELD,

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -14,6 +14,8 @@ import {
   FieldDisplayType,
   FieldMetaData,
   RawEntityGetResponse,
+  LogicalOperator,
+  QueryFilterOperator,
 } from '../../../../src/models/data-fabric/entities.types';
 
 // Cache for choice set values to avoid repeated API calls within a test run
@@ -736,6 +738,52 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(Array.isArray(result.items)).toBe(true);
       expect(result.items.length).toBeLessThanOrEqual(2);
       expect(hasValidPagination(result)).toBe(true);
+    });
+
+    it('should query records with filterGroup and pageSize', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+      // If filterGroup were serialized as a query param it would produce
+      // filterGroup=%5Bobject+Object%5D and the API would return an error or wrong results
+      const result = await entities.queryRecordsById(entityId, {
+        pageSize: 2,
+        filterGroup: {
+          logicalOperator: LogicalOperator.And,
+          queryFilters: [
+            { fieldName: 'Id', operator: QueryFilterOperator.NotEquals, value: '00000000-0000-0000-0000-000000000000' },
+          ],
+        },
+      });
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
+      expect(hasValidPagination(result)).toBe(true);
+    });
+
+    it('should query records with sortOptions', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+      const asc = await entities.queryRecordsById(entityId, {
+        pageSize: 5,
+        sortOptions: [{ fieldName: 'Id', isDescending: false }],
+      });
+      const desc = await entities.queryRecordsById(entityId, {
+        pageSize: 5,
+        sortOptions: [{ fieldName: 'Id', isDescending: true }],
+      });
+      expect(asc.items.length).toBeGreaterThan(0);
+      expect(desc.items.length).toBeGreaterThan(0);
+      // If more than one record, verify sort order is reversed between asc and desc
+      if (asc.items.length > 1) {
+        expect(asc.items[0].Id).not.toBe(desc.items[0].Id);
+      }
     });
   });
 

--- a/tests/unit/utils/pagination/helpers.test.ts
+++ b/tests/unit/utils/pagination/helpers.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../utils/mocks/pagination';
 import { DEFAULT_TOTAL_COUNT_FIELD, DEFAULT_ITEMS_FIELD } from '../../../../src/utils/pagination/constants';
 import { FOLDER_ID } from '../../../../src/utils/constants/headers';
+import { HTTP_METHODS } from '../../../../src/utils/constants/common';
 
 // ===== TEST SUITE =====
 describe('PaginationHelpers Unit Tests', () => {
@@ -525,6 +526,32 @@ describe('PaginationHelpers Unit Tests', () => {
         expect.any(Object)
       );
     });
+
+    it('should pass additionalParams in body (not params) for POST requests', async () => {
+      const mockResponse = createMockPaginatedResponse(MOCK_RAW_ITEMS);
+      vi.mocked(mockServiceAccess.requestWithPagination).mockResolvedValue(mockResponse);
+
+      const filterGroup = { logicalOperator: 'And', queryFilters: [] };
+
+      await PaginationHelpers.getAllPaginated({
+        serviceAccess: mockServiceAccess,
+        getEndpoint: () => PAGINATION_TEST_CONSTANTS.ENDPOINT_API_ITEMS,
+        paginationParams: { pageSize: PAGINATION_TEST_CONSTANTS.PAGE_SIZE },
+        additionalParams: { filterGroup },
+        method: HTTP_METHODS.POST,
+        options: { paginationType: PaginationType.OFFSET },
+      });
+
+      expect(mockServiceAccess.requestWithPagination).toHaveBeenCalledWith(
+        HTTP_METHODS.POST,
+        PAGINATION_TEST_CONSTANTS.ENDPOINT_API_ITEMS,
+        { pageSize: PAGINATION_TEST_CONSTANTS.PAGE_SIZE },
+        expect.objectContaining({
+          body: { filterGroup },
+          params: {},
+        })
+      );
+    });
   });
 
   describe('getAllNonPaginated', () => {
@@ -854,6 +881,28 @@ describe('PaginationHelpers Unit Tests', () => {
 
       expect(mockServiceAccess.get).toHaveBeenCalled();
       expect(result.items).toEqual([]);
+    });
+
+    it('should pass additionalParams in body (not params) for POST paginated requests', async () => {
+      const mockResponse = createMockPaginatedResponse(MOCK_RAW_ITEM);
+      vi.mocked(mockServiceAccess.requestWithPagination).mockResolvedValue(mockResponse);
+
+      const filterGroup = { logicalOperator: 0, queryFilters: [{ fieldName: 'status', operator: '=', value: 'active' }] };
+
+      await PaginationHelpers.getAll(
+        { ...mockConfig, method: HTTP_METHODS.POST, excludeFromPrefix: ['filterGroup'] },
+        { pageSize: PAGINATION_TEST_CONSTANTS.PAGE_SIZE, filterGroup }
+      );
+
+      expect(mockServiceAccess.requestWithPagination).toHaveBeenCalledWith(
+        HTTP_METHODS.POST,
+        PAGINATION_TEST_CONSTANTS.ENDPOINT_API_ITEMS,
+        { pageSize: PAGINATION_TEST_CONSTANTS.PAGE_SIZE },
+        expect.objectContaining({
+          body: { filterGroup },
+          params: {},
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
Fixed the paginated request for QueryById—the filter parameters were being sent as string in the POST request query params. Updated it to pass them in the request body, consistent with the non-paginated request.
