### PR TITLE
feat(orchestrator): getByName for Assets + Processes, encoded folder header, meta-tag fallback [PLT-92768][PLT-92817][PLT-92813]

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,6 +51,8 @@ jobs:
           echo "tenant_name=${{ secrets.UIPATH_TENANT_NAME_DEV || secrets.UIPATH_TENANT_NAME }}" >> $GITHUB_OUTPUT
           echo "secret=${{ secrets.UIPATH_SECRET_DEV || secrets.UIPATH_SECRET }}" >> $GITHUB_OUTPUT
           echo "integration_test_folder_id=${{ secrets.UIPATH_INTEGRATION_TEST_FOLDER_DEV || secrets.UIPATH_INTEGRATION_TEST_FOLDER }}" >> $GITHUB_OUTPUT
+          echo "integration_test_folder_key=${{ secrets.UIPATH_INTEGRATION_TEST_FOLDER_KEY_DEV || secrets.UIPATH_INTEGRATION_TEST_FOLDER_KEY }}" >> $GITHUB_OUTPUT
+          echo "integration_test_folder_path=${{ secrets.UIPATH_INTEGRATION_TEST_FOLDER_PATH_DEV || secrets.UIPATH_INTEGRATION_TEST_FOLDER_PATH }}" >> $GITHUB_OUTPUT
           echo "orchestrator_test_process_key=${{ secrets.UIPATH_INTEGRATION_TEST_PROCESS_KEY_DEV || secrets.UIPATH_INTEGRATION_TEST_PROCESS_KEY }}" >> $GITHUB_OUTPUT
           echo "data_fabric_test_entity_id=${{ secrets.UIPATH_DATA_FABRIC_TEST_ENTITY_ID_DEV || secrets.UIPATH_DATA_FABRIC_TEST_ENTITY_ID }}" >> $GITHUB_OUTPUT
           echo "data_fabric_test_choiceset_id=${{ secrets.UIPATH_DATA_FABRIC_TEST_CHOICESET_ID_DEV || secrets.UIPATH_DATA_FABRIC_TEST_CHOICESET_ID }}" >> $GITHUB_OUTPUT
@@ -71,6 +73,8 @@ jobs:
           INTEGRATION_TEST_TIMEOUT=30000
           INTEGRATION_TEST_SKIP_CLEANUP=false
           INTEGRATION_TEST_FOLDER_ID=${{ steps.config.outputs.integration_test_folder_id }}
+          INTEGRATION_TEST_FOLDER_KEY=${{ steps.config.outputs.integration_test_folder_key }}
+          INTEGRATION_TEST_FOLDER_PATH=${{ steps.config.outputs.integration_test_folder_path }}
           DATA_FABRIC_TEST_ENTITY_ID=${{ steps.config.outputs.data_fabric_test_entity_id }}
           DATA_FABRIC_TEST_CHOICESET_ID=${{ steps.config.outputs.data_fabric_test_choiceset_id }}
           DATA_FABRIC_TEST_ATTACHMENT_FIELD=${{ steps.config.outputs.data_fabric_test_attachment_field }}

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -8,6 +8,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `OR.Assets` or `OR.Assets.Read` |
 | `getById()` | `OR.Assets` or `OR.Assets.Read` |
+| `getByName()` | `OR.Assets` or `OR.Assets.Read` |
 
 ## Jobs
 
@@ -161,6 +162,7 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 |--------|-------------|
 | `getAll()` | `OR.Execution` or `OR.Execution.Read` |
 | `getById()` | `OR.Execution` or `OR.Execution.Read` |
+| `getByName()` | `OR.Execution` or `OR.Execution.Read` |
 | `start()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ## Queues

--- a/src/core/config/runtime.ts
+++ b/src/core/config/runtime.ts
@@ -3,6 +3,13 @@ import { UiPathMetaTags } from '../../utils/runtime/constants';
 import { isBrowser } from '../../utils/platform';
 
 /**
+ * Meta-tag-derived config. Extends {@link PartialUiPathConfig} with
+ * `folderKey`, which is sourced only from `<meta name="uipath:folder-key">`
+ * (not accepted via the public SDK constructor).
+ */
+export type MetaTagConfig = PartialUiPathConfig & { folderKey?: string };
+
+/**
  * Get the content of a meta tag by name.
  * Returns undefined if not in browser environment or meta tag is not found.
  */
@@ -18,16 +25,17 @@ export function getMetaTagContent(name: string): string | undefined {
  *
  * Returns partial config with values found, or null if no meta tags present.
  */
-export function loadFromMetaTags(): PartialUiPathConfig | null {
+export function loadFromMetaTags(): MetaTagConfig | null {
   if (!isBrowser) return null;
 
-  const config: PartialUiPathConfig = {
+  const config: MetaTagConfig = {
     clientId: getMetaTagContent(UiPathMetaTags.CLIENT_ID),
     scope: getMetaTagContent(UiPathMetaTags.SCOPE),
     orgName: getMetaTagContent(UiPathMetaTags.ORG_NAME),
     tenantName: getMetaTagContent(UiPathMetaTags.TENANT_NAME),
     baseUrl: getMetaTagContent(UiPathMetaTags.BASE_URL),
     redirectUri: getMetaTagContent(UiPathMetaTags.REDIRECT_URI),
+    folderKey: getMetaTagContent(UiPathMetaTags.FOLDER_KEY),
   };
 
   const hasAnyValue = Object.values(config).some(Boolean);

--- a/src/core/internals/types.ts
+++ b/src/core/internals/types.ts
@@ -18,4 +18,11 @@ export interface PrivateSDK {
   context: ExecutionContext;
   /** Token manager for authentication */
   tokenManager: TokenManager;
+  /**
+   * Default folder key (GUID), sourced only from `<meta name="uipath:folder-key">`
+   * (injected during coded-app deployment). Used by folder-scoped services
+   * as a fallback when the caller doesn't supply folder context.
+   * Not user-settable via the SDK constructor.
+   */
+  folderKey?: string;
 }

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -48,6 +48,10 @@ export class UiPath implements IUiPath {
   #initialized: boolean = false;
   #partialConfig?: PartialUiPathConfig;
   #multiLogin: boolean = false;
+  // Folder key sourced only from `<meta name="uipath:folder-key">` (coded-app
+  // deployments). Not accepted via the public constructor; lives here so the
+  // SDK can flow it through to BaseService.config without polluting BaseConfig.
+  #metaFolderKey?: string;
 
   /** Read-only config for user convenience */
   public readonly config!: Readonly<BaseConfig>;
@@ -55,6 +59,7 @@ export class UiPath implements IUiPath {
   constructor(config?: PartialUiPathConfig) {
     // Load configuration from meta tags
     const configFromMetaTags = loadFromMetaTags();
+    this.#metaFolderKey = configFromMetaTags?.folderKey;
 
     // Merge configuration: constructor config overrides meta tags
     const mergedConfig = config ? { ...configFromMetaTags, ...config } : configFromMetaTags;
@@ -81,7 +86,7 @@ export class UiPath implements IUiPath {
       secret: hasSecretAuth ? config.secret : undefined,
       clientId: hasOAuthAuth ? config.clientId : undefined,
       redirectUri: hasOAuthAuth ? config.redirectUri : undefined,
-      scope: hasOAuthAuth ? config.scope : undefined
+      scope: hasOAuthAuth ? config.scope : undefined,
     });
 
     const executionContext = new ExecutionContext();
@@ -91,11 +96,14 @@ export class UiPath implements IUiPath {
     }
     this.#config = internalConfig;
 
-    // Store internals in SDKInternalsRegistry (not visible on instance)
+    // Store internals in SDKInternalsRegistry (not visible on instance).
+    // `folderKey` is meta-tag-only — kept off `UiPathConfig` (which mirrors
+    // user-passed values) and lives here on the runtime registry instead.
     SDKInternalsRegistry.set(this, {
       config: internalConfig,
       context: executionContext,
-      tokenManager: this.#authService.getTokenManager()
+      tokenManager: this.#authService.getTokenManager(),
+      folderKey: this.#metaFolderKey,
     });
 
     // Expose read-only config for user convenience
@@ -129,6 +137,7 @@ export class UiPath implements IUiPath {
   #loadConfig(): UiPathSDKConfig {
     // Load from meta tags
     const metaConfig = loadFromMetaTags();
+    this.#metaFolderKey = metaConfig?.folderKey;
 
     // Merge with any partial config from constructor (constructor overrides meta tags)
     const merged = { ...metaConfig, ...this.#partialConfig };

--- a/src/models/common/types.ts
+++ b/src/models/common/types.ts
@@ -45,3 +45,18 @@ export interface RequestOptions extends BaseOptions {
   filter?: string;
   orderby?: string;
 }
+
+/**
+ * Options that scope a name-based lookup (e.g. `getByName`) to a folder.
+ * Provide one of `folderId`, `folderKey`, or `folderPath`. When more than
+ * one is supplied, all are forwarded; the server applies precedence
+ * `folderPath` > `folderKey` > `folderId`.
+ */
+export interface FolderScopedOptions extends BaseOptions {
+  /** Numeric folder ID. */
+  folderId?: number;
+  /** Folder key (GUID-formatted string). */
+  folderKey?: string;
+  /** Slash-delimited folder path, e.g. `'Shared/Finance'`. */
+  folderPath?: string;
+}

--- a/src/models/orchestrator/assets.models.ts
+++ b/src/models/orchestrator/assets.models.ts
@@ -1,4 +1,4 @@
-import { AssetGetAllOptions, AssetGetResponse, AssetGetByIdOptions } from './assets.types';
+import { AssetGetAllOptions, AssetGetResponse, AssetGetByIdOptions, AssetGetByNameOptions } from './assets.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -66,4 +66,28 @@ export interface AssetServiceModel {
    * ```
    */
   getById(id: number, folderId: number, options?: AssetGetByIdOptions): Promise<AssetGetResponse>;
-} 
+
+  /**
+   * Retrieves a single asset by name.
+   *
+   * @param name - Asset name to search for
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional query parameters (`expand`, `select`)
+   * @returns Promise resolving to a single asset
+   * {@link AssetGetResponse}
+   * @example
+   * ```typescript
+   * // By folder ID
+   * await assets.getByName('ApiKey', { folderId: 123 });
+   *
+   * // By folder key (GUID)
+   * await assets.getByName('ApiKey', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await assets.getByName('ApiKey', { folderPath: 'Shared/Finance' });
+   *
+   * // With expand
+   * await assets.getByName('ApiKey', { folderPath: 'Shared/Finance', expand: 'keyValueList' });
+   * ```
+   */
+  getByName(name: string, options?: AssetGetByNameOptions): Promise<AssetGetResponse>;
+}

--- a/src/models/orchestrator/assets.types.ts
+++ b/src/models/orchestrator/assets.types.ts
@@ -1,4 +1,4 @@
-import { BaseOptions, RequestOptions } from '../common/types';
+import { BaseOptions, FolderScopedOptions, RequestOptions } from '../common/types';
 import { PaginationOptions } from '../../utils/pagination';
 
 /**
@@ -68,3 +68,8 @@ export type AssetGetAllOptions = RequestOptions & PaginationOptions & {
  * Options for getting a single asset by ID
  */
 export interface AssetGetByIdOptions extends BaseOptions {}
+
+/**
+ * Options for getting a single asset by name
+ */
+export interface AssetGetByNameOptions extends FolderScopedOptions {}

--- a/src/models/orchestrator/processes.models.ts
+++ b/src/models/orchestrator/processes.models.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from '../common/types';
-import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions } from './processes.types';
+import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions, ProcessGetByNameOptions } from './processes.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -78,10 +78,34 @@ export interface ProcessServiceModel {
    * ```
    */
   getById(id: number, folderId: number, options?: ProcessGetByIdOptions): Promise<ProcessGetResponse>;
-  
+
+  /**
+   * Retrieves a single process by name.
+   *
+   * @param name - Process name to search for
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional query parameters (`expand`, `select`)
+   * @returns Promise resolving to a single process
+   * {@link ProcessGetResponse}
+   * @example
+   * ```typescript
+   * // By folder ID
+   * await processes.getByName('MyProcess', { folderId: 123 });
+   *
+   * // By folder key (GUID)
+   * await processes.getByName('MyProcess', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await processes.getByName('MyProcess', { folderPath: 'Shared/Finance' });
+   *
+   * // With expand
+   * await processes.getByName('MyProcess', { folderPath: 'Shared/Finance', expand: 'entryPoints' });
+   * ```
+   */
+  getByName(name: string, options?: ProcessGetByNameOptions): Promise<ProcessGetResponse>;
+
   /**
    * Starts a process with the specified configuration
-   * 
+   *
    * @param request - Process start configuration
    * @param folderId - Required folder ID
    * @param options - Optional request options
@@ -101,4 +125,4 @@ export interface ProcessServiceModel {
    * ```
    */
   start(request: ProcessStartRequest, folderId: number, options?: RequestOptions): Promise<ProcessStartResponse[]>;
-} 
+}

--- a/src/models/orchestrator/processes.types.ts
+++ b/src/models/orchestrator/processes.types.ts
@@ -1,4 +1,4 @@
-import { JobState, RequestOptions, BaseOptions } from '../common/types';
+import { JobState, RequestOptions, BaseOptions, FolderScopedOptions } from '../common/types';
 import { PaginationOptions } from '../../utils/pagination';
 
 /**
@@ -380,3 +380,9 @@ export type ProcessGetAllOptions = RequestOptions & PaginationOptions & {
  * Options for getting a single process by ID
  */
 export interface ProcessGetByIdOptions extends BaseOptions {}
+
+/**
+ * Options for getting a single process by name
+ */
+export interface ProcessGetByNameOptions extends FolderScopedOptions {}
+

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -40,6 +40,12 @@ export class BaseService {
   #apiClient: ApiClient;
 
   /**
+   * SDK configuration (read-only). Available to subclasses so they can
+   * fall back to init-time defaults like `folderKey`.
+   */
+  protected readonly config: { folderKey?: string };
+
+  /**
    * Creates a base service instance with dependency injection.
    *
    * Extracts configuration, execution context, and token manager from the UiPath instance
@@ -70,8 +76,9 @@ export class BaseService {
    * ```
    */
   constructor(instance: IUiPath, headers?: Record<string, string>) {
-    const { config, context, tokenManager } = SDKInternalsRegistry.get(instance);
+    const { config, context, tokenManager, folderKey } = SDKInternalsRegistry.get(instance);
     this.#apiClient = new ApiClient(config, context, tokenManager, headers ? { headers } : {});
+    this.config = { folderKey };
   }
 
   /**

--- a/src/services/folder-scoped.ts
+++ b/src/services/folder-scoped.ts
@@ -1,9 +1,18 @@
 import { BaseService } from './base';
-import { CollectionResponse } from '../models/common/types';
+import { CollectionResponse, FolderScopedOptions } from '../models/common/types';
 import { createHeaders } from '../utils/http/headers';
 import { FOLDER_ID } from '../utils/constants/headers';
 import { ODATA_PREFIX } from '../utils/constants/common';
 import { addPrefixToKeys } from '../utils/transform';
+import { NotFoundError } from '../core/errors';
+import { validateName } from '../utils/validation/name-validator';
+import { resolveFolderHeaders } from '../utils/folder/folder-headers';
+
+/**
+ * Matches single-quote characters in OData string literals — escaped to `''`
+ * inside the `$filter=Name eq '…'` clause built by `getByNameLookup`.
+ */
+const SINGLE_QUOTE_RE = /'/g;
 
 /**
  * Base service for services that need folder-specific functionality.
@@ -18,7 +27,7 @@ import { addPrefixToKeys } from '../utils/transform';
 export class FolderScopedService extends BaseService {
   /**
    * Gets resources in a folder with optional query parameters
-   * 
+   *
    * @param endpoint - API endpoint to call
    * @param folderId - required folder ID
    * @param options - Query options
@@ -26,8 +35,8 @@ export class FolderScopedService extends BaseService {
    * @returns Promise resolving to an array of resources
    */
   protected async _getByFolder<T, R = T>(
-    endpoint: string, 
-    folderId: number, 
+    endpoint: string,
+    folderId: number,
     options: Record<string, any> = {},
     transformFn?: (item: T) => R
   ): Promise<R[]> {
@@ -35,10 +44,10 @@ export class FolderScopedService extends BaseService {
 
     const keysToPrefix = Object.keys(options);
     const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
+
     const response = await this.get<CollectionResponse<T>>(
       endpoint,
-      { 
+      {
         params: apiOptions,
         headers
       }
@@ -47,7 +56,83 @@ export class FolderScopedService extends BaseService {
     if (transformFn) {
       return response.data?.value.map(transformFn);
     }
-    
+
     return response.data?.value as unknown as R[];
   }
-} 
+
+  /**
+   * Look up a single resource by name on a folder-scoped OData collection.
+   *
+   * Shared by `getByName` implementations across services (Assets, Processes, etc).
+   * Handles:
+   * - Name validation via `validateName`
+   * - Folder header resolution via `resolveFolderHeaders` (folderId → ID/key
+   *   header by type, folderPath → encoded path header, falls back to
+   *   init-time `config.folderKey` from the `uipath:folder-key` meta tag)
+   * - OData `$filter=Name eq '…'` with single-quote escaping + `$top=1`
+   * - Empty-result → `NotFoundError` with folder context in the message
+   *
+   * The transform step is caller-provided because each resource has its own
+   * PascalCase → camelCase field mapping.
+   *
+   * @param resourceType - Resource label used in validation + error messages (e.g. 'Asset', 'Process')
+   * @param endpoint - Folder-scoped OData collection endpoint
+   * @param name - Resource name to search for
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) + OData query options (`expand`, `select`)
+   * @param transform - Maps a raw OData item to the typed response (e.g. PascalCase → camelCase via field map)
+   * @throws ValidationError when inputs are malformed; NotFoundError when no match
+   */
+  protected async getByNameLookup<TRaw extends object, T>(
+    resourceType: string,
+    endpoint: string,
+    name: string,
+    options: FolderScopedOptions,
+    transform: (raw: TRaw) => T,
+  ): Promise<T> {
+    const validatedName = validateName(resourceType, name);
+    const { folderId, folderKey, folderPath, ...queryOptions } = options;
+
+    const headers = resolveFolderHeaders({
+      folderId,
+      folderKey,
+      folderPath,
+      resourceType: `${resourceType}.getByName`,
+      fallbackFolderKey: this.config.folderKey,
+    });
+
+    const apiOptions = {
+      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, Object.keys(queryOptions)),
+      '$filter': `Name eq '${validatedName.replace(SINGLE_QUOTE_RE, "''")}'`,
+      '$top': '1',
+    };
+
+    const response = await this.get<CollectionResponse<TRaw>>(endpoint, {
+      headers,
+      params: apiOptions,
+    });
+
+    const items = response.data?.value;
+    if (!items?.length) {
+      const folderHint = describeFolderForError(folderId, folderKey, folderPath);
+      throw new NotFoundError({
+        message: `${resourceType} '${validatedName}' not found${folderHint}.`,
+      });
+    }
+
+    return transform(items[0]);
+  }
+}
+
+/** Renders the supplied folder for a NotFoundError message. */
+function describeFolderForError(
+  folderId: number | undefined,
+  folderKey: string | undefined,
+  folderPath: string | undefined,
+): string {
+  const path = folderPath?.trim();
+  if (path) return ` in folder '${path}'`;
+  const key = folderKey?.trim();
+  if (key) return ` in folder (key: ${key})`;
+  if (typeof folderId === 'number') return ` in folder (id: ${folderId})`;
+  return '';
+}

--- a/src/services/orchestrator/assets/assets.ts
+++ b/src/services/orchestrator/assets/assets.ts
@@ -1,5 +1,5 @@
 import { FolderScopedService } from '../../folder-scoped';
-import { AssetGetResponse, AssetGetAllOptions, AssetGetByIdOptions } from '../../../models/orchestrator/assets.types';
+import { AssetGetResponse, AssetGetAllOptions, AssetGetByIdOptions, AssetGetByNameOptions } from '../../../models/orchestrator/assets.types';
 import { AssetServiceModel } from '../../../models/orchestrator/assets.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
@@ -115,7 +115,44 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
     );
 
     const transformedAsset = transformData(pascalToCamelCaseKeys(response.data) as AssetGetResponse, AssetMap);
-    
+
     return transformedAsset;
+  }
+
+  /**
+   * Retrieves a single asset by name.
+   *
+   * @param name - Asset name to search for
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional query parameters (`expand`, `select`)
+   * @returns Promise resolving to a single asset
+   * {@link AssetGetResponse}
+   * @example
+   * ```typescript
+   * import { Assets } from '@uipath/uipath-typescript/assets';
+   *
+   * const assets = new Assets(sdk);
+   *
+   * // By folder ID
+   * await assets.getByName('ApiKey', { folderId: 123 });
+   *
+   * // By folder key (GUID)
+   * await assets.getByName('ApiKey', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await assets.getByName('ApiKey', { folderPath: 'Shared/Finance' });
+   *
+   * // With expand
+   * await assets.getByName('ApiKey', { folderPath: 'Shared/Finance', expand: 'keyValueList' });
+   * ```
+   */
+  @track('Assets.GetByName')
+  async getByName(name: string, options: AssetGetByNameOptions = {}): Promise<AssetGetResponse> {
+    return this.getByNameLookup<AssetGetResponse, AssetGetResponse>(
+      'Asset',
+      ASSET_ENDPOINTS.GET_BY_FOLDER,
+      name,
+      options,
+      (raw) => transformData(pascalToCamelCaseKeys(raw), AssetMap),
+    );
   }
 }

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -1,11 +1,12 @@
-import { BaseService } from '../../base';
+import { FolderScopedService } from '../../folder-scoped';
 import { CollectionResponse, RequestOptions } from '../../../models/common/types';
 import {
   ProcessGetResponse,
   ProcessGetAllOptions,
   ProcessStartRequest,
   ProcessStartResponse,
-  ProcessGetByIdOptions
+  ProcessGetByIdOptions,
+  ProcessGetByNameOptions,
 } from '../../../models/orchestrator/processes.types';
 import { ProcessServiceModel } from '../../../models/orchestrator/processes.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest } from '../../../utils/transform';
@@ -22,7 +23,7 @@ import { track } from '../../../core/telemetry';
 /**
  * Service for interacting with UiPath Orchestrator Processes API
  */
-export class ProcessService extends BaseService implements ProcessServiceModel {
+export class ProcessService extends FolderScopedService implements ProcessServiceModel {
   /**
    * Gets all processes across folders with optional filtering and folder scoping
    * 
@@ -99,12 +100,12 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
 
   /**
    * Starts a process execution (job)
-   * 
+   *
    * @param request - Process start request body
    * @param folderId - Required folder ID
    * @param options - Optional query parameters
    * @returns Promise resolving to the created jobs
-   * 
+   *
    * @example
    * ```typescript
    * import { Processes } from '@uipath/uipath-typescript/processes';
@@ -137,17 +138,17 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
     // Prefix all query parameter keys with '$' for OData
     const keysToPrefix = Object.keys(options);
     const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
+
     const response = await this.post<CollectionResponse<ProcessStartResponse>>(
       PROCESS_ENDPOINTS.START_PROCESS,
       requestBody,
-      { 
+      {
         params: apiOptions,
         headers
       }
     );
-    
-    const transformedProcess = response.data?.value.map(process => 
+
+    const transformedProcess = response.data?.value.map(process =>
       transformData(pascalToCamelCaseKeys(process) as ProcessStartResponse, ProcessMap)
     );
 
@@ -188,7 +189,44 @@ export class ProcessService extends BaseService implements ProcessServiceModel {
     );
 
     const transformedProcess = transformData(pascalToCamelCaseKeys(response.data) as ProcessGetResponse, ProcessMap);
-    
+
     return transformedProcess;
+  }
+
+  /**
+   * Retrieves a single process by name.
+   *
+   * @param name - Process name to search for
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional query parameters (`expand`, `select`)
+   * @returns Promise resolving to a single process
+   * {@link ProcessGetResponse}
+   * @example
+   * ```typescript
+   * import { Processes } from '@uipath/uipath-typescript/processes';
+   *
+   * const processes = new Processes(sdk);
+   *
+   * // By folder ID
+   * await processes.getByName('MyProcess', { folderId: 123 });
+   *
+   * // By folder key (GUID)
+   * await processes.getByName('MyProcess', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await processes.getByName('MyProcess', { folderPath: 'Shared/Finance' });
+   *
+   * // With expand
+   * await processes.getByName('MyProcess', { folderPath: 'Shared/Finance', expand: 'entryPoints' });
+   * ```
+   */
+  @track('Processes.GetByName')
+  async getByName(name: string, options: ProcessGetByNameOptions = {}): Promise<ProcessGetResponse> {
+    return this.getByNameLookup<ProcessGetResponse, ProcessGetResponse>(
+      'Process',
+      PROCESS_ENDPOINTS.GET_ALL,
+      name,
+      options,
+      (raw) => transformData(pascalToCamelCaseKeys(raw), ProcessMap),
+    );
   }
 }

--- a/src/utils/constants/headers.ts
+++ b/src/utils/constants/headers.ts
@@ -1,5 +1,5 @@
 export const  FOLDER_KEY = 'X-UIPATH-FolderKey';
-export const  FOLDER_PATH = 'X-UIPATH-FolderPath';
+export const  FOLDER_PATH_ENCODED = 'X-UIPATH-FolderPath-Encoded';
 export const  USER_AGENT = 'X-UIPATH-UserAgent';
 export const  TENANT_ID = 'X-UIPATH-Internal-TenantId';
 export const  ACCOUNT_ID = 'X-UIPATH-Internal-AccountId';

--- a/src/utils/encoding/folder-path.ts
+++ b/src/utils/encoding/folder-path.ts
@@ -1,0 +1,30 @@
+/**
+ * Encodes a folder path for the `X-UIPATH-FolderPath-Encoded` header.
+ *
+ * Orchestrator decodes this header as **base64-encoded UTF-16 LE bytes**
+ * (see `HttpHeadersProviderExtensions.GetDecoded` + `OrganizationUnitProvider`
+ * in the Orchestrator repo, which call `Encoding.Unicode.GetString(...)`).
+ * URL-encoding is NOT what the server expects — it must be base64-of-UTF-16-LE
+ * bytes.
+ *
+ * @param folderPath - The folder path (e.g. 'Shared/Finance')
+ * @returns Base64 string suitable for the `X-UIPATH-FolderPath-Encoded` header
+ */
+export function encodeFolderPathHeader(folderPath: string): string {
+  // Force little-endian regardless of host byte order. `Uint16Array` viewed
+  // as `Uint8Array` would use the host's native order — correct on LE hosts
+  // (x86/ARM-LE) but wrong on BE hosts. `DataView.setUint16(..., true)`
+  // pins LE.
+  const buf = new ArrayBuffer(folderPath.length * 2);
+  const view = new DataView(buf);
+  for (let i = 0; i < folderPath.length; i++) {
+    view.setUint16(i * 2, folderPath.charCodeAt(i), true);
+  }
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  // btoa is browser-native; Node 16+ also has it as a global
+  return btoa(binary);
+}

--- a/src/utils/encoding/index.ts
+++ b/src/utils/encoding/index.ts
@@ -1,1 +1,2 @@
 export * from './base64';
+export * from './folder-path';

--- a/src/utils/folder/folder-headers.ts
+++ b/src/utils/folder/folder-headers.ts
@@ -1,0 +1,82 @@
+import { ValidationError } from '../../core/errors';
+import { createHeaders } from '../http/headers';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../constants/headers';
+import { encodeFolderPathHeader } from '../encoding/folder-path';
+
+export interface ResolveFolderHeadersInput {
+  /** Numeric folder ID — sent as `X-UIPATH-OrganizationUnitId`. */
+  folderId?: number;
+
+  /** Folder key (GUID) — sent as `X-UIPATH-FolderKey`. */
+  folderKey?: string;
+
+  /**
+   * Folder path (slash-delimited, e.g. `'Shared/Finance'`). Sent as
+   * `X-UIPATH-FolderPath-Encoded` (encoded as base64-of-UTF-16-LE per the
+   * Orchestrator contract).
+   */
+  folderPath?: string;
+
+  /**
+   * Resource label used in `ValidationError` messages (e.g. `'Asset.getByName'`,
+   * `'processes.start'`). Helps callers locate the offending call site.
+   */
+  resourceType: string;
+
+  /**
+   * SDK init-time folder key (sourced from `<meta name="uipath:folder-key">`
+   * in coded-app deployments). Used as a fallback when none of `folderId`,
+   * `folderKey`, or `folderPath` is supplied.
+   */
+  fallbackFolderKey?: string;
+}
+
+/**
+ * Resolves folder context into the appropriate Orchestrator folder headers.
+ *
+ * Centralized so all folder-scoped methods (e.g. `assets.getByName`,
+ * `processes.getByName`, future Queues/Buckets/Jobs) share one implementation.
+ *
+ * Each input field maps directly to its header — no auto-detection or type
+ * coercion. When multiple fields are supplied, all corresponding headers
+ * are forwarded and the server resolves precedence.
+ *
+ * Routing:
+ * - `folderId` → `X-UIPATH-OrganizationUnitId`
+ * - `folderKey` → `X-UIPATH-FolderKey`
+ * - `folderPath` → `X-UIPATH-FolderPath-Encoded`
+ * - none set + `fallbackFolderKey` → fallback used as `X-UIPATH-FolderKey`
+ * - none set + no fallback → `ValidationError`
+ *
+ * @throws ValidationError when no folder context can be resolved.
+ */
+export function resolveFolderHeaders(input: ResolveFolderHeadersInput): Record<string, string> {
+  const { folderId, folderKey, folderPath, resourceType, fallbackFolderKey } = input;
+
+  const trimmedKey = folderKey?.trim();
+  const trimmedPath = folderPath?.trim();
+
+  const headers: Record<string, string | number | undefined> = {};
+
+  if (folderId !== undefined) {
+    headers[FOLDER_ID] = folderId;
+  }
+  if (trimmedKey) {
+    headers[FOLDER_KEY] = trimmedKey;
+  }
+  if (trimmedPath) {
+    headers[FOLDER_PATH_ENCODED] = encodeFolderPathHeader(trimmedPath);
+  }
+
+  // No explicit folder context → meta-tag fallback or error.
+  if (Object.keys(headers).length === 0) {
+    if (!fallbackFolderKey) {
+      throw new ValidationError({
+        message: `${resourceType} requires folder context: pass \`folderId\`, \`folderKey\`, or \`folderPath\`, or initialize the SDK with a folder context.`,
+      });
+    }
+    headers[FOLDER_KEY] = fallbackFolderKey;
+  }
+
+  return createHeaders(headers);
+}

--- a/src/utils/runtime/constants.ts
+++ b/src/utils/runtime/constants.ts
@@ -16,4 +16,7 @@ export enum UiPathMetaTags {
   // Asset resolution and routing
   CDN_BASE = 'uipath:cdn-base',
   APP_BASE = 'uipath:app-base',
+
+  // Folder context (injected during coded-app deployment)
+  FOLDER_KEY = 'uipath:folder-key',
 }

--- a/src/utils/validation/name-validator.ts
+++ b/src/utils/validation/name-validator.ts
@@ -1,0 +1,25 @@
+import { ValidationError } from '../../core/errors';
+
+/**
+ * Validates the `name` argument passed to a `getByName(name, ...)` method.
+ * Trims whitespace and rejects empty/whitespace-only names.
+ *
+ * @param resourceType - Resource label used in error messages (e.g. 'Asset', 'Process')
+ * @param name - Resource name to validate
+ * @returns The trimmed name
+ * @throws ValidationError when `name` is missing or empty after trimming
+ */
+export function validateName(resourceType: string, name: string): string {
+  if (!name) {
+    throw new ValidationError({
+      message: `${resourceType} name is required and cannot be empty.`,
+    });
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new ValidationError({
+      message: `${resourceType} name is required and cannot be empty.`,
+    });
+  }
+  return trimmed;
+}

--- a/tests/.env.integration.example
+++ b/tests/.env.integration.example
@@ -33,6 +33,14 @@ INTEGRATION_TEST_SKIP_CLEANUP=false
 # Leave empty to use default folder
 INTEGRATION_TEST_FOLDER_ID=
 
+# Folder key (GUID) matching INTEGRATION_TEST_FOLDER_ID
+# Used by getByName integration tests for assets/processes
+INTEGRATION_TEST_FOLDER_KEY=
+
+# Folder path (e.g. "Shared/Finance") matching INTEGRATION_TEST_FOLDER_ID
+# Used by getByName integration tests for assets/processes
+INTEGRATION_TEST_FOLDER_PATH=
+
 # ============================================
 # Optional: Pre-existing Test Data
 # (for read-only tests that need existing resources)

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -12,6 +12,8 @@ export interface IntegrationConfig {
   timeout: number;
   skipCleanup: boolean;
   folderId?: string;
+  folderKey?: string;
+  folderPath?: string;
   maestroTestProcessKey?: string;
   orchestratorTestProcessKey?: string;
   dataFabricTestEntityId?: string;
@@ -62,6 +64,8 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     timeout: typeof rawConfig.timeout === 'number' && rawConfig.timeout > 0 ? rawConfig.timeout : 30000,
     skipCleanup: typeof rawConfig.skipCleanup === 'boolean' ? rawConfig.skipCleanup : false,
     folderId: typeof rawConfig.folderId === 'string' ? rawConfig.folderId : undefined,
+    folderKey: typeof rawConfig.folderKey === 'string' ? rawConfig.folderKey : undefined,
+    folderPath: typeof rawConfig.folderPath === 'string' ? rawConfig.folderPath : undefined,
     maestroTestProcessKey: typeof rawConfig.maestroTestProcessKey === 'string' ? rawConfig.maestroTestProcessKey : undefined,
     orchestratorTestProcessKey: typeof rawConfig.orchestratorTestProcessKey === 'string' ? rawConfig.orchestratorTestProcessKey : undefined,
     dataFabricTestEntityId: typeof rawConfig.dataFabricTestEntityId === 'string' ? rawConfig.dataFabricTestEntityId : undefined,
@@ -96,6 +100,8 @@ export function loadIntegrationConfig(): IntegrationConfig {
       : 30000,
     skipCleanup: process.env.INTEGRATION_TEST_SKIP_CLEANUP === 'true',
     folderId: process.env.INTEGRATION_TEST_FOLDER_ID || undefined,
+    folderKey: process.env.INTEGRATION_TEST_FOLDER_KEY || undefined,
+    folderPath: process.env.INTEGRATION_TEST_FOLDER_PATH || undefined,
     maestroTestProcessKey: process.env.MAESTRO_TEST_PROCESS_KEY || undefined,
     orchestratorTestProcessKey: process.env.ORCHESTRATOR_TEST_PROCESS_KEY || undefined,
     dataFabricTestEntityId: process.env.DATA_FABRIC_TEST_ENTITY_ID || undefined,

--- a/tests/integration/shared/orchestrator/assets.integration.test.ts
+++ b/tests/integration/shared/orchestrator/assets.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { isNotFoundError } from '../../../../src/core/errors';
 
 const modes: InitMode[] = ['v0', 'v1'];
 
@@ -76,6 +77,85 @@ describe.each(modes)('Orchestrator Assets - Integration Tests [%s]', (mode) => {
       expect(result.name).toBeDefined();
       expect(result.valueType).toBeDefined();
       expect(typeof result.name).toBe('string');
+    });
+  });
+
+  describe('getByName', () => {
+    it('should retrieve an asset by name using folderKey', async () => {
+      const { assets } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderKey, 'INTEGRATION_TEST_FOLDER_KEY must be configured for getByName').toBeDefined();
+
+      // Pick an existing asset in the folder so we have a real name to look up
+      const allAssets = await assets.getAll({
+        folderId: config.folderId ? Number(config.folderId) : undefined,
+        pageSize: 1,
+      });
+      expect(allAssets.items.length, 'No assets available to test getByName').toBeGreaterThan(0);
+      const existing = allAssets.items[0];
+
+      const result = await assets.getByName(existing.name, { folderKey: config.folderKey });
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(existing.id);
+      expect(result.name).toBe(existing.name);
+      expect(result.key).toBe(existing.key);
+    });
+
+    it('should retrieve an asset by name using folderPath', async () => {
+      const { assets } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderPath, 'INTEGRATION_TEST_FOLDER_PATH must be configured for getByName').toBeDefined();
+
+      const allAssets = await assets.getAll({
+        folderId: config.folderId ? Number(config.folderId) : undefined,
+        pageSize: 1,
+      });
+      expect(allAssets.items.length, 'No assets available to test getByName').toBeGreaterThan(0);
+      const existing = allAssets.items[0];
+
+      const result = await assets.getByName(existing.name, { folderPath: config.folderPath });
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(existing.id);
+      expect(result.name).toBe(existing.name);
+    });
+
+    it('should return transformed camelCase fields (no PascalCase leaks)', async () => {
+      const { assets } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderKey, 'INTEGRATION_TEST_FOLDER_KEY must be configured for getByName').toBeDefined();
+
+      const allAssets = await assets.getAll({
+        folderId: config.folderId ? Number(config.folderId) : undefined,
+        pageSize: 1,
+      });
+      expect(allAssets.items.length, 'No assets available to validate transform').toBeGreaterThan(0);
+
+      const result = await assets.getByName(allAssets.items[0].name, { folderKey: config.folderKey });
+
+      // Transformed camelCase fields should be present
+      expect(result.createdTime).toBeDefined();
+      expect(result.valueType).toBeDefined();
+      // Original PascalCase keys from the raw OData payload must be gone
+      expect((result as any).CreationTime).toBeUndefined();
+      expect((result as any).LastModificationTime).toBeUndefined();
+      expect((result as any).ValueType).toBeUndefined();
+    });
+
+    it('should throw NotFoundError for a nonexistent asset name', async () => {
+      const { assets } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderKey, 'INTEGRATION_TEST_FOLDER_KEY must be configured for getByName').toBeDefined();
+
+      const missingName = `__uipath-sdk-nonexistent-asset-${Date.now()}`;
+      await expect(
+        assets.getByName(missingName, { folderKey: config.folderKey }),
+      ).rejects.toSatisfy(isNotFoundError);
     });
   });
 

--- a/tests/integration/shared/orchestrator/processes.integration.test.ts
+++ b/tests/integration/shared/orchestrator/processes.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { isNotFoundError } from '../../../../src/core/errors';
 
 const modes: InitMode[] = ['v0', 'v1'];
 
@@ -136,6 +137,82 @@ describe.each(modes)('Orchestrator Processes - Integration Tests [%s]', (mode) =
       if (result.length > 0) {
         expect(result[0].id).toBeDefined();
       }
+    });
+  });
+
+  describe('getByName', () => {
+    it('should retrieve a process by name using folderKey', async () => {
+      const { processes } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderKey, 'INTEGRATION_TEST_FOLDER_KEY must be configured for getByName').toBeDefined();
+
+      const allProcesses = await processes.getAll({
+        folderId: config.folderId ? Number(config.folderId) : undefined,
+        pageSize: 1,
+      });
+      expect(allProcesses.items.length, 'No processes available to test getByName').toBeGreaterThan(0);
+      const existing = allProcesses.items[0];
+
+      const result = await processes.getByName(existing.name, { folderKey: config.folderKey });
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(existing.id);
+      expect(result.name).toBe(existing.name);
+      expect(result.key).toBe(existing.key);
+    });
+
+    it('should retrieve a process by name using folderPath', async () => {
+      const { processes } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderPath, 'INTEGRATION_TEST_FOLDER_PATH must be configured for getByName').toBeDefined();
+
+      const allProcesses = await processes.getAll({
+        folderId: config.folderId ? Number(config.folderId) : undefined,
+        pageSize: 1,
+      });
+      expect(allProcesses.items.length, 'No processes available to test getByName').toBeGreaterThan(0);
+      const existing = allProcesses.items[0];
+
+      const result = await processes.getByName(existing.name, { folderPath: config.folderPath });
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(existing.id);
+      expect(result.name).toBe(existing.name);
+    });
+
+    it('should return transformed camelCase fields (no PascalCase leaks)', async () => {
+      const { processes } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderKey, 'INTEGRATION_TEST_FOLDER_KEY must be configured for getByName').toBeDefined();
+
+      const allProcesses = await processes.getAll({
+        folderId: config.folderId ? Number(config.folderId) : undefined,
+        pageSize: 1,
+      });
+      expect(allProcesses.items.length, 'No processes available to validate transform').toBeGreaterThan(0);
+
+      const result = await processes.getByName(allProcesses.items[0].name, { folderKey: config.folderKey });
+
+      expect(result.createdTime).toBeDefined();
+      expect(result.folderId).toBeDefined();
+      expect((result as any).CreationTime).toBeUndefined();
+      expect((result as any).LastModificationTime).toBeUndefined();
+      expect((result as any).OrganizationUnitId).toBeUndefined();
+    });
+
+    it('should throw NotFoundError for a nonexistent process name', async () => {
+      const { processes } = getServices();
+      const config = getTestConfig();
+
+      expect(config.folderKey, 'INTEGRATION_TEST_FOLDER_KEY must be configured for getByName').toBeDefined();
+
+      const missingName = `__uipath-sdk-nonexistent-process-${Date.now()}`;
+      await expect(
+        processes.getByName(missingName, { folderKey: config.folderKey }),
+      ).rejects.toSatisfy(isNotFoundError);
     });
   });
 

--- a/tests/unit/services/orchestrator/assets.test.ts
+++ b/tests/unit/services/orchestrator/assets.test.ts
@@ -20,7 +20,8 @@ import { PaginatedResponse } from '../../../../src/utils/pagination';
 import { ASSET_TEST_CONSTANTS } from '../../../utils/constants/assets';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
 import { ASSET_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
-import { FOLDER_ID } from '../../../../src/utils/constants/headers';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
+import { NotFoundError, ValidationError } from '../../../../src/core/errors';
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -227,6 +228,178 @@ describe('AssetService Unit Tests', () => {
       vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
 
       await expect(assetService.getAll()).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('getByName', () => {
+    it('should return a transformed asset when the OData response contains one item', async () => {
+      const rawAsset = createMockRawAsset();
+      mockApiClient.get.mockResolvedValue({ value: [rawAsset] });
+
+      const result = await assetService.getByName(
+        ASSET_TEST_CONSTANTS.ASSET_NAME,
+        { folderPath: ASSET_TEST_CONSTANTS.FOLDER_PATH },
+      );
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(ASSET_TEST_CONSTANTS.ASSET_ID);
+      expect(result.name).toBe(ASSET_TEST_CONSTANTS.ASSET_NAME);
+      expect(result.key).toBe(ASSET_TEST_CONSTANTS.ASSET_KEY);
+      expect(result.valueType).toBe(AssetValueType.DBConnectionString);
+
+      // Transform validation — camelCase fields present, PascalCase originals absent
+      expect(result.createdTime).toBe(ASSET_TEST_CONSTANTS.CREATED_TIME);
+      expect((result as any).CreationTime).toBeUndefined();
+      expect(result.lastModifiedTime).toBe(ASSET_TEST_CONSTANTS.LAST_MODIFIED_TIME);
+      expect((result as any).LastModificationTime).toBeUndefined();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ASSET_ENDPOINTS.GET_BY_FOLDER,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$filter': `Name eq '${ASSET_TEST_CONSTANTS.ASSET_NAME}'`,
+            '$top': '1',
+          }),
+        }),
+      );
+    });
+
+    it('should route a numeric folderId to X-UIPATH-OrganizationUnitId', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await assetService.getByName(ASSET_TEST_CONSTANTS.ASSET_NAME, { folderId: TEST_CONSTANTS.FOLDER_ID });
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+      });
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should route folderKey to X-UIPATH-FolderKey', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await assetService.getByName(ASSET_TEST_CONSTANTS.ASSET_NAME, { folderKey: ASSET_TEST_CONSTANTS.FOLDER_KEY });
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_KEY]: ASSET_TEST_CONSTANTS.FOLDER_KEY,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should route folderPath to X-UIPATH-FolderPath-Encoded (base64-of-UTF-16-LE)', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await assetService.getByName(
+        ASSET_TEST_CONSTANTS.ASSET_NAME,
+        { folderPath: ASSET_TEST_CONSTANTS.FOLDER_PATH_WITH_SPACE },
+      );
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_PATH_ENCODED]: ASSET_TEST_CONSTANTS.FOLDER_PATH_WITH_SPACE_ENCODED,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+    });
+
+    it('should pass OData query options through to the request', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await assetService.getByName(
+        ASSET_TEST_CONSTANTS.ASSET_NAME,
+        {
+          folderPath: ASSET_TEST_CONSTANTS.FOLDER_PATH,
+          expand: ASSET_TEST_CONSTANTS.ODATA_EXPAND_KEY_VALUE_LIST,
+        },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ASSET_ENDPOINTS.GET_BY_FOLDER,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$expand': ASSET_TEST_CONSTANTS.ODATA_EXPAND_KEY_VALUE_LIST,
+          }),
+        }),
+      );
+    });
+
+    it('should OData-escape single quotes in the name', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await assetService.getByName(
+        ASSET_TEST_CONSTANTS.ASSET_NAME_WITH_QUOTE,
+        { folderKey: ASSET_TEST_CONSTANTS.FOLDER_KEY },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ASSET_ENDPOINTS.GET_BY_FOLDER,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$filter': `Name eq '${ASSET_TEST_CONSTANTS.ASSET_NAME_WITH_QUOTE_ESCAPED}'`,
+          }),
+        }),
+      );
+    });
+
+    it('should throw NotFoundError when the OData value array is empty', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [] });
+
+      await expect(
+        assetService.getByName(ASSET_TEST_CONSTANTS.MISSING_ASSET_NAME, { folderPath: ASSET_TEST_CONSTANTS.FOLDER_PATH }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('should throw ValidationError for an empty name', async () => {
+      await expect(
+        assetService.getByName('   ', { folderKey: ASSET_TEST_CONSTANTS.FOLDER_KEY }),
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to SDK init-time folderKey when no folder is provided', async () => {
+      // Simulates the coded-app meta-tag (`uipath:folder-key`) path.
+      const { instance } = createServiceTestDependencies({ folderKey: ASSET_TEST_CONSTANTS.FOLDER_KEY });
+      vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+      const scopedService = new AssetService(instance);
+
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await scopedService.getByName(ASSET_TEST_CONSTANTS.ASSET_NAME);
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_KEY]: ASSET_TEST_CONSTANTS.FOLDER_KEY,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should suppress the init-time folderKey fallback when the caller provides explicit folder', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: ASSET_TEST_CONSTANTS.FOLDER_KEY });
+      vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+      const scopedService = new AssetService(instance);
+
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await scopedService.getByName(ASSET_TEST_CONSTANTS.ASSET_NAME, { folderPath: ASSET_TEST_CONSTANTS.FOLDER_PATH });
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_PATH_ENCODED]: ASSET_TEST_CONSTANTS.FOLDER_PATH_ENCODED,
+      });
+      // folderKey from config must NOT leak when folder is explicitly supplied
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+    });
+
+    it('should throw ValidationError when no folder context is resolvable', async () => {
+      // No folder arg AND no init-time folderKey on config — must reject.
+      await expect(assetService.getByName(ASSET_TEST_CONSTANTS.ASSET_NAME))
+        .rejects.toBeInstanceOf(ValidationError);
+      expect(mockApiClient.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/services/orchestrator/processes.test.ts
+++ b/tests/unit/services/orchestrator/processes.test.ts
@@ -19,8 +19,9 @@ import {
 } from '../../../utils/constants';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { JobPriority, ProcessGetAllOptions, ProcessGetByIdOptions, ProcessStartRequest } from '../../../../src/models/orchestrator/processes.types';
-import { FOLDER_ID } from '../../../../src/utils/constants/headers';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
 import { RequestOptions } from '../../../../src/models/common';
+import { NotFoundError, ValidationError } from '../../../../src/core/errors';
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -340,6 +341,178 @@ describe('ProcessService Unit Tests', () => {
       const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
       await expect(service.start(request, TEST_CONSTANTS.FOLDER_ID))
         .rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('getByName', () => {
+    it('should return a transformed process when the OData response contains one item', async () => {
+      const rawProcess = createMockRawOrchestratorProcess();
+      mockApiClient.get.mockResolvedValue({ value: [rawProcess] });
+
+      const result = await service.getByName(
+        PROCESS_TEST_CONSTANTS.PROCESS_NAME,
+        { folderPath: PROCESS_TEST_CONSTANTS.FOLDER_PATH },
+      );
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(PROCESS_TEST_CONSTANTS.PROCESS_ID);
+      expect(result.key).toBe(PROCESS_TEST_CONSTANTS.PROCESS_KEY);
+      expect(result.name).toBe(PROCESS_TEST_CONSTANTS.PROCESS_NAME);
+
+      // Transform validation — camelCase fields present, PascalCase originals absent
+      expect(result.createdTime).toBe(PROCESS_TEST_CONSTANTS.TIME);
+      expect((result as any).CreationTime).toBeUndefined();
+      expect(result.lastModifiedTime).toBe(PROCESS_TEST_CONSTANTS.TIME);
+      expect((result as any).LastModificationTime).toBeUndefined();
+      expect(result.folderId).toBe(TEST_CONSTANTS.FOLDER_ID);
+      expect((result as any).OrganizationUnitId).toBeUndefined();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.GET_ALL,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$filter': `Name eq '${PROCESS_TEST_CONSTANTS.PROCESS_NAME}'`,
+            '$top': '1',
+          }),
+        }),
+      );
+    });
+
+    it('should route a numeric folderId to X-UIPATH-OrganizationUnitId', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await service.getByName(PROCESS_TEST_CONSTANTS.PROCESS_NAME, { folderId: TEST_CONSTANTS.FOLDER_ID });
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+      });
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should route folderKey to X-UIPATH-FolderKey', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await service.getByName(PROCESS_TEST_CONSTANTS.PROCESS_NAME, { folderKey: PROCESS_TEST_CONSTANTS.FOLDER_KEY });
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_KEY]: PROCESS_TEST_CONSTANTS.FOLDER_KEY,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should route folderPath to X-UIPATH-FolderPath-Encoded (base64-of-UTF-16-LE)', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await service.getByName(
+        PROCESS_TEST_CONSTANTS.PROCESS_NAME,
+        { folderPath: PROCESS_TEST_CONSTANTS.FOLDER_PATH_WITH_SPACE },
+      );
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_PATH_ENCODED]: PROCESS_TEST_CONSTANTS.FOLDER_PATH_WITH_SPACE_ENCODED,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+    });
+
+    it('should pass OData query options through to the request', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await service.getByName(
+        PROCESS_TEST_CONSTANTS.PROCESS_NAME,
+        {
+          folderPath: PROCESS_TEST_CONSTANTS.FOLDER_PATH,
+          expand: PROCESS_TEST_CONSTANTS.EXPAND_ARGUMENTS,
+        },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.GET_ALL,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$expand': PROCESS_TEST_CONSTANTS.EXPAND_ARGUMENTS,
+          }),
+        }),
+      );
+    });
+
+    it('should OData-escape single quotes in the name', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await service.getByName(
+        PROCESS_TEST_CONSTANTS.PROCESS_NAME_WITH_QUOTE,
+        { folderKey: PROCESS_TEST_CONSTANTS.FOLDER_KEY },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.GET_ALL,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$filter': `Name eq '${PROCESS_TEST_CONSTANTS.PROCESS_NAME_WITH_QUOTE_ESCAPED}'`,
+          }),
+        }),
+      );
+    });
+
+    it('should throw NotFoundError when the OData value array is empty', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [] });
+
+      await expect(
+        service.getByName(PROCESS_TEST_CONSTANTS.MISSING_PROCESS_NAME, { folderPath: PROCESS_TEST_CONSTANTS.FOLDER_PATH }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('should throw ValidationError for an empty name', async () => {
+      await expect(
+        service.getByName('   ', { folderKey: PROCESS_TEST_CONSTANTS.FOLDER_KEY }),
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to SDK init-time folderKey when no folder is provided', async () => {
+      // Simulates the coded-app meta-tag (`uipath:folder-key`) path.
+      const { instance } = createServiceTestDependencies({ folderKey: PROCESS_TEST_CONSTANTS.FOLDER_KEY });
+      vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+      const scopedService = new ProcessService(instance);
+
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await scopedService.getByName(PROCESS_TEST_CONSTANTS.PROCESS_NAME);
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_KEY]: PROCESS_TEST_CONSTANTS.FOLDER_KEY,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should suppress the init-time folderKey fallback when the caller provides explicit folder', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: PROCESS_TEST_CONSTANTS.FOLDER_KEY });
+      vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+      const scopedService = new ProcessService(instance);
+
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await scopedService.getByName(PROCESS_TEST_CONSTANTS.PROCESS_NAME, { folderPath: PROCESS_TEST_CONSTANTS.FOLDER_PATH });
+
+      const [, requestSpec] = mockApiClient.get.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_PATH_ENCODED]: PROCESS_TEST_CONSTANTS.FOLDER_PATH_ENCODED,
+      });
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+    });
+
+    it('should throw ValidationError when no folder context is resolvable', async () => {
+      // No folder arg AND no init-time folderKey on config — must reject.
+      await expect(service.getByName(PROCESS_TEST_CONSTANTS.PROCESS_NAME))
+        .rejects.toBeInstanceOf(ValidationError);
+      expect(mockApiClient.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/utils/encoding/folder-path.test.ts
+++ b/tests/unit/utils/encoding/folder-path.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { encodeFolderPathHeader } from '../../../../src/utils/encoding/folder-path';
+
+describe('encodeFolderPathHeader', () => {
+  // Reference values produced by Node:
+  //   Buffer.from(<path>, 'utf16le').toString('base64')
+  // which mirrors Orchestrator's `Encoding.Unicode.GetString(...)` decode.
+
+  it('encodes ASCII paths as base64-of-UTF-16-LE bytes', () => {
+    expect(encodeFolderPathHeader('Shared/Finance')).toBe('UwBoAGEAcgBlAGQALwBGAGkAbgBhAG4AYwBlAA==');
+  });
+
+  it('encodes paths containing spaces', () => {
+    expect(encodeFolderPathHeader('Shared/My Finance')).toBe(
+      'UwBoAGEAcgBlAGQALwBNAHkAIABGAGkAbgBhAG4AYwBlAA==',
+    );
+  });
+
+  it('encodes the empty string to the empty base64 string', () => {
+    expect(encodeFolderPathHeader('')).toBe('');
+  });
+});

--- a/tests/unit/utils/folder/folder-headers.test.ts
+++ b/tests/unit/utils/folder/folder-headers.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFolderHeaders } from '../../../../src/utils/folder/folder-headers';
+import { encodeFolderPathHeader } from '../../../../src/utils/encoding/folder-path';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
+import { ValidationError } from '../../../../src/core/errors';
+
+const GUID = '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba';
+
+describe('resolveFolderHeaders', () => {
+  describe('field routing', () => {
+    it('routes folderId to X-UIPATH-OrganizationUnitId', () => {
+      const headers = resolveFolderHeaders({ folderId: 123, resourceType: 'Test' });
+      expect(headers).toEqual({ [FOLDER_ID]: '123' });
+    });
+
+    it('routes folderKey to X-UIPATH-FolderKey', () => {
+      const headers = resolveFolderHeaders({ folderKey: GUID, resourceType: 'Test' });
+      expect(headers).toEqual({ [FOLDER_KEY]: GUID });
+    });
+
+    it('routes folderPath to X-UIPATH-FolderPath-Encoded (base64-of-UTF-16-LE)', () => {
+      const headers = resolveFolderHeaders({ folderPath: 'Shared/Finance', resourceType: 'Test' });
+      expect(headers).toEqual({
+        [FOLDER_PATH_ENCODED]: encodeFolderPathHeader('Shared/Finance'),
+      });
+    });
+
+    it('trims whitespace around folderKey', () => {
+      const headers = resolveFolderHeaders({ folderKey: `  ${GUID}  `, resourceType: 'Test' });
+      expect(headers).toEqual({ [FOLDER_KEY]: GUID });
+    });
+
+    it('trims whitespace around folderPath before encoding', () => {
+      const headers = resolveFolderHeaders({ folderPath: '  Shared/Finance  ', resourceType: 'Test' });
+      expect(headers).toEqual({
+        [FOLDER_PATH_ENCODED]: encodeFolderPathHeader('Shared/Finance'),
+      });
+    });
+
+    it('treats an empty folderKey as missing', () => {
+      const headers = resolveFolderHeaders({
+        folderKey: '',
+        resourceType: 'Test',
+        fallbackFolderKey: GUID,
+      });
+      expect(headers).toEqual({ [FOLDER_KEY]: GUID });
+    });
+
+    it('treats an empty folderPath as missing', () => {
+      const headers = resolveFolderHeaders({
+        folderPath: '',
+        resourceType: 'Test',
+        fallbackFolderKey: GUID,
+      });
+      expect(headers).toEqual({ [FOLDER_KEY]: GUID });
+    });
+  });
+
+  describe('combined fields', () => {
+    it('forwards all three headers when all fields are set (server resolves precedence)', () => {
+      const headers = resolveFolderHeaders({
+        folderId: 123,
+        folderKey: GUID,
+        folderPath: 'Shared/Finance',
+        resourceType: 'Test',
+      });
+      expect(headers).toEqual({
+        [FOLDER_ID]: '123',
+        [FOLDER_KEY]: GUID,
+        [FOLDER_PATH_ENCODED]: encodeFolderPathHeader('Shared/Finance'),
+      });
+    });
+
+    it('forwards both headers when folderId + folderPath are set', () => {
+      const headers = resolveFolderHeaders({
+        folderId: 123,
+        folderPath: 'Shared/Finance',
+        resourceType: 'Test',
+      });
+      expect(headers).toEqual({
+        [FOLDER_ID]: '123',
+        [FOLDER_PATH_ENCODED]: encodeFolderPathHeader('Shared/Finance'),
+      });
+    });
+  });
+
+  describe('fallback', () => {
+    it('uses fallbackFolderKey when no folder is supplied', () => {
+      const headers = resolveFolderHeaders({ resourceType: 'Test', fallbackFolderKey: GUID });
+      expect(headers).toEqual({ [FOLDER_KEY]: GUID });
+    });
+
+    it('does not use fallback when folderId is supplied', () => {
+      const headers = resolveFolderHeaders({
+        folderId: 123,
+        resourceType: 'Test',
+        fallbackFolderKey: GUID,
+      });
+      expect(headers).toEqual({ [FOLDER_ID]: '123' });
+    });
+
+    it('does not use fallback when folderKey is supplied', () => {
+      const headers = resolveFolderHeaders({
+        folderKey: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        resourceType: 'Test',
+        fallbackFolderKey: GUID,
+      });
+      expect(headers).toEqual({ [FOLDER_KEY]: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' });
+    });
+
+    it('does not use fallback when folderPath is supplied', () => {
+      const headers = resolveFolderHeaders({
+        folderPath: 'Shared/Finance',
+        resourceType: 'Test',
+        fallbackFolderKey: GUID,
+      });
+      expect(headers).toEqual({
+        [FOLDER_PATH_ENCODED]: encodeFolderPathHeader('Shared/Finance'),
+      });
+    });
+  });
+
+  describe('errors', () => {
+    it('throws ValidationError when no folder context is supplied and no fallback', () => {
+      expect(() => resolveFolderHeaders({ resourceType: 'Test' }))
+        .toThrow(ValidationError);
+    });
+
+    it('includes the resourceType in the error message', () => {
+      expect(() => resolveFolderHeaders({ resourceType: 'Asset.getByName' }))
+        .toThrow(/Asset\.getByName/);
+    });
+  });
+});

--- a/tests/utils/constants/assets.ts
+++ b/tests/utils/constants/assets.ts
@@ -30,8 +30,20 @@ export const ASSET_TEST_CONSTANTS = {
   
   // Error Messages
   ERROR_ASSET_NOT_FOUND: 'Asset not found',
-  
+
   // OData Parameters
   ODATA_EXPAND_KEY_VALUE_LIST: 'keyValueList',
   ODATA_SELECT_FIELDS: 'id,name,value',
+
+  // getByName
+  FOLDER_PATH: 'Shared/Finance',
+  FOLDER_PATH_WITH_SPACE: 'Shared/My Finance',
+  // base64-of-UTF-16-LE encoded values matching encodeFolderPathHeader().
+  // Reference: Buffer.from(<path>, 'utf16le').toString('base64').
+  FOLDER_PATH_ENCODED: 'UwBoAGEAcgBlAGQALwBGAGkAbgBhAG4AYwBlAA==',
+  FOLDER_PATH_WITH_SPACE_ENCODED: 'UwBoAGEAcgBlAGQALwBNAHkAIABGAGkAbgBhAG4AYwBlAA==',
+  FOLDER_KEY: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  ASSET_NAME_WITH_QUOTE: "O'Brien",
+  ASSET_NAME_WITH_QUOTE_ESCAPED: "O''Brien",
+  MISSING_ASSET_NAME: 'MissingAsset',
 } as const;

--- a/tests/utils/constants/processes.ts
+++ b/tests/utils/constants/processes.ts
@@ -43,4 +43,16 @@ export const PROCESS_TEST_CONSTANTS = {
     jobPriority: 'High',
     inputArguments: '{"test": "input"}'
   },
+
+  // getByName
+  FOLDER_PATH: 'Shared/Finance',
+  FOLDER_PATH_WITH_SPACE: 'Shared/My Finance',
+  // base64-of-UTF-16-LE encoded values matching encodeFolderPathHeader().
+  // Reference: Buffer.from(<path>, 'utf16le').toString('base64').
+  FOLDER_PATH_ENCODED: 'UwBoAGEAcgBlAGQALwBGAGkAbgBhAG4AYwBlAA==',
+  FOLDER_PATH_WITH_SPACE_ENCODED: 'UwBoAGEAcgBlAGQALwBNAHkAIABGAGkAbgBhAG4AYwBlAA==',
+  FOLDER_KEY: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  PROCESS_NAME_WITH_QUOTE: "Joe's Process",
+  PROCESS_NAME_WITH_QUOTE_ESCAPED: "Joe''s Process",
+  MISSING_PROCESS_NAME: 'MissingProcess',
 } as const;

--- a/tests/utils/setup.ts
+++ b/tests/utils/setup.ts
@@ -98,9 +98,10 @@ export const createMockApiClient = () => ({
  * ```
  */
 export const createMockUiPath = (
-  configOverrides?: Partial<UiPathConfig>,
+  overrides?: Partial<UiPathConfig> & { folderKey?: string },
   tokenManagerOverrides?: Partial<TokenManager>
 ): UiPath => {
+  const { folderKey, ...configOverrides } = overrides ?? {};
   const config = createMockConfig(configOverrides);
   const executionContext = createMockExecutionContext();
   const tokenManager = createMockTokenManager(tokenManagerOverrides);
@@ -119,7 +120,8 @@ export const createMockUiPath = (
   SDKInternalsRegistry.set(mockInstance, {
     config,
     context: executionContext,
-    tokenManager
+    tokenManager,
+    folderKey,
   });
 
   return mockInstance;
@@ -142,9 +144,11 @@ export const createMockUiPath = (
  * ```
  */
 export const createServiceTestDependencies = (
-  configOverrides?: Partial<UiPathConfig>,
+  overrides?: Partial<UiPathConfig> & { folderKey?: string },
   tokenManagerOverrides?: Partial<MockableTokenManager>
 ) => {
+  // `folderKey` is meta-tag-only — not on UiPathConfig; lives on PrivateSDK.
+  const { folderKey, ...configOverrides } = overrides ?? {};
   const config = createMockConfig(configOverrides);
   const executionContext = createMockExecutionContext();
   const tokenManager = createMockTokenManager(tokenManagerOverrides);
@@ -167,7 +171,8 @@ export const createServiceTestDependencies = (
   SDKInternalsRegistry.set(mockInstance, {
     config,
     context: executionContext,
-    tokenManager
+    tokenManager,
+    folderKey,
   });
 
   return {


### PR DESCRIPTION
## Summary

Prerequisite SDK work for the coded-apps bindings/overwrites initiative (PLT-92768 / PLT-93599). Adds name-based resource lookup for two Orchestrator services and the folder-context plumbing the runtime overwrite flow depends on.

- **`assets.getByName(name, options?)`** — OData `$filter=Name eq '…'` + `$top=1` on the folder-scoped Assets endpoint.
- **`processes.getByName(name, options?)`** — same shape against `/odata/Releases`.
- **`FolderScopedOptions`** — new shared type in `models/common/types.ts`. Three explicit fields:
  - `folderId?: number` → `X-UIPATH-OrganizationUnitId`
  - `folderKey?: string` → `X-UIPATH-FolderKey`
  - `folderPath?: string` → `X-UIPATH-FolderPath-Encoded`
  When more than one is supplied, all corresponding headers are forwarded and the server resolves precedence.
- **Folder header resolver** — `resolveFolderHeaders()` in `src/utils/folder/folder-headers.ts`. Centralizes folder-context routing so future folder-scoped methods (Queues, Buckets, Jobs, …) reuse one implementation. Each option field maps directly to its header — no auto-detection.
- **Encoding utility** — `encodeFolderPathHeader()` in `src/utils/encoding/folder-path.ts`. Folder paths are base64-of-UTF-16-LE bytes (matching `Encoding.Unicode` in Orchestrator). Cross-platform safe via `DataView.setUint16(..., true)`.
- **Shared lookup helper** — `FolderScopedService.getByNameLookup<TRaw, T>(...)` encapsulates name validation → header resolution → OData filter → empty-result `NotFoundError`. Both `getByName` implementations are ~10 lines each on top of it.
- **Init-time folder context via meta tag** — SDK reads `<meta name="uipath:folder-key">` (auto-injected by jamjam on coded-app deployments). Used as the default folder context when the caller doesn't supply one. `folderKey` is **not** accepted via the SDK constructor; it lives on the runtime registry (`PrivateSDK.folderKey`), populated from the meta tag only.
- **Validation** — `validateName()` in `src/utils/validation/name-validator.ts` trims and rejects empty / whitespace-only names with a `ValidationError`.
- **NotFoundError** messages now include folder context (id / key / path) for easier debugging.

## Usage

```typescript
import { Assets } from '@uipath/uipath-typescript/assets';
import { Processes } from '@uipath/uipath-typescript/processes';

const assets = new Assets(sdk);
const processes = new Processes(sdk);

// By folder ID
await assets.getByName('ApiKey', { folderId: 123 });

// By folder key (GUID)
await assets.getByName('ApiKey', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });

// By folder path
await assets.getByName('ApiKey', { folderPath: 'Shared/Finance' });

// With OData query parameters
await assets.getByName('ApiKey', { folderPath: 'Shared/Finance', expand: 'KeyValueList' });

// Coded-app — folder resolved automatically from `<meta name="uipath:folder-key">`
await assets.getByName('ApiKey');

// Same convention for processes
await processes.getByName('MyProcess', { folderPath: 'Shared/Finance' });
```

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm run test:unit` — 1372 pass
- [x] `npm run build` — rollup outputs produced

**New unit tests:**
- `tests/unit/utils/folder/folder-headers.test.ts` (15) — every resolver branch (each field's routing, multi-field forwarding, fallback, error)
- `tests/unit/utils/encoding/folder-path.test.ts` (3) — verifies base64-of-UTF-16-LE output against `Buffer.from(<path>, 'utf16le').toString('base64')`
- `tests/unit/services/orchestrator/assets.test.ts` — adds 9 cases for `getByName` (success + transform validation, header routing for each folder field, OData query passthrough, quote-escape, NotFoundError, ValidationError for empty name, meta-tag fallback, fallback suppression)
- `tests/unit/services/orchestrator/processes.test.ts` — same 9 cases for processes

**New integration tests** (`tests/integration/shared/orchestrator/`):
- `getByName` with `folderKey` → live API
- `getByName` with `folderPath` → live API
- Transform validation against the live API (camelCase fields present, PascalCase originals absent)
- `NotFoundError` for a nonexistent name

Requires three env vars for integration runs:
- `INTEGRATION_TEST_FOLDER_ID` (existing)
- `INTEGRATION_TEST_FOLDER_KEY` (new — same folder, GUID)
- `INTEGRATION_TEST_FOLDER_PATH` (new — same folder, FullyQualifiedName)

The CI workflow (`pr-checks.yml`) is wired to read these from the corresponding repo secrets.

## Out of scope (deferred)

- **`processes.start()`** — extending it for `folderKey`/`folderPath` is going out as its own PR (overload pattern, deprecate the existing positional shape). Tracked separately so the v1.x positional shape isn't touched here.
- Buckets / Queues / Jobs `getByName` — the resolver + helper are reusable; those will land as separate onboardings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)