### PR TITLE
feat(orchestrator): getByName for Assets + Processes, encoded folder header, meta-tag fallback [PLT-92768]

### DIFF
--- a/samples/asset-by-name-app/.env.example
+++ b/samples/asset-by-name-app/.env.example
@@ -3,4 +3,4 @@ VITE_UIPATH_ORG_NAME=your-organization
 VITE_UIPATH_TENANT_NAME=your-tenant
 VITE_UIPATH_CLIENT_ID=your-oauth-client-id
 VITE_UIPATH_REDIRECT_URI=http://localhost:5173
-VITE_UIPATH_SCOPE=offline_access OR.Assets OR.Folders OR.Execution.Read
+VITE_UIPATH_SCOPE=offline_access OR.Assets OR.Folders OR.Execution OR.Jobs

--- a/samples/asset-by-name-app/.env.example
+++ b/samples/asset-by-name-app/.env.example
@@ -3,4 +3,4 @@ VITE_UIPATH_ORG_NAME=your-organization
 VITE_UIPATH_TENANT_NAME=your-tenant
 VITE_UIPATH_CLIENT_ID=your-oauth-client-id
 VITE_UIPATH_REDIRECT_URI=http://localhost:5173
-VITE_UIPATH_SCOPE=offline_access OR.Assets OR.Folders
+VITE_UIPATH_SCOPE=offline_access OR.Assets OR.Folders OR.Execution.Read

--- a/samples/asset-by-name-app/.env.example
+++ b/samples/asset-by-name-app/.env.example
@@ -1,0 +1,6 @@
+VITE_UIPATH_BASE_URL=https://cloud.uipath.com
+VITE_UIPATH_ORG_NAME=your-organization
+VITE_UIPATH_TENANT_NAME=your-tenant
+VITE_UIPATH_CLIENT_ID=your-oauth-client-id
+VITE_UIPATH_REDIRECT_URI=http://localhost:5173
+VITE_UIPATH_SCOPE=offline_access OR.Assets OR.Folders

--- a/samples/asset-by-name-app/.gitignore
+++ b/samples/asset-by-name-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.env.local
+.env.*.local

--- a/samples/asset-by-name-app/README.md
+++ b/samples/asset-by-name-app/README.md
@@ -1,0 +1,33 @@
+# Asset getByName Demo
+
+Minimal React + Vite app that demonstrates `assets.getByName()` from the UiPath TypeScript SDK.
+
+After OAuth login, the app:
+
+1. Lists all assets visible to the user across folders (via `assets.getAll()`).
+2. Lets the user click a row to prefill the form below.
+3. Resolves a single asset by **name + folderPath** via `assets.getByName()` and renders the raw JSON response.
+
+## Setup
+
+1. Register a **Non-Confidential External Application** in UiPath Admin with scopes `OR.Assets OR.Folders offline_access` and redirect URI `http://localhost:5173`.
+2. Copy `.env.example` to `.env.local` and fill in your Client ID / org / tenant.
+3. Install and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Open http://localhost:5173.
+
+## What this demonstrates
+
+```typescript
+import { Assets } from '@uipath/uipath-typescript/assets';
+
+const assets = new Assets(sdk);
+
+// Folder path is sent as X-UIPATH-FolderPath header; server resolves the folder.
+const asset = await assets.getByName('ApiKey', { folderPath: 'Shared/Finance' });
+```

--- a/samples/asset-by-name-app/index.html
+++ b/samples/asset-by-name-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Asset getByName Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/samples/asset-by-name-app/index.html
+++ b/samples/asset-by-name-app/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Demo: simulates jamjam's injection. SDK picks this up as the default
+         folderKey when callers don't pass folderPath/folderKey at call site. -->
+    <meta name="uipath:folder-key" content="5de8ef41-6ea5-4620-a47f-f66f0119398f" />
     <title>Asset getByName Demo</title>
   </head>
   <body>

--- a/samples/asset-by-name-app/package-lock.json
+++ b/samples/asset-by-name-app/package-lock.json
@@ -1,0 +1,2808 @@
+{
+  "name": "asset-by-name-app",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "asset-by-name-app",
+      "version": "0.0.0",
+      "dependencies": {
+        "@uipath/uipath-typescript": "file:../..",
+        "path-browserify": "^1.0.1",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1"
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.13",
+        "@types/react-dom": "^19.1.9",
+        "@vitejs/plugin-react": "^5.0.3",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^3.4.17",
+        "typescript": "~5.8.3",
+        "vite": "^7.1.7"
+      }
+    },
+    "../..": {
+      "name": "@uipath/uipath-typescript",
+      "version": "1.2.2",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@opentelemetry/sdk-logs": "^0.204.0",
+        "socket.io-client": "^4.8.1"
+      },
+      "devDependencies": {
+        "@rollup/plugin-alias": "^6.0.0",
+        "@rollup/plugin-commonjs": "^25.0.0",
+        "@rollup/plugin-json": "^6.0.0",
+        "@rollup/plugin-node-resolve": "^15.2.0",
+        "@rollup/plugin-typescript": "^11.1.0",
+        "@types/node": "^20.11.19",
+        "@types/uuid": "^9.0.8",
+        "@vitest/coverage-v8": "^3.2.4",
+        "@vitest/ui": "^3.2.4",
+        "builtin-modules": "^3.3.0",
+        "dotenv": "^17.2.0",
+        "oxlint": "^1.43.0",
+        "rimraf": "^6.0.1",
+        "rollup": "^4.59.1",
+        "rollup-plugin-dts": "^6.1.0",
+        "typedoc": "^0.28.13",
+        "typedoc-plugin-markdown": "^4.8.1",
+        "typescript": "^5.3.3",
+        "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "zod": "^4.2.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@uipath/uipath-typescript": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/samples/asset-by-name-app/package.json
+++ b/samples/asset-by-name-app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "asset-by-name-app",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Sample app demonstrating assets.getByName() via folderPath — lists assets across folders and resolves a single asset by name",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@uipath/uipath-typescript": "file:../..",
+    "path-browserify": "^1.0.1",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^5.0.3",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
+    "typescript": "~5.8.3",
+    "vite": "^7.1.7"
+  }
+}

--- a/samples/asset-by-name-app/postcss.config.js
+++ b/samples/asset-by-name-app/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/samples/asset-by-name-app/src/App.css
+++ b/samples/asset-by-name-app/src/App.css
@@ -1,0 +1,42 @@
+#root {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+.logo {
+  height: 6em;
+  padding: 1.5em;
+  will-change: filter;
+  transition: filter 300ms;
+}
+.logo:hover {
+  filter: drop-shadow(0 0 2em #646cffaa);
+}
+.logo.react:hover {
+  filter: drop-shadow(0 0 2em #61dafbaa);
+}
+
+@keyframes logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  a:nth-of-type(2) .logo {
+    animation: logo-spin infinite 20s linear;
+  }
+}
+
+.card {
+  padding: 2em;
+}
+
+.read-the-docs {
+  color: #888;
+}

--- a/samples/asset-by-name-app/src/App.tsx
+++ b/samples/asset-by-name-app/src/App.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { Header } from './components/Header';
 import { LoginScreen } from './components/LoginScreen';
-import { AssetList } from './components/AssetList';
-import { GetByNameDemo } from './components/GetByNameDemo';
+import { AssetList } from './components/assets/AssetList';
+import { AssetsGetByName } from './components/assets/AssetsGetByName';
+import { ProcessList } from './components/processes/ProcessList';
+import { ProcessesGetByName } from './components/processes/ProcessesGetByName';
 import type { UiPathSDKConfig } from '@uipath/uipath-typescript/core';
 
 const authConfig: UiPathSDKConfig = {
@@ -15,11 +17,23 @@ const authConfig: UiPathSDKConfig = {
   scope: import.meta.env.VITE_UIPATH_SCOPE || 'offline_access',
 };
 
+type ResourceTab = 'assets' | 'processes';
+
+interface TabState {
+  name: string;
+  folderPath: string;
+  folderKey: string;
+}
+
+const emptyState: TabState = { name: '', folderPath: '', folderKey: '' };
+
 function AppContent() {
   const { isAuthenticated, isLoading } = useAuth();
-  const [name, setName] = useState('');
-  const [folderPath, setFolderPath] = useState('');
-  const [folderKey, setFolderKey] = useState('');
+  const [activeTab, setActiveTab] = useState<ResourceTab>('assets');
+  // Each resource tab keeps its own form state so switching tabs doesn't
+  // wipe what the user typed.
+  const [assetState, setAssetState] = useState<TabState>(emptyState);
+  const [processState, setProcessState] = useState<TabState>(emptyState);
 
   if (isLoading) {
     return (
@@ -36,25 +50,68 @@ function AppContent() {
     return <LoginScreen />;
   }
 
+  const tabs: Array<{ id: ResourceTab; label: string }> = [
+    { id: 'assets', label: 'Assets' },
+    { id: 'processes', label: 'Processes' },
+  ];
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
+      <nav className="bg-white border-b border-gray-200">
+        <div className="max-w-[80rem] mx-auto px-4 sm:px-6 lg:px-8 flex gap-1">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={
+                'px-5 py-3 text-sm font-medium border-b-2 transition-colors ' +
+                (activeTab === tab.id
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-600 hover:text-gray-900')
+              }
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </nav>
       <main className="max-w-[80rem] mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
-        <AssetList
-          onPickAsset={(n, fp, fk) => {
-            setName(n);
-            setFolderPath(fp);
-            setFolderKey(fk);
-          }}
-        />
-        <GetByNameDemo
-          name={name}
-          folderPath={folderPath}
-          folderKey={folderKey}
-          onNameChange={setName}
-          onFolderPathChange={setFolderPath}
-          onFolderKeyChange={setFolderKey}
-        />
+        {activeTab === 'assets' && (
+          <>
+            <AssetList
+              onPickAsset={(name, folderPath, folderKey) =>
+                setAssetState({ name, folderPath, folderKey })
+              }
+            />
+            <AssetsGetByName
+              name={assetState.name}
+              folderPath={assetState.folderPath}
+              folderKey={assetState.folderKey}
+              onNameChange={(name) => setAssetState((s) => ({ ...s, name }))}
+              onFolderPathChange={(folderPath) => setAssetState((s) => ({ ...s, folderPath }))}
+              onFolderKeyChange={(folderKey) => setAssetState((s) => ({ ...s, folderKey }))}
+            />
+          </>
+        )}
+
+        {activeTab === 'processes' && (
+          <>
+            <ProcessList
+              onPickProcess={(name, folderPath, folderKey) =>
+                setProcessState({ name, folderPath, folderKey })
+              }
+            />
+            <ProcessesGetByName
+              name={processState.name}
+              folderPath={processState.folderPath}
+              folderKey={processState.folderKey}
+              onNameChange={(name) => setProcessState((s) => ({ ...s, name }))}
+              onFolderPathChange={(folderPath) => setProcessState((s) => ({ ...s, folderPath }))}
+              onFolderKeyChange={(folderKey) => setProcessState((s) => ({ ...s, folderKey }))}
+            />
+          </>
+        )}
       </main>
     </div>
   );

--- a/samples/asset-by-name-app/src/App.tsx
+++ b/samples/asset-by-name-app/src/App.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { AuthProvider, useAuth } from './hooks/useAuth';
+import { Header } from './components/Header';
+import { LoginScreen } from './components/LoginScreen';
+import { AssetList } from './components/AssetList';
+import { GetByNameDemo } from './components/GetByNameDemo';
+import type { UiPathSDKConfig } from '@uipath/uipath-typescript/core';
+
+const authConfig: UiPathSDKConfig = {
+  clientId: import.meta.env.VITE_UIPATH_CLIENT_ID || 'your-client-id',
+  orgName: import.meta.env.VITE_UIPATH_ORG_NAME || 'your-organization',
+  tenantName: import.meta.env.VITE_UIPATH_TENANT_NAME || 'your-tenant',
+  baseUrl: import.meta.env.VITE_UIPATH_BASE_URL || window.location.origin,
+  redirectUri: import.meta.env.VITE_UIPATH_REDIRECT_URI || window.location.origin,
+  scope: import.meta.env.VITE_UIPATH_SCOPE || 'offline_access',
+};
+
+function AppContent() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const [name, setName] = useState('');
+  const [folderPath, setFolderPath] = useState('');
+  const [folderKey, setFolderKey] = useState('');
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="flex items-center space-x-3">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+          <span className="text-gray-600 font-medium">Initializing UiPath SDK…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <LoginScreen />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <main className="max-w-[80rem] mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <AssetList
+          onPickAsset={(n, fp, fk) => {
+            setName(n);
+            setFolderPath(fp);
+            setFolderKey(fk);
+          }}
+        />
+        <GetByNameDemo
+          name={name}
+          folderPath={folderPath}
+          folderKey={folderKey}
+          onNameChange={setName}
+          onFolderPathChange={setFolderPath}
+          onFolderKeyChange={setFolderKey}
+        />
+      </main>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <AuthProvider config={authConfig}>
+      <AppContent />
+    </AuthProvider>
+  );
+}
+
+export default App;

--- a/samples/asset-by-name-app/src/App.tsx
+++ b/samples/asset-by-name-app/src/App.tsx
@@ -6,6 +6,8 @@ import { AssetList } from './components/assets/AssetList';
 import { AssetsGetByName } from './components/assets/AssetsGetByName';
 import { ProcessList } from './components/processes/ProcessList';
 import { ProcessesGetByName } from './components/processes/ProcessesGetByName';
+import { BucketList } from './components/buckets/BucketList';
+import { BucketsGetByName } from './components/buckets/BucketsGetByName';
 import type { UiPathSDKConfig } from '@uipath/uipath-typescript/core';
 
 const authConfig: UiPathSDKConfig = {
@@ -17,7 +19,7 @@ const authConfig: UiPathSDKConfig = {
   scope: import.meta.env.VITE_UIPATH_SCOPE || 'offline_access',
 };
 
-type ResourceTab = 'assets' | 'processes';
+type ResourceTab = 'assets' | 'processes' | 'buckets';
 
 interface TabState {
   name: string;
@@ -34,6 +36,7 @@ function AppContent() {
   // wipe what the user typed.
   const [assetState, setAssetState] = useState<TabState>(emptyState);
   const [processState, setProcessState] = useState<TabState>(emptyState);
+  const [bucketState, setBucketState] = useState<TabState>(emptyState);
 
   if (isLoading) {
     return (
@@ -53,6 +56,7 @@ function AppContent() {
   const tabs: Array<{ id: ResourceTab; label: string }> = [
     { id: 'assets', label: 'Assets' },
     { id: 'processes', label: 'Processes' },
+    { id: 'buckets', label: 'Buckets' },
   ];
 
   return (
@@ -109,6 +113,24 @@ function AppContent() {
               onNameChange={(name) => setProcessState((s) => ({ ...s, name }))}
               onFolderPathChange={(folderPath) => setProcessState((s) => ({ ...s, folderPath }))}
               onFolderKeyChange={(folderKey) => setProcessState((s) => ({ ...s, folderKey }))}
+            />
+          </>
+        )}
+
+        {activeTab === 'buckets' && (
+          <>
+            <BucketList
+              onPickBucket={(name, folderPath, folderKey) =>
+                setBucketState({ name, folderPath, folderKey })
+              }
+            />
+            <BucketsGetByName
+              name={bucketState.name}
+              folderPath={bucketState.folderPath}
+              folderKey={bucketState.folderKey}
+              onNameChange={(name) => setBucketState((s) => ({ ...s, name }))}
+              onFolderPathChange={(folderPath) => setBucketState((s) => ({ ...s, folderPath }))}
+              onFolderKeyChange={(folderKey) => setBucketState((s) => ({ ...s, folderKey }))}
             />
           </>
         )}

--- a/samples/asset-by-name-app/src/App.tsx
+++ b/samples/asset-by-name-app/src/App.tsx
@@ -8,6 +8,10 @@ import { ProcessList } from './components/processes/ProcessList';
 import { ProcessesGetByName } from './components/processes/ProcessesGetByName';
 import { BucketList } from './components/buckets/BucketList';
 import { BucketsGetByName } from './components/buckets/BucketsGetByName';
+import { MaestroProcessList } from './components/maestro-processes/MaestroProcessList';
+import { MaestroProcessesGetByName } from './components/maestro-processes/MaestroProcessesGetByName';
+import { CaseList } from './components/cases/CaseList';
+import { CasesGetByName } from './components/cases/CasesGetByName';
 import type { UiPathSDKConfig } from '@uipath/uipath-typescript/core';
 
 const authConfig: UiPathSDKConfig = {
@@ -19,7 +23,7 @@ const authConfig: UiPathSDKConfig = {
   scope: import.meta.env.VITE_UIPATH_SCOPE || 'offline_access',
 };
 
-type ResourceTab = 'assets' | 'processes' | 'buckets';
+type ResourceTab = 'assets' | 'processes' | 'buckets' | 'maestro' | 'cases';
 
 interface TabState {
   name: string;
@@ -37,6 +41,8 @@ function AppContent() {
   const [assetState, setAssetState] = useState<TabState>(emptyState);
   const [processState, setProcessState] = useState<TabState>(emptyState);
   const [bucketState, setBucketState] = useState<TabState>(emptyState);
+  const [maestroState, setMaestroState] = useState<TabState>(emptyState);
+  const [caseState, setCaseState] = useState<TabState>(emptyState);
 
   if (isLoading) {
     return (
@@ -57,6 +63,8 @@ function AppContent() {
     { id: 'assets', label: 'Assets' },
     { id: 'processes', label: 'Processes' },
     { id: 'buckets', label: 'Buckets' },
+    { id: 'maestro', label: 'Maestro processes' },
+    { id: 'cases', label: 'Cases' },
   ];
 
   return (
@@ -131,6 +139,42 @@ function AppContent() {
               onNameChange={(name) => setBucketState((s) => ({ ...s, name }))}
               onFolderPathChange={(folderPath) => setBucketState((s) => ({ ...s, folderPath }))}
               onFolderKeyChange={(folderKey) => setBucketState((s) => ({ ...s, folderKey }))}
+            />
+          </>
+        )}
+
+        {activeTab === 'maestro' && (
+          <>
+            <MaestroProcessList
+              onPickProcess={(name, folderPath, folderKey) =>
+                setMaestroState({ name, folderPath, folderKey })
+              }
+            />
+            <MaestroProcessesGetByName
+              name={maestroState.name}
+              folderPath={maestroState.folderPath}
+              folderKey={maestroState.folderKey}
+              onNameChange={(name) => setMaestroState((s) => ({ ...s, name }))}
+              onFolderPathChange={(folderPath) => setMaestroState((s) => ({ ...s, folderPath }))}
+              onFolderKeyChange={(folderKey) => setMaestroState((s) => ({ ...s, folderKey }))}
+            />
+          </>
+        )}
+
+        {activeTab === 'cases' && (
+          <>
+            <CaseList
+              onPickCase={(name, folderPath, folderKey) =>
+                setCaseState({ name, folderPath, folderKey })
+              }
+            />
+            <CasesGetByName
+              name={caseState.name}
+              folderPath={caseState.folderPath}
+              folderKey={caseState.folderKey}
+              onNameChange={(name) => setCaseState((s) => ({ ...s, name }))}
+              onFolderPathChange={(folderPath) => setCaseState((s) => ({ ...s, folderPath }))}
+              onFolderKeyChange={(folderKey) => setCaseState((s) => ({ ...s, folderKey }))}
             />
           </>
         )}

--- a/samples/asset-by-name-app/src/components/AssetList.tsx
+++ b/samples/asset-by-name-app/src/components/AssetList.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { Assets } from '@uipath/uipath-typescript/assets';
+import { useAuth } from '../hooks/useAuth';
+
+interface Folder {
+  id: number;
+  key: string;
+  fullyQualifiedName: string;
+  displayName: string;
+}
+
+interface AssetRow {
+  id: number;
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  valueType: string;
+}
+
+interface Props {
+  onPickAsset: (name: string, folderPath: string, folderKey: string) => void;
+}
+
+const MAX_FOLDERS = 25;
+const MAX_ASSETS_PER_FOLDER = 100;
+
+export const AssetList = ({ onPickAsset }: Props) => {
+  const { sdk } = useAuth();
+  const [rows, setRows] = useState<AssetRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const token = sdk.getToken();
+        if (!token) throw new Error('No auth token — please sign in again.');
+        const { baseUrl, orgName, tenantName } = sdk.config;
+
+        // Step 1 — list folders so we can show path + key for each asset.
+        const foldersResp = await fetch(
+          `${baseUrl}/${orgName}/${tenantName}/orchestrator_/odata/Folders?$top=${MAX_FOLDERS}`,
+          { headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' } },
+        );
+        if (!foldersResp.ok) {
+          throw new Error(
+            `Folders request failed: ${foldersResp.status} ${foldersResp.statusText}`,
+          );
+        }
+        const foldersData = (await foldersResp.json()) as { value?: Array<Record<string, unknown>> };
+        const folders: Folder[] = (foldersData.value ?? []).map((f) => ({
+          id: f.Id as number,
+          key: (f.Key as string) ?? '',
+          fullyQualifiedName: (f.FullyQualifiedName as string) ?? '',
+          displayName: (f.DisplayName as string) ?? '',
+        }));
+
+        // Step 2 — for each folder, list its assets via the SDK.
+        const assets = new Assets(sdk);
+        const perFolder = await Promise.all(
+          folders.map(async (folder) => {
+            try {
+              const result = await assets.getAll({
+                folderId: folder.id,
+                pageSize: MAX_ASSETS_PER_FOLDER,
+              });
+              return result.items.map<AssetRow>((asset) => ({
+                id: asset.id,
+                name: asset.name,
+                folderPath: folder.fullyQualifiedName || folder.displayName,
+                folderKey: folder.key,
+                valueType: asset.valueType as unknown as string,
+              }));
+            } catch (err) {
+              console.warn(
+                `[AssetList] skipped folder "${folder.fullyQualifiedName}":`,
+                err instanceof Error ? err.message : err,
+              );
+              return [];
+            }
+          }),
+        );
+
+        if (cancelled) return;
+        setRows(perFolder.flat());
+      } catch (err) {
+        console.error('Failed to load assets', err);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load assets');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [sdk]);
+
+  return (
+    <section className="bg-white rounded-xl shadow border border-gray-200">
+      <header className="px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Assets across folders
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Click a row to prefill the <code>getByName</code> form below.
+        </p>
+      </header>
+
+      {isLoading && (
+        <div className="px-6 py-10 text-center text-gray-500">Loading assets…</div>
+      )}
+
+      {error && !isLoading && (
+        <div className="px-6 py-4 bg-red-50 border-b border-red-200 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="px-6 py-3 text-left font-medium">Name</th>
+                <th className="px-6 py-3 text-left font-medium">Folder path</th>
+                <th className="px-6 py-3 text-left font-medium">Folder key</th>
+                <th className="px-6 py-3 text-left font-medium">Value type</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-6 py-10 text-center text-gray-500">
+                    No assets found in this tenant.
+                  </td>
+                </tr>
+              )}
+              {rows.map((row, idx) => (
+                <tr
+                  key={`${row.folderKey}-${row.id}-${idx}`}
+                  onClick={() => onPickAsset(row.name, row.folderPath, row.folderKey)}
+                  className="cursor-pointer hover:bg-blue-50"
+                >
+                  <td className="px-6 py-3 font-medium text-gray-900">{row.name}</td>
+                  <td className="px-6 py-3 text-gray-700">{row.folderPath || '—'}</td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">
+                    {row.folderKey || '—'}
+                  </td>
+                  <td className="px-6 py-3 text-gray-700">{row.valueType}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/samples/asset-by-name-app/src/components/GetByNameDemo.tsx
+++ b/samples/asset-by-name-app/src/components/GetByNameDemo.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { Assets } from '@uipath/uipath-typescript/assets';
+import type { AssetGetResponse } from '@uipath/uipath-typescript/assets';
+import { useAuth } from '../hooks/useAuth';
+
+interface Props {
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  onNameChange: (v: string) => void;
+  onFolderPathChange: (v: string) => void;
+  onFolderKeyChange: (v: string) => void;
+}
+
+type Result =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'success'; data: AssetGetResponse; tookMs: number }
+  | { kind: 'error'; message: string };
+
+export const GetByNameDemo = ({
+  name,
+  folderPath,
+  folderKey,
+  onNameChange,
+  onFolderPathChange,
+  onFolderKeyChange,
+}: Props) => {
+  const { sdk } = useAuth();
+  const [result, setResult] = useState<Result>({ kind: 'idle' });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setResult({ kind: 'error', message: 'Asset name is required' });
+      return;
+    }
+    setResult({ kind: 'loading' });
+    const started = performance.now();
+    try {
+      const assets = new Assets(sdk);
+      // Orchestrator prefers FolderPath when both headers are sent,
+      // so pass whichever the user provided (or both).
+      const options: { folderPath?: string; folderKey?: string } = {};
+      if (folderPath.trim()) options.folderPath = folderPath.trim();
+      if (folderKey.trim()) options.folderKey = folderKey.trim();
+      const data = await assets.getByName(
+        name.trim(),
+        Object.keys(options).length ? options : undefined,
+      );
+      setResult({
+        kind: 'success',
+        data,
+        tookMs: Math.round(performance.now() - started),
+      });
+    } catch (err) {
+      console.error('getByName failed', err);
+      setResult({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Request failed',
+      });
+    }
+  };
+
+  return (
+    <section className="bg-white rounded-xl shadow border border-gray-200">
+      <header className="px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">
+          assets.getByName()
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Resolves an asset by name via the <code>X-UIPATH-FolderPath</code> header.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">Asset name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => onNameChange(e.target.value)}
+              placeholder="ApiKey"
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">
+              Folder path <span className="text-gray-400">(optional)</span>
+            </span>
+            <input
+              type="text"
+              value={folderPath}
+              onChange={(e) => onFolderPathChange(e.target.value)}
+              placeholder="Shared/Finance"
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">
+              Folder key <span className="text-gray-400">(optional)</span>
+            </span>
+            <input
+              type="text"
+              value={folderKey}
+              onChange={(e) => onFolderKeyChange(e.target.value)}
+              placeholder="guid"
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </label>
+        </div>
+        <p className="text-xs text-gray-500">
+          Pass <code>folderPath</code>, <code>folderKey</code>, or both — Orchestrator
+          prefers <code>folderPath</code> when both are present.
+        </p>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={result.kind === 'loading'}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium px-5 py-2 rounded-lg transition-colors"
+          >
+            {result.kind === 'loading' ? 'Fetching…' : 'Get asset'}
+          </button>
+          {result.kind === 'success' && (
+            <span className="text-sm text-gray-500">
+              Resolved in {result.tookMs} ms
+            </span>
+          )}
+        </div>
+      </form>
+
+      {result.kind === 'error' && (
+        <div className="mx-6 mb-6 bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+          <strong className="font-semibold">Error:</strong> {result.message}
+        </div>
+      )}
+
+      {result.kind === 'success' && (
+        <div className="mx-6 mb-6">
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">Response</h3>
+          <pre className="bg-gray-900 text-green-200 text-xs rounded-lg p-4 overflow-x-auto">
+{JSON.stringify(result.data, null, 2)}
+          </pre>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/samples/asset-by-name-app/src/components/Header.tsx
+++ b/samples/asset-by-name-app/src/components/Header.tsx
@@ -1,0 +1,36 @@
+import { useAuth } from '../hooks/useAuth';
+
+export const Header = () => {
+  const { isAuthenticated, logout } = useAuth();
+
+  return (
+    <header className="bg-white shadow-lg border-b border-gray-200">
+      <div className="max-w-[95rem] mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center">
+            <div className="flex-shrink-0 flex items-center gap-3">
+              <h1 className="text-2xl font-bold text-blue-600">Asset getByName demo</h1>
+            </div>
+          </div>
+          
+          <div className="flex items-center space-x-4">
+            {isAuthenticated && (
+              <>
+                <div className="flex items-center space-x-2">
+                  <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+                  <span className="text-sm text-gray-600">Connected</span>
+                </div>
+                <button
+                  onClick={logout}
+                  className="bg-gray-100 hover:bg-gray-200 text-gray-700 px-4 py-2 rounded-lg font-medium transition-colors"
+                >
+                  Logout
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/samples/asset-by-name-app/src/components/LoginScreen.tsx
+++ b/samples/asset-by-name-app/src/components/LoginScreen.tsx
@@ -1,0 +1,77 @@
+import { useAuth } from '../hooks/useAuth';
+
+export const LoginScreen = () => {
+  const { login, error, isLoading } = useAuth();
+
+  const handleLogin = async () => {
+    try {
+      await login();
+    } catch (err) {
+      console.error('Login failed:', err);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Asset getByName</h1>
+          <p className="text-gray-600">Demo: look up an Orchestrator asset by name + folderPath</p>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+            <div className="flex">
+              <div className="text-red-400">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">Please login</h3>
+                <p className="text-sm text-red-600 mt-1">{error}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-6">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <h3 className="text-sm font-medium text-blue-800 mb-2">Before you begin:</h3>
+            <ul className="text-sm text-blue-700 space-y-1">
+              <li>• Ensure you have UiPath Cloud access</li>
+              <li>• Configure OAuth app in Admin Center</li>
+              <li>• Set correct redirect URI</li>
+            </ul>
+          </div>
+
+          <button
+            onClick={handleLogin}
+            disabled={isLoading}
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium py-3 px-4 rounded-lg transition-colors flex items-center justify-center"
+          >
+            {isLoading ? (
+              <>
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                Connecting...
+              </>
+            ) : (
+              <>
+                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                </svg>
+                Sign in with UiPath
+              </>
+            )}
+          </button>
+
+          <div className="text-center">
+            <p className="text-xs text-gray-500">
+              You'll be redirected to UiPath Cloud for authentication
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/samples/asset-by-name-app/src/components/assets/AssetList.tsx
+++ b/samples/asset-by-name-app/src/components/assets/AssetList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Assets } from '@uipath/uipath-typescript/assets';
-import { useAuth } from '../hooks/useAuth';
+import { useAuth } from '../../hooks/useAuth';
 
 interface Folder {
   id: number;

--- a/samples/asset-by-name-app/src/components/assets/AssetsGetByName.tsx
+++ b/samples/asset-by-name-app/src/components/assets/AssetsGetByName.tsx
@@ -1,0 +1,33 @@
+import { Assets } from '@uipath/uipath-typescript/assets';
+import type { AssetGetResponse } from '@uipath/uipath-typescript/assets';
+import { useAuth } from '../../hooks/useAuth';
+import { GetByNameForm } from '../shared/GetByNameForm';
+
+interface Props {
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  onNameChange: (v: string) => void;
+  onFolderPathChange: (v: string) => void;
+  onFolderKeyChange: (v: string) => void;
+}
+
+export const AssetsGetByName = (props: Props) => {
+  const { sdk } = useAuth();
+
+  return (
+    <GetByNameForm<AssetGetResponse>
+      {...props}
+      title="assets.getByName()"
+      description={
+        <>
+          Resolves an asset by name via the <code>X-UIPATH-FolderPath</code> /{' '}
+          <code>X-UIPATH-FolderKey</code> header.
+        </>
+      }
+      namePlaceholder="ApiKey"
+      submitLabel="Get asset"
+      fetch={(name, options) => new Assets(sdk).getByName(name, options)}
+    />
+  );
+};

--- a/samples/asset-by-name-app/src/components/buckets/BucketList.tsx
+++ b/samples/asset-by-name-app/src/components/buckets/BucketList.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { Buckets } from '@uipath/uipath-typescript/buckets';
+import { useAuth } from '../../hooks/useAuth';
+
+interface Folder {
+  id: number;
+  key: string;
+  fullyQualifiedName: string;
+  displayName: string;
+}
+
+interface BucketRow {
+  id: number;
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  identifier: string;
+}
+
+interface Props {
+  onPickBucket: (name: string, folderPath: string, folderKey: string) => void;
+}
+
+const MAX_FOLDERS = 25;
+const MAX_BUCKETS_PER_FOLDER = 100;
+
+export const BucketList = ({ onPickBucket }: Props) => {
+  const { sdk } = useAuth();
+  const [rows, setRows] = useState<BucketRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const token = sdk.getToken();
+        if (!token) throw new Error('No auth token — please sign in again.');
+        const { baseUrl, orgName, tenantName } = sdk.config;
+
+        // Step 1 — list folders so we can show path + key for each bucket.
+        const foldersResp = await fetch(
+          `${baseUrl}/${orgName}/${tenantName}/orchestrator_/odata/Folders?$top=${MAX_FOLDERS}`,
+          { headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' } },
+        );
+        if (!foldersResp.ok) {
+          throw new Error(
+            `Folders request failed: ${foldersResp.status} ${foldersResp.statusText}`,
+          );
+        }
+        const foldersData = (await foldersResp.json()) as { value?: Array<Record<string, unknown>> };
+        const folders: Folder[] = (foldersData.value ?? []).map((f) => ({
+          id: f.Id as number,
+          key: (f.Key as string) ?? '',
+          fullyQualifiedName: (f.FullyQualifiedName as string) ?? '',
+          displayName: (f.DisplayName as string) ?? '',
+        }));
+
+        // Step 2 — for each folder, list its buckets via the SDK.
+        const buckets = new Buckets(sdk);
+        const perFolder = await Promise.all(
+          folders.map(async (folder) => {
+            try {
+              const result = await buckets.getAll({
+                folderId: folder.id,
+                pageSize: MAX_BUCKETS_PER_FOLDER,
+              });
+              return result.items.map<BucketRow>((bucket) => ({
+                id: bucket.id,
+                name: bucket.name,
+                folderPath: folder.fullyQualifiedName || folder.displayName,
+                folderKey: folder.key,
+                identifier: bucket.identifier,
+              }));
+            } catch (err) {
+              console.warn(
+                `[BucketList] skipped folder "${folder.fullyQualifiedName}":`,
+                err instanceof Error ? err.message : err,
+              );
+              return [];
+            }
+          }),
+        );
+
+        if (cancelled) return;
+        setRows(perFolder.flat());
+      } catch (err) {
+        console.error('Failed to load buckets', err);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load buckets');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [sdk]);
+
+  return (
+    <section className="bg-white rounded-xl shadow border border-gray-200">
+      <header className="px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Buckets across folders
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Click a row to prefill the <code>getByName</code> form below.
+        </p>
+      </header>
+
+      {isLoading && (
+        <div className="px-6 py-10 text-center text-gray-500">Loading buckets…</div>
+      )}
+
+      {error && !isLoading && (
+        <div className="px-6 py-4 bg-red-50 border-b border-red-200 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="px-6 py-3 text-left font-medium">Name</th>
+                <th className="px-6 py-3 text-left font-medium">Folder path</th>
+                <th className="px-6 py-3 text-left font-medium">Folder key</th>
+                <th className="px-6 py-3 text-left font-medium">Identifier</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-6 py-10 text-center text-gray-500">
+                    No buckets found in this tenant.
+                  </td>
+                </tr>
+              )}
+              {rows.map((row, idx) => (
+                <tr
+                  key={`${row.folderKey}-${row.id}-${idx}`}
+                  onClick={() => onPickBucket(row.name, row.folderPath, row.folderKey)}
+                  className="cursor-pointer hover:bg-blue-50"
+                >
+                  <td className="px-6 py-3 font-medium text-gray-900">{row.name}</td>
+                  <td className="px-6 py-3 text-gray-700">{row.folderPath || '—'}</td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">
+                    {row.folderKey || '—'}
+                  </td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">{row.identifier}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/samples/asset-by-name-app/src/components/buckets/BucketsGetByName.tsx
+++ b/samples/asset-by-name-app/src/components/buckets/BucketsGetByName.tsx
@@ -1,0 +1,33 @@
+import { Buckets } from '@uipath/uipath-typescript/buckets';
+import type { BucketGetResponse } from '@uipath/uipath-typescript/buckets';
+import { useAuth } from '../../hooks/useAuth';
+import { GetByNameForm } from '../shared/GetByNameForm';
+
+interface Props {
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  onNameChange: (v: string) => void;
+  onFolderPathChange: (v: string) => void;
+  onFolderKeyChange: (v: string) => void;
+}
+
+export const BucketsGetByName = (props: Props) => {
+  const { sdk } = useAuth();
+
+  return (
+    <GetByNameForm<BucketGetResponse>
+      {...props}
+      title="buckets.getByName()"
+      description={
+        <>
+          Resolves a bucket by name via the <code>X-UIPATH-FolderPath-Encoded</code> /{' '}
+          <code>X-UIPATH-FolderKey</code> header.
+        </>
+      }
+      namePlaceholder="MyBucket"
+      submitLabel="Get bucket"
+      fetch={(name, options) => new Buckets(sdk).getByName(name, options)}
+    />
+  );
+};

--- a/samples/asset-by-name-app/src/components/cases/CaseList.tsx
+++ b/samples/asset-by-name-app/src/components/cases/CaseList.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import { Cases } from '@uipath/uipath-typescript/cases';
+import { useAuth } from '../../hooks/useAuth';
+
+interface CaseRow {
+  processKey: string;
+  name: string;
+  folderName: string;
+  folderKey: string;
+  packageId: string;
+  runningCount: number;
+}
+
+interface Props {
+  onPickCase: (name: string, folderPath: string, folderKey: string) => void;
+}
+
+export const CaseList = ({ onPickCase }: Props) => {
+  const { sdk } = useAuth();
+  const [rows, setRows] = useState<CaseRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const cases = await new Cases(sdk).getAll();
+        if (cancelled) return;
+        setRows(
+          cases.map((c) => ({
+            processKey: c.processKey,
+            name: c.name,
+            folderName: c.folderName,
+            folderKey: c.folderKey,
+            packageId: c.packageId,
+            runningCount: c.runningCount,
+          })),
+        );
+      } catch (err) {
+        console.error('Failed to load cases', err);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load cases');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [sdk]);
+
+  return (
+    <section className="bg-white rounded-xl shadow border border-gray-200">
+      <header className="px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">Case management processes</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Click a row to prefill the <code>getByName</code> form below. Names are
+          derived from <code>packageId</code> by stripping the <code>CaseManagement.</code>{' '}
+          prefix.
+        </p>
+      </header>
+
+      {isLoading && (
+        <div className="px-6 py-10 text-center text-gray-500">Loading cases…</div>
+      )}
+
+      {error && !isLoading && (
+        <div className="px-6 py-4 bg-red-50 border-b border-red-200 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="px-6 py-3 text-left font-medium">Name</th>
+                <th className="px-6 py-3 text-left font-medium">Folder</th>
+                <th className="px-6 py-3 text-left font-medium">Folder key</th>
+                <th className="px-6 py-3 text-left font-medium">Running</th>
+                <th className="px-6 py-3 text-left font-medium">Package ID</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-6 py-10 text-center text-gray-500">
+                    No case management processes found in this tenant.
+                  </td>
+                </tr>
+              )}
+              {rows.map((row) => (
+                <tr
+                  key={row.processKey}
+                  onClick={() => onPickCase(row.name, row.folderName, row.folderKey)}
+                  className="cursor-pointer hover:bg-blue-50"
+                >
+                  <td className="px-6 py-3 font-medium text-gray-900">{row.name}</td>
+                  <td className="px-6 py-3 text-gray-700">{row.folderName || '—'}</td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">
+                    {row.folderKey || '—'}
+                  </td>
+                  <td className="px-6 py-3 text-gray-700">{row.runningCount}</td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">{row.packageId}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/samples/asset-by-name-app/src/components/cases/CasesGetByName.tsx
+++ b/samples/asset-by-name-app/src/components/cases/CasesGetByName.tsx
@@ -1,0 +1,41 @@
+import { Cases } from '@uipath/uipath-typescript/cases';
+import type { CaseGetAllResponse } from '@uipath/uipath-typescript/cases';
+import { useAuth } from '../../hooks/useAuth';
+import { GetByNameForm } from '../shared/GetByNameForm';
+
+interface Props {
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  onNameChange: (v: string) => void;
+  onFolderPathChange: (v: string) => void;
+  onFolderKeyChange: (v: string) => void;
+}
+
+export const CasesGetByName = (props: Props) => {
+  const { sdk } = useAuth();
+
+  return (
+    <GetByNameForm<CaseGetAllResponse>
+      {...props}
+      title="cases.getByName()"
+      description={
+        <>
+          Client-side lookup over <code>cases.getAll()</code>. The name matches the
+          derived <code>name</code> field (with <code>CaseManagement.</code> stripped
+          and hyphens replaced with spaces).
+        </>
+      }
+      helpText={
+        <>
+          <code>folderPath</code> is matched against the response's <code>folderName</code>
+          {' '}field. Leave blank to fall back to the init-time <code>folderKey</code>
+          {' '}(<code>uipath:folder-key</code> meta tag).
+        </>
+      }
+      namePlaceholder="Onboarding Case"
+      submitLabel="Get case"
+      fetch={(name, options) => new Cases(sdk).getByName(name, options)}
+    />
+  );
+};

--- a/samples/asset-by-name-app/src/components/maestro-processes/MaestroProcessList.tsx
+++ b/samples/asset-by-name-app/src/components/maestro-processes/MaestroProcessList.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
+import { useAuth } from '../../hooks/useAuth';
+
+interface ProcessRow {
+  processKey: string;
+  name: string;
+  folderName: string;
+  folderKey: string;
+  packageId: string;
+  runningCount: number;
+}
+
+interface Props {
+  onPickProcess: (name: string, folderPath: string, folderKey: string) => void;
+}
+
+export const MaestroProcessList = ({ onPickProcess }: Props) => {
+  const { sdk } = useAuth();
+  const [rows, setRows] = useState<ProcessRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const processes = await new MaestroProcesses(sdk).getAll();
+        if (cancelled) return;
+        setRows(
+          processes.map((p) => ({
+            processKey: p.processKey,
+            name: p.name,
+            folderName: p.folderName,
+            folderKey: p.folderKey,
+            packageId: p.packageId,
+            runningCount: p.runningCount,
+          })),
+        );
+      } catch (err) {
+        console.error('Failed to load Maestro processes', err);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load Maestro processes');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [sdk]);
+
+  return (
+    <section className="bg-white rounded-xl shadow border border-gray-200">
+      <header className="px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">Maestro processes</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Click a row to prefill the <code>getByName</code> form below.
+        </p>
+      </header>
+
+      {isLoading && (
+        <div className="px-6 py-10 text-center text-gray-500">Loading Maestro processes…</div>
+      )}
+
+      {error && !isLoading && (
+        <div className="px-6 py-4 bg-red-50 border-b border-red-200 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="px-6 py-3 text-left font-medium">Name</th>
+                <th className="px-6 py-3 text-left font-medium">Folder</th>
+                <th className="px-6 py-3 text-left font-medium">Folder key</th>
+                <th className="px-6 py-3 text-left font-medium">Running</th>
+                <th className="px-6 py-3 text-left font-medium">Process key</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-6 py-10 text-center text-gray-500">
+                    No Maestro processes found in this tenant.
+                  </td>
+                </tr>
+              )}
+              {rows.map((row) => (
+                <tr
+                  key={row.processKey}
+                  onClick={() => onPickProcess(row.name, row.folderName, row.folderKey)}
+                  className="cursor-pointer hover:bg-blue-50"
+                >
+                  <td className="px-6 py-3 font-medium text-gray-900">{row.name}</td>
+                  <td className="px-6 py-3 text-gray-700">{row.folderName || '—'}</td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">
+                    {row.folderKey || '—'}
+                  </td>
+                  <td className="px-6 py-3 text-gray-700">{row.runningCount}</td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">{row.processKey}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/samples/asset-by-name-app/src/components/maestro-processes/MaestroProcessesGetByName.tsx
+++ b/samples/asset-by-name-app/src/components/maestro-processes/MaestroProcessesGetByName.tsx
@@ -1,0 +1,41 @@
+import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
+import type { MaestroProcessGetAllResponse } from '@uipath/uipath-typescript/maestro-processes';
+import { useAuth } from '../../hooks/useAuth';
+import { GetByNameForm } from '../shared/GetByNameForm';
+
+interface Props {
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  onNameChange: (v: string) => void;
+  onFolderPathChange: (v: string) => void;
+  onFolderKeyChange: (v: string) => void;
+}
+
+export const MaestroProcessesGetByName = (props: Props) => {
+  const { sdk } = useAuth();
+
+  return (
+    <GetByNameForm<MaestroProcessGetAllResponse>
+      {...props}
+      title="maestroProcesses.getByName()"
+      description={
+        <>
+          Client-side lookup over <code>maestroProcesses.getAll()</code> — Maestro's{' '}
+          <code>/processes/summary</code> endpoint has no name-based filter, so the SDK
+          fetches the list once and matches locally.
+        </>
+      }
+      helpText={
+        <>
+          <code>folderPath</code> is matched against the response's <code>folderName</code>
+          {' '}field. Leave blank to fall back to the init-time <code>folderKey</code>
+          {' '}(<code>uipath:folder-key</code> meta tag).
+        </>
+      }
+      namePlaceholder="MyMaestroProcess"
+      submitLabel="Get process"
+      fetch={(name, options) => new MaestroProcesses(sdk).getByName(name, options)}
+    />
+  );
+};

--- a/samples/asset-by-name-app/src/components/processes/ProcessList.tsx
+++ b/samples/asset-by-name-app/src/components/processes/ProcessList.tsx
@@ -15,11 +15,53 @@ interface Props {
   onPickProcess: (name: string, folderName: string, folderKey: string) => void;
 }
 
+type StartMode = 'path' | 'key';
+
+type StartState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; rowKey: string; mode: StartMode }
+  | { kind: 'success'; rowKey: string; mode: StartMode; jobKey: string }
+  | { kind: 'error'; rowKey: string; mode: StartMode; message: string };
+
 export const ProcessList = ({ onPickProcess }: Props) => {
   const { sdk } = useAuth();
   const [rows, setRows] = useState<ProcessRow[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [startState, setStartState] = useState<StartState>({ kind: 'idle' });
+
+  const handleStart = async (row: ProcessRow, mode: StartMode) => {
+    const rowKey = `${row.folderKey}-${row.id}`;
+    setStartState({ kind: 'loading', rowKey, mode });
+    try {
+      // Exercises the B2 options-bag shape. Two test paths:
+      //  - 'path' → only folderPath sent → X-UIPATH-FolderPath-Encoded header
+      //  - 'key'  → only folderKey  sent → X-UIPATH-FolderKey header
+      const processes = new Processes(sdk);
+      const folderOptions =
+        mode === 'path'
+          ? { folderPath: row.folderName || undefined }
+          : { folderKey: row.folderKey || undefined };
+      const jobs = await processes.start(
+        { processName: row.name },
+        folderOptions,
+      );
+      setStartState({
+        kind: 'success',
+        rowKey,
+        mode,
+        jobKey: jobs[0]?.key ?? '(no key)',
+      });
+    } catch (err) {
+      console.error('processes.start failed', err);
+      setStartState({
+        kind: 'error',
+        rowKey,
+        mode,
+        message: err instanceof Error ? err.message : 'Start failed',
+      });
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -87,30 +129,84 @@ export const ProcessList = ({ onPickProcess }: Props) => {
                 <th className="px-6 py-3 text-left font-medium">Folder</th>
                 <th className="px-6 py-3 text-left font-medium">Folder key</th>
                 <th className="px-6 py-3 text-left font-medium">Version</th>
+                <th className="px-6 py-3 text-left font-medium">Start</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
               {rows.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="px-6 py-10 text-center text-gray-500">
+                  <td colSpan={5} className="px-6 py-10 text-center text-gray-500">
                     No processes found in this tenant.
                   </td>
                 </tr>
               )}
-              {rows.map((row) => (
-                <tr
-                  key={`${row.folderKey}-${row.id}`}
-                  onClick={() => onPickProcess(row.name, row.folderName, row.folderKey)}
-                  className="cursor-pointer hover:bg-blue-50"
-                >
-                  <td className="px-6 py-3 font-medium text-gray-900">{row.name}</td>
-                  <td className="px-6 py-3 text-gray-700">{row.folderName || '—'}</td>
-                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">
-                    {row.folderKey || '—'}
-                  </td>
-                  <td className="px-6 py-3 text-gray-700">{row.packageVersion}</td>
-                </tr>
-              ))}
+              {rows.map((row) => {
+                const rowKey = `${row.folderKey}-${row.id}`;
+                const renderButton = (mode: StartMode, label: string) => {
+                  const isStarting =
+                    startState.kind === 'loading' &&
+                    startState.rowKey === rowKey &&
+                    startState.mode === mode;
+                  const startedHere =
+                    startState.kind === 'success' &&
+                    startState.rowKey === rowKey &&
+                    startState.mode === mode;
+                  const failedHere =
+                    startState.kind === 'error' &&
+                    startState.rowKey === rowKey &&
+                    startState.mode === mode;
+                  const disabled =
+                    isStarting ||
+                    (mode === 'path' && !row.folderName) ||
+                    (mode === 'key' && !row.folderKey);
+                  return (
+                    <span className="inline-flex items-center mr-3">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleStart(row, mode);
+                        }}
+                        disabled={disabled}
+                        className="text-xs px-3 py-1 rounded border border-blue-300 text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                      >
+                        {isStarting ? 'Starting…' : label}
+                      </button>
+                      {startedHere && (
+                        <span className="ml-2 text-xs text-green-700">
+                          ✓ {startState.jobKey.slice(0, 8)}…
+                        </span>
+                      )}
+                      {failedHere && (
+                        <span
+                          className="ml-2 text-xs text-red-600"
+                          title={startState.message}
+                        >
+                          ✗ failed
+                        </span>
+                      )}
+                    </span>
+                  );
+                };
+                return (
+                  <tr key={rowKey} className="hover:bg-blue-50">
+                    <td
+                      className="px-6 py-3 font-medium text-gray-900 cursor-pointer"
+                      onClick={() => onPickProcess(row.name, row.folderName, row.folderKey)}
+                    >
+                      {row.name}
+                    </td>
+                    <td className="px-6 py-3 text-gray-700">{row.folderName || '—'}</td>
+                    <td className="px-6 py-3 text-gray-500 font-mono text-xs">
+                      {row.folderKey || '—'}
+                    </td>
+                    <td className="px-6 py-3 text-gray-700">{row.packageVersion}</td>
+                    <td className="px-6 py-3 whitespace-nowrap">
+                      {renderButton('path', 'Start (path)')}
+                      {renderButton('key', 'Start (key)')}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/samples/asset-by-name-app/src/components/processes/ProcessList.tsx
+++ b/samples/asset-by-name-app/src/components/processes/ProcessList.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { Processes } from '@uipath/uipath-typescript/processes';
+import type { ProcessGetResponse } from '@uipath/uipath-typescript/processes';
+import { useAuth } from '../../hooks/useAuth';
+
+interface ProcessRow {
+  id: number;
+  name: string;
+  folderName: string;
+  folderKey: string;
+  packageVersion: string;
+}
+
+interface Props {
+  onPickProcess: (name: string, folderName: string, folderKey: string) => void;
+}
+
+export const ProcessList = ({ onPickProcess }: Props) => {
+  const { sdk } = useAuth();
+  const [rows, setRows] = useState<ProcessRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        // Processes.getAll() returns folder context per row (folderName + folderKey)
+        // since /odata/Releases exposes them — so no per-folder loop needed here.
+        const processes = new Processes(sdk);
+        const result = await processes.getAll({ pageSize: 100 });
+        if (cancelled) return;
+        const flat: ProcessRow[] = result.items.map((p: ProcessGetResponse) => ({
+          id: p.id,
+          name: p.name,
+          folderName: p.folderName ?? '',
+          folderKey: p.folderKey ?? '',
+          packageVersion: p.packageVersion,
+        }));
+        setRows(flat);
+      } catch (err) {
+        console.error('Failed to load processes', err);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load processes');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [sdk]);
+
+  return (
+    <section className="bg-white rounded-xl shadow border border-gray-200">
+      <header className="px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Processes across folders
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Click a row to prefill the <code>getByName</code> form below.
+        </p>
+      </header>
+
+      {isLoading && (
+        <div className="px-6 py-10 text-center text-gray-500">Loading processes…</div>
+      )}
+
+      {error && !isLoading && (
+        <div className="px-6 py-4 bg-red-50 border-b border-red-200 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="px-6 py-3 text-left font-medium">Name</th>
+                <th className="px-6 py-3 text-left font-medium">Folder</th>
+                <th className="px-6 py-3 text-left font-medium">Folder key</th>
+                <th className="px-6 py-3 text-left font-medium">Version</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-6 py-10 text-center text-gray-500">
+                    No processes found in this tenant.
+                  </td>
+                </tr>
+              )}
+              {rows.map((row) => (
+                <tr
+                  key={`${row.folderKey}-${row.id}`}
+                  onClick={() => onPickProcess(row.name, row.folderName, row.folderKey)}
+                  className="cursor-pointer hover:bg-blue-50"
+                >
+                  <td className="px-6 py-3 font-medium text-gray-900">{row.name}</td>
+                  <td className="px-6 py-3 text-gray-700">{row.folderName || '—'}</td>
+                  <td className="px-6 py-3 text-gray-500 font-mono text-xs">
+                    {row.folderKey || '—'}
+                  </td>
+                  <td className="px-6 py-3 text-gray-700">{row.packageVersion}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/samples/asset-by-name-app/src/components/processes/ProcessesGetByName.tsx
+++ b/samples/asset-by-name-app/src/components/processes/ProcessesGetByName.tsx
@@ -1,0 +1,33 @@
+import { Processes } from '@uipath/uipath-typescript/processes';
+import type { ProcessGetResponse } from '@uipath/uipath-typescript/processes';
+import { useAuth } from '../../hooks/useAuth';
+import { GetByNameForm } from '../shared/GetByNameForm';
+
+interface Props {
+  name: string;
+  folderPath: string;
+  folderKey: string;
+  onNameChange: (v: string) => void;
+  onFolderPathChange: (v: string) => void;
+  onFolderKeyChange: (v: string) => void;
+}
+
+export const ProcessesGetByName = (props: Props) => {
+  const { sdk } = useAuth();
+
+  return (
+    <GetByNameForm<ProcessGetResponse>
+      {...props}
+      title="processes.getByName()"
+      description={
+        <>
+          Resolves a process by name via the <code>X-UIPATH-FolderPath</code> /{' '}
+          <code>X-UIPATH-FolderKey</code> header.
+        </>
+      }
+      namePlaceholder="MyProcess"
+      submitLabel="Get process"
+      fetch={(name, options) => new Processes(sdk).getByName(name, options)}
+    />
+  );
+};

--- a/samples/asset-by-name-app/src/components/shared/GetByNameForm.tsx
+++ b/samples/asset-by-name-app/src/components/shared/GetByNameForm.tsx
@@ -1,53 +1,62 @@
 import { useState } from 'react';
-import { Assets } from '@uipath/uipath-typescript/assets';
-import type { AssetGetResponse } from '@uipath/uipath-typescript/assets';
-import { useAuth } from '../hooks/useAuth';
 
-interface Props {
+interface Props<TResponse> {
+  /** Heading shown above the form — e.g. "assets.getByName()". */
+  title: string;
+  /** Subheading explaining what this form does. */
+  description: React.ReactNode;
+  /** Placeholder for the resource-name input. */
+  namePlaceholder: string;
+  /** Label for the submit button. */
+  submitLabel: string;
+  /** Current form values (controlled from parent so row-clicks can prefill). */
   name: string;
   folderPath: string;
   folderKey: string;
   onNameChange: (v: string) => void;
   onFolderPathChange: (v: string) => void;
   onFolderKeyChange: (v: string) => void;
+  /** Caller-supplied resource fetch — receives trimmed values, returns the resource. */
+  fetch: (
+    name: string,
+    options: { folderPath?: string; folderKey?: string },
+  ) => Promise<TResponse>;
 }
 
-type Result =
+type Result<T> =
   | { kind: 'idle' }
   | { kind: 'loading' }
-  | { kind: 'success'; data: AssetGetResponse; tookMs: number }
+  | { kind: 'success'; data: T; tookMs: number }
   | { kind: 'error'; message: string };
 
-export const GetByNameDemo = ({
+export function GetByNameForm<TResponse>({
+  title,
+  description,
+  namePlaceholder,
+  submitLabel,
   name,
   folderPath,
   folderKey,
   onNameChange,
   onFolderPathChange,
   onFolderKeyChange,
-}: Props) => {
-  const { sdk } = useAuth();
-  const [result, setResult] = useState<Result>({ kind: 'idle' });
+  fetch,
+}: Props<TResponse>) {
+  const [result, setResult] = useState<Result<TResponse>>({ kind: 'idle' });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) {
-      setResult({ kind: 'error', message: 'Asset name is required' });
+      setResult({ kind: 'error', message: 'Name is required' });
       return;
     }
     setResult({ kind: 'loading' });
     const started = performance.now();
     try {
-      const assets = new Assets(sdk);
-      // Orchestrator prefers FolderPath when both headers are sent,
-      // so pass whichever the user provided (or both).
       const options: { folderPath?: string; folderKey?: string } = {};
       if (folderPath.trim()) options.folderPath = folderPath.trim();
       if (folderKey.trim()) options.folderKey = folderKey.trim();
-      const data = await assets.getByName(
-        name.trim(),
-        Object.keys(options).length ? options : undefined,
-      );
+      const data = await fetch(name.trim(), options);
       setResult({
         kind: 'success',
         data,
@@ -65,23 +74,19 @@ export const GetByNameDemo = ({
   return (
     <section className="bg-white rounded-xl shadow border border-gray-200">
       <header className="px-6 py-4 border-b border-gray-200">
-        <h2 className="text-lg font-semibold text-gray-900">
-          assets.getByName()
-        </h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Resolves an asset by name via the <code>X-UIPATH-FolderPath</code> header.
-        </p>
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        <p className="text-sm text-gray-500 mt-1">{description}</p>
       </header>
 
       <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <label className="block">
-            <span className="text-sm font-medium text-gray-700">Asset name</span>
+            <span className="text-sm font-medium text-gray-700">Name</span>
             <input
               type="text"
               value={name}
               onChange={(e) => onNameChange(e.target.value)}
-              placeholder="ApiKey"
+              placeholder={namePlaceholder}
               className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </label>
@@ -121,7 +126,7 @@ export const GetByNameDemo = ({
             disabled={result.kind === 'loading'}
             className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium px-5 py-2 rounded-lg transition-colors"
           >
-            {result.kind === 'loading' ? 'Fetching…' : 'Get asset'}
+            {result.kind === 'loading' ? 'Fetching…' : submitLabel}
           </button>
           {result.kind === 'success' && (
             <span className="text-sm text-gray-500">
@@ -147,4 +152,4 @@ export const GetByNameDemo = ({
       )}
     </section>
   );
-};
+}

--- a/samples/asset-by-name-app/src/components/shared/GetByNameForm.tsx
+++ b/samples/asset-by-name-app/src/components/shared/GetByNameForm.tsx
@@ -21,6 +21,8 @@ interface Props<TResponse> {
     name: string,
     options: { folderPath?: string; folderKey?: string },
   ) => Promise<TResponse>;
+  /** Optional help text rendered below the inputs. Defaults to Orchestrator-style guidance. */
+  helpText?: React.ReactNode;
 }
 
 type Result<T> =
@@ -41,6 +43,7 @@ export function GetByNameForm<TResponse>({
   onFolderPathChange,
   onFolderKeyChange,
   fetch,
+  helpText,
 }: Props<TResponse>) {
   const [result, setResult] = useState<Result<TResponse>>({ kind: 'idle' });
 
@@ -116,8 +119,12 @@ export function GetByNameForm<TResponse>({
           </label>
         </div>
         <p className="text-xs text-gray-500">
-          Pass <code>folderPath</code>, <code>folderKey</code>, or both — Orchestrator
-          prefers <code>folderPath</code> when both are present.
+          {helpText ?? (
+            <>
+              Pass <code>folderPath</code>, <code>folderKey</code>, or both — Orchestrator
+              prefers <code>folderPath</code> when both are present.
+            </>
+          )}
         </p>
 
         <div className="flex items-center gap-3">

--- a/samples/asset-by-name-app/src/hooks/useAuth.tsx
+++ b/samples/asset-by-name-app/src/hooks/useAuth.tsx
@@ -1,0 +1,90 @@
+import React, { useState, useEffect, createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+import { UiPath, UiPathError } from '@uipath/uipath-typescript/core';
+import type { UiPathSDKConfig } from '@uipath/uipath-typescript/core';
+interface AuthContextType {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  sdk: UiPath;
+  login: () => Promise<void>;
+  logout: () => void;
+  error: string | null;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: ReactNode; config: UiPathSDKConfig }> = ({ children, config }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sdk] = useState<UiPath>(() => new UiPath(config));
+
+  useEffect(() => {
+    const initializeAuth = async () => {
+      setIsLoading(true);
+      setError(null);
+      
+      try {
+        // Handle OAuth callback if present
+        if (sdk.isInOAuthCallback()) {
+          await sdk.completeOAuth();
+        }
+        // Check authentication status
+        setIsAuthenticated(sdk.isAuthenticated());
+      } catch (err) {
+        console.error('Authentication initialization failed:', err);
+        setError(err instanceof UiPathError ? err.message : 'Authentication failed');
+        setIsAuthenticated(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    
+    initializeAuth();
+  }, [sdk]);
+
+  const login = async () => {
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      await sdk.initialize();
+      setIsAuthenticated(sdk.isAuthenticated());
+    } catch (err) {
+      console.error('Login failed:', err);
+      setError(err instanceof UiPathError ? err.message : 'Login failed');
+      setIsAuthenticated(false);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const logout = () => {
+    sdk.logout();
+    setIsAuthenticated(false);
+    setError(null);
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        isAuthenticated,
+        isLoading,
+        sdk,
+        login,
+        logout,
+        error,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/samples/asset-by-name-app/src/index.css
+++ b/samples/asset-by-name-app/src/index.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/samples/asset-by-name-app/src/main.tsx
+++ b/samples/asset-by-name-app/src/main.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <App />
+)

--- a/samples/asset-by-name-app/src/vite-env.d.ts
+++ b/samples/asset-by-name-app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/samples/asset-by-name-app/tailwind.config.js
+++ b/samples/asset-by-name-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/samples/asset-by-name-app/tsconfig.app.json
+++ b/samples/asset-by-name-app/tsconfig.app.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/samples/asset-by-name-app/tsconfig.json
+++ b/samples/asset-by-name-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/samples/asset-by-name-app/tsconfig.node.json
+++ b/samples/asset-by-name-app/tsconfig.node.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/samples/asset-by-name-app/vite.config.ts
+++ b/samples/asset-by-name-app/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    global: 'globalThis',
+  },
+  resolve: {
+    alias: {
+      path: 'path-browserify',
+    },
+  },
+  optimizeDeps: {
+    include: ['@uipath/uipath-typescript'],
+  },
+})

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -7,7 +7,8 @@ export const ConfigSchema = z.object({
   secret: z.string().optional(),
   clientId: z.string().optional(),
   redirectUri: z.string().url().optional(),
-  scope: z.string().optional()
+  scope: z.string().optional(),
+  folderKey: z.string().optional()
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -20,6 +21,7 @@ interface ConfigOptions {
   clientId?: string;
   redirectUri?: string;
   scope?: string;
+  folderKey?: string;
 }
 
 export class UiPathConfig {
@@ -30,6 +32,7 @@ export class UiPathConfig {
   public readonly clientId?: string;
   public readonly redirectUri?: string;
   public readonly scope?: string;
+  public readonly folderKey?: string;
 
   constructor(options: ConfigOptions) {
     this.baseUrl = options.baseUrl;
@@ -39,6 +42,7 @@ export class UiPathConfig {
     this.clientId = options.clientId;
     this.redirectUri = options.redirectUri;
     this.scope = options.scope;
+    this.folderKey = options.folderKey;
   }
 }
 

--- a/src/core/config/runtime.ts
+++ b/src/core/config/runtime.ts
@@ -28,6 +28,7 @@ export function loadFromMetaTags(): PartialUiPathConfig | null {
     tenantName: getMetaTagContent(UiPathMetaTags.TENANT_NAME),
     baseUrl: getMetaTagContent(UiPathMetaTags.BASE_URL),
     redirectUri: getMetaTagContent(UiPathMetaTags.REDIRECT_URI),
+    folderKey: getMetaTagContent(UiPathMetaTags.FOLDER_KEY),
   };
 
   const hasAnyValue = Object.values(config).some(Boolean);

--- a/src/core/config/sdk-config.ts
+++ b/src/core/config/sdk-config.ts
@@ -3,6 +3,13 @@ export interface BaseConfig {
   baseUrl: string;
   orgName: string;
   tenantName: string;
+  /**
+   * Optional default folder key (GUID). Applied to folder-scoped service
+   * calls (e.g. `getByName`) when the caller doesn't pass `folderKey` /
+   * `folderPath` explicitly. Populated from `<meta name="uipath:folder-key">`
+   * in browser coded-app deployments, or can be set explicitly on SDK init.
+   */
+  folderKey?: string;
 }
 
 // OAuth specific fields

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -80,7 +80,8 @@ export class UiPath implements IUiPath {
       secret: hasSecretAuth ? config.secret : undefined,
       clientId: hasOAuthAuth ? config.clientId : undefined,
       redirectUri: hasOAuthAuth ? config.redirectUri : undefined,
-      scope: hasOAuthAuth ? config.scope : undefined
+      scope: hasOAuthAuth ? config.scope : undefined,
+      folderKey: config.folderKey
     });
 
     const executionContext = new ExecutionContext();
@@ -98,7 +99,8 @@ export class UiPath implements IUiPath {
     (this as any).config = {
       baseUrl: internalConfig.baseUrl,
       orgName: internalConfig.orgName,
-      tenantName: internalConfig.tenantName
+      tenantName: internalConfig.tenantName,
+      folderKey: internalConfig.folderKey
     };
 
     // Initialize telemetry with SDK configuration

--- a/src/models/common/types.ts
+++ b/src/models/common/types.ts
@@ -45,3 +45,21 @@ export interface RequestOptions extends BaseOptions {
   filter?: string;
   orderby?: string;
 }
+
+/**
+ * Folder-scoping options accepted by methods that resolve a resource by name.
+ * Both `folderPath` and `folderKey` are optional; the server prefers
+ * `folderPath` when both are sent.
+ */
+export interface FolderScopedOptions extends BaseOptions {
+  /**
+   * Slash-delimited folder path that scopes the lookup, e.g. `'Shared/Finance'`.
+   * When both `folderPath` and `folderKey` are supplied, `folderPath` wins.
+   */
+  folderPath?: string;
+  /**
+   * Folder key (GUID) that scopes the lookup. When both `folderPath` and
+   * `folderKey` are supplied, `folderPath` wins.
+   */
+  folderKey?: string;
+}

--- a/src/models/maestro/cases.models.ts
+++ b/src/models/maestro/cases.models.ts
@@ -3,7 +3,7 @@
  * Model classes for Maestro cases
  */
 
-import { CaseGetAllResponse} from './cases.types';
+import { CaseGetAllResponse, CaseGetByNameOptions } from './cases.types';
 
 /**
  * Service for managing UiPath Maestro Cases
@@ -39,4 +39,33 @@ export interface CasesServiceModel {
    * ```
    */
   getAll(): Promise<CaseGetAllResponse[]>;
+
+  /**
+   * Retrieves a single case process by name, optionally scoped to a folder.
+   *
+   * Implemented as a client-side filter over `getAll()` because the Maestro
+   * API does not expose a name-based lookup endpoint. `folderPath` is matched
+   * client-side against the `folderName` field returned by `getAll()`;
+   * `folderKey` matches `folderKey`. When neither is supplied, the SDK falls
+   * back to the init-time folderKey (e.g. from the `uipath:folder-key` meta
+   * tag in coded-app deployments).
+   *
+   * Useful for bindings-driven code that has `name` (+ optional folder
+   * context) at design time and wants to resolve to the operational
+   * `processKey`.
+   *
+   * @param name - Case process name to search for
+   * @param options - Optional folderPath / folderKey scoping
+   * @returns Promise resolving to a single case process
+   * {@link CaseGetAllResponse}
+   * @throws NotFoundError if no case process matches
+   * @example
+   * ```typescript
+   * const caseProcess = await cases.getByName('OnboardingCase', {
+   *   folderPath: 'Shared/Onboarding',
+   * });
+   * console.log(caseProcess.processKey, caseProcess.runningCount);
+   * ```
+   */
+  getByName(name: string, options?: CaseGetByNameOptions): Promise<CaseGetAllResponse>;
 }

--- a/src/models/maestro/cases.types.ts
+++ b/src/models/maestro/cases.types.ts
@@ -4,6 +4,26 @@
  */
 
 /**
+ * Options for looking up a single case process by name.
+ *
+ * Maestro's `/processes/summary` endpoint only sends `folderKey` on the wire,
+ * but the SDK accepts `folderPath` and matches it client-side against the
+ * `folderName` field returned by `getAll()` for API parity with Orchestrator
+ * services. When neither is supplied, the SDK falls back to the init-time
+ * folderKey (e.g. from the `uipath:folder-key` meta tag in coded-app
+ * deployments).
+ */
+export interface CaseGetByNameOptions {
+  /**
+   * Folder path that scopes the lookup. Matched client-side against the
+   * `folderName` field returned by Maestro.
+   */
+  folderPath?: string;
+  /** Folder key (GUID) that scopes the lookup. */
+  folderKey?: string;
+}
+
+/**
  * Case information with instance statistics
  */
 export interface CaseGetAllResponse {

--- a/src/models/maestro/processes.models.ts
+++ b/src/models/maestro/processes.models.ts
@@ -3,7 +3,7 @@
  * Model classes for Maestro processes
  */
 
-import { RawMaestroProcessGetAllResponse } from './processes.types';
+import { MaestroProcessGetByNameOptions, RawMaestroProcessGetAllResponse } from './processes.types';
 import { ProcessIncidentGetResponse } from './process-incidents.types';
 
 /**
@@ -44,6 +44,38 @@ export interface MaestroProcessesServiceModel {
    * ```
    */
   getAll(): Promise<MaestroProcessGetAllResponse[]>;
+
+  /**
+   * Retrieves a single Maestro process by name, optionally scoped to a folder.
+   *
+   * Implemented as a client-side filter over `getAll()` because the Maestro
+   * API does not expose a name-based lookup endpoint. `folderPath` is matched
+   * client-side against the `folderName` field returned by `getAll()`;
+   * `folderKey` matches `folderKey`. When neither is supplied, the SDK falls
+   * back to the init-time folderKey (e.g. from the `uipath:folder-key` meta
+   * tag in coded-app deployments).
+   *
+   * Useful for bindings-driven code that has `name` (+ optional folder
+   * context) at design time and wants to resolve to the operational
+   * `processKey`.
+   *
+   * @param name - Process name (currently maps to `packageId`)
+   * @param options - Optional folderPath / folderKey scoping
+   * @returns Promise resolving to a single Maestro process with bound methods
+   * {@link MaestroProcessGetAllResponse}
+   * @throws NotFoundError if no process matches
+   * @example
+   * ```typescript
+   * // Get a process by name within a folder
+   * const process = await maestroProcesses.getByName('MyMaestroProcess', {
+   *   folderPath: 'Shared/Finance',
+   * });
+   *
+   * // Then operate on it
+   * const incidents = await process.getIncidents();
+   * ```
+   */
+  getByName(name: string, options?: MaestroProcessGetByNameOptions): Promise<MaestroProcessGetAllResponse>;
 
   /**
    * Get incidents for a specific process

--- a/src/models/maestro/processes.types.ts
+++ b/src/models/maestro/processes.types.ts
@@ -4,6 +4,26 @@
  */
 
 /**
+ * Options for looking up a single Maestro process by name.
+ *
+ * Maestro's `/processes/summary` endpoint only sends `folderKey` on the wire,
+ * but the SDK accepts `folderPath` and matches it client-side against the
+ * `folderName` field returned by `getAll()` for API parity with Orchestrator
+ * services. When neither is supplied, the SDK falls back to the init-time
+ * folderKey (e.g. from the `uipath:folder-key` meta tag in coded-app
+ * deployments).
+ */
+export interface MaestroProcessGetByNameOptions {
+  /**
+   * Folder path that scopes the lookup. Matched client-side against the
+   * `folderName` field returned by Maestro.
+   */
+  folderPath?: string;
+  /** Folder key (GUID) that scopes the lookup. */
+  folderKey?: string;
+}
+
+/**
  * Process information with instance statistics
  */
 export interface RawMaestroProcessGetAllResponse {

--- a/src/models/orchestrator/assets.models.ts
+++ b/src/models/orchestrator/assets.models.ts
@@ -71,8 +71,9 @@ export interface AssetServiceModel {
    * Retrieves a single asset by name, optionally scoped to a folder
    *
    * Uses the asset name and folder path to look up the resource. The folder context
-   * is resolved server-side via the X-UIPATH-FolderPath header — no client-side
-   * folder ID resolution is needed.
+   * is resolved server-side via the X-UIPATH-FolderPath-Encoded /
+   * X-UIPATH-FolderKey headers — no client-side folder ID resolution is needed.
+   * The folder path is URL-encoded automatically before being sent.
    *
    * @param name - Asset name to search for
    * @param options - Optional folder scoping and query parameters

--- a/src/models/orchestrator/assets.models.ts
+++ b/src/models/orchestrator/assets.models.ts
@@ -1,4 +1,4 @@
-import { AssetGetAllOptions, AssetGetResponse, AssetGetByIdOptions } from './assets.types';
+import { AssetGetAllOptions, AssetGetResponse, AssetGetByIdOptions, AssetGetByNameOptions } from './assets.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -66,4 +66,29 @@ export interface AssetServiceModel {
    * ```
    */
   getById(id: number, folderId: number, options?: AssetGetByIdOptions): Promise<AssetGetResponse>;
-} 
+
+  /**
+   * Retrieves a single asset by name, optionally scoped to a folder
+   *
+   * Uses the asset name and folder path to look up the resource. The folder context
+   * is resolved server-side via the X-UIPATH-FolderPath header — no client-side
+   * folder ID resolution is needed.
+   *
+   * @param name - Asset name to search for
+   * @param options - Optional folder scoping and query parameters
+   * @returns Promise resolving to a single asset
+   * {@link AssetGetResponse}
+   * @example
+   * ```typescript
+   * // Get asset by name with folder path
+   * const asset = await assets.getByName('ApiKey', { folderPath: 'Shared/Finance' });
+   *
+   * // Get asset by name with folder key
+   * const asset = await assets.getByName('ApiKey', { folderKey: 'folder-guid' });
+   *
+   * // Get asset by name (uses default folder context)
+   * const asset = await assets.getByName('ApiKey');
+   * ```
+   */
+  getByName(name: string, options?: AssetGetByNameOptions): Promise<AssetGetResponse>;
+}

--- a/src/models/orchestrator/assets.types.ts
+++ b/src/models/orchestrator/assets.types.ts
@@ -1,4 +1,4 @@
-import { BaseOptions, RequestOptions } from '../common/types';
+import { BaseOptions, FolderScopedOptions, RequestOptions } from '../common/types';
 import { PaginationOptions } from '../../utils/pagination';
 
 /**
@@ -70,17 +70,8 @@ export type AssetGetAllOptions = RequestOptions & PaginationOptions & {
 export interface AssetGetByIdOptions extends BaseOptions {}
 
 /**
- * Options for getting a single asset by name
+ * Options for getting a single asset by name.
+ * Both `folderPath` and `folderKey` are optional; the server prefers
+ * `folderPath` when both are supplied.
  */
-export interface AssetGetByNameOptions extends BaseOptions {
-  /**
-   * Folder path to scope the asset lookup (e.g. 'Shared/Finance').
-   * Mutually exclusive with folderKey.
-   */
-  folderPath?: string;
-  /**
-   * Folder key (GUID) to scope the asset lookup.
-   * Mutually exclusive with folderPath.
-   */
-  folderKey?: string;
-}
+export interface AssetGetByNameOptions extends FolderScopedOptions {}

--- a/src/models/orchestrator/assets.types.ts
+++ b/src/models/orchestrator/assets.types.ts
@@ -68,3 +68,19 @@ export type AssetGetAllOptions = RequestOptions & PaginationOptions & {
  * Options for getting a single asset by ID
  */
 export interface AssetGetByIdOptions extends BaseOptions {}
+
+/**
+ * Options for getting a single asset by name
+ */
+export interface AssetGetByNameOptions extends BaseOptions {
+  /**
+   * Folder path to scope the asset lookup (e.g. 'Shared/Finance').
+   * Mutually exclusive with folderKey.
+   */
+  folderPath?: string;
+  /**
+   * Folder key (GUID) to scope the asset lookup.
+   * Mutually exclusive with folderPath.
+   */
+  folderKey?: string;
+}

--- a/src/models/orchestrator/buckets.models.ts
+++ b/src/models/orchestrator/buckets.models.ts
@@ -1,4 +1,4 @@
-import { BucketGetAllOptions, BucketGetByIdOptions, BucketGetResponse, BucketGetFileMetaDataWithPaginationOptions, BucketGetReadUriOptions, BucketGetUriResponse, BucketUploadFileOptions, BucketUploadResponse, BlobItem } from './buckets.types';
+import { BucketGetAllOptions, BucketGetByIdOptions, BucketGetByNameOptions, BucketGetResponse, BucketGetFileMetaDataWithPaginationOptions, BucketGetReadUriOptions, BucketGetUriResponse, BucketUploadFileOptions, BucketUploadResponse, BlobItem } from './buckets.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -79,6 +79,32 @@ export interface BucketServiceModel {
    * ```
    */
   getById(bucketId: number, folderId: number, options?: BucketGetByIdOptions): Promise<BucketGetResponse>;
+
+  /**
+   * Retrieves a single bucket by name, optionally scoped to a folder
+   *
+   * Uses the bucket name and folder path (or folder key) to look up the resource.
+   * The folder context is resolved server-side via the X-UIPATH-FolderPath-Encoded /
+   * X-UIPATH-FolderKey headers — no client-side folder ID resolution is needed.
+   * The folder path is URL-encoded automatically before being sent.
+   *
+   * @param name - Bucket name to search for
+   * @param options - Optional folder scoping and query parameters
+   * @returns Promise resolving to a single bucket
+   * {@link BucketGetResponse}
+   * @example
+   * ```typescript
+   * // Get bucket by name with folder path
+   * const bucket = await buckets.getByName('MyBucket', { folderPath: 'Shared/Finance' });
+   *
+   * // Get bucket by name with folder key
+   * const bucket = await buckets.getByName('MyBucket', { folderKey: 'folder-guid' });
+   *
+   * // Get bucket by name (uses default folder context)
+   * const bucket = await buckets.getByName('MyBucket');
+   * ```
+   */
+  getByName(name: string, options?: BucketGetByNameOptions): Promise<BucketGetResponse>;
 
   /**
    * Gets metadata for files in a bucket with optional filtering and pagination

--- a/src/models/orchestrator/buckets.types.ts
+++ b/src/models/orchestrator/buckets.types.ts
@@ -1,4 +1,4 @@
-import { BaseOptions, RequestOptions } from "../common/types";
+import { BaseOptions, FolderScopedOptions, RequestOptions } from "../common/types";
 import { PaginationOptions } from "../../utils/pagination";
 
 export enum BucketOptions {
@@ -30,20 +30,11 @@ export type BucketGetAllOptions = RequestOptions & PaginationOptions & {
 export interface BucketGetByIdOptions extends BaseOptions {}
 
 /**
- * Options for getting a single bucket by name
+ * Options for getting a single bucket by name.
+ * Both `folderPath` and `folderKey` are optional; the server prefers
+ * `folderPath` when both are supplied.
  */
-export interface BucketGetByNameOptions extends BaseOptions {
-  /**
-   * Folder path to scope the bucket lookup (e.g. 'Shared/Finance').
-   * Mutually exclusive with folderKey.
-   */
-  folderPath?: string;
-  /**
-   * Folder key (GUID) to scope the bucket lookup.
-   * Mutually exclusive with folderPath.
-   */
-  folderKey?: string;
-}
+export interface BucketGetByNameOptions extends FolderScopedOptions {}
 
 /**
  * Maps header names to their values

--- a/src/models/orchestrator/buckets.types.ts
+++ b/src/models/orchestrator/buckets.types.ts
@@ -30,6 +30,22 @@ export type BucketGetAllOptions = RequestOptions & PaginationOptions & {
 export interface BucketGetByIdOptions extends BaseOptions {}
 
 /**
+ * Options for getting a single bucket by name
+ */
+export interface BucketGetByNameOptions extends BaseOptions {
+  /**
+   * Folder path to scope the bucket lookup (e.g. 'Shared/Finance').
+   * Mutually exclusive with folderKey.
+   */
+  folderPath?: string;
+  /**
+   * Folder key (GUID) to scope the bucket lookup.
+   * Mutually exclusive with folderPath.
+   */
+  folderKey?: string;
+}
+
+/**
  * Maps header names to their values
  * 
  * @example

--- a/src/models/orchestrator/processes.models.ts
+++ b/src/models/orchestrator/processes.models.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from '../common/types';
-import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions } from './processes.types';
+import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions, ProcessGetByNameOptions } from './processes.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -78,7 +78,33 @@ export interface ProcessServiceModel {
    * ```
    */
   getById(id: number, folderId: number, options?: ProcessGetByIdOptions): Promise<ProcessGetResponse>;
-  
+
+  /**
+   * Retrieves a single process by name, optionally scoped to a folder
+   *
+   * Uses the process name and folder path (or folder key) to look up the resource.
+   * The folder context is resolved server-side via the X-UIPATH-FolderPath-Encoded /
+   * X-UIPATH-FolderKey headers — no client-side folder ID resolution is needed.
+   * The folder path is URL-encoded automatically before being sent.
+   *
+   * @param name - Process name to search for
+   * @param options - Optional folder scoping and query parameters
+   * @returns Promise resolving to a single process
+   * {@link ProcessGetResponse}
+   * @example
+   * ```typescript
+   * // Get process by name with folder path
+   * const process = await processes.getByName('MyProcess', { folderPath: 'Shared/Finance' });
+   *
+   * // Get process by name with folder key
+   * const process = await processes.getByName('MyProcess', { folderKey: 'folder-guid' });
+   *
+   * // Get process by name (uses default folder context)
+   * const process = await processes.getByName('MyProcess');
+   * ```
+   */
+  getByName(name: string, options?: ProcessGetByNameOptions): Promise<ProcessGetResponse>;
+
   /**
    * Starts a process with the specified configuration
    * 

--- a/src/models/orchestrator/processes.models.ts
+++ b/src/models/orchestrator/processes.models.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from '../common/types';
-import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions, ProcessGetByNameOptions } from './processes.types';
+import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions, ProcessGetByNameOptions, ProcessStartOptions } from './processes.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -106,25 +106,41 @@ export interface ProcessServiceModel {
   getByName(name: string, options?: ProcessGetByNameOptions): Promise<ProcessGetResponse>;
 
   /**
-   * Starts a process with the specified configuration
-   * 
-   * @param request - Process start configuration
-   * @param folderId - Required folder ID
-   * @param options - Optional request options
-   * @returns Promise resolving to array of started process instances
+   * Starts a process execution (job).
+   *
+   * Folder context is supplied via the options object using `folderId`,
+   * `folderPath`, or `folderKey`. When more than one is supplied, the server
+   * prefers `folderPath` > `folderKey` > `folderId`.
+   *
+   * The legacy positional-`folderId` form (`start(request, 123, options?)`)
+   * remains supported for backward compatibility but is deprecated; prefer
+   * passing the options object.
+   *
+   * @param request - Process start configuration. Either `processKey` or `processName` must be provided.
+   * @param optionsOrFolderId - Options object (preferred) or legacy positional folder ID
+   * @param legacyOptions - Legacy options object (used only with positional folderId)
+   * @returns Promise resolving to the started jobs
    * {@link ProcessStartResponse}
    * @example
    * ```typescript
-   * // Start a process by process key
-   * const result = await processes.start({
-   *   processKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-   * }, <folderId>); // folderId is required
+   * // Preferred — options object with folder context
+   * await processes.start(
+   *   { processName: 'MyProcess' },
+   *   { folderPath: 'Shared/Finance' },
+   * );
    *
-   * // Start a process by name with specific robots
-   * const result = await processes.start({
-   *   processName: "MyProcess"
-   * }, <folderId>); // folderId is required
+   * await processes.start(
+   *   { processKey: '<process-key>' },
+   *   { folderKey: '<folder-guid>' },
+   * );
+   *
+   * // Legacy positional form (still works)
+   * await processes.start({ processName: 'MyProcess' }, <folderId>);
    * ```
    */
-  start(request: ProcessStartRequest, folderId: number, options?: RequestOptions): Promise<ProcessStartResponse[]>;
-} 
+  start(
+    request: ProcessStartRequest,
+    optionsOrFolderId?: ProcessStartOptions | number,
+    legacyOptions?: RequestOptions,
+  ): Promise<ProcessStartResponse[]>;
+}

--- a/src/models/orchestrator/processes.types.ts
+++ b/src/models/orchestrator/processes.types.ts
@@ -380,3 +380,19 @@ export type ProcessGetAllOptions = RequestOptions & PaginationOptions & {
  * Options for getting a single process by ID
  */
 export interface ProcessGetByIdOptions extends BaseOptions {}
+
+/**
+ * Options for getting a single process by name
+ */
+export interface ProcessGetByNameOptions extends BaseOptions {
+  /**
+   * Folder path to scope the process lookup (e.g. 'Shared/Finance').
+   * Mutually exclusive with folderKey.
+   */
+  folderPath?: string;
+  /**
+   * Folder key (GUID) to scope the process lookup.
+   * Mutually exclusive with folderPath.
+   */
+  folderKey?: string;
+}

--- a/src/models/orchestrator/processes.types.ts
+++ b/src/models/orchestrator/processes.types.ts
@@ -1,4 +1,4 @@
-import { JobState, RequestOptions, BaseOptions } from '../common/types';
+import { JobState, RequestOptions, BaseOptions, FolderScopedOptions } from '../common/types';
 import { PaginationOptions } from '../../utils/pagination';
 
 /**
@@ -382,17 +382,30 @@ export type ProcessGetAllOptions = RequestOptions & PaginationOptions & {
 export interface ProcessGetByIdOptions extends BaseOptions {}
 
 /**
- * Options for getting a single process by name
+ * Options for getting a single process by name.
+ * Both `folderPath` and `folderKey` are optional; the server prefers
+ * `folderPath` when both are supplied.
  */
-export interface ProcessGetByNameOptions extends BaseOptions {
+export interface ProcessGetByNameOptions extends FolderScopedOptions {}
+
+/**
+ * Options for `processes.start()`. Folder context lives here in the new
+ * options shape: `folderId`, `folderPath`, or `folderKey`. When multiple are
+ * supplied, the server prefers `folderPath` > `folderKey` > `folderId`.
+ */
+export interface ProcessStartOptions extends RequestOptions {
   /**
-   * Folder path to scope the process lookup (e.g. 'Shared/Finance').
-   * Mutually exclusive with folderKey.
+   * Numeric folder ID. Sent as `X-UIPATH-OrganizationUnitId`. Equivalent to
+   * the legacy positional `folderId` argument.
+   */
+  folderId?: number;
+  /**
+   * Slash-delimited folder path. Sent as `X-UIPATH-FolderPath-Encoded`
+   * (base64-of-UTF-16-LE).
    */
   folderPath?: string;
   /**
-   * Folder key (GUID) to scope the process lookup.
-   * Mutually exclusive with folderPath.
+   * Folder key (GUID). Sent as `X-UIPATH-FolderKey`.
    */
   folderKey?: string;
 }

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -40,6 +40,12 @@ export class BaseService {
   #apiClient: ApiClient;
 
   /**
+   * SDK configuration (read-only). Available to subclasses so they can
+   * fall back to init-time defaults like `folderKey`.
+   */
+  protected readonly config: { folderKey?: string };
+
+  /**
    * Creates a base service instance with dependency injection.
    *
    * Extracts configuration, execution context, and token manager from the UiPath instance
@@ -70,6 +76,7 @@ export class BaseService {
   constructor(instance: IUiPath) {
     const { config, context, tokenManager } = SDKInternalsRegistry.get(instance);
     this.#apiClient = new ApiClient(config, context, tokenManager);
+    this.config = { folderKey: config.folderKey };
   }
 
   /**

--- a/src/services/folder-scoped.ts
+++ b/src/services/folder-scoped.ts
@@ -1,15 +1,18 @@
 import { BaseService } from './base';
-import { CollectionResponse } from '../models/common/types';
+import { CollectionResponse, FolderScopedOptions } from '../models/common/types';
 import { createHeaders } from '../utils/http/headers';
-import { FOLDER_ID } from '../utils/constants/headers';
+import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../utils/constants/headers';
 import { ODATA_PREFIX } from '../utils/constants/common';
 import { addPrefixToKeys } from '../utils/transform';
+import { NotFoundError } from '../core/errors';
+import { validateGetByNameArgs } from '../utils/validation/name-validator';
+import { encodeFolderPathHeader } from '../utils/encoding/folder-path';
 
 /**
  * Base service for services that need folder-specific functionality.
  *
  * Extends BaseService with additional methods for working with folder-scoped resources
- * in UiPath Orchestrator. Services that work with folders (Assets, Queues) extend this class.
+ * in UiPath Orchestrator. Services that work with folders (Assets, Buckets, Queues, Processes) extend this class.
  *
  * @remarks
  * This class provides helper methods for making folder-scoped API calls, handling folder IDs
@@ -18,7 +21,7 @@ import { addPrefixToKeys } from '../utils/transform';
 export class FolderScopedService extends BaseService {
   /**
    * Gets resources in a folder with optional query parameters
-   * 
+   *
    * @param endpoint - API endpoint to call
    * @param folderId - required folder ID
    * @param options - Query options
@@ -26,8 +29,8 @@ export class FolderScopedService extends BaseService {
    * @returns Promise resolving to an array of resources
    */
   protected async _getByFolder<T, R = T>(
-    endpoint: string, 
-    folderId: number, 
+    endpoint: string,
+    folderId: number,
     options: Record<string, any> = {},
     transformFn?: (item: T) => R
   ): Promise<R[]> {
@@ -35,10 +38,10 @@ export class FolderScopedService extends BaseService {
 
     const keysToPrefix = Object.keys(options);
     const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
+
     const response = await this.get<CollectionResponse<T>>(
       endpoint,
-      { 
+      {
         params: apiOptions,
         headers
       }
@@ -47,7 +50,74 @@ export class FolderScopedService extends BaseService {
     if (transformFn) {
       return response.data?.value.map(transformFn);
     }
-    
+
     return response.data?.value as unknown as R[];
   }
-} 
+
+  /**
+   * Look up a single resource by name on a folder-scoped OData collection.
+   *
+   * Shared by `getByName` implementations across services (Assets, Processes, Buckets, ...).
+   * Handles:
+   * - Input validation via `validateGetByNameArgs`
+   * - Folder context resolution with init-time `config.folderKey` as fallback
+   * - OData `$filter=Name eq '…'` with single-quote escaping + `$top=1`
+   * - `X-UIPATH-FolderPath-Encoded` / `X-UIPATH-FolderKey` header construction
+   * - Empty-result → `NotFoundError` with folder context in the message
+   *
+   * The transform step is caller-provided because each resource has its own
+   * PascalCase → camelCase field mapping.
+   *
+   * @param resourceType - Resource label used in validation + error messages (e.g. 'Asset', 'Process', 'Bucket')
+   * @param endpoint - Folder-scoped OData collection endpoint
+   * @param name - Resource name to search for
+   * @param options - Folder scoping (`folderPath` / `folderKey`) + extra OData query options (`expand`, `select`, ...)
+   * @param transform - Maps a raw OData item to the typed response (e.g. PascalCase → camelCase via field map)
+   * @throws ValidationError when inputs are malformed; NotFoundError when no match
+   */
+  protected async getByNameLookup<TRaw extends object, T>(
+    resourceType: string,
+    endpoint: string,
+    name: string,
+    options: FolderScopedOptions,
+    transform: (raw: TRaw) => T,
+  ): Promise<T> {
+    const { folderPath, folderKey, ...queryOptions } = options;
+    const validated = validateGetByNameArgs(resourceType, name, folderPath, folderKey);
+
+    // Fall back to the SDK's init-time folderKey (e.g. populated from the
+    // `uipath:folder-key` meta tag in coded-app deployments) when the caller
+    // didn't supply any folder context.
+    const effectiveFolderKey =
+      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
+
+    const headers = createHeaders({
+      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeFolderPathHeader(validated.folderPath) : undefined,
+      [FOLDER_KEY]: effectiveFolderKey,
+    });
+
+    const apiOptions = {
+      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, Object.keys(queryOptions)),
+      '$filter': `Name eq '${validated.name.replace(/'/g, "''")}'`,
+      '$top': '1',
+    };
+
+    const response = await this.get<CollectionResponse<TRaw>>(endpoint, {
+      headers,
+      params: apiOptions,
+    });
+
+    const items = response.data?.value;
+    if (!items?.length) {
+      const folderHint =
+        validated.folderPath ? ` in folder '${validated.folderPath}'`
+        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
+        : '';
+      throw new NotFoundError({
+        message: `${resourceType} '${validated.name}' not found${folderHint}.`,
+      });
+    }
+
+    return transform(items[0]);
+  }
+}

--- a/src/services/maestro/cases/cases.ts
+++ b/src/services/maestro/cases/cases.ts
@@ -1,10 +1,13 @@
 import { CaseGetAllResponse } from '../../../models/maestro';
+import { CaseGetByNameOptions } from '../../../models/maestro/cases.types';
 import { ProcessType } from '../../../models/maestro/cases.internal-types';
 import { BaseService } from '../../base';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
 import type { CasesServiceModel } from '../../../models/maestro/cases.models';
 import { track } from '../../../core/telemetry';
 import { createParams } from '../../../utils/http/params';
+import { NotFoundError } from '../../../core/errors';
+import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
 
 /**
  * Service for interacting with UiPath Maestro Cases
@@ -46,6 +49,71 @@ export class CasesService extends BaseService implements CasesServiceModel {
       ...caseItem,
       name: this.extractCaseName(caseItem.packageId)
     }));
+  }
+
+  /**
+   * Retrieves a single case process by name, optionally scoped to a folder.
+   *
+   * Implemented as a client-side filter over `getAll()` because the Maestro
+   * `/api/v1/processes/summary` endpoint returns the full list and exposes no
+   * name-based lookup. `folderPath` is matched against the `folderName` field
+   * returned by `getAll()`; `folderKey` is matched against `folderKey`. When
+   * neither is supplied, the SDK falls back to the init-time folderKey
+   * (e.g. `uipath:folder-key` meta tag in coded-app deployments). No extra
+   * network call; the data was already fetched.
+   *
+   * @param name - Case process name to search for
+   * @param options - Optional folderPath / folderKey scoping
+   * @returns Promise resolving to a single case process
+   * @throws ValidationError when inputs are malformed; NotFoundError when no match
+   *
+   * @example
+   * ```typescript
+   * import { Cases } from '@uipath/uipath-typescript/cases';
+   *
+   * const cases = new Cases(sdk);
+   *
+   * const caseProcess = await cases.getByName('OnboardingCase', {
+   *   folderPath: 'Shared/Onboarding',
+   * });
+   * console.log(caseProcess.processKey, caseProcess.runningCount);
+   * ```
+   */
+  @track('Cases.GetByName')
+  async getByName(
+    name: string,
+    options: CaseGetByNameOptions = {},
+  ): Promise<CaseGetAllResponse> {
+    const validated = validateGetByNameArgs(
+      'Case',
+      name,
+      options.folderPath,
+      options.folderKey,
+    );
+
+    // Fall back to init-time folderKey (e.g. uipath:folder-key meta tag) only
+    // when the caller didn't supply any folder context.
+    const effectiveFolderKey =
+      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
+
+    const all = await this.getAll();
+    const match = all.find(
+      (c) =>
+        c.name === validated.name &&
+        (validated.folderPath ? c.folderName === validated.folderPath : true) &&
+        (effectiveFolderKey ? c.folderKey === effectiveFolderKey : true),
+    );
+
+    if (!match) {
+      const folderHint =
+        validated.folderPath ? ` in folder '${validated.folderPath}'`
+        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
+        : '';
+      throw new NotFoundError({
+        message: `Case '${validated.name}' not found${folderHint}.`,
+      });
+    }
+    return match;
   }
 
   /**

--- a/src/services/maestro/processes/processes.ts
+++ b/src/services/maestro/processes/processes.ts
@@ -1,4 +1,5 @@
 import { MaestroProcessGetAllResponse, ProcessIncidentGetResponse } from '../../../models/maestro';
+import { MaestroProcessGetByNameOptions } from '../../../models/maestro/processes.types';
 import { BaseService } from '../../base';
 import type { IUiPath } from '../../../core/types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -8,6 +9,8 @@ import { BpmnHelpers } from './helpers';
 import { track } from '../../../core/telemetry';
 import { createHeaders } from '../../../utils/http/headers';
 import { FOLDER_KEY } from '../../../utils/constants/headers';
+import { NotFoundError } from '../../../core/errors';
+import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
 import { ProcessInstancesService } from './process-instances';
 
 /**
@@ -60,6 +63,71 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
 
     // Add methods to each process
     return processesWithName.map(process => createProcessWithMethods(process, this));
+  }
+
+  /**
+   * Retrieves a single Maestro process by name, optionally scoped to a folder.
+   *
+   * Implemented as a client-side filter over `getAll()` because the Maestro
+   * `/api/v1/processes/summary` endpoint returns the full list and exposes no
+   * name-based lookup. `folderPath` is matched against the `folderName` field
+   * returned by `getAll()`; `folderKey` is matched against `folderKey`. When
+   * neither is supplied, the SDK falls back to the init-time folderKey
+   * (e.g. `uipath:folder-key` meta tag in coded-app deployments). No extra
+   * network call; the data was already fetched.
+   *
+   * @param name - Process name to search for
+   * @param options - Optional folderPath / folderKey scoping
+   * @returns Promise resolving to a single Maestro process with bound methods
+   * @throws ValidationError when inputs are malformed; NotFoundError when no match
+   *
+   * @example
+   * ```typescript
+   * import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
+   *
+   * const maestroProcesses = new MaestroProcesses(sdk);
+   *
+   * const process = await maestroProcesses.getByName('MyMaestroProcess', {
+   *   folderPath: 'Shared/Finance',
+   * });
+   * const incidents = await process.getIncidents();
+   * ```
+   */
+  @track('MaestroProcesses.GetByName')
+  async getByName(
+    name: string,
+    options: MaestroProcessGetByNameOptions = {},
+  ): Promise<MaestroProcessGetAllResponse> {
+    const validated = validateGetByNameArgs(
+      'MaestroProcess',
+      name,
+      options.folderPath,
+      options.folderKey,
+    );
+
+    // Fall back to init-time folderKey (e.g. uipath:folder-key meta tag) only
+    // when the caller didn't supply any folder context.
+    const effectiveFolderKey =
+      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
+
+    const all = await this.getAll();
+    const match = all.find(
+      (p) =>
+        p.name === validated.name &&
+        (validated.folderPath ? p.folderName === validated.folderPath : true) &&
+        (effectiveFolderKey ? p.folderKey === effectiveFolderKey : true),
+    );
+
+    if (!match) {
+      const folderHint =
+        validated.folderPath ? ` in folder '${validated.folderPath}'`
+        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
+        : '';
+      throw new NotFoundError({
+        message: `MaestroProcess '${validated.name}' not found${folderHint}.`,
+      });
+    }
+    return match;
   }
 
   /**

--- a/src/services/orchestrator/assets/assets.ts
+++ b/src/services/orchestrator/assets/assets.ts
@@ -3,14 +3,10 @@ import { AssetGetResponse, AssetGetAllOptions, AssetGetByIdOptions, AssetGetByNa
 import { AssetServiceModel } from '../../../models/orchestrator/assets.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../../../utils/constants/headers';
+import { FOLDER_ID } from '../../../utils/constants/headers';
 import { ASSET_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
 import { AssetMap } from '../../../models/orchestrator/assets.constants';
-import { CollectionResponse } from '../../../models/common/types';
-import { NotFoundError } from '../../../core/errors';
-import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
-import { encodeFolderPathHeader } from '../../../utils/encoding/folder-path';
 import { ODATA_PAGINATION } from '../../../utils/constants/common';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
@@ -148,46 +144,12 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
    */
   @track('Assets.GetByName')
   async getByName(name: string, options: AssetGetByNameOptions = {}): Promise<AssetGetResponse> {
-    const { folderPath: rawFolderPath, folderKey: rawFolderKey, ...queryOptions } = options;
-    const validated = validateGetByNameArgs('Asset', name, rawFolderPath, rawFolderKey);
-
-    // Fall back to the SDK's init-time folderKey (e.g. populated from the
-    // `uipath:folder-key` meta tag in coded-app deployments) when the
-    // caller didn't supply any folder context.
-    const effectiveFolderKey =
-      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
-
-    const headers = createHeaders({
-      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeFolderPathHeader(validated.folderPath) : undefined,
-      [FOLDER_KEY]: effectiveFolderKey,
-    });
-
-    const keysToPrefix = Object.keys(queryOptions);
-    const apiOptions = {
-      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix),
-      '$filter': `Name eq '${validated.name.replace(/'/g, "''")}'`,
-      '$top': '1',
-    };
-
-    const response = await this.get<CollectionResponse<AssetGetResponse>>(
+    return this.getByNameLookup<AssetGetResponse, AssetGetResponse>(
+      'Asset',
       ASSET_ENDPOINTS.GET_BY_FOLDER,
-      {
-        headers,
-        params: apiOptions,
-      }
+      name,
+      options,
+      (raw) => transformData(pascalToCamelCaseKeys(raw), AssetMap),
     );
-
-    const items = response.data?.value;
-    if (!items?.length) {
-      const folderHint =
-        validated.folderPath ? ` in folder '${validated.folderPath}'`
-        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
-        : '';
-      throw new NotFoundError({
-        message: `Asset '${validated.name}' not found${folderHint}.`,
-      });
-    }
-
-    return transformData(pascalToCamelCaseKeys(items[0]) as AssetGetResponse, AssetMap);
   }
 }

--- a/src/services/orchestrator/assets/assets.ts
+++ b/src/services/orchestrator/assets/assets.ts
@@ -1,12 +1,14 @@
 import { FolderScopedService } from '../../folder-scoped';
-import { AssetGetResponse, AssetGetAllOptions, AssetGetByIdOptions } from '../../../models/orchestrator/assets.types';
+import { AssetGetResponse, AssetGetAllOptions, AssetGetByIdOptions, AssetGetByNameOptions } from '../../../models/orchestrator/assets.types';
 import { AssetServiceModel } from '../../../models/orchestrator/assets.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_ID } from '../../../utils/constants/headers';
+import { FOLDER_ID, FOLDER_PATH, FOLDER_KEY } from '../../../utils/constants/headers';
 import { ASSET_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
 import { AssetMap } from '../../../models/orchestrator/assets.constants';
+import { CollectionResponse } from '../../../models/common/types';
+import { NotFoundError } from '../../../core/errors';
 import { ODATA_PAGINATION } from '../../../utils/constants/common';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
@@ -115,7 +117,62 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
     );
 
     const transformedAsset = transformData(pascalToCamelCaseKeys(response.data) as AssetGetResponse, AssetMap);
-    
+
     return transformedAsset;
+  }
+
+  /**
+   * Retrieves a single asset by name, optionally scoped to a folder
+   *
+   * @param name - Asset name to search for
+   * @param options - Optional folder scoping and query parameters
+   * @returns Promise resolving to a single asset
+   *
+   * @example
+   * ```typescript
+   * import { Assets } from '@uipath/uipath-typescript/assets';
+   *
+   * const assets = new Assets(sdk);
+   *
+   * // Get asset by name with folder path
+   * const asset = await assets.getByName('ApiKey', { folderPath: 'Shared/Finance' });
+   *
+   * // Get asset by name with folder key
+   * const asset = await assets.getByName('ApiKey', { folderKey: 'folder-guid' });
+   *
+   * // Get asset by name (uses default folder context)
+   * const asset = await assets.getByName('ApiKey');
+   * ```
+   */
+  @track('Assets.GetByName')
+  async getByName(name: string, options: AssetGetByNameOptions = {}): Promise<AssetGetResponse> {
+    const { folderPath, folderKey, ...queryOptions } = options;
+
+    const headers = createHeaders({
+      [FOLDER_PATH]: folderPath,
+      [FOLDER_KEY]: folderKey,
+    });
+
+    const keysToPrefix = Object.keys(queryOptions);
+    const apiOptions = {
+      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix),
+      '$filter': `Name eq '${name.replace(/'/g, "''")}'`,
+      '$top': '1',
+    };
+
+    const response = await this.get<CollectionResponse<AssetGetResponse>>(
+      ASSET_ENDPOINTS.GET_BY_FOLDER,
+      {
+        headers,
+        params: apiOptions,
+      }
+    );
+
+    const items = response.data?.value;
+    if (!items?.length) {
+      throw new NotFoundError({ message: `Asset with name '${name}' not found` });
+    }
+
+    return transformData(pascalToCamelCaseKeys(items[0]) as AssetGetResponse, AssetMap);
   }
 }

--- a/src/services/orchestrator/assets/assets.ts
+++ b/src/services/orchestrator/assets/assets.ts
@@ -3,12 +3,13 @@ import { AssetGetResponse, AssetGetAllOptions, AssetGetByIdOptions, AssetGetByNa
 import { AssetServiceModel } from '../../../models/orchestrator/assets.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_ID, FOLDER_PATH, FOLDER_KEY } from '../../../utils/constants/headers';
+import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../../../utils/constants/headers';
 import { ASSET_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
 import { AssetMap } from '../../../models/orchestrator/assets.constants';
 import { CollectionResponse } from '../../../models/common/types';
 import { NotFoundError } from '../../../core/errors';
+import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
 import { ODATA_PAGINATION } from '../../../utils/constants/common';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
@@ -146,17 +147,24 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
    */
   @track('Assets.GetByName')
   async getByName(name: string, options: AssetGetByNameOptions = {}): Promise<AssetGetResponse> {
-    const { folderPath, folderKey, ...queryOptions } = options;
+    const { folderPath: rawFolderPath, folderKey: rawFolderKey, ...queryOptions } = options;
+    const validated = validateGetByNameArgs('Asset', name, rawFolderPath, rawFolderKey);
+
+    // Fall back to the SDK's init-time folderKey (e.g. populated from the
+    // `uipath:folder-key` meta tag in coded-app deployments) when the
+    // caller didn't supply any folder context.
+    const effectiveFolderKey =
+      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
 
     const headers = createHeaders({
-      [FOLDER_PATH]: folderPath,
-      [FOLDER_KEY]: folderKey,
+      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeURIComponent(validated.folderPath) : undefined,
+      [FOLDER_KEY]: effectiveFolderKey,
     });
 
     const keysToPrefix = Object.keys(queryOptions);
     const apiOptions = {
       ...addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix),
-      '$filter': `Name eq '${name.replace(/'/g, "''")}'`,
+      '$filter': `Name eq '${validated.name.replace(/'/g, "''")}'`,
       '$top': '1',
     };
 
@@ -170,7 +178,13 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
 
     const items = response.data?.value;
     if (!items?.length) {
-      throw new NotFoundError({ message: `Asset with name '${name}' not found` });
+      const folderHint =
+        validated.folderPath ? ` in folder '${validated.folderPath}'`
+        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
+        : '';
+      throw new NotFoundError({
+        message: `Asset '${validated.name}' not found${folderHint}.`,
+      });
     }
 
     return transformData(pascalToCamelCaseKeys(items[0]) as AssetGetResponse, AssetMap);

--- a/src/services/orchestrator/assets/assets.ts
+++ b/src/services/orchestrator/assets/assets.ts
@@ -10,6 +10,7 @@ import { AssetMap } from '../../../models/orchestrator/assets.constants';
 import { CollectionResponse } from '../../../models/common/types';
 import { NotFoundError } from '../../../core/errors';
 import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
+import { encodeFolderPathHeader } from '../../../utils/encoding/folder-path';
 import { ODATA_PAGINATION } from '../../../utils/constants/common';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
@@ -157,7 +158,7 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
       validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
 
     const headers = createHeaders({
-      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeURIComponent(validated.folderPath) : undefined,
+      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeFolderPathHeader(validated.folderPath) : undefined,
       [FOLDER_KEY]: effectiveFolderKey,
     });
 

--- a/src/services/orchestrator/buckets/buckets.ts
+++ b/src/services/orchestrator/buckets/buckets.ts
@@ -1,9 +1,10 @@
 import { FolderScopedService } from '../../folder-scoped';
-import { ValidationError, HttpStatus } from '../../../core/errors';
+import { ValidationError, NotFoundError, HttpStatus } from '../../../core/errors';
 import {
   BucketGetResponse,
   BucketGetAllOptions,
   BucketGetByIdOptions,
+  BucketGetByNameOptions,
   BucketGetUriResponse,
   BucketGetReadUriOptions,
   BucketGetFileMetaDataWithPaginationOptions,
@@ -16,7 +17,10 @@ import { BucketServiceModel } from '../../../models/orchestrator/buckets.models'
 import { pascalToCamelCaseKeys, addPrefixToKeys, transformData, arrayDictionaryToRecord } from '../../../utils/transform';
 import { filterUndefined } from '../../../utils/object';
 import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_ID } from '../../../utils/constants/headers';
+import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../../../utils/constants/headers';
+import { CollectionResponse } from '../../../models/common/types';
+import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
+import { encodeFolderPathHeader } from '../../../utils/encoding/folder-path';
 import { BUCKET_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, BUCKET_PAGINATION, ODATA_OFFSET_PARAMS, BUCKET_TOKEN_PARAMS } from '../../../utils/constants/common';
 import { BucketMap } from '../../../models/orchestrator/buckets.constants';
@@ -70,6 +74,68 @@ export class BucketService extends FolderScopedService implements BucketServiceM
     
     // Transform response from PascalCase to camelCase
     return pascalToCamelCaseKeys(response.data) as BucketGetResponse;
+  }
+
+  /**
+   * Retrieves a single bucket by name, optionally scoped to a folder
+   *
+   * @param name - Bucket name to search for
+   * @param options - Optional folder scoping and query parameters
+   * @returns Promise resolving to a single bucket
+   *
+   * @example
+   * ```typescript
+   * import { Buckets } from '@uipath/uipath-typescript/buckets';
+   *
+   * const buckets = new Buckets(sdk);
+   *
+   * // Get bucket by name with folder path
+   * const bucket = await buckets.getByName('MyBucket', { folderPath: 'Shared/Finance' });
+   *
+   * // Get bucket by name with folder key
+   * const bucket = await buckets.getByName('MyBucket', { folderKey: 'folder-guid' });
+   * ```
+   */
+  @track('Buckets.GetByName')
+  async getByName(name: string, options: BucketGetByNameOptions = {}): Promise<BucketGetResponse> {
+    const { folderPath: rawFolderPath, folderKey: rawFolderKey, ...queryOptions } = options;
+    const validated = validateGetByNameArgs('Bucket', name, rawFolderPath, rawFolderKey);
+
+    const effectiveFolderKey =
+      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
+
+    const headers = createHeaders({
+      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeFolderPathHeader(validated.folderPath) : undefined,
+      [FOLDER_KEY]: effectiveFolderKey,
+    });
+
+    const keysToPrefix = Object.keys(queryOptions);
+    const apiOptions = {
+      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix),
+      '$filter': `Name eq '${validated.name.replace(/'/g, "''")}'`,
+      '$top': '1',
+    };
+
+    const response = await this.get<CollectionResponse<BucketGetResponse>>(
+      BUCKET_ENDPOINTS.GET_BY_FOLDER,
+      {
+        headers,
+        params: apiOptions,
+      },
+    );
+
+    const items = response.data?.value;
+    if (!items?.length) {
+      const folderHint =
+        validated.folderPath ? ` in folder '${validated.folderPath}'`
+        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
+        : '';
+      throw new NotFoundError({
+        message: `Bucket '${validated.name}' not found${folderHint}.`,
+      });
+    }
+
+    return pascalToCamelCaseKeys(items[0]) as BucketGetResponse;
   }
 
   /**

--- a/src/services/orchestrator/buckets/buckets.ts
+++ b/src/services/orchestrator/buckets/buckets.ts
@@ -1,5 +1,5 @@
 import { FolderScopedService } from '../../folder-scoped';
-import { ValidationError, NotFoundError, HttpStatus } from '../../../core/errors';
+import { ValidationError, HttpStatus } from '../../../core/errors';
 import {
   BucketGetResponse,
   BucketGetAllOptions,
@@ -17,10 +17,7 @@ import { BucketServiceModel } from '../../../models/orchestrator/buckets.models'
 import { pascalToCamelCaseKeys, addPrefixToKeys, transformData, arrayDictionaryToRecord } from '../../../utils/transform';
 import { filterUndefined } from '../../../utils/object';
 import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../../../utils/constants/headers';
-import { CollectionResponse } from '../../../models/common/types';
-import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
-import { encodeFolderPathHeader } from '../../../utils/encoding/folder-path';
+import { FOLDER_ID } from '../../../utils/constants/headers';
 import { BUCKET_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, BUCKET_PAGINATION, ODATA_OFFSET_PARAMS, BUCKET_TOKEN_PARAMS } from '../../../utils/constants/common';
 import { BucketMap } from '../../../models/orchestrator/buckets.constants';
@@ -98,44 +95,13 @@ export class BucketService extends FolderScopedService implements BucketServiceM
    */
   @track('Buckets.GetByName')
   async getByName(name: string, options: BucketGetByNameOptions = {}): Promise<BucketGetResponse> {
-    const { folderPath: rawFolderPath, folderKey: rawFolderKey, ...queryOptions } = options;
-    const validated = validateGetByNameArgs('Bucket', name, rawFolderPath, rawFolderKey);
-
-    const effectiveFolderKey =
-      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
-
-    const headers = createHeaders({
-      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeFolderPathHeader(validated.folderPath) : undefined,
-      [FOLDER_KEY]: effectiveFolderKey,
-    });
-
-    const keysToPrefix = Object.keys(queryOptions);
-    const apiOptions = {
-      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix),
-      '$filter': `Name eq '${validated.name.replace(/'/g, "''")}'`,
-      '$top': '1',
-    };
-
-    const response = await this.get<CollectionResponse<BucketGetResponse>>(
+    return this.getByNameLookup<BucketGetResponse, BucketGetResponse>(
+      'Bucket',
       BUCKET_ENDPOINTS.GET_BY_FOLDER,
-      {
-        headers,
-        params: apiOptions,
-      },
+      name,
+      options,
+      (raw) => pascalToCamelCaseKeys(raw),
     );
-
-    const items = response.data?.value;
-    if (!items?.length) {
-      const folderHint =
-        validated.folderPath ? ` in folder '${validated.folderPath}'`
-        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
-        : '';
-      throw new NotFoundError({
-        message: `Bucket '${validated.name}' not found${folderHint}.`,
-      });
-    }
-
-    return pascalToCamelCaseKeys(items[0]) as BucketGetResponse;
   }
 
   /**

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -1,4 +1,4 @@
-import { BaseService } from '../../base';
+import { FolderScopedService } from '../../folder-scoped';
 import { CollectionResponse, RequestOptions } from '../../../models/common/types';
 import {
   ProcessGetResponse,
@@ -6,15 +6,14 @@ import {
   ProcessStartRequest,
   ProcessStartResponse,
   ProcessGetByIdOptions,
-  ProcessGetByNameOptions
+  ProcessGetByNameOptions,
+  ProcessStartOptions,
 } from '../../../models/orchestrator/processes.types';
 import { ProcessServiceModel } from '../../../models/orchestrator/processes.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
 import { ProcessMap } from '../../../models/orchestrator/processes.constants';
 import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../../../utils/constants/headers';
-import { NotFoundError } from '../../../core/errors';
-import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
 import { encodeFolderPathHeader } from '../../../utils/encoding/folder-path';
 import { PROCESS_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, ODATA_PAGINATION, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
@@ -26,17 +25,17 @@ import { track } from '../../../core/telemetry';
 /**
  * Service for interacting with UiPath Orchestrator Processes API
  */
-export class ProcessService extends BaseService implements ProcessServiceModel {
+export class ProcessService extends FolderScopedService implements ProcessServiceModel {
   /**
    * Gets all processes across folders with optional filtering and folder scoping
-   * 
+   *
    * The method returns either:
    * - An array of processes (when no pagination parameters are provided)
    * - A paginated result with navigation cursors (when any pagination parameter is provided)
-   * 
+   *
    * @param options - Query options including optional folderId
    * @returns Promise resolving to an array of processes or paginated result
-   * 
+   *
    * @example
    * ```typescript
    * import { Processes } from '@uipath/uipath-typescript/processes';
@@ -47,28 +46,7 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
    * const allProcesses = await processes.getAll();
    *
    * // Get processes within a specific folder
-   * const folderProcesses = await processes.getAll({
-   *   folderId: 123
-   * });
-   *
-   * // Get processes with filtering
-   * const filteredProcesses = await processes.getAll({
-   *   filter: "name eq 'MyProcess'"
-   * });
-   *
-   * // First page with pagination
-   * const page1 = await processes.getAll({ pageSize: 10 });
-   *
-   * // Navigate using cursor
-   * if (page1.hasNextPage) {
-   *   const page2 = await processes.getAll({ cursor: page1.nextCursor });
-   * }
-   *
-   * // Jump to specific page
-   * const page5 = await processes.getAll({
-   *   jumpToPage: 5,
-   *   pageSize: 10
-   * });
+   * const folderProcesses = await processes.getAll({ folderId: 123 });
    * ```
    */
   @track('Processes.GetAll')
@@ -79,8 +57,7 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
       ? PaginatedResponse<ProcessGetResponse>
       : NonPaginatedResponse<ProcessGetResponse>
   > {
-    // Transformation function for processes
-    const transformProcessResponse = (process: any) => 
+    const transformProcessResponse = (process: any) =>
       transformData(pascalToCamelCaseKeys(process) as ProcessGetResponse, ProcessMap);
 
     return PaginationHelpers.getAll({
@@ -93,107 +70,121 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
         itemsField: ODATA_PAGINATION.ITEMS_FIELD,
         totalCountField: ODATA_PAGINATION.TOTAL_COUNT_FIELD,
         paginationParams: {
-          pageSizeParam: ODATA_OFFSET_PARAMS.PAGE_SIZE_PARAM,      
-          offsetParam: ODATA_OFFSET_PARAMS.OFFSET_PARAM,           
-          countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM              
+          pageSizeParam: ODATA_OFFSET_PARAMS.PAGE_SIZE_PARAM,
+          offsetParam: ODATA_OFFSET_PARAMS.OFFSET_PARAM,
+          countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM
         }
       }
     }, options) as any;
   }
 
   /**
-   * Starts a process execution (job)
-   * 
+   * Starts a process execution (job).
+   *
+   * **Folder context** can be supplied three ways via the options object:
+   * `folderId` (numeric), `folderPath` (e.g. `'Shared/Finance'`), or `folderKey`
+   * (GUID). At least one is required. When more than one is supplied, the
+   * server prefers `folderPath` > `folderKey` > `folderId`.
+   *
+   * The legacy positional-`folderId` form (`start(request, 123, options?)`)
+   * remains supported for backward compatibility but is deprecated; prefer the
+   * options object.
+   *
    * @param request - Process start request body
-   * @param folderId - Required folder ID
-   * @param options - Optional query parameters
+   * @param optionsOrFolderId - Options object **or** legacy positional folder ID
+   * @param legacyOptions - Legacy options object (only used with positional folderId)
    * @returns Promise resolving to the created jobs
-   * 
+   *
    * @example
    * ```typescript
-   * import { Processes } from '@uipath/uipath-typescript/processes';
+   * // New (preferred) — options object
+   * const jobs = await processes.start(
+   *   { processName: 'MyProcess' },
+   *   { folderPath: 'Shared/Finance' },
+   * );
    *
-   * const processes = new Processes(sdk);
+   * // With folder key
+   * await processes.start({ processKey: '...' }, { folderKey: 'guid' });
    *
-   * // Start a process by process key
-   * const jobs = await processes.start({
-   *   processKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-   * }, 123); // folderId is required
-   *
-   * // Start a process by name with specific robots
-   * const jobs = await processes.start({
-   *   processName: "MyProcess"
-   * }, 123); // folderId is required
+   * // Legacy positional form (still works)
+   * await processes.start({ processName: 'MyProcess' }, 123);
    * ```
    */
   @track('Processes.Start')
-  async start(request: ProcessStartRequest, folderId: number, options: RequestOptions = {}): Promise<ProcessStartResponse[]> {
-    const headers = createHeaders({ [FOLDER_ID]: folderId });
+  async start(
+    request: ProcessStartRequest,
+    optionsOrFolderId?: ProcessStartOptions | number,
+    legacyOptions: RequestOptions = {},
+  ): Promise<ProcessStartResponse[]> {
+    // Normalize the two call shapes into a single options object.
+    const opts: ProcessStartOptions =
+      typeof optionsOrFolderId === 'number'
+        ? { folderId: optionsOrFolderId, ...legacyOptions }
+        : (optionsOrFolderId ?? {});
+
+    const { folderId, folderPath, folderKey, ...queryOptions } = opts;
+
+    // Fall back to init-time folderKey (e.g. uipath:folder-key meta tag) only
+    // when the caller supplied no folder context at all.
+    const effectiveFolderKey =
+      folderKey ?? (folderPath || folderId ? undefined : this.config.folderKey);
+
+    const headers = createHeaders({
+      [FOLDER_ID]: folderId,
+      [FOLDER_PATH_ENCODED]: folderPath ? encodeFolderPathHeader(folderPath) : undefined,
+      [FOLDER_KEY]: effectiveFolderKey,
+    });
 
     // Transform SDK field names to API field names (e.g., processKey → releaseKey)
     const apiRequest = transformRequest(request, ProcessMap);
+    const requestBody = { startInfo: apiRequest };
 
-    // Create the request object according to API spec
-    const requestBody = {
-      startInfo: apiRequest
-    };
+    const keysToPrefix = Object.keys(queryOptions);
+    const apiOptions = addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix);
 
-    // Prefix all query parameter keys with '$' for OData
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
     const response = await this.post<CollectionResponse<ProcessStartResponse>>(
       PROCESS_ENDPOINTS.START_PROCESS,
       requestBody,
-      { 
+      {
         params: apiOptions,
         headers
       }
     );
-    
-    const transformedProcess = response.data?.value.map(process => 
+
+    return response.data?.value.map(process =>
       transformData(pascalToCamelCaseKeys(process) as ProcessStartResponse, ProcessMap)
     );
-
-    return transformedProcess;
   }
 
   /**
    * Gets a single process by ID
-   * 
+   *
    * @param id - Process ID
    * @param folderId - Required folder ID
-   * @param options - Optional query parameters 
+   * @param options - Optional query parameters
    * @returns Promise resolving to a single process
-   * 
+   *
    * @example
    * ```typescript
-   * import { Processes } from '@uipath/uipath-typescript/processes';
-   *
-   * const processes = new Processes(sdk);
-   *
-   * // Get process by ID
    * const process = await processes.getById(123, 456);
    * ```
    */
   @track('Processes.GetById')
   async getById(id: number, folderId: number, options: ProcessGetByIdOptions = {}): Promise<ProcessGetResponse> {
     const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
+
     const keysToPrefix = Object.keys(options);
     const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
+
     const response = await this.get<ProcessGetResponse>(
       PROCESS_ENDPOINTS.GET_BY_ID(id),
-      { 
+      {
         headers,
         params: apiOptions
       }
     );
 
-    const transformedProcess = transformData(pascalToCamelCaseKeys(response.data) as ProcessGetResponse, ProcessMap);
-
-    return transformedProcess;
+    return transformData(pascalToCamelCaseKeys(response.data) as ProcessGetResponse, ProcessMap);
   }
 
   /**
@@ -205,59 +196,17 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
    *
    * @example
    * ```typescript
-   * import { Processes } from '@uipath/uipath-typescript/processes';
-   *
-   * const processes = new Processes(sdk);
-   *
-   * // Get process by name with folder path
    * const process = await processes.getByName('MyProcess', { folderPath: 'Shared/Finance' });
-   *
-   * // Get process by name with folder key
-   * const process = await processes.getByName('MyProcess', { folderKey: 'folder-guid' });
    * ```
    */
   @track('Processes.GetByName')
   async getByName(name: string, options: ProcessGetByNameOptions = {}): Promise<ProcessGetResponse> {
-    const { folderPath: rawFolderPath, folderKey: rawFolderKey, ...queryOptions } = options;
-    const validated = validateGetByNameArgs('Process', name, rawFolderPath, rawFolderKey);
-
-    // Fall back to the SDK's init-time folderKey (e.g. populated from the
-    // `uipath:folder-key` meta tag in coded-app deployments) when the
-    // caller didn't supply any folder context.
-    const effectiveFolderKey =
-      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
-
-    const headers = createHeaders({
-      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeFolderPathHeader(validated.folderPath) : undefined,
-      [FOLDER_KEY]: effectiveFolderKey,
-    });
-
-    const keysToPrefix = Object.keys(queryOptions);
-    const apiOptions = {
-      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix),
-      '$filter': `Name eq '${validated.name.replace(/'/g, "''")}'`,
-      '$top': '1',
-    };
-
-    const response = await this.get<CollectionResponse<ProcessGetResponse>>(
+    return this.getByNameLookup<ProcessGetResponse, ProcessGetResponse>(
+      'Process',
       PROCESS_ENDPOINTS.GET_ALL,
-      {
-        headers,
-        params: apiOptions,
-      },
+      name,
+      options,
+      (raw) => transformData(pascalToCamelCaseKeys(raw), ProcessMap),
     );
-
-    const items = response.data?.value;
-    if (!items?.length) {
-      const folderHint =
-        validated.folderPath ? ` in folder '${validated.folderPath}'`
-        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
-        : '';
-      throw new NotFoundError({
-        message: `Process '${validated.name}' not found${folderHint}.`,
-      });
-    }
-
-    return transformData(pascalToCamelCaseKeys(items[0]) as ProcessGetResponse, ProcessMap);
   }
 }

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -15,6 +15,7 @@ import { ProcessMap } from '../../../models/orchestrator/processes.constants';
 import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../../../utils/constants/headers';
 import { NotFoundError } from '../../../core/errors';
 import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
+import { encodeFolderPathHeader } from '../../../utils/encoding/folder-path';
 import { PROCESS_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, ODATA_PAGINATION, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
@@ -227,7 +228,7 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
       validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
 
     const headers = createHeaders({
-      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeURIComponent(validated.folderPath) : undefined,
+      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeFolderPathHeader(validated.folderPath) : undefined,
       [FOLDER_KEY]: effectiveFolderKey,
     });
 

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -5,13 +5,16 @@ import {
   ProcessGetAllOptions,
   ProcessStartRequest,
   ProcessStartResponse,
-  ProcessGetByIdOptions
+  ProcessGetByIdOptions,
+  ProcessGetByNameOptions
 } from '../../../models/orchestrator/processes.types';
 import { ProcessServiceModel } from '../../../models/orchestrator/processes.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
 import { ProcessMap } from '../../../models/orchestrator/processes.constants';
-import { FOLDER_ID } from '../../../utils/constants/headers';
+import { FOLDER_ID, FOLDER_PATH_ENCODED, FOLDER_KEY } from '../../../utils/constants/headers';
+import { NotFoundError } from '../../../core/errors';
+import { validateGetByNameArgs } from '../../../utils/validation/name-validator';
 import { PROCESS_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, ODATA_PAGINATION, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
@@ -188,7 +191,72 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
     );
 
     const transformedProcess = transformData(pascalToCamelCaseKeys(response.data) as ProcessGetResponse, ProcessMap);
-    
+
     return transformedProcess;
+  }
+
+  /**
+   * Retrieves a single process by name, optionally scoped to a folder
+   *
+   * @param name - Process name to search for
+   * @param options - Optional folder scoping and query parameters
+   * @returns Promise resolving to a single process
+   *
+   * @example
+   * ```typescript
+   * import { Processes } from '@uipath/uipath-typescript/processes';
+   *
+   * const processes = new Processes(sdk);
+   *
+   * // Get process by name with folder path
+   * const process = await processes.getByName('MyProcess', { folderPath: 'Shared/Finance' });
+   *
+   * // Get process by name with folder key
+   * const process = await processes.getByName('MyProcess', { folderKey: 'folder-guid' });
+   * ```
+   */
+  @track('Processes.GetByName')
+  async getByName(name: string, options: ProcessGetByNameOptions = {}): Promise<ProcessGetResponse> {
+    const { folderPath: rawFolderPath, folderKey: rawFolderKey, ...queryOptions } = options;
+    const validated = validateGetByNameArgs('Process', name, rawFolderPath, rawFolderKey);
+
+    // Fall back to the SDK's init-time folderKey (e.g. populated from the
+    // `uipath:folder-key` meta tag in coded-app deployments) when the
+    // caller didn't supply any folder context.
+    const effectiveFolderKey =
+      validated.folderKey ?? (validated.folderPath ? undefined : this.config.folderKey);
+
+    const headers = createHeaders({
+      [FOLDER_PATH_ENCODED]: validated.folderPath ? encodeURIComponent(validated.folderPath) : undefined,
+      [FOLDER_KEY]: effectiveFolderKey,
+    });
+
+    const keysToPrefix = Object.keys(queryOptions);
+    const apiOptions = {
+      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix),
+      '$filter': `Name eq '${validated.name.replace(/'/g, "''")}'`,
+      '$top': '1',
+    };
+
+    const response = await this.get<CollectionResponse<ProcessGetResponse>>(
+      PROCESS_ENDPOINTS.GET_ALL,
+      {
+        headers,
+        params: apiOptions,
+      },
+    );
+
+    const items = response.data?.value;
+    if (!items?.length) {
+      const folderHint =
+        validated.folderPath ? ` in folder '${validated.folderPath}'`
+        : effectiveFolderKey ? ` in folder (key: ${effectiveFolderKey})`
+        : '';
+      throw new NotFoundError({
+        message: `Process '${validated.name}' not found${folderHint}.`,
+      });
+    }
+
+    return transformData(pascalToCamelCaseKeys(items[0]) as ProcessGetResponse, ProcessMap);
   }
 }

--- a/src/utils/constants/headers.ts
+++ b/src/utils/constants/headers.ts
@@ -1,5 +1,5 @@
 export const  FOLDER_KEY = 'X-UIPATH-FolderKey';
-export const  FOLDER_PATH = 'X-UIPATH-FolderPath';
+export const  FOLDER_PATH_ENCODED = 'X-UIPATH-FolderPath-Encoded';
 export const  USER_AGENT = 'X-UIPATH-UserAgent';
 export const  TENANT_ID = 'X-UIPATH-Internal-TenantId';
 export const  ACCOUNT_ID = 'X-UIPATH-Internal-AccountId';

--- a/src/utils/encoding/folder-path.ts
+++ b/src/utils/encoding/folder-path.ts
@@ -1,0 +1,24 @@
+/**
+ * Encodes a folder path for the `X-UIPATH-FolderPath-Encoded` header.
+ *
+ * Orchestrator decodes this header as **base64-encoded UTF-16 LE bytes**
+ * (see `HttpHeadersProviderExtensions.GetDecoded` + `OrganizationUnitProvider`
+ * in the Orchestrator repo). URL-encoding is NOT what OR expects — it must be
+ * base64-of-UTF-16-LE bytes, matching `Encoding.Unicode.GetString(...)`.
+ *
+ * @param folderPath - The folder path (e.g. 'Shared/Finance')
+ * @returns Base64 string suitable for the `X-UIPATH-FolderPath-Encoded` header
+ */
+export function encodeFolderPathHeader(folderPath: string): string {
+  const utf16 = new Uint16Array(folderPath.length);
+  for (let i = 0; i < folderPath.length; i++) {
+    utf16[i] = folderPath.charCodeAt(i);
+  }
+  const bytes = new Uint8Array(utf16.buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  // btoa is browser-native; Node 16+ also has it as a global
+  return btoa(binary);
+}

--- a/src/utils/runtime/constants.ts
+++ b/src/utils/runtime/constants.ts
@@ -16,4 +16,7 @@ export enum UiPathMetaTags {
   // Asset resolution and routing
   CDN_BASE = 'uipath:cdn-base',
   APP_BASE = 'uipath:app-base',
+
+  // Folder context (injected by jamjam when deploying coded apps)
+  FOLDER_KEY = 'uipath:folder-key',
 }

--- a/src/utils/validation/name-validator.ts
+++ b/src/utils/validation/name-validator.ts
@@ -1,0 +1,57 @@
+import { ValidationError } from '../../core/errors';
+
+export interface ValidatedGetByNameArgs {
+  name: string;
+  folderPath?: string;
+  folderKey?: string;
+}
+
+/**
+ * Validates arguments passed to a `getByName(name, { folderPath?, folderKey? })`
+ * method. Catches bad input at the SDK boundary instead of failing
+ * mid-request with an opaque server error.
+ *
+ * Checks:
+ * - `name` is a non-empty string (trimmed)
+ * - `folderPath` / `folderKey` are strings if provided; empty strings are
+ *   normalized to `undefined` so callers don't have to guard themselves
+ *
+ * @param resourceType - Resource label used in error messages (e.g. 'Asset',
+ *                       'Process'). Keeps errors contextual for the caller.
+ * @throws ValidationError when any argument fails validation
+ * @returns Trimmed, type-checked copies of the inputs ready to be passed to HTTP layers
+ */
+export function validateGetByNameArgs(
+  resourceType: string,
+  name: unknown,
+  folderPath?: unknown,
+  folderKey?: unknown,
+): ValidatedGetByNameArgs {
+  if (typeof name !== 'string') {
+    throw new ValidationError({
+      message: `${resourceType} name must be a string, received ${name === null ? 'null' : typeof name}.`,
+    });
+  }
+  const trimmedName = name.trim();
+  if (!trimmedName) {
+    throw new ValidationError({
+      message: `${resourceType} name is required and cannot be empty.`,
+    });
+  }
+
+  const trimmedPath = validateOptionalString('folderPath', folderPath);
+  const trimmedKey = validateOptionalString('folderKey', folderKey);
+
+  return { name: trimmedName, folderPath: trimmedPath, folderKey: trimmedKey };
+}
+
+function validateOptionalString(fieldName: string, value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new ValidationError({
+      message: `${fieldName} must be a string, received ${typeof value}.`,
+    });
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}


### PR DESCRIPTION
## Summary

Prerequisite SDK work for the coded-apps bindings/overwrites initiative (PLT-92768 / PLT-93599). Adds name-based resource lookup for two Orchestrator services and wires the folder-context plumbing that the runtime overwrite flow depends on.

- **`assets.getByName(name, { folderPath?, folderKey? })`** — OData `$filter=Name eq '…'` + `$top=1` on the folder-scoped endpoint.
- **`processes.getByName(name, { folderPath?, folderKey? })`** — same shape against `/odata/Releases`.
- **`X-UIPATH-FolderPath-Encoded`** replaces the raw `X-UIPATH-FolderPath` header (OR team's recommendation; URL-encoded transport is safer for special characters in paths). Both `folderPath` and `folderKey` are accepted simultaneously — OR's middleware prefers `folderPath`.
- **Init-time folder context via meta tags**. The SDK now reads `<meta name="uipath:folder-key">` (auto-injected by jamjam on coded-app deployments) and uses it as the default folder context when the caller doesn't pass one. Resolution chain: call-site args > `new UiPath({ folderKey })` > meta tag > no folder header.
- **Input validation + better not-found errors**. New `utils/validation/name-validator.ts` throws `ValidationError` with descriptive messages for non-string names, empty names, and non-string folder fields — the guard TS types can't enforce for JS callers. Not-found errors now include the folder context (path or key) to make debugging easier


## Usage

```typescript
import { Assets } from '@uipath/uipath-typescript/assets';
import { Processes } from '@uipath/uipath-typescript/processes';

const assets = new Assets(sdk);
const processes = new Processes(sdk);

// Call-site wins
const a = await assets.getByName('ApiKey', { folderPath: 'Shared/Finance' });
const b = await assets.getByName('ApiKey', { folderKey: 'bc2d…' });

// Folder resolved from <meta name="uipath:folder-key"> 
const c = await assets.getByName('ApiKey');

// Same semantics for processes
const p = await processes.getByName('MyProcess', { folderPath: 'Shared/Finance' });
```

## Not-done / follow-ups

- Unit + integration tests for `getByName` (this PR is a draft for visual verification first)
- `docs/oauth-scopes.md` update
- Same `getByName` on Buckets / Queues — tracked separately


https://github.com/user-attachments/assets/1a1b04f3-8e32-4ab1-9e11-6376d997cf4e

