### PR TITLE
fix(integration): use env entity ID for cleanup

### DIFF
--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -971,8 +971,9 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
   afterAll(async () => {
     const config = getTestConfig();
     if (!config.skipCleanup) {
-      if (createdRecordIds.length > 0 && testEntityId) {
-        await cleanupTestEntityRecords(testEntityId, createdRecordIds);
+      const cleanupEntityId = config.dataFabricTestEntityId || testEntityId;
+      if (createdRecordIds.length > 0 && cleanupEntityId) {
+        await cleanupTestEntityRecords(cleanupEntityId, createdRecordIds);
       }
       // Clean up any entities created by schema management tests (no-op when those tests are skipped)
       if (createdEntityIds.length > 0) {


### PR DESCRIPTION
## Summary
- `afterAll` cleanup was gated on `testEntityId`, which stays `null` when `DATA_FABRIC_TEST_ENTITY_ID` is set in env — causing all inserted records to leak after every test run
- Fix uses `config.dataFabricTestEntityId || testEntityId` so cleanup runs correctly regardless of which source provides the entity ID