### PR TITLE
fix: skip download attachment tests due to API bug

### DIFF
--- a/tests/integration/shared/data-fabric/attachment.integration.test.ts
+++ b/tests/integration/shared/data-fabric/attachment.integration.test.ts
@@ -133,7 +133,8 @@ describe.skipIf(!hasAttachmentConfig).each(modes)(
       });
     });
 
-    describe('downloadAttachment', () => {
+    // TODO: skipped due to API bug returning 500 on download — re-enable once fixed
+    describe.skip('downloadAttachment', () => {
       it('should upload and then download an attachment via service method', async () => {
         const { entities } = getServices();
 


### PR DESCRIPTION
## Summary
- Skipped `downloadAttachment` integration tests (both service and entity method variants) due to a known API bug returning 500 Internal Server Error on the download endpoint in certain orgs
- Added TODO comment to re-enable once the API bug is fixed