### PR TITLE
feat(cas): add support for new tool confirmation

### DIFF
--- a/src/models/conversational-agent/conversations/types/events/message.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/message.types.ts
@@ -17,6 +17,7 @@ import type {
   MessageEvent,
   MessageStartEvent,
   MetaEvent,
+  ToolCallConfirmationEvent,
   ToolCallStartEvent
 } from './protocol.types';
 import type { CompletedContentPart, ContentPartStream } from './content-part.types';
@@ -340,6 +341,26 @@ export interface MessageStream {
    * ```
    */
   sendInterruptEnd(interruptId: string, endInterrupt: InterruptEndEvent): void;
+
+  /**
+   * Registers a handler for tool-call confirmation events on this message
+   *
+   * Fired when a peer responds to a tool call that was emitted with
+   * `requireConfirmation: true`. The handler runs at the message level, so it
+   * fires even if no per-tool-call stream exists for the confirmed `toolCallId`.
+   *
+   * @param cb - Callback receiving the toolCallId and the confirmation event
+   * @returns Cleanup function to remove the handler
+   *
+   * @example Handling a tool-call confirmation response
+   * ```typescript
+   * message.onToolCallConfirm(({ toolCallId, confirmEvent }) => {
+   *   if (confirmEvent.approved) executeTool(toolCallId, confirmEvent.input);
+   *   else cancelToolCall(toolCallId);
+   * });
+   * ```
+   */
+  onToolCallConfirm(cb: (args: { toolCallId: string; confirmEvent: ToolCallConfirmationEvent }) => void): () => void;
 
   // ==================== Content Part Management ====================
 

--- a/src/models/conversational-agent/conversations/types/events/message.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/message.types.ts
@@ -349,7 +349,7 @@ export interface MessageStream {
    * `requireConfirmation: true`. The handler runs at the message level, so it
    * fires even if no per-tool-call stream exists for the confirmed `toolCallId`.
    *
-   * @param cb - Callback receiving the toolCallId and the confirmation event
+   * @param callback - Callback receiving the toolCallId and the confirmation event
    * @returns Cleanup function to remove the handler
    *
    * @example Handling a tool-call confirmation response
@@ -360,7 +360,7 @@ export interface MessageStream {
    * });
    * ```
    */
-  onToolCallConfirm(cb: (args: { toolCallId: string; confirmEvent: ToolCallConfirmationEvent }) => void): () => void;
+  onToolCallConfirm(callback: (args: { toolCallId: string; confirmEvent: ToolCallConfirmationEvent }) => void): () => void;
 
   // ==================== Content Part Management ====================
 

--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -381,6 +381,34 @@ export interface ToolCallStartEvent {
    * Optional metadata pertaining to the tool call.
    */
   metaData?: MetaData;
+  /**
+   * Indicates that the tool call requires user confirmation before execution.
+   * When true, the client should render a confirmation UI and respond with a
+   * `confirmToolCall` event on the same tool call.
+   */
+  requireConfirmation?: boolean;
+  /**
+   * JSON schema describing the tool's input parameters. Present when
+   * `requireConfirmation` is true so the client can render an editable form.
+   */
+  inputSchema?: JSONValue;
+}
+
+/**
+ * Sent by the client to approve or reject a tool call that was emitted with
+ * `requireConfirmation: true`. Carries the user's decision and, when approved,
+ * the (possibly edited) input the tool should execute with.
+ */
+export interface ToolCallConfirmationEvent {
+  /**
+   * Whether the user approved the tool call.
+   */
+  approved: boolean;
+  /**
+   * The (possibly edited) input parameters for the tool call. Required when
+   * `approved` is true.
+   */
+  input?: JSONValue;
 }
 
 /**
@@ -446,6 +474,11 @@ export interface ToolCallEvent {
    * Signals the end of a tool call.
    */
   endToolCall?: ToolCallEndEvent;
+  /**
+   * Signals the user's approve/reject decision for a tool call that was
+   * emitted with `requireConfirmation: true`.
+   */
+  confirmToolCall?: ToolCallConfirmationEvent;
   /**
    * Allows additional events to be sent in the context of the enclosing event stream.
    */

--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -398,18 +398,14 @@ export interface ToolCallStartEvent {
  * Sent by the client to approve or reject a tool call that was emitted with
  * `requireConfirmation: true`. Carries the user's decision and, when approved,
  * the (possibly edited) input the tool should execute with.
+ *
+ * `input` is required when `approved` is `true` and optional when `approved`
+ * is `false`. The discriminated union enforces this at compile time so
+ * `{ approved: true }` (no `input`) is a type error.
  */
-export interface ToolCallConfirmationEvent {
-  /**
-   * Whether the user approved the tool call.
-   */
-  approved: boolean;
-  /**
-   * The (possibly edited) input parameters for the tool call. Required when
-   * `approved` is true.
-   */
-  input?: JSONValue;
-}
+export type ToolCallConfirmationEvent =
+  | { approved: true; input: JSONValue }
+  | { approved: false; input?: JSONValue };
 
 /**
  * Signals the end of a tool call.

--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -487,6 +487,11 @@ export interface ToolCallEvent {
 
 /**
  * Schema for tool call confirmation interrupt value.
+ *
+ * @deprecated Tool call confirmation now travels on {@link ToolCallStartEvent} via
+ * `requireConfirmation: true` / `inputSchema` and is responded to with
+ * {@link ToolCallConfirmationEvent}. This shape is retained for agents on the legacy
+ * runtime that still emit confirmations as interrupts.
  */
 export interface ToolCallConfirmationValue {
   /**
@@ -509,6 +514,10 @@ export interface ToolCallConfirmationValue {
 
 /**
  * Schema for tool call confirmation end value.
+ *
+ * @deprecated Confirmation responses now use {@link ToolCallConfirmationEvent} (sent via
+ * {@link ToolCallStream.sendToolCallConfirm}). This shape is retained for agents on the
+ * legacy runtime that consume confirmations through the interrupt-end channel.
  */
 export interface ToolCallConfirmationEndValue {
   /**
@@ -523,6 +532,11 @@ export interface ToolCallConfirmationEndValue {
 
 /**
  * Known interrupt start event for tool call confirmation.
+ *
+ * @deprecated Emitted only by agents on the legacy runtime. Agents on the current runtime
+ * express confirmation as `requireConfirmation: true` on {@link ToolCallStartEvent}, with
+ * the client responding via {@link ToolCallConfirmationEvent} (`confirmToolCall` on
+ * {@link ToolCallEvent}).
  */
 export interface ToolCallConfirmationInterruptStartEvent {
   /**

--- a/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
@@ -130,13 +130,13 @@ export interface ToolCallStream {
    *
    * @example Handling a confirmation response (agent-side)
    * ```typescript
-   * toolCall.onConfirmToolCall(({ approved, input }) => {
+   * toolCall.onToolCallConfirm(({ approved, input }) => {
    *   if (approved) executeTool(toolCall.startEvent.toolName, input);
    *   else cancelToolCall();
    * });
    * ```
    */
-  onConfirmToolCall(cb: (confirmToolCall: ToolCallConfirmationEvent) => void): () => void;
+  onToolCallConfirm(cb: (confirmToolCall: ToolCallConfirmationEvent) => void): () => void;
 
   // ==================== Sending ====================
 
@@ -164,15 +164,15 @@ export interface ToolCallStream {
    *
    * @example Approving a tool call
    * ```typescript
-   * toolCall.sendConfirmToolCall({ approved: true, input: editedInput });
+   * toolCall.sendToolCallConfirm({ approved: true, input: editedInput });
    * ```
    *
    * @example Rejecting a tool call
    * ```typescript
-   * toolCall.sendConfirmToolCall({ approved: false });
+   * toolCall.sendToolCallConfirm({ approved: false });
    * ```
    */
-  sendConfirmToolCall(confirmToolCall: ToolCallConfirmationEvent): void;
+  sendToolCallConfirm(confirmToolCall: ToolCallConfirmationEvent): void;
 
   // ==================== Advanced ====================
 

--- a/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
@@ -7,7 +7,7 @@
  */
 
 import type { MakeRequired } from '..';
-import type { ErrorEndEvent, ErrorStartEvent, MetaEvent, ToolCallEndEvent, ToolCallEvent, ToolCallStartEvent } from './protocol.types';
+import type { ErrorEndEvent, ErrorStartEvent, MetaEvent, ToolCallConfirmationEvent, ToolCallEndEvent, ToolCallEvent, ToolCallStartEvent } from './protocol.types';
 
 /**
  * Aggregated data for a completed tool call
@@ -120,6 +120,24 @@ export interface ToolCallStream {
    */
   onToolCallEnd(cb: (endToolCall: ToolCallEndEvent) => void): () => void;
 
+  /**
+   * Registers a handler for tool call confirmation events. Fired when the
+   * peer responds to a tool call that was emitted with
+   * `requireConfirmation: true` on its start event.
+   *
+   * @param cb - Callback receiving the confirmation event
+   * @returns Cleanup function to remove the handler
+   *
+   * @example Handling a confirmation response (agent-side)
+   * ```typescript
+   * toolCall.onConfirmToolCall(({ approved, input }) => {
+   *   if (approved) executeTool(toolCall.startEvent.toolName, input);
+   *   else cancelToolCall();
+   * });
+   * ```
+   */
+  onConfirmToolCall(cb: (confirmToolCall: ToolCallConfirmationEvent) => void): () => void;
+
   // ==================== Sending ====================
 
   /**
@@ -135,6 +153,26 @@ export interface ToolCallStream {
    * ```
    */
   sendToolCallEnd(endToolCall?: ToolCallEndEvent): void;
+
+  /**
+   * Sends a tool call confirmation (approve or reject) for a tool call that
+   * was emitted with `requireConfirmation: true`. Replaces the legacy
+   * interrupt-based confirmation flow.
+   *
+   * @param confirmToolCall - The user's decision and (when approved) the
+   *   possibly-edited input the tool should execute with
+   *
+   * @example Approving a tool call
+   * ```typescript
+   * toolCall.sendConfirmToolCall({ approved: true, input: editedInput });
+   * ```
+   *
+   * @example Rejecting a tool call
+   * ```typescript
+   * toolCall.sendConfirmToolCall({ approved: false });
+   * ```
+   */
+  sendConfirmToolCall(confirmToolCall: ToolCallConfirmationEvent): void;
 
   // ==================== Advanced ====================
 

--- a/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
@@ -155,7 +155,7 @@ export interface ToolCallStream {
    * peer responds to a tool call that was emitted with
    * `requireConfirmation: true` on its start event.
    *
-   * @param cb - Callback receiving the confirmation event
+   * @param callback - Callback receiving the confirmation event
    * @returns Cleanup function to remove the handler
    *
    * @example Handling a confirmation response (agent-side)
@@ -166,7 +166,7 @@ export interface ToolCallStream {
    * });
    * ```
    */
-  onToolCallConfirm(cb: (confirmToolCall: ToolCallConfirmationEvent) => void): () => void;
+  onToolCallConfirm(callback: (confirmToolCall: ToolCallConfirmationEvent) => void): () => void;
 
   // ==================== Sending ====================
 

--- a/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
@@ -63,6 +63,36 @@ export type CompletedToolCall = ToolCallStartEvent & ToolCallEndEvent & {
  *   });
  * });
  * ```
+ *
+ * @example Migrating from legacy interrupt-based confirmation
+ * ```typescript
+ * // BEFORE — legacy interrupt flow
+ * message.onInterruptStart(async ({ interruptId, startEvent }) => {
+ *   if (startEvent.type !== InterruptType.ToolCallConfirmation) return;
+ *   const { toolName, inputSchema, inputValue } = startEvent.value;
+ *
+ *   const decision = await showConfirmationDialog({
+ *     toolName, inputSchema, input: inputValue,
+ *   });
+ *   message.sendInterruptEnd(interruptId, {
+ *     approved: decision.approved,
+ *     input: decision.editedInput,
+ *   });
+ * });
+ *
+ * // AFTER — new tool-call confirmation flow
+ * message.onToolCallStart(async (toolCall) => {
+ *   const { toolName, input, requireConfirmation, inputSchema } = toolCall.startEvent;
+ *   if (!requireConfirmation) return;
+ *
+ *   const decision = await showConfirmationDialog({ toolName, inputSchema, input });
+ *   if (decision.approved) {
+ *     toolCall.sendToolCallConfirm({ approved: true, input: decision.editedInput });
+ *   } else {
+ *     toolCall.sendToolCallConfirm({ approved: false });
+ *   }
+ * });
+ * ```
  */
 export interface ToolCallStream {
   /** Unique identifier for this tool call */

--- a/src/services/conversational-agent/helpers/conversation-event-helper-common.ts
+++ b/src/services/conversational-agent/helpers/conversation-event-helper-common.ts
@@ -23,6 +23,7 @@ import type {
   SessionStartedEvent,
   SessionStartEvent,
   Simplify,
+  ToolCallConfirmationEvent,
   ToolCallEndEvent,
   ToolCallStartEvent
 } from '@/models/conversational-agent';
@@ -76,6 +77,8 @@ export type SessionStartHandlerAsync = (session: SessionEventHelper) => Promise<
 export type ToolCallEndHandler = (endToolCall: ToolCallEndEvent) => void;
 export type ToolCallStartHandler = (toolCall: ToolCallEventHelper) => void;
 export type ToolCallStartHandlerAsync = (toolCall: ToolCallEventHelper) => Promise<ToolCallEndEvent | void>;
+export type ToolCallConfirmationHandler = (confirmToolCall: ToolCallConfirmationEvent) => void;
+export type ToolCallConfirmHandler = (args: ToolCallConfirmationHandlerArgs) => void;
 export type ToolCallCompletedHandler = (completedToolCall: CompletedToolCall) => void;
 export type ContentPartCompletedHandler = (completedContentPart: CompletedContentPart) => void;
 export type MessageCompletedHandler = (completedMessage: CompletedMessage) => void;
@@ -118,6 +121,8 @@ export type UnhandledErrorEndHandlerArgs = AnyErrorEndHandlerArgs;
 export type InterruptStartHandlerArgs = { interruptId: string; startEvent: InterruptStartEvent };
 export type InterruptEndHandlerArgs = { interruptId: string; endEvent: InterruptEndEvent };
 export type InterruptCompletedHandlerArgs = { interruptId: string; startEvent: InterruptStartEvent; endEvent: InterruptEndEvent };
+
+export type ToolCallConfirmationHandlerArgs = { toolCallId: string; confirmEvent: ToolCallConfirmationEvent };
 
 export type ConversationEventErrorSource = ConversationEventHelperBase<any, any>;
 

--- a/src/services/conversational-agent/helpers/message-event-helper.ts
+++ b/src/services/conversational-agent/helpers/message-event-helper.ts
@@ -27,6 +27,7 @@ import type {
   MessageCompletedHandler,
   MessageEndHandler,
   ToolCallCompletedHandler,
+  ToolCallConfirmHandler,
   ToolCallStartEventWithId,
   ToolCallStartHandler,
   ToolCallStartHandlerAsync
@@ -55,6 +56,7 @@ export abstract class MessageEventHelper extends ConversationEventHelperBase<
   protected readonly _toolCallMap = new Map<string, ToolCallEventHelperImpl>();
   protected readonly _interruptStartHandlers = new Array<InterruptStartHandler>();
   protected readonly _interruptEndHandlers = new Array<InterruptEndHandler>();
+  protected readonly _toolCallConfirmHandlers = new Array<ToolCallConfirmHandler>();
 
   constructor(
     public readonly exchange: ExchangeEventHelper,
@@ -340,6 +342,25 @@ export abstract class MessageEventHelper extends ConversationEventHelperBase<
   }
 
   /**
+   * Registers a handler for tool-call confirmation events. Fired when a peer
+   * responds to a tool call that was emitted with `requireConfirmation: true`.
+   *
+   * Fires at the message level before the event is delegated to the per-tool-call
+   * helper, so this handler runs even when no `ToolCallEventHelper` exists for the
+   * confirmed tool call (e.g. on the agent side after the originating helper has
+   * been cleaned up, or on the client side if no `onToolCallStart` is registered).
+   *
+   * @returns Cleanup function to remove the handler.
+   */
+  public onToolCallConfirm(cb: ToolCallConfirmHandler) {
+    this._toolCallConfirmHandlers.push(cb);
+    return () => {
+      const index = this._toolCallConfirmHandlers.indexOf(cb);
+      if (index >= 0) this._toolCallConfirmHandlers.splice(index, 1);
+    };
+  }
+
+  /**
    * Sends an interrupt start event.
    */
   public sendInterrupt(interruptId: string, startInterrupt: InterruptStartEvent) {
@@ -483,6 +504,17 @@ export class MessageEventHelperImpl extends MessageEventHelper {
     }
 
     if (messageEvent.toolCall) {
+      // Dispatch confirmToolCall at the message level (flat dispatch) before delegating
+      // to the per-tool-call helper. Needed because the tool-call helper may not exist
+      // for this id on the receiving side.
+      if (messageEvent.toolCall.confirmToolCall) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this._toolCallConfirmHandlers.forEach(cb => cb({
+          toolCallId: messageEvent.toolCall!.toolCallId,
+          confirmEvent: messageEvent.toolCall!.confirmToolCall!
+        }));
+      }
+
       let toolCallHelper = this._toolCallMap.get(messageEvent.toolCall.toolCallId);
       if (!toolCallHelper && this._toolCallStartHandlers.length > 0) {
         toolCallHelper = new ToolCallEventHelperImpl(this, messageEvent.toolCall.toolCallId, messageEvent.toolCall.startToolCall);

--- a/src/services/conversational-agent/helpers/message-event-helper.ts
+++ b/src/services/conversational-agent/helpers/message-event-helper.ts
@@ -352,10 +352,10 @@ export abstract class MessageEventHelper extends ConversationEventHelperBase<
    *
    * @returns Cleanup function to remove the handler.
    */
-  public onToolCallConfirm(cb: ToolCallConfirmHandler) {
-    this._toolCallConfirmHandlers.push(cb);
+  public onToolCallConfirm(callback: ToolCallConfirmHandler) {
+    this._toolCallConfirmHandlers.push(callback);
     return () => {
-      const index = this._toolCallConfirmHandlers.indexOf(cb);
+      const index = this._toolCallConfirmHandlers.indexOf(callback);
       if (index >= 0) this._toolCallConfirmHandlers.splice(index, 1);
     };
   }

--- a/src/services/conversational-agent/helpers/tool-call-event-helper.ts
+++ b/src/services/conversational-agent/helpers/tool-call-event-helper.ts
@@ -114,7 +114,7 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
    * peer responds to a tool call that was emitted with `requireConfirmation`.
    * @returns Cleanup function to remove the handler.
    */
-  public onConfirmToolCall(cb: ToolCallConfirmationHandler) {
+  public onToolCallConfirm(cb: ToolCallConfirmationHandler) {
     this._confirmHandlers.push(cb);
     return () => {
       const index = this._confirmHandlers.indexOf(cb);
@@ -128,7 +128,7 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
    * `sendInterruptEnd` flow for tool call confirmation.
    * @throws Error if tool call has already ended.
    */
-  public sendConfirmToolCall(confirmToolCall: ToolCallConfirmationEvent) {
+  public sendToolCallConfirm(confirmToolCall: ToolCallConfirmationEvent) {
     this.assertNotEnded();
     this.emit({ confirmToolCall });
   }

--- a/src/services/conversational-agent/helpers/tool-call-event-helper.ts
+++ b/src/services/conversational-agent/helpers/tool-call-event-helper.ts
@@ -2,6 +2,7 @@ import type {
   MakeRequired,
   MetaEvent,
   ToolCall,
+  ToolCallConfirmationEvent,
   ToolCallEndEvent,
   ToolCallEvent,
   ToolCallStartEvent
@@ -12,6 +13,7 @@ import {
   ConversationEventValidationError,
   type ErrorEndEventOptions,
   type ErrorStartEventOptions,
+  type ToolCallConfirmationHandler,
   type ToolCallEndHandler
 } from './conversation-event-helper-common';
 import type { ToolCallStream } from '@/models/conversational-agent';
@@ -27,6 +29,7 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
 > implements ToolCallStream {
 
   protected readonly _endHandlers = new Array<ToolCallEndHandler>();
+  protected readonly _confirmHandlers = new Array<ToolCallConfirmationHandler>();
 
   constructor(
     public readonly message: MessageEventHelper,
@@ -104,6 +107,30 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
    */
   public onEndToolCall(cb: ToolCallEndHandler) {
     this.onToolCallEnd(cb);
+  }
+
+  /**
+   * Registers a handler for tool call confirmation events. Fired when the
+   * peer responds to a tool call that was emitted with `requireConfirmation`.
+   * @returns Cleanup function to remove the handler.
+   */
+  public onConfirmToolCall(cb: ToolCallConfirmationHandler) {
+    this._confirmHandlers.push(cb);
+    return () => {
+      const index = this._confirmHandlers.indexOf(cb);
+      if (index >= 0) this._confirmHandlers.splice(index, 1);
+    };
+  }
+
+  /**
+   * Sends a tool call confirmation (approve/reject) for a tool call that was
+   * emitted with `requireConfirmation: true`. Replaces the legacy
+   * `sendInterruptEnd` flow for tool call confirmation.
+   * @throws Error if tool call has already ended.
+   */
+  public sendConfirmToolCall(confirmToolCall: ToolCallConfirmationEvent) {
+    this.assertNotEnded();
+    this.emit({ confirmToolCall });
   }
 
   /**
@@ -192,6 +219,11 @@ export class ToolCallEventHelperImpl extends ToolCallEventHelper {
 
     if (toolCallEvent.toolCallError?.endError) {
       this.dispatchErrorEnd(toolCallEvent.toolCallError.errorId, toolCallEvent.toolCallError.endError);
+    }
+
+    if (toolCallEvent.confirmToolCall) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this._confirmHandlers.forEach(cb => cb(toolCallEvent.confirmToolCall!));
     }
 
     if (toolCallEvent.endToolCall) {

--- a/src/services/conversational-agent/helpers/tool-call-event-helper.ts
+++ b/src/services/conversational-agent/helpers/tool-call-event-helper.ts
@@ -114,10 +114,10 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
    * peer responds to a tool call that was emitted with `requireConfirmation`.
    * @returns Cleanup function to remove the handler.
    */
-  public onToolCallConfirm(cb: ToolCallConfirmationHandler) {
-    this._confirmHandlers.push(cb);
+  public onToolCallConfirm(callback: ToolCallConfirmationHandler) {
+    this._confirmHandlers.push(callback);
     return () => {
-      const index = this._confirmHandlers.indexOf(cb);
+      const index = this._confirmHandlers.indexOf(callback);
       if (index >= 0) this._confirmHandlers.splice(index, 1);
     };
   }

--- a/tests/unit/helpers/conversational-agent/message-event-helper.test.ts
+++ b/tests/unit/helpers/conversational-agent/message-event-helper.test.ts
@@ -474,6 +474,16 @@ describe('MessageEventHelper', () => {
       cleanup();
       expect((message as any)._interruptEndHandlers).toHaveLength(0);
     });
+
+    it('should register and unregister onToolCallConfirm handler', () => {
+      const { message } = createMessage();
+      const handler = vi.fn();
+      const cleanup = message.onToolCallConfirm(handler);
+
+      expect((message as any)._toolCallConfirmHandlers).toHaveLength(1);
+      cleanup();
+      expect((message as any)._toolCallConfirmHandlers).toHaveLength(0);
+    });
   });
 
   describe('dispatch', () => {
@@ -543,6 +553,76 @@ describe('MessageEventHelper', () => {
       expect(intEndSpy).toHaveBeenCalledWith(
         expect.objectContaining({ interruptId: 'int-1' })
       );
+    });
+
+    it('should dispatch confirmToolCall to message-level onToolCallConfirm handler', () => {
+      const { message } = createMessage();
+      const confirmSpy = vi.fn();
+      message.onToolCallConfirm(confirmSpy);
+
+      message.dispatch({
+        messageId: MESSAGE_ID,
+        toolCall: {
+          toolCallId: 'tc-confirm-1',
+          confirmToolCall: { approved: true, input: { v: 1 } },
+        },
+      });
+
+      expect(confirmSpy).toHaveBeenCalledWith({
+        toolCallId: 'tc-confirm-1',
+        confirmEvent: { approved: true, input: { v: 1 } },
+      });
+    });
+
+    it('should fire message-level onToolCallConfirm even when no per-tool-call helper exists', () => {
+      const { message } = createMessage();
+      const confirmSpy = vi.fn();
+      message.onToolCallConfirm(confirmSpy);
+
+      // No onToolCallStart registered; no per-tool-call helper is created.
+      message.dispatch({
+        messageId: MESSAGE_ID,
+        toolCall: {
+          toolCallId: 'tc-no-helper',
+          confirmToolCall: { approved: false },
+        },
+      });
+
+      expect(confirmSpy).toHaveBeenCalledWith({
+        toolCallId: 'tc-no-helper',
+        confirmEvent: { approved: false },
+      });
+      expect((message as any)._toolCallMap.size).toBe(0);
+    });
+
+    it('should fire message-level onToolCallConfirm before per-tool-call onToolCallConfirm', () => {
+      const { message } = createMessage();
+      const order: string[] = [];
+
+      message.onToolCallConfirm(() => order.push('message'));
+      message.onToolCallStart((tc) => {
+        tc.onToolCallConfirm(() => order.push('toolCall'));
+      });
+
+      // Create the per-tool-call helper via a start event
+      message.dispatch({
+        messageId: MESSAGE_ID,
+        toolCall: {
+          toolCallId: 'tc-order-1',
+          startToolCall: { toolName: 'search' },
+        },
+      });
+
+      // Dispatch a confirmation
+      message.dispatch({
+        messageId: MESSAGE_ID,
+        toolCall: {
+          toolCallId: 'tc-order-1',
+          confirmToolCall: { approved: true, input: {} },
+        },
+      });
+
+      expect(order).toEqual(['message', 'toolCall']);
     });
 
     it('should dispatch endMessage and mark ended and deleted', () => {

--- a/tests/unit/helpers/conversational-agent/message-event-helper.test.ts
+++ b/tests/unit/helpers/conversational-agent/message-event-helper.test.ts
@@ -480,9 +480,18 @@ describe('MessageEventHelper', () => {
       const handler = vi.fn();
       const cleanup = message.onToolCallConfirm(handler);
 
-      expect((message as any)._toolCallConfirmHandlers).toHaveLength(1);
+      message.dispatch({
+        messageId: MESSAGE_ID,
+        toolCall: { toolCallId: 'tc-cleanup', confirmToolCall: { approved: false } },
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
+
       cleanup();
-      expect((message as any)._toolCallConfirmHandlers).toHaveLength(0);
+      message.dispatch({
+        messageId: MESSAGE_ID,
+        toolCall: { toolCallId: 'tc-cleanup', confirmToolCall: { approved: false } },
+      });
+      expect(handler).toHaveBeenCalledTimes(1); // not called again after cleanup
     });
   });
 
@@ -592,7 +601,7 @@ describe('MessageEventHelper', () => {
         toolCallId: 'tc-no-helper',
         confirmEvent: { approved: false },
       });
-      expect((message as any)._toolCallMap.size).toBe(0);
+      expect(message.getToolCall('tc-no-helper')).toBeUndefined();
     });
 
     it('should fire message-level onToolCallConfirm before per-tool-call onToolCallConfirm', () => {

--- a/tests/unit/helpers/conversational-agent/tool-call-event-helper.test.ts
+++ b/tests/unit/helpers/conversational-agent/tool-call-event-helper.test.ts
@@ -199,6 +199,74 @@ describe('ToolCallEventHelper', () => {
       cleanup();
       expect((toolCall as any)._endHandlers).toHaveLength(0);
     });
+
+    it('should register and unregister onToolCallConfirm handler', () => {
+      const { toolCall } = createToolCall();
+      const handler = vi.fn();
+      const cleanup = toolCall.onToolCallConfirm(handler);
+
+      expect((toolCall as any)._confirmHandlers).toHaveLength(1);
+      cleanup();
+      expect((toolCall as any)._confirmHandlers).toHaveLength(0);
+    });
+  });
+
+  describe('sendToolCallConfirm', () => {
+    it('should emit confirmToolCall with approved=true and input', () => {
+      const { emitSpy, toolCall } = createToolCall();
+
+      toolCall.sendToolCallConfirm({ approved: true, input: { query: 'edited' } });
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exchange: expect.objectContaining({
+            message: expect.objectContaining({
+              toolCall: expect.objectContaining({
+                toolCallId: TOOL_CALL_ID,
+                confirmToolCall: { approved: true, input: { query: 'edited' } },
+              }),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should emit confirmToolCall with approved=false', () => {
+      const { emitSpy, toolCall } = createToolCall();
+
+      toolCall.sendToolCallConfirm({ approved: false });
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exchange: expect.objectContaining({
+            message: expect.objectContaining({
+              toolCall: expect.objectContaining({
+                toolCallId: TOOL_CALL_ID,
+                confirmToolCall: { approved: false },
+              }),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should not mark the tool call as ended', () => {
+      const { toolCall } = createToolCall();
+
+      toolCall.sendToolCallConfirm({ approved: true, input: {} });
+
+      expect(toolCall.ended).toBe(false);
+      expect(toolCall.deleted).toBe(false);
+    });
+
+    it('should throw after the tool call has ended', () => {
+      const { toolCall } = createToolCall();
+      toolCall.sendToolCallEnd();
+
+      expect(() => toolCall.sendToolCallConfirm({ approved: false })).toThrow(
+        ConversationEventInvalidOperationError
+      );
+    });
   });
 
   describe('dispatch', () => {
@@ -261,6 +329,33 @@ describe('ToolCallEventHelper', () => {
       expect(errorEndSpy).toHaveBeenCalledWith(
         expect.objectContaining({ errorId: 'tc-err-1' })
       );
+    });
+
+    it('should dispatch confirmToolCall to confirm handlers', () => {
+      const { toolCall } = createToolCall();
+      const confirmSpy = vi.fn();
+      toolCall.onToolCallConfirm(confirmSpy);
+
+      toolCall.dispatch({
+        toolCallId: TOOL_CALL_ID,
+        confirmToolCall: { approved: true, input: { query: 'q' } },
+      });
+
+      expect(confirmSpy).toHaveBeenCalledWith({ approved: true, input: { query: 'q' } });
+      expect(toolCall.ended).toBe(false);
+    });
+
+    it('should not invoke end handlers when dispatching confirmToolCall', () => {
+      const { toolCall } = createToolCall();
+      const endSpy = vi.fn();
+      toolCall.onToolCallEnd(endSpy);
+
+      toolCall.dispatch({
+        toolCallId: TOOL_CALL_ID,
+        confirmToolCall: { approved: false },
+      });
+
+      expect(endSpy).not.toHaveBeenCalled();
     });
 
     it('should ignore events for different toolCallId', () => {

--- a/tests/unit/helpers/conversational-agent/tool-call-event-helper.test.ts
+++ b/tests/unit/helpers/conversational-agent/tool-call-event-helper.test.ts
@@ -205,9 +205,12 @@ describe('ToolCallEventHelper', () => {
       const handler = vi.fn();
       const cleanup = toolCall.onToolCallConfirm(handler);
 
-      expect((toolCall as any)._confirmHandlers).toHaveLength(1);
+      toolCall.dispatch({ toolCallId: TOOL_CALL_ID, confirmToolCall: { approved: false } });
+      expect(handler).toHaveBeenCalledTimes(1);
+
       cleanup();
-      expect((toolCall as any)._confirmHandlers).toHaveLength(0);
+      toolCall.dispatch({ toolCallId: TOOL_CALL_ID, confirmToolCall: { approved: false } });
+      expect(handler).toHaveBeenCalledTimes(1); // not called again after cleanup
     });
   });
 


### PR DESCRIPTION
## Description

Conversational agents revamped how tool confirmation works for unified runtime agents. The legacy SDK gained support for the new flow; this PR ports those changes into the new SDK so confirmation works end-to-end with the chat widget UI.

## Background

Previously, tool-call confirmation was modeled as an *interrupt* (`sendInterruptEnd` on the message). The runtime now models it as a first-class event on the tool call itself: a `requireConfirmation` flag on `startToolCall`, paired with a `confirmToolCall` response carrying the user's decision (and optionally edited input).

## Protocol changes (`protocol.types.ts`)

- `ToolCallStartEvent` gains:
  - `requireConfirmation?: boolean` — when true, the client should render a confirmation UI.
  - `inputSchema?: JSONValue` — JSON schema for the tool inputs so the client can render an editable form.
- New `ToolCallConfirmationEvent` — a discriminated union:
  ```ts
  | { approved: true; input: JSONValue }
  | { approved: false; input?: JSONValue }
  ```
  This enforces at compile time that `input` is required when approved and optional when rejected.
- `ToolCallEvent` gains an optional `confirmToolCall` field carrying that event.

## SDK surface

**`ToolCallStream`** (`tool-call.types.ts`)
- `onToolCallConfirm(cb)` — register a handler for confirmation responses on a specific tool call.
- `sendToolCallConfirm(event)` — send approve/reject from the client. Throws if the tool call has already ended. Replaces the legacy `sendInterruptEnd` confirmation flow.

**`MessageStream`** (`message.types.ts`)
- `onToolCallConfirm(cb)` — message-level handler that fires for *any* confirmed tool call on the message, even when no per-tool-call helper exists for that id.

### Why both message-level and tool-call-level dispatch?

A per-tool-call helper isn't always present when the confirmation arrives:
- On the agent side, the originating helper may already be cleaned up.
- On the client side, no per-tool-call helper is created if `onToolCallStart` isn't registered.

The message-level handler runs first (flat dispatch in `MessageEventHelperImpl.dispatch`), then the event is delegated to the per-tool-call helper if one exists. Tested explicitly: ordering, no-helper case, and per-tool-call dispatch.

## Tests

- `tool-call-event-helper.test.ts` — register/unregister, `sendToolCallConfirm` for both approve/reject, post-end throw behavior, dispatch routing, and isolation from `endToolCall`.
- `message-event-helper.test.ts` — register/unregister, message-level dispatch, dispatch when no per-tool-call helper exists, and message→tool-call ordering.

## Out of scope

- No widget UI changes — this PR is the protocol/SDK plumbing only. The widget will consume `onToolCallConfirm` / `inputSchema` in a follow-up [here](https://github.com/UiPath/uipath-ui-widgets/pull/67).
- The legacy interrupt-based confirmation flow remains; this is additive.
