### PR TITLE
fix: handle HTML error responses for invalid org/tenant in auth-errors integration test

### DIFF
--- a/tests/integration/auth-errors.integration.test.ts
+++ b/tests/integration/auth-errors.integration.test.ts
@@ -59,6 +59,16 @@ async function expectApiToFail(
     await apiCall();
     expect.fail(`Expected API call to fail: ${testDescription}`);
   } catch (error: any) {
+    console.log(`[DEBUG] ${testDescription} — error shape:`, JSON.stringify({
+      constructorName: error?.constructor?.name,
+      type: error?.type,
+      message: error?.message,
+      statusCode: error?.statusCode,
+      status: error?.status,
+      requestId: error?.requestId,
+      isSyntaxError: error instanceof SyntaxError,
+      keys: error ? Object.keys(error) : [],
+    }, null, 2));
     expect(error).toBeDefined();
     expect(errorValidator(error)).toBe(true);
     console.log(`✓ ${testDescription}:`, error.message);

--- a/tests/integration/auth-errors.integration.test.ts
+++ b/tests/integration/auth-errors.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { UiPath } from '../../src';
+import { NetworkError } from '../../src/core/errors/network';
 import { loadIntegrationConfig } from './config/test-config';
 
 /**
@@ -17,6 +18,7 @@ function isForbiddenError(error: any, keywords: string[] = []): boolean {
     // Server may return HTML (redirect/error page) for invalid org/tenant,
     // causing a JSON parse error — this still indicates rejection
     (error instanceof SyntaxError && error.message?.includes('is not valid JSON')) ||
+    (error instanceof NetworkError && error.message?.includes('is not valid JSON')) ||
     allKeywords.some(kw => error.message?.toLowerCase().includes(kw))
   );
 }
@@ -59,16 +61,6 @@ async function expectApiToFail(
     await apiCall();
     expect.fail(`Expected API call to fail: ${testDescription}`);
   } catch (error: any) {
-    console.log(`[DEBUG] ${testDescription} — error shape:`, JSON.stringify({
-      constructorName: error?.constructor?.name,
-      type: error?.type,
-      message: error?.message,
-      statusCode: error?.statusCode,
-      status: error?.status,
-      requestId: error?.requestId,
-      isSyntaxError: error instanceof SyntaxError,
-      keys: error ? Object.keys(error) : [],
-    }, null, 2));
     expect(error).toBeDefined();
     expect(errorValidator(error)).toBe(true);
     console.log(`✓ ${testDescription}:`, error.message);


### PR DESCRIPTION
The isForbiddenError helper in auth-errors.integration.test.ts was checking for error instanceof SyntaxError to detect HTML error page responses from the API, but GitHub Actions runners receive a NetworkError (SDK's own class) instead of a native SyntaxError for the same scenario
Added error instanceof NetworkError check alongside the existing SyntaxError check so both local and CI environments are handled correctly

