### PR TITLE
fix(docs): escape angle brackets in coded-apps getting-started

### DIFF
--- a/docs/coded-apps/getting-started.md
+++ b/docs/coded-apps/getting-started.md
@@ -172,7 +172,7 @@ When deployed, the platform injects these config tags automatically — the plug
 
 ## Pre-deployment Checklist
 
-Coded app will be deployed and served at `https://<orgName>.uipath.host/<appName>`. When deployed, platform injects `<base href="/your-app-name/">` into your `index.html`. Make sure your app handles this correctly by following below best practices:
+Coded app will be deployed and served at `https://<orgName>.uipath.host/<appName>`. When deployed, platform injects `<base href="/your-app-name/">` into your `index.html`. Make sure your app handles this correctly by following the best practices below:
 
 ### 1. Configure relative asset paths
 
@@ -282,8 +282,8 @@ https://<orgName>.uipath.host/<appName>
 Refer to [CLI Reference](cli-reference.md) for details.
 
 !!! info "Coded apps deployment domain"
-    Coded Apps uses `uipath.host` domain (for example, <orgname>.uipath.host) because Coded Apps is a static-site hosting service separate from the main UiPath application site. Key reasons are:
+    Coded Apps uses `uipath.host` domain (for example, `<orgname>.uipath.host`) because Coded Apps is a static-site hosting service separate from the main UiPath application site. Key reasons are:
 
-    - Separation of concerns: Coded Apps publishes static HTML/CSS/JS from your package and exposes it at a dedicated site URL under uipath.host rather than the UiPath product domain. 
-    - Site types and naming: Coded app sites are published under https://<orgname>.uipath.host/<appname>. This provides a predictable, account-scoped URL scheme.
+    - Separation of concerns: Coded Apps publishes static HTML/CSS/JS from your package and exposes it at a dedicated site URL under uipath.host rather than the UiPath product domain.
+    - Site types and naming: Coded app sites are published under `https://<orgname>.uipath.host/<appname>`. This provides a predictable, account-scoped URL scheme.
 


### PR DESCRIPTION
in coded apps docs
The `<orgname>` and `<appname>` placeholders are completely invisible because they're parsed as HTML tags:


## before
<img width="842" height="333" alt="Screenshot 2026-04-27 at 3 16 15 PM" src="https://github.com/user-attachments/assets/daafea1e-5575-41a1-ad22-a14398ea24d4" />

## After


<img width="957" height="287" alt="Screenshot 2026-04-27 at 3 16 45 PM" src="https://github.com/user-attachments/assets/adc46fc1-76a2-4fd4-96ec-6c7bdd399a68" />
