### PR TITLE
feat(datafabric): Adding support for advanced field option[DS-8268]

### DIFF
--- a/src/models/data-fabric/entities.constants.ts
+++ b/src/models/data-fabric/entities.constants.ts
@@ -1,5 +1,10 @@
 import { EntityFieldDataType, FieldDisplayType } from "./entities.types";
-import { EntitySchemaFieldMapping, SqlFieldType } from "./entities.internal-types";
+import {
+  EntitySchemaFieldMapping,
+  SqlFieldType,
+  EntityFieldConstraint,
+  FieldConstraintRange,
+} from "./entities.internal-types";
 export { SqlFieldType } from "./entities.internal-types";
 
 /**
@@ -46,6 +51,72 @@ export const FieldDisplayTypeToDataType: Partial<Record<FieldDisplayType, Entity
   [FieldDisplayType.ChoiceSetMultiple]: EntityFieldDataType.CHOICE_SET_MULTIPLE,
   [FieldDisplayType.AutoNumber]:        EntityFieldDataType.AUTO_NUMBER,
   [FieldDisplayType.Relationship]:      EntityFieldDataType.RELATIONSHIP,
+};
+
+/**
+ * Default and fixed sqlType constraint values applied when the user does not provide them.
+ * The API requires these to be present on field creation — without them the field
+ * is stored in an incomplete state, causing "Field type cannot be changed" errors
+ * when the UI later tries to edit advanced options.
+ */
+export const ENTITY_FIELD_CONSTRAINT_DEFAULTS = {
+  STRING_LENGTH_LIMIT: 200,
+  MULTILINE_TEXT_LENGTH_LIMIT: 200,
+  /** Fixed (non-overridable) length limit on DECIMAL payloads*/
+  DECIMAL_LENGTH_LIMIT: 1000,
+  DECIMAL_PRECISION: 2,
+  /** Fixed (non-overridable) length limit for BIT (BOOLEAN) fields */
+  BOOLEAN_LENGTH_LIMIT: 100,
+  /** Fixed (non-overridable) length limit for DATE / DATETIMEOFFSET fields */
+  DATE_LENGTH_LIMIT: 1000,
+  /** Fixed (non-overridable) length limit for UNIQUEIDENTIFIER-backed FILE and RELATIONSHIP fields */
+  UNIQUEIDENTIFIER_LENGTH_LIMIT: 300,
+  /** Fixed (non-overridable) length limit for CHOICE_SET_MULTIPLE fields */
+  CHOICE_SET_MULTIPLE_LENGTH_LIMIT: 4000,
+  NUMERIC_MAX_VALUE: 1_000_000_000_000,
+  NUMERIC_MIN_VALUE: -1_000_000_000_000,
+} as const;
+
+/**
+ * Per-field-type spec describing which {@link EntityFieldConstraint}s the user
+ * may supply on create / update, and the inclusive value range for each.
+ *
+ * Source of truth: the platform's `Constants.cs` constraint table. Keys absent
+ * from a type's spec are not user-configurable for that type; passing one
+ * throws a `ValidationError`. Field types absent from this map (BOOLEAN, DATE,
+ * DATETIME, DATETIME_WITH_TZ, FILE, RELATIONSHIP, UUID, CHOICE_SET_SINGLE,
+ * CHOICE_SET_MULTIPLE, AUTO_NUMBER) accept no user-supplied constraints.
+ */
+export const ENTITY_FIELD_CONSTRAINT_SPEC: Partial<Record<EntityFieldDataType, Partial<Record<EntityFieldConstraint, FieldConstraintRange>>>> = {
+  [EntityFieldDataType.STRING]: {
+    [EntityFieldConstraint.LengthLimit]: { min: 1, max: 4000 },
+  },
+  [EntityFieldDataType.MULTILINE_TEXT]: {
+    [EntityFieldConstraint.LengthLimit]: { min: 1, max: 10000 },
+  },
+  [EntityFieldDataType.INTEGER]: {
+    [EntityFieldConstraint.MaxValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.MinValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+  },
+  [EntityFieldDataType.BIG_INTEGER]: {
+    [EntityFieldConstraint.MaxValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.MinValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+  },
+  [EntityFieldDataType.DECIMAL]: {
+    [EntityFieldConstraint.MaxValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.MinValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.DecimalPrecision]: { min: 0, max: 10 },
+  },
+  [EntityFieldDataType.FLOAT]: {
+    [EntityFieldConstraint.MaxValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.MinValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.DecimalPrecision]: { min: 0, max: 10 },
+  },
+  [EntityFieldDataType.DOUBLE]: {
+    [EntityFieldConstraint.MaxValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.MinValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    [EntityFieldConstraint.DecimalPrecision]: { min: 0, max: 10 },
+  },
 };
 
 /**

--- a/src/models/data-fabric/entities.internal-types.ts
+++ b/src/models/data-fabric/entities.internal-types.ts
@@ -38,6 +38,28 @@ export interface EntityQueryRawResponse {
 }
 
 /**
+ * Names of the per-field SQL constraint properties (i.e. the contents of `sqlType`
+ * excluding its `name`). Used internally to validate user-supplied constraints
+ * against the set of constraints that each `EntityFieldDataType` accepts.
+ *
+ * Enum values match the corresponding property names on `EntityCreateFieldOptions`.
+ */
+export enum EntityFieldConstraint {
+  LengthLimit = 'lengthLimit',
+  MaxValue = 'maxValue',
+  MinValue = 'minValue',
+  DecimalPrecision = 'decimalPrecision',
+}
+
+/**
+ * Inclusive [min, max] range for a single user-configurable constraint value.
+ */
+export interface FieldConstraintRange {
+  min: number;
+  max: number;
+}
+
+/**
  * Entity field data types (SQL types from API)
  */
 export enum SqlFieldType {

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -526,6 +526,13 @@ export interface EntityServiceModel {
    *   { fieldName: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true },
    *   { fieldName: "price", type: EntityFieldDataType.INTEGER, defaultValue: "0" },
    * ], { displayName: "Product Catalog", description: "Our product catalog", isRbacEnabled: true });
+   *
+   * // With advanced sqlType constraints (lengthLimit, decimalPrecision, maxValue, minValue) and defaultValue
+   * const ordersId = await entities.create("orders", [
+   *   { fieldName: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true, lengthLimit: 500 },
+   *   { fieldName: "price", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *   { fieldName: "quantity", type: EntityFieldDataType.INTEGER, maxValue: 10000, minValue: 1, defaultValue: "0" },
+   * ]);
    * ```
    * @internal
    */
@@ -574,6 +581,17 @@ export interface EntityServiceModel {
    * await entities.updateById(<id>, {
    *   updateFields: [{ id: <fieldId>, displayName: "Unit Price", isRequired: true }],
    *   displayName: "Price Catalog",
+   * });
+   *
+   * // Add a STRING/DECIMAL field with explicit advanced sqlType constraints and defaultValue
+   * await entities.updateById(<id>, {
+   *   addFields: [
+   *     { fieldName: "summary", type: EntityFieldDataType.STRING, lengthLimit: 500, defaultValue: "summary" },
+   *     { fieldName: "amount", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *   ],
+   *   updateFields: [
+   *     { id: <fieldId>, lengthLimit: 1000 },
+   *   ],
    * });
    * ```
    * @internal
@@ -781,6 +799,14 @@ export interface EntityMethods {
    * await entity.update({
    *   displayName: "Updated Name",
    *   addFields: [{ fieldName: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
+   * });
+   *
+   * // Add a STRING/DECIMAL field with explicit advanced sqlType constraints 
+   * await entity.update({
+   *   addFields: [
+   *     { fieldName: "summary", type: EntityFieldDataType.STRING, lengthLimit: 500, defaultValue: "string" },
+   *     { fieldName: "amount", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *   ],
    * });
    * ```
    * @internal

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -241,6 +241,14 @@ export interface EntityFieldBase {
   isEncrypted?: boolean;
   /** Default value for the field */
   defaultValue?: string;
+  /** Maximum character length for STRING fields (default: 200, range: 1–4000) and MULTILINE_TEXT fields (default: 200, range: 1–10000). */
+  lengthLimit?: number;
+  /** Maximum allowed value for numeric fields (INTEGER, BIG_INTEGER, FLOAT, DOUBLE, DECIMAL — default: 1,000,000,000,000; range: ±9,007,199,254,740,991) */
+  maxValue?: number;
+  /** Minimum allowed value for numeric fields (INTEGER, BIG_INTEGER, FLOAT, DOUBLE, DECIMAL — default: -1,000,000,000,000; range: ±9,007,199,254,740,991) */
+  minValue?: number;
+  /** Number of decimal places for DECIMAL, FLOAT, and DOUBLE fields (default: 2, range: 0–10) */
+  decimalPrecision?: number;
 }
 
 /**

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -30,6 +30,8 @@ import {
   EntityCreateFieldOptions,
   EntityFieldDataType,
   EntityUpdateByIdOptions,
+  SqlType,
+  FieldDisplayType,
 } from '../../models/data-fabric/entities.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination/types';
 import { PaginationType } from '../../utils/pagination/internal-types';
@@ -39,8 +41,15 @@ import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../utils
 import { RESPONSE_TYPES } from '../../utils/constants/headers';
 import { createParams } from '../../utils/http/params';
 import { transformData } from '../../utils/transform';
-import { EntityFieldTypeMap, EntityMap, EntitySchemaFieldTypeMap, FieldDisplayTypeToDataType } from '../../models/data-fabric/entities.constants';
-import { FieldSchemaPayload, SqlFieldType } from '../../models/data-fabric/entities.internal-types';
+import {
+  EntityFieldTypeMap,
+  EntityMap,
+  EntitySchemaFieldTypeMap,
+  FieldDisplayTypeToDataType,
+  ENTITY_FIELD_CONSTRAINT_DEFAULTS,
+  ENTITY_FIELD_CONSTRAINT_SPEC,
+} from '../../models/data-fabric/entities.constants';
+import { FieldSchemaPayload, SqlFieldType, EntityFieldConstraint } from '../../models/data-fabric/entities.internal-types';
 import { track } from '../../core/telemetry';
 
 /**
@@ -714,6 +723,13 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *   { fieldName: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true },
    *   { fieldName: "price", type: EntityFieldDataType.INTEGER, defaultValue: "0" },
    * ], { displayName: "Product Catalog", description: "Our product catalog", isRbacEnabled: true });
+   *
+   * // With advanced sqlType constraints (lengthLimit, decimalPrecision, maxValue, minValue) and defaultValue
+   * const ordersId = await entities.create("orders", [
+   *   { fieldName: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true, lengthLimit: 500 },
+   *   { fieldName: "price", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *   { fieldName: "quantity", type: EntityFieldDataType.INTEGER, maxValue: 10000, minValue: 1, defaultValue: "0" },
+   * ]);
    * ```
    * @internal
    */
@@ -791,6 +807,17 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *   updateFields: [{ id: "<fieldId>", displayName: "Unit Price", isRequired: true }],
    *   displayName: "Price Catalog",
    * });
+   *
+   * // Add a STRING/DECIMAL field with explicit advanced sqlType constraints and defaultValue
+   * await entities.updateById("<entityId>", {
+   *   addFields: [
+   *     { fieldName: "summary", type: EntityFieldDataType.STRING, lengthLimit: 500, defaultValue: "summary" },
+   *     { fieldName: "amount", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *   ],
+   *   updateFields: [
+   *     { id: "<fieldId>", lengthLimit: 1000 },
+   *   ],
+   * });
    * ```
    * @internal
    */
@@ -841,6 +868,21 @@ export class EntityService extends BaseService implements EntityServiceModel {
       fields = fields.map(f => {
         const update = updateMap.get(f.id ?? '');
         if (!update) return f;
+        const constraintUpdate = {
+          ...(update.lengthLimit !== undefined && { lengthLimit: update.lengthLimit }),
+          ...(update.maxValue !== undefined && { maxValue: update.maxValue }),
+          ...(update.minValue !== undefined && { minValue: update.minValue }),
+          ...(update.decimalPrecision !== undefined && { decimalPrecision: update.decimalPrecision }),
+        };
+        const hasConstraintUpdate = Object.keys(constraintUpdate).length > 0;
+        if (hasConstraintUpdate) {
+          if (!f.sqlType) {
+            throw new ValidationError({
+              message: `Cannot update constraints on field '${f.name}' (id: ${f.id}) — the field is missing sqlType metadata in the entity definition.`,
+            });
+          }
+          this.validateFieldConstraints(this.resolveFieldDataType(f), update, f.name);
+        }
         return {
           ...f,
           ...(update.displayName !== undefined && { displayName: update.displayName }),
@@ -850,6 +892,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
           ...(update.isRbacEnabled !== undefined && { isRbacEnabled: update.isRbacEnabled }),
           ...(update.isEncrypted !== undefined && { isEncrypted: update.isEncrypted }),
           ...(update.defaultValue !== undefined && { defaultValue: update.defaultValue }),
+          ...(hasConstraintUpdate && f.sqlType && { sqlType: { ...f.sqlType, ...constraintUpdate } }),
         };
       });
     }
@@ -897,31 +940,38 @@ export class EntityService extends BaseService implements EntityServiceModel {
    */
   private mapFieldTypes(metadata: RawEntityGetResponse): void {
     if (!metadata.fields?.length) return;
-    
+
     metadata.fields = metadata.fields.map(field => {
       // Rename sqlType to fieldDataType
       let transformedField = transformData(field, EntityMap);
-      
+
       // Map field type: prefer fieldDisplayType for types that share SQL types (File, ChoiceSet, AutoNumber)
       if (transformedField.fieldDataType?.name) {
-        const displayTypeMapped = transformedField.fieldDisplayType
-          ? FieldDisplayTypeToDataType[transformedField.fieldDisplayType]
-          : undefined;
-        if (displayTypeMapped) {
-          transformedField.fieldDataType.name = displayTypeMapped;
-        } else {
-          const rawSqlTypeName = field.sqlType?.name as SqlFieldType | undefined;
-          const mapped = rawSqlTypeName ? EntityFieldTypeMap[rawSqlTypeName] : undefined;
-          if (mapped) {
-            transformedField.fieldDataType.name = mapped;
-          }
+        const mapped = this.tryResolveFieldDataType(transformedField.fieldDisplayType, field.sqlType?.name);
+        if (mapped) {
+          transformedField.fieldDataType.name = mapped;
         }
       }
-      
+
       this.transformNestedReferences(transformedField);
-      
+
       return transformedField;
     });
+  }
+
+  /**
+   * Resolves an {@link EntityFieldDataType} from a field's `fieldDisplayType` and
+   * raw SQL type name. Prefers `fieldDisplayType` to disambiguate types that
+   * share a SQL type (FILE, CHOICE_SET_*, AUTO_NUMBER, RELATIONSHIP); falls back
+   * to the SQL-type-name mapping. Returns `undefined` if neither resolves.
+   */
+  private tryResolveFieldDataType(
+    fieldDisplayType: FieldDisplayType | undefined,
+    sqlTypeName: string | undefined,
+  ): EntityFieldDataType | undefined {
+    const displayMapped = fieldDisplayType ? FieldDisplayTypeToDataType[fieldDisplayType] : undefined;
+    if (displayMapped) return displayMapped;
+    return sqlTypeName ? EntityFieldTypeMap[sqlTypeName as SqlFieldType] : undefined;
   }
 
   /**
@@ -966,11 +1016,16 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /** Converts a user-facing EntityCreateFieldOptions to the raw API field payload */
   private buildSchemaFieldPayload(field: EntityCreateFieldOptions): FieldSchemaPayload {
     this.validateName(field.fieldName, 'field');
-    const mapping = EntitySchemaFieldTypeMap[field.type ?? EntityFieldDataType.STRING];
+    const fieldType = field.type ?? EntityFieldDataType.STRING;
+    this.validateFieldConstraints(fieldType, field, field.fieldName);
+    const mapping = EntitySchemaFieldTypeMap[fieldType];
     return {
       name: field.fieldName,
       displayName: field.displayName ?? field.fieldName,
-      sqlType: { name: mapping.sqlTypeName },
+      sqlType: {
+        name: mapping.sqlTypeName,
+        ...this.buildSqlTypeConstraints(fieldType, field),
+      },
       fieldDisplayType: mapping.fieldDisplayType,
       description: field.description ?? '',
       isRequired: field.isRequired ?? false,
@@ -982,6 +1037,117 @@ export class EntityService extends BaseService implements EntityServiceModel {
       ...(field.referenceEntityName !== undefined && { referenceEntityName: field.referenceEntityName }),
       ...(field.referenceFieldName !== undefined && { referenceFieldName: field.referenceFieldName }),
     };
+  }
+
+  /**
+   * Derives the user-facing {@link EntityFieldDataType} for a field on the raw
+   * API response. Throws if the field's `fieldDisplayType` and `sqlType.name`
+   * are both unmappable.
+   */
+  private resolveFieldDataType(f: FieldMetaData): EntityFieldDataType {
+    const mapped = this.tryResolveFieldDataType(f.fieldDisplayType, f.sqlType?.name);
+    if (!mapped) {
+      throw new ValidationError({
+        message: `Cannot determine field type for '${f.name}' (id: ${f.id}) — sqlType '${f.sqlType?.name ?? '(missing)'}' and fieldDisplayType '${f.fieldDisplayType ?? '(missing)'}' are both unrecognized.`,
+      });
+    }
+    return mapped;
+  }
+
+  /**
+   * Validates that the user-supplied constraint properties on a field are
+   * supported by the field's data type. Throws a `ValidationError` listing
+   * any unsupported properties.
+   */
+  private validateFieldConstraints(
+    type: EntityFieldDataType,
+    field: Pick<EntityCreateFieldOptions, EntityFieldConstraint>,
+    fieldName: string,
+  ): void {
+    const spec = ENTITY_FIELD_CONSTRAINT_SPEC[type] ?? {};
+    const supported = Object.keys(spec) as EntityFieldConstraint[];
+    const provided = Object.values(EntityFieldConstraint).filter(name => field[name] !== undefined);
+
+    const unsupported = provided.filter(p => !(p in spec));
+    if (unsupported.length > 0) {
+      const allowedDesc = supported.length > 0 ? supported.join(', ') : 'none';
+      throw new ValidationError({
+        message: `Field '${fieldName}' of type ${type} does not accept ${unsupported.join(', ')}. Allowed constraints for this type: ${allowedDesc}.`,
+      });
+    }
+
+    // Range check: each user-supplied constraint must be within its allowed bounds.
+    for (const name of provided) {
+      const range = spec[name];
+      const value = field[name];
+      if (range && value !== undefined && (value < range.min || value > range.max)) {
+        throw new ValidationError({
+          message: `Field '${fieldName}' of type ${type} has ${name} ${value} out of range [${range.min}, ${range.max}].`,
+        });
+      }
+    }
+
+    // Cross-field check: when both bounds are user-supplied in the same call,
+    // minValue must be strictly less than maxValue.
+    if (field.minValue !== undefined && field.maxValue !== undefined && field.minValue >= field.maxValue) {
+      throw new ValidationError({
+        message: `Field '${fieldName}' of type ${type} has minValue ${field.minValue} >= maxValue ${field.maxValue}. minValue must be strictly less than maxValue.`,
+      });
+    }
+  }
+
+  /**
+   * Returns the sqlType constraint fields for a given field type.
+   *
+   * The API requires specific constraint properties to be set per SQL type;
+   * without them the field is stored in an incomplete state, causing
+   * "Field type cannot be changed" errors when the UI later tries to edit
+   * advanced options. User-supplied values from `EntityCreateFieldOptions`
+   * override the defaults where the type accepts overrides.
+   */
+  private buildSqlTypeConstraints(type: EntityFieldDataType, field: EntityCreateFieldOptions): Omit<SqlType, 'name'> {
+    const defaults = ENTITY_FIELD_CONSTRAINT_DEFAULTS;
+    switch (type) {
+      case EntityFieldDataType.STRING:
+        return { lengthLimit: field.lengthLimit ?? defaults.STRING_LENGTH_LIMIT };
+      case EntityFieldDataType.MULTILINE_TEXT:
+        return { lengthLimit: field.lengthLimit ?? defaults.MULTILINE_TEXT_LENGTH_LIMIT };
+      case EntityFieldDataType.DECIMAL:
+        return {
+          lengthLimit: defaults.DECIMAL_LENGTH_LIMIT,
+          decimalPrecision: field.decimalPrecision ?? defaults.DECIMAL_PRECISION,
+          maxValue: field.maxValue ?? defaults.NUMERIC_MAX_VALUE,
+          minValue: field.minValue ?? defaults.NUMERIC_MIN_VALUE,
+        };
+      case EntityFieldDataType.BOOLEAN:
+        return { lengthLimit: defaults.BOOLEAN_LENGTH_LIMIT };
+      case EntityFieldDataType.DATE:
+      case EntityFieldDataType.DATETIME_WITH_TZ:
+        return { lengthLimit: defaults.DATE_LENGTH_LIMIT };
+      case EntityFieldDataType.INTEGER:
+      case EntityFieldDataType.BIG_INTEGER:
+        return {
+          maxValue: field.maxValue ?? defaults.NUMERIC_MAX_VALUE,
+          minValue: field.minValue ?? defaults.NUMERIC_MIN_VALUE,
+        };
+      case EntityFieldDataType.FLOAT:
+      case EntityFieldDataType.DOUBLE:
+        return {
+          decimalPrecision: field.decimalPrecision ?? defaults.DECIMAL_PRECISION,
+          maxValue: field.maxValue ?? defaults.NUMERIC_MAX_VALUE,
+          minValue: field.minValue ?? defaults.NUMERIC_MIN_VALUE,
+        };
+      case EntityFieldDataType.FILE:
+      case EntityFieldDataType.RELATIONSHIP:
+        // UNIQUEIDENTIFIER fixed lengthLimit (300)
+        return { lengthLimit: defaults.UNIQUEIDENTIFIER_LENGTH_LIMIT };
+      case EntityFieldDataType.CHOICE_SET_MULTIPLE:
+        // CHOICE_SET_MULTIPLE fixed lengthLimit (4000)
+        return { lengthLimit: defaults.CHOICE_SET_MULTIPLE_LENGTH_LIMIT };
+      default:
+        // UUID, CHOICE_SET_SINGLE, AUTO_NUMBER, DATETIME — (sqlType: { name })
+        return {};
+    }
   }
 
   private static readonly RESERVED_FIELD_NAMES = new Set([

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -929,6 +929,247 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
   });
 
   // Skipped: requires DataFabric.Schema.Write OAuth scope, not available in standard test environment
+  describe.skip('sqlType constraint defaults', () => {
+    it('should create STRING field with default lengthLimit 200', async () => {
+      const { entities } = getServices();
+      const name = `sdk_str_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'str_field', type: EntityFieldDataType.STRING },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'str_field');
+      expect(field).toBeDefined();
+      expect(field?.fieldDataType.lengthLimit).toBe(200);
+    });
+
+    it('should create STRING field with user-provided lengthLimit', async () => {
+      const { entities } = getServices();
+      const name = `sdk_str_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 500 },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'str_field');
+      expect(field?.fieldDataType.lengthLimit).toBe(500);
+    });
+
+    it('should create MULTILINE_TEXT field with default lengthLimit 200', async () => {
+      const { entities } = getServices();
+      const name = `sdk_ml_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'ml_field', type: EntityFieldDataType.MULTILINE_TEXT },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'ml_field');
+      expect(field?.fieldDataType.lengthLimit).toBe(200);
+    });
+
+    it('should create DECIMAL field with correct default constraints', async () => {
+      const { entities } = getServices();
+      const name = `sdk_dec_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'dec_field', type: EntityFieldDataType.DECIMAL },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'dec_field');
+      expect(field?.fieldDataType.lengthLimit).toBe(1000);
+      expect(field?.fieldDataType.decimalPrecision).toBe(2);
+      expect(field?.fieldDataType.maxValue).toBe(1000000000000);
+      expect(field?.fieldDataType.minValue).toBe(-1000000000000);
+    });
+
+    it('should create DECIMAL field with user-provided constraints', async () => {
+      const { entities } = getServices();
+      const name = `sdk_dec_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        {
+          fieldName: 'dec_field',
+          type: EntityFieldDataType.DECIMAL,
+          decimalPrecision: 4,
+          maxValue: 99999,
+          minValue: -99999,
+        },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'dec_field');
+      expect(field?.fieldDataType.decimalPrecision).toBe(4);
+      expect(field?.fieldDataType.maxValue).toBe(99999);
+      expect(field?.fieldDataType.minValue).toBe(-99999);
+    });
+
+    it('should create BOOLEAN field with fixed lengthLimit 100', async () => {
+      const { entities } = getServices();
+      const name = `sdk_bit_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'bool_field', type: EntityFieldDataType.BOOLEAN },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'bool_field');
+      expect(field?.fieldDataType.lengthLimit).toBe(100);
+    });
+
+    it('should create DATE field with fixed lengthLimit 1000', async () => {
+      const { entities } = getServices();
+      const name = `sdk_date_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'date_field', type: EntityFieldDataType.DATE },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'date_field');
+      expect(field?.fieldDataType.lengthLimit).toBe(1000);
+    });
+
+    it('should create DATETIME_WITH_TZ field with fixed lengthLimit 1000', async () => {
+      const { entities } = getServices();
+      const name = `sdk_dtz_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'dtz_field', type: EntityFieldDataType.DATETIME_WITH_TZ },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'dtz_field');
+      expect(field?.fieldDataType.lengthLimit).toBe(1000);
+    });
+
+    it('should allow updating STRING field lengthLimit without "Field type cannot be changed" error', async () => {
+      const { entities } = getServices();
+      const name = `sdk_upd_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'str_field', type: EntityFieldDataType.STRING },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const before = await entities.getById(entityId);
+      const field = before.fields.find(f => f.name === 'str_field');
+      if (!field?.id) {
+        throw new Error('Could not find str_field id in entity schema');
+      }
+
+      // Must not throw "Field type cannot be changed"
+      await entities.updateById(entityId, {
+        updateFields: [{ id: field.id, lengthLimit: 500 }],
+      });
+
+      const after = await entities.getById(entityId);
+      const updated = after.fields.find(f => f.name === 'str_field');
+      expect(updated?.fieldDataType.lengthLimit).toBe(500);
+    });
+
+    it('should allow updating DECIMAL field constraints via updateById', async () => {
+      const { entities } = getServices();
+      const name = `sdk_upddec_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'dec_field', type: EntityFieldDataType.DECIMAL },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const before = await entities.getById(entityId);
+      const field = before.fields.find(f => f.name === 'dec_field');
+      if (!field?.id) {
+        throw new Error('Could not find dec_field id in entity schema');
+      }
+
+      await entities.updateById(entityId, {
+        updateFields: [{ id: field.id, decimalPrecision: 4, maxValue: 9999, minValue: -9999 }],
+      });
+
+      const after = await entities.getById(entityId);
+      const updated = after.fields.find(f => f.name === 'dec_field');
+      expect(updated?.fieldDataType.decimalPrecision).toBe(4);
+      expect(updated?.fieldDataType.maxValue).toBe(9999);
+      expect(updated?.fieldDataType.minValue).toBe(-9999);
+    });
+
+    it('should reject STRING with lengthLimit above max (5000) without hitting the API', async () => {
+      const { entities } = getServices();
+      const name = `sdk_str_oor_${generateRandomString(8).toLowerCase()}`;
+
+      // SDK validation must throw before any API call is made.
+      await expect(
+        entities.create(name, [
+          { fieldName: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 5000 },
+        ]),
+      ).rejects.toThrow(/lengthLimit 5000 out of range \[1, 4000\]/);
+
+      // Verify no entity was created server-side
+      const all = await entities.getAll();
+      expect(all.find(e => e.name === name)).toBeUndefined();
+    });
+
+    it('should reject MULTILINE_TEXT with lengthLimit above max (15000) without hitting the API', async () => {
+      const { entities } = getServices();
+      const name = `sdk_ml_oor_${generateRandomString(8).toLowerCase()}`;
+
+      await expect(
+        entities.create(name, [
+          { fieldName: 'ml_field', type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 15000 },
+        ]),
+      ).rejects.toThrow(/lengthLimit 15000 out of range \[1, 10000\]/);
+
+      const all = await entities.getAll();
+      expect(all.find(e => e.name === name)).toBeUndefined();
+    });
+
+    it('should reject STRING with lengthLimit below min (0) without hitting the API', async () => {
+      const { entities } = getServices();
+      const name = `sdk_str_zero_${generateRandomString(8).toLowerCase()}`;
+
+      await expect(
+        entities.create(name, [
+          { fieldName: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 0 },
+        ]),
+      ).rejects.toThrow(/lengthLimit 0 out of range \[1, 4000\]/);
+
+      const all = await entities.getAll();
+      expect(all.find(e => e.name === name)).toBeUndefined();
+    });
+
+    it('should apply default lengthLimit (200) when STRING lengthLimit is omitted, confirmed via GET', async () => {
+      const { entities } = getServices();
+      const name = `sdk_str_default_${generateRandomString(8).toLowerCase()}`;
+
+      const entityId = await entities.create(name, [
+        { fieldName: 'str_field', type: EntityFieldDataType.STRING },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'str_field');
+      // Default is applied client-side and round-trips through the API as 200
+      expect(field?.fieldDataType.lengthLimit).toBe(200);
+    });
+
+    it('should reject INTEGER when minValue >= maxValue without hitting the API', async () => {
+      const { entities } = getServices();
+      const name = `sdk_int_minmax_${generateRandomString(8).toLowerCase()}`;
+
+      await expect(
+        entities.create(name, [
+          { fieldName: 'int_field', type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 },
+        ]),
+      ).rejects.toThrow(/minValue 100 >= maxValue 50/);
+
+      const all = await entities.getAll();
+      expect(all.find(e => e.name === name)).toBeUndefined();
+    });
+  });
+
+  // Skipped: requires DataFabric.Schema.Write OAuth scope, not available in standard test environment
   describe.skip('deleteById', () => {
     it('should delete an entity created for this test', async () => {
       const { entities } = getServices();
@@ -977,13 +1218,13 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       // Clean up any entities created by schema management tests (no-op when those tests are skipped)
       if (createdEntityIds.length > 0) {
         const { entities } = getServices();
-        for (const entityId of createdEntityIds) {
-          try {
-            await entities.deleteById(entityId);
-          } catch {
-            // Best-effort cleanup — entity may have already been deleted
-          }
-        }
+        await Promise.all(
+          createdEntityIds.map(entityId =>
+            entities.deleteById(entityId).catch(() => {
+              // Best-effort cleanup — entity may have already been deleted
+            })
+          )
+        );
       }
     }
   });

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -47,7 +47,7 @@ import {
 import { ENTITY_TEST_CONSTANTS } from "../../../utils/constants/entities";
 import { TEST_CONSTANTS } from "../../../utils/constants/common";
 import { DATA_FABRIC_ENDPOINTS } from "../../../../src/utils/constants/endpoints";
-import { SqlFieldType } from "@/models/data-fabric/entities.internal-types";
+import { SqlFieldType, FieldSchemaPayload } from "@/models/data-fabric/entities.internal-types";
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -1384,14 +1384,15 @@ describe("EntityService Unit Tests", () => {
     });
 
     it("should support jumpToPage for direct page navigation", async () => {
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({
+      const mockPaginatedResponse = {
         items: [],
         totalCount: 50,
         hasNextPage: false,
         supportsPageJump: true,
         currentPage: 3,
         totalPages: 5,
-      });
+      };
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockPaginatedResponse);
 
       await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
         jumpToPage: 3,
@@ -1648,6 +1649,261 @@ describe("EntityService Unit Tests", () => {
         TEST_CONSTANTS.ERROR_MESSAGE,
       );
     });
+
+    describe("advanced field options", () => {
+      beforeEach(() => {
+        mockApiClient.post.mockResolvedValue(ENTITY_TEST_CONSTANTS.ENTITY_ID);
+      });
+
+      const getCreatedFields = (): FieldSchemaPayload[] =>
+        mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+
+      it("should default STRING lengthLimit to 200", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "str_field", type: EntityFieldDataType.STRING },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "str_field");
+        expect(f?.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 200 });
+      });
+
+      it("should use user-provided lengthLimit for STRING fields", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 500 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "str_field");
+        expect(f?.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 500 });
+      });
+
+      it("should default MULTILINE_TEXT lengthLimit to 200", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "ml_field");
+        expect(f?.sqlType).toEqual({ name: "MULTILINE", lengthLimit: 200 });
+      });
+
+      it("should default DECIMAL constraints to default values", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "dec_field");
+        expect(f?.sqlType).toEqual({
+          name: "DECIMAL",
+          lengthLimit: 1000,
+          decimalPrecision: 2,
+          maxValue: 1000000000000,
+          minValue: -1000000000000,
+        });
+      });
+
+      it("should allow user to override DECIMAL decimalPrecision, maxValue and minValue", async () => {
+        await entityService.create("my_entity", [
+          {
+            fieldName: "dec_field",
+            type: EntityFieldDataType.DECIMAL,
+            decimalPrecision: 4,
+            maxValue: 9999,
+            minValue: -9999,
+          },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "dec_field");
+        expect(f?.sqlType.decimalPrecision).toBe(4);
+        expect(f?.sqlType.maxValue).toBe(9999);
+        expect(f?.sqlType.minValue).toBe(-9999);
+      });
+
+      it("should default INTEGER min/max to default values", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "int_field", type: EntityFieldDataType.INTEGER },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "int_field");
+        expect(f?.sqlType).toEqual({ name: "INT", maxValue: 1000000000000, minValue: -1000000000000 });
+      });
+
+      it("should allow user to override INTEGER min/max", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: 500, minValue: -500 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "int_field");
+        expect(f?.sqlType).toEqual({ name: "INT", maxValue: 500, minValue: -500 });
+      });
+
+      it("should default BIG_INTEGER min/max to default values", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "bigint_field", type: EntityFieldDataType.BIG_INTEGER },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "bigint_field");
+        expect(f?.sqlType).toEqual({ name: "BIGINT", maxValue: 1000000000000, minValue: -1000000000000 });
+      });
+
+      it("should throw ValidationError when STRING lengthLimit exceeds 4000", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4001 },
+          ]),
+        ).rejects.toThrow(/lengthLimit 4001 out of range \[1, 4000\]/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when STRING lengthLimit is less than 1", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 0 },
+          ]),
+        ).rejects.toThrow(/lengthLimit 0 out of range \[1, 4000\]/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when MULTILINE_TEXT lengthLimit exceeds 10000", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10001 },
+          ]),
+        ).rejects.toThrow(/lengthLimit 10001 out of range \[1, 10000\]/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when DECIMAL decimalPrecision exceeds 10", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 11 },
+          ]),
+        ).rejects.toThrow(/decimalPrecision 11 out of range \[0, 10\]/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when DECIMAL decimalPrecision is negative", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: -1 },
+          ]),
+        ).rejects.toThrow(/decimalPrecision -1 out of range \[0, 10\]/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when INTEGER maxValue exceeds Number.MAX_SAFE_INTEGER", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: Number.MAX_SAFE_INTEGER + 1 },
+          ]),
+        ).rejects.toThrow(/maxValue .* out of range/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for BOOLEAN", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "bool_field", type: EntityFieldDataType.BOOLEAN, lengthLimit: 50 },
+          ]),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for INTEGER", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, lengthLimit: 50 },
+          ]),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when user passes maxValue for STRING", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "str_field", type: EntityFieldDataType.STRING, maxValue: 100 },
+          ]),
+        ).rejects.toThrow(/does not accept maxValue/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when user passes decimalPrecision for INTEGER", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, decimalPrecision: 2 },
+          ]),
+        ).rejects.toThrow(/does not accept decimalPrecision/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for DECIMAL (not user-configurable)", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, lengthLimit: 500 },
+          ]),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should accept STRING lengthLimit at the boundary value 4000", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4000 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "str_field");
+        expect(f?.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 4000 });
+      });
+
+      it("should accept MULTILINE_TEXT lengthLimit at the boundary value 10000", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10000 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "ml_field");
+        expect(f?.sqlType).toEqual({ name: "MULTILINE", lengthLimit: 10000 });
+      });
+
+      it("should accept FLOAT with user-supplied decimalPrecision in range", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "float_field", type: EntityFieldDataType.FLOAT, decimalPrecision: 5 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "float_field");
+        expect(f?.sqlType.decimalPrecision).toBe(5);
+      });
+
+      it("should throw ValidationError when INTEGER minValue is greater than maxValue", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 },
+          ]),
+        ).rejects.toThrow(/minValue 100 >= maxValue 50.*minValue must be strictly less than maxValue/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when DECIMAL minValue equals maxValue", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, minValue: 10, maxValue: 10 },
+          ]),
+        ).rejects.toThrow(/minValue 10 >= maxValue 10/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when FLOAT minValue is greater than maxValue", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "float_field", type: EntityFieldDataType.FLOAT, minValue: 5, maxValue: -5 },
+          ]),
+        ).rejects.toThrow(/minValue 5 >= maxValue -5/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should accept INTEGER when minValue is strictly less than maxValue", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: -100, maxValue: 100 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "int_field");
+        expect(f?.sqlType.minValue).toBe(-100);
+        expect(f?.sqlType.maxValue).toBe(100);
+      });
+
+      it("should not enforce minValue < maxValue when only one is user-supplied (other comes from defaults)", async () => {
+        // Only minValue is provided; maxValue is filled from defaults — no cross-field check triggers.
+        await entityService.create("my_entity", [
+          { fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: -50 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "int_field");
+        expect(f?.sqlType.minValue).toBe(-50);
+      });
+    });
   });
 
   describe("deleteById", () => {
@@ -1718,7 +1974,7 @@ describe("EntityService Unit Tests", () => {
               expect.objectContaining({ name: "title" }),
               expect.objectContaining({
                 name: "count",
-                sqlType: { name: "INT" },
+                sqlType: { name: "INT", maxValue: 1000000000000, minValue: -1000000000000 },
               }),
             ]),
           }),
@@ -1886,6 +2142,404 @@ describe("EntityService Unit Tests", () => {
         (f: any) => f.name === "secret_field",
       );
       expect(secretField?.isEncrypted).toBe(true);
+    });
+
+    describe("sqlType constraint defaults", () => {
+      beforeEach(() => {
+        mockApiClient.get.mockResolvedValue(mockRawEntity);
+        mockApiClient.post.mockResolvedValue(undefined);
+      });
+
+      it("should default STRING lengthLimit to 200", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "str_field");
+        expect(f.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 200 });
+      });
+
+      it("should use user-provided lengthLimit for STRING fields", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 500 }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "str_field");
+        expect(f.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 500 });
+      });
+
+      it("should default MULTILINE_TEXT lengthLimit to 200", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "ml_field");
+        expect(f.sqlType).toEqual({ name: "MULTILINE", lengthLimit: 200 });
+      });
+
+      it("should default DECIMAL constraints to default values", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "dec_field");
+        expect(f.sqlType).toEqual({
+          name: "DECIMAL",
+          lengthLimit: 1000,
+          decimalPrecision: 2,
+          maxValue: 1000000000000,
+          minValue: -1000000000000,
+        });
+      });
+
+      it("should allow user to override DECIMAL constraints", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 9999, minValue: -9999 }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "dec_field");
+        expect(f.sqlType.decimalPrecision).toBe(4);
+        expect(f.sqlType.maxValue).toBe(9999);
+        expect(f.sqlType.minValue).toBe(-9999);
+      });
+
+      it("should set BOOLEAN lengthLimit to fixed value 100", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "bool_field", type: EntityFieldDataType.BOOLEAN }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "bool_field");
+        expect(f.sqlType).toEqual({ name: "BIT", lengthLimit: 100 });
+      });
+
+      it("should set DATE lengthLimit to fixed value 1000", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "date_field", type: EntityFieldDataType.DATE }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "date_field");
+        expect(f.sqlType).toEqual({ name: "DATE", lengthLimit: 1000 });
+      });
+
+      it("should set DATETIME_WITH_TZ lengthLimit to fixed value 1000", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "dtz_field", type: EntityFieldDataType.DATETIME_WITH_TZ }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "dtz_field");
+        expect(f.sqlType).toEqual({ name: "DATETIMEOFFSET", lengthLimit: 1000 });
+      });
+
+      it("should default INTEGER min/max to default values", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "int_field");
+        expect(f.sqlType).toEqual({ name: "INT", maxValue: 1000000000000, minValue: -1000000000000 });
+      });
+
+      it("should allow user to override INTEGER min/max", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: 500, minValue: -500 }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "int_field");
+        expect(f.sqlType).toEqual({ name: "INT", maxValue: 500, minValue: -500 });
+      });
+
+      it("should default BIG_INTEGER min/max to default values", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "bigint_field", type: EntityFieldDataType.BIG_INTEGER }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "bigint_field");
+        expect(f.sqlType).toEqual({ name: "BIGINT", maxValue: 1000000000000, minValue: -1000000000000 });
+      });
+
+      it("should default FLOAT to defaults including decimalPrecision", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "float_field", type: EntityFieldDataType.FLOAT }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "float_field");
+        expect(f.sqlType).toEqual({ name: "FLOAT", decimalPrecision: 2, maxValue: 1000000000000, minValue: -1000000000000 });
+      });
+
+      it("should default DOUBLE to defaults including decimalPrecision", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "double_field", type: EntityFieldDataType.DOUBLE }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "double_field");
+        expect(f.sqlType).toEqual({ name: "REAL", decimalPrecision: 2, maxValue: 1000000000000, minValue: -1000000000000 });
+      });
+
+      it("should set CHOICE_SET_SINGLE sqlType to plain INT (no constraints)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "css_field", type: EntityFieldDataType.CHOICE_SET_SINGLE }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "css_field");
+        expect(f.sqlType).toEqual({ name: "INT" });
+      });
+
+      it("should set FILE lengthLimit to fixed value 300 (UNIQUEIDENTIFIER)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "file_field", type: EntityFieldDataType.FILE }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "file_field");
+        expect(f.sqlType).toEqual({ name: "UNIQUEIDENTIFIER", lengthLimit: 300 });
+      });
+
+      it("should set RELATIONSHIP lengthLimit to fixed value 300 (UNIQUEIDENTIFIER)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "rel_field", type: EntityFieldDataType.RELATIONSHIP }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "rel_field");
+        expect(f.sqlType).toEqual({ name: "UNIQUEIDENTIFIER", lengthLimit: 300 });
+      });
+
+      it("should set CHOICE_SET_MULTIPLE lengthLimit to fixed value 4000 (NVARCHAR)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "csm_field", type: EntityFieldDataType.CHOICE_SET_MULTIPLE }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "csm_field");
+        expect(f.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 4000 });
+      });
+
+      it("should set AUTO_NUMBER sqlType to plain DECIMAL (no constraints)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "an_field", type: EntityFieldDataType.AUTO_NUMBER }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "an_field");
+        expect(f.sqlType).toEqual({ name: "DECIMAL" });
+      });
+
+    });
+
+    describe("sqlType constraint validation", () => {
+      beforeEach(() => {
+        mockApiClient.get.mockResolvedValue(mockRawEntity);
+        mockApiClient.post.mockResolvedValue(undefined);
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for BOOLEAN", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "bool_field", type: EntityFieldDataType.BOOLEAN, lengthLimit: 50 }],
+          }),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for INTEGER", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, lengthLimit: 50 }],
+          }),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+      });
+
+      it("should throw ValidationError when user passes maxValue for STRING", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, maxValue: 100 }],
+          }),
+        ).rejects.toThrow(/does not accept maxValue/);
+      });
+
+      it("should throw ValidationError when user passes decimalPrecision for INTEGER", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, decimalPrecision: 2 }],
+          }),
+        ).rejects.toThrow(/does not accept decimalPrecision/);
+      });
+
+      it("should throw ValidationError when updateFields targets a field with missing sqlType", async () => {
+        const entityWithMissingSqlType = {
+          ...mockRawEntity,
+          fields: [
+            {
+              ...mockRawEntity.fields[0],
+              sqlType: undefined,
+            },
+          ],
+        };
+        mockApiClient.get.mockResolvedValue(entityWithMissingSqlType);
+
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            updateFields: [{ id: ENTITY_TEST_CONSTANTS.FIELD_ID, lengthLimit: 500 }],
+          }),
+        ).rejects.toThrow(/missing sqlType metadata/);
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for FILE", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "file_field", type: EntityFieldDataType.FILE, lengthLimit: 500 }],
+          }),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for RELATIONSHIP", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "rel_field", type: EntityFieldDataType.RELATIONSHIP, lengthLimit: 500 }],
+          }),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+      });
+
+      it("should throw ValidationError when user passes maxValue for CHOICE_SET_SINGLE", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "css_field", type: EntityFieldDataType.CHOICE_SET_SINGLE, maxValue: 100 }],
+          }),
+        ).rejects.toThrow(/does not accept maxValue/);
+      });
+
+      it("should throw ValidationError when user passes lengthLimit for DATE", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "date_field", type: EntityFieldDataType.DATE, lengthLimit: 500 }],
+          }),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+      });
+
+      it("should throw ValidationError when STRING lengthLimit exceeds 4000", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4001 }],
+          }),
+        ).rejects.toThrow(/lengthLimit 4001 out of range \[1, 4000\]/);
+      });
+
+      it("should throw ValidationError when STRING lengthLimit is less than 1", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 0 }],
+          }),
+        ).rejects.toThrow(/lengthLimit 0 out of range \[1, 4000\]/);
+      });
+
+      it("should throw ValidationError when MULTILINE_TEXT lengthLimit exceeds 10000", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10001 }],
+          }),
+        ).rejects.toThrow(/lengthLimit 10001 out of range \[1, 10000\]/);
+      });
+
+      it("should throw ValidationError when DECIMAL is given lengthLimit by user (not user-configurable)", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, lengthLimit: 500 }],
+          }),
+        ).rejects.toThrow(/does not accept lengthLimit/);
+      });
+
+      it("should throw ValidationError when DECIMAL decimalPrecision exceeds 10", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 11 }],
+          }),
+        ).rejects.toThrow(/decimalPrecision 11 out of range \[0, 10\]/);
+      });
+
+      it("should throw ValidationError when DECIMAL decimalPrecision is negative", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: -1 }],
+          }),
+        ).rejects.toThrow(/decimalPrecision -1 out of range \[0, 10\]/);
+      });
+
+      it("should throw ValidationError when INTEGER maxValue exceeds Number.MAX_SAFE_INTEGER", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: Number.MAX_SAFE_INTEGER + 1 }],
+          }),
+        ).rejects.toThrow(/maxValue .* out of range/);
+      });
+
+      it("should throw ValidationError when addFields INTEGER minValue >= maxValue", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 }],
+          }),
+        ).rejects.toThrow(/minValue 100 >= maxValue 50.*minValue must be strictly less than maxValue/);
+      });
+
+      it("should throw ValidationError when updateFields targets a numeric field with minValue >= maxValue", async () => {
+        const numericRawEntity = {
+          ...mockRawEntity,
+          fields: [
+            {
+              ...mockRawEntity.fields[0],
+              name: "int_field",
+              sqlType: { name: "INT", maxValue: 1000, minValue: -1000 },
+            },
+          ],
+        };
+        mockApiClient.get.mockResolvedValue(numericRawEntity);
+
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            updateFields: [{ id: ENTITY_TEST_CONSTANTS.FIELD_ID, minValue: 200, maxValue: 100 }],
+          }),
+        ).rejects.toThrow(/minValue 200 >= maxValue 100/);
+      });
+
+      it("should accept FLOAT with user-supplied decimalPrecision in range", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "float_field", type: EntityFieldDataType.FLOAT, decimalPrecision: 5 }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "float_field");
+        expect(f.sqlType.decimalPrecision).toBe(5);
+      });
+
+      it("should accept STRING lengthLimit at the boundary value 4000", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4000 }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "str_field");
+        expect(f.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 4000 });
+      });
+
+      it("should accept MULTILINE_TEXT lengthLimit at the boundary value 10000", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10000 }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "ml_field");
+        expect(f.sqlType).toEqual({ name: "MULTILINE", lengthLimit: 10000 });
+      });
+
+      it("should preserve existing sqlType on updateFields when no constraint is provided", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          updateFields: [{ id: ENTITY_TEST_CONSTANTS.FIELD_ID, displayName: "Renamed Title" }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "title");
+        expect(f.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 200 });
+        expect(f.displayName).toBe("Renamed Title");
+      });
+
+      it("should overlay only user-provided constraints onto existing sqlType in updateFields", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          updateFields: [{ id: ENTITY_TEST_CONSTANTS.FIELD_ID, lengthLimit: 1000 }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "title");
+        expect(f.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 1000 });
+      });
     });
 
     it("should call UPDATE_METADATA endpoint when only metadata options are provided", async () => {


### PR DESCRIPTION
Fixes a class of "Field type cannot be changed" errors caused by incomplete
  sqlType payloads on entity field creation.                                       
                                          
  Changes:                                                                         
  - buildSqlTypeConstraints now returns API-required defaults per field type:      
    - STRING → lengthLimit: 200                                              
    - MULTILINE_TEXT → lengthLimit: 200                                          
    - DECIMAL → lengthLimit: 1000, decimalPrecision: 2, maxValue/minValue: ±1e12
    - INTEGER, BIG_INTEGER, FLOAT, DOUBLE → maxValue/minValue: ±1e12               
    - BOOLEAN → lengthLimit: 100 (fixed)                            
    - DATE, DATETIME_WITH_TZ → lengthLimit: 1000 (fixed)                           
    - All defaults are user-overridable via EntityCreateFieldOptions    