### PR TITLE
chore: bump version to 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "license": "MIT",
             "workspaces": [
                 "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
## Summary
- Patch version bump from 1.3.3 → 1.3.4 for release

## Changes
- `package.json` version updated to 1.3.4
- `package-lock.json` updated accordingly