### PR TITLE
feat(feedback): add Feedback.getById method

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -153,6 +153,7 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | Method | OAuth Scope |
 |--------|-------------|
 | `getAll()` | `Traces.Api` |
+| `getById()` | `Traces.Api` |
 
 ## Processes
 

--- a/src/models/agents/feedback/feedback.internal-types.ts
+++ b/src/models/agents/feedback/feedback.internal-types.ts
@@ -14,6 +14,7 @@ export interface RawFeedbackGetResponse {
   metadata?: string;
   isPositive: boolean;
   feedbackCategories: FeedbackCategory[];
+  folderKey?: string;
   userEmail?: string;
   status: FeedbackStatus;
   createdAt: string;

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -66,4 +66,32 @@ export interface FeedbackServiceModel {
       ? PaginatedResponse<FeedbackGetResponse>
       : NonPaginatedResponse<FeedbackGetResponse>
   >;
+
+  /**
+   * Gets a single feedback entry by its unique identifier.
+   *
+   * Retrieves detailed information about a specific feedback entry, including
+   * its associated categories, user email, status, and timing information.
+   *
+   * @param id - Unique identifier (GUID) of the feedback entry
+   * @returns Promise resolving to {@link FeedbackGetResponse}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * // Get a specific feedback entry
+   * const item = await feedback.getById('<feedbackId>');
+   * console.log(item.isPositive, item.comment, item.status);
+   * ```
+   * @example
+   * ```typescript
+   * // Get feedback ID from getAll, then retrieve details
+   * const allFeedback = await feedback.getAll({ pageSize: 10 });
+   * const feedbackId = allFeedback.items[0].id;
+   * const item = await feedback.getById(feedbackId);
+   * ```
+   */
+  getById(id: string): Promise<FeedbackGetResponse>;
 }

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -68,12 +68,9 @@ export interface FeedbackServiceModel {
   >;
 
   /**
-   * Gets a single feedback entry by its unique identifier.
+   * Gets a single feedback entry by its feedback ID.
    *
-   * Retrieves detailed information about a specific feedback entry, including
-   * its associated categories, user email, status, and timing information.
-   *
-   * @param id - Unique identifier (GUID) of the feedback entry
+   * @param id - Feedback ID (GUID) of the feedback entry
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -82,12 +79,12 @@ export interface FeedbackServiceModel {
    * const feedback = new Feedback(sdk);
    *
    * // Get a specific feedback entry
-   * const item = await feedback.getById('<feedbackId>');
+   * const item = await feedback.getById(<feedbackId>);
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    * @example
    * ```typescript
-   * // Get feedback ID from getAll, then retrieve details
+   * // First, get feedback entries to obtain the ID
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
    * const item = await feedback.getById(feedbackId);

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -1,6 +1,7 @@
 import type {
   FeedbackGetResponse,
   FeedbackGetAllOptions,
+  FeedbackGetByIdOptions,
 } from './feedback.types';
 import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 
@@ -71,7 +72,7 @@ export interface FeedbackServiceModel {
    * Gets a single feedback entry by its feedback ID.
    *
    * @param id - Feedback ID (GUID) of the feedback entry
-   * @param folderKey The folder key for authorization
+   * @param options - Optional query parameters including folderKey for authorization {@link FeedbackGetByIdOptions}
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -83,9 +84,9 @@ export interface FeedbackServiceModel {
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
    * const folderKey = allFeedback.items[0].folderKey;
-   * const item = await feedback.getById(feedbackId, folderKey);
+   * const item = await feedback.getById(feedbackId, { folderKey });
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
-  getById(id: string, folderKey: string): Promise<FeedbackGetResponse>;
+  getById(id: string, options?: FeedbackGetByIdOptions): Promise<FeedbackGetResponse>;
 }

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -1,7 +1,7 @@
 import type {
   FeedbackGetResponse,
   FeedbackGetAllOptions,
-  FeedbackGetByIdOptions,
+  FeedbackOptions,
 } from './feedback.types';
 import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 
@@ -72,7 +72,7 @@ export interface FeedbackServiceModel {
    * Gets a single feedback entry by its feedback ID.
    *
    * @param id - Feedback ID (GUID) of the feedback entry
-   * @param options - Optional query parameters including folderKey for authorization {@link FeedbackGetByIdOptions}
+   * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -88,5 +88,5 @@ export interface FeedbackServiceModel {
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
-  getById(id: string, options?: FeedbackGetByIdOptions): Promise<FeedbackGetResponse>;
+  getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse>;
 }

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -71,6 +71,7 @@ export interface FeedbackServiceModel {
    * Gets a single feedback entry by its feedback ID.
    *
    * @param id - Feedback ID (GUID) of the feedback entry
+   * @param folderKey The folder key for authorization
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -78,17 +79,13 @@ export interface FeedbackServiceModel {
    *
    * const feedback = new Feedback(sdk);
    *
-   * // Get a specific feedback entry
-   * const item = await feedback.getById(<feedbackId>);
-   * console.log(item.isPositive, item.comment, item.status);
-   * ```
-   * @example
-   * ```typescript
-   * // First, get feedback entries to obtain the ID
+   * // First, get feedback entries to obtain the ID and folder key
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
-   * const item = await feedback.getById(feedbackId);
+   * const folderKey = allFeedback.items[0].folderKey;
+   * const item = await feedback.getById(feedbackId, folderKey);
+   * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
-  getById(id: string): Promise<FeedbackGetResponse>;
+  getById(id: string, folderKey: string): Promise<FeedbackGetResponse>;
 }

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -66,11 +66,11 @@ export interface FeedbackGetResponse {
 }
 
 /**
- * Options for retrieving a single feedback entry by ID
+ * Options shared across feedback operations
  */
-export interface FeedbackGetByIdOptions {
-  /** Folder key for authorization (required for folder-scoped tenants) */
-  folderKey?: string;
+export interface FeedbackOptions {
+  /** Folder key for authorization */
+  folderKey: string;
 }
 
 /**

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -66,6 +66,14 @@ export interface FeedbackGetResponse {
 }
 
 /**
+ * Options for retrieving a single feedback entry by ID
+ */
+export interface FeedbackGetByIdOptions {
+  /** Folder key for authorization (required for folder-scoped tenants) */
+  folderKey?: string;
+}
+
+/**
  * Options for retrieving multiple feedback entries
  */
 export type FeedbackGetAllOptions = PaginationOptions & {

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -53,6 +53,8 @@ export interface FeedbackGetResponse {
   isPositive: boolean;
   /** Categories associated with this feedback entry */
   feedbackCategories: FeedbackCategory[];
+  /** Folder key (GUID) of the folder the feedback belongs to */
+  folderKey?: string;
   /** Email address of the user who submitted the feedback */
   userEmail?: string;
   /** Current status of the feedback in the review workflow */

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -2,6 +2,7 @@ import { BaseService } from '../../base';
 import {
   FeedbackGetResponse,
   FeedbackGetAllOptions,
+  FeedbackGetByIdOptions,
 } from '../../../models/agents/feedback/feedback.types';
 import { FeedbackServiceModel } from '../../../models/agents/feedback/feedback.models';
 import { FeedbackMap } from '../../../models/agents/feedback/feedback.constants';
@@ -89,7 +90,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * Gets a single feedback entry by its feedback ID.
    *
    * @param id - Feedback ID (GUID) of the feedback entry
-   * @param folderKey The folder key for authorization
+   * @param options - Optional query parameters including folderKey for authorization {@link FeedbackGetByIdOptions}
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -101,18 +102,17 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
    * const folderKey = allFeedback.items[0].folderKey;
-   * const item = await feedback.getById(feedbackId, folderKey);
+   * const item = await feedback.getById(feedbackId, { folderKey });
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
   @track('Feedback.GetById')
-  async getById(id: string, folderKey: string): Promise<FeedbackGetResponse> {
+  async getById(id: string, options?: FeedbackGetByIdOptions): Promise<FeedbackGetResponse> {
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for getById' });
-    if (!folderKey) throw new ValidationError({ message: 'Folder key is required for getById' });
 
     const response = await this.get<RawFeedbackGetResponse>(
       FEEDBACK_ENDPOINTS.GET_BY_ID(id),
-      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
     );
     return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
   }

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -84,12 +84,9 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
   }
 
   /**
-   * Gets a single feedback entry by its unique identifier.
+   * Gets a single feedback entry by its feedback ID.
    *
-   * Retrieves detailed information about a specific feedback entry, including
-   * its associated categories, user email, status, and timing information.
-   *
-   * @param id - Unique identifier (GUID) of the feedback entry
+   * @param id - Feedback ID (GUID) of the feedback entry
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -98,12 +95,12 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * const feedback = new Feedback(sdk);
    *
    * // Get a specific feedback entry
-   * const item = await feedback.getById('<feedbackId>');
+   * const item = await feedback.getById(<feedbackId>);
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    * @example
    * ```typescript
-   * // Get feedback ID from getAll, then retrieve details
+   * // First, get feedback entries to obtain the ID
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
    * const item = await feedback.getById(feedbackId);

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -2,7 +2,7 @@ import { BaseService } from '../../base';
 import {
   FeedbackGetResponse,
   FeedbackGetAllOptions,
-  FeedbackGetByIdOptions,
+  FeedbackOptions,
 } from '../../../models/agents/feedback/feedback.types';
 import { FeedbackServiceModel } from '../../../models/agents/feedback/feedback.models';
 import { FeedbackMap } from '../../../models/agents/feedback/feedback.constants';
@@ -90,7 +90,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * Gets a single feedback entry by its feedback ID.
    *
    * @param id - Feedback ID (GUID) of the feedback entry
-   * @param options - Optional query parameters including folderKey for authorization {@link FeedbackGetByIdOptions}
+   * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -107,8 +107,9 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * ```
    */
   @track('Feedback.GetById')
-  async getById(id: string, options?: FeedbackGetByIdOptions): Promise<FeedbackGetResponse> {
+  async getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse> {
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for getById' });
+    if (!options?.folderKey) throw new ValidationError({ message: 'folderKey is required for getById' });
 
     const response = await this.get<RawFeedbackGetResponse>(
       FEEDBACK_ENDPOINTS.GET_BY_ID(id),

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -13,6 +13,7 @@ import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '.
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
 import { track } from '../../../core/telemetry';
+import { ValidationError } from '../../../core/errors';
 
 /**
  * Service for interacting with UiPath Agent Feedback API
@@ -80,5 +81,39 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
       },
       excludeFromPrefix: Object.keys(options || {}),
     }, options);
+  }
+
+  /**
+   * Gets a single feedback entry by its unique identifier.
+   *
+   * Retrieves detailed information about a specific feedback entry, including
+   * its associated categories, user email, status, and timing information.
+   *
+   * @param id - Unique identifier (GUID) of the feedback entry
+   * @returns Promise resolving to {@link FeedbackGetResponse}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * // Get a specific feedback entry
+   * const item = await feedback.getById('<feedbackId>');
+   * console.log(item.isPositive, item.comment, item.status);
+   * ```
+   * @example
+   * ```typescript
+   * // Get feedback ID from getAll, then retrieve details
+   * const allFeedback = await feedback.getAll({ pageSize: 10 });
+   * const feedbackId = allFeedback.items[0].id;
+   * const item = await feedback.getById(feedbackId);
+   * ```
+   */
+  @track('Feedback.GetById')
+  async getById(id: string): Promise<FeedbackGetResponse> {
+    if (!id) throw new ValidationError({ message: 'Feedback ID is required' });
+
+    const response = await this.get<RawFeedbackGetResponse>(FEEDBACK_ENDPOINTS.GET_BY_ID(id));
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
   }
 }

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -14,6 +14,8 @@ import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
 import { track } from '../../../core/telemetry';
 import { ValidationError } from '../../../core/errors';
+import { createHeaders } from '../../../utils/http/headers';
+import { FOLDER_KEY } from '../../../utils/constants/headers';
 
 /**
  * Service for interacting with UiPath Agent Feedback API
@@ -87,6 +89,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * Gets a single feedback entry by its feedback ID.
    *
    * @param id - Feedback ID (GUID) of the feedback entry
+   * @param folderKey The folder key for authorization
    * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
@@ -94,23 +97,23 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    *
    * const feedback = new Feedback(sdk);
    *
-   * // Get a specific feedback entry
-   * const item = await feedback.getById(<feedbackId>);
-   * console.log(item.isPositive, item.comment, item.status);
-   * ```
-   * @example
-   * ```typescript
-   * // First, get feedback entries to obtain the ID
+   * // First, get feedback entries to obtain the ID and folder key
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
-   * const item = await feedback.getById(feedbackId);
+   * const folderKey = allFeedback.items[0].folderKey;
+   * const item = await feedback.getById(feedbackId, folderKey);
+   * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
   @track('Feedback.GetById')
-  async getById(id: string): Promise<FeedbackGetResponse> {
-    if (!id) throw new ValidationError({ message: 'Feedback ID is required' });
+  async getById(id: string, folderKey: string): Promise<FeedbackGetResponse> {
+    if (!id) throw new ValidationError({ message: 'Feedback ID is required for getById' });
+    if (!folderKey) throw new ValidationError({ message: 'Folder key is required for getById' });
 
-    const response = await this.get<RawFeedbackGetResponse>(FEEDBACK_ENDPOINTS.GET_BY_ID(id));
+    const response = await this.get<RawFeedbackGetResponse>(
+      FEEDBACK_ENDPOINTS.GET_BY_ID(id),
+      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+    );
     return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
   }
 }

--- a/src/utils/constants/endpoints/feedback.ts
+++ b/src/utils/constants/endpoints/feedback.ts
@@ -5,4 +5,5 @@ import { LLMOPS_BASE } from './base';
  */
 export const FEEDBACK_ENDPOINTS = {
   GET_ALL: `${LLMOPS_BASE}/api/Feedback`,
+  GET_BY_ID: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
 } as const;

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -67,6 +67,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     let existingFolderKey!: string;
 
     beforeAll(async () => {
+      feedback = getServices().feedback!;
       const result = await feedback.getAll({ pageSize: 1 });
       if (result.items.length === 0) {
         throw new Error('No feedback available for getById tests — create at least one feedback entry first');

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -73,7 +73,10 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
         throw new Error('No feedback available for getById tests — create at least one feedback entry first');
       }
       existingFeedbackId = result.items[0].id;
-      existingFolderKey = result.items[0].folderKey!;
+      if (!result.items[0].folderKey) {
+        throw new Error('Feedback entry missing folderKey — cannot run getById tests');
+      }
+      existingFolderKey = result.items[0].folderKey;
     });
 
     it('should retrieve feedback by ID', async () => {

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { Feedback } from '../../../../src/services/agents/feedback';
 import { FeedbackStatus, FeedbackGetResponse } from '../../../../src/models/agents/feedback/feedback.types';
@@ -63,25 +63,27 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
   });
 
   describe('getById', () => {
-    let existingFeedbackId: string;
+    let existingFeedbackId!: string;
+    let existingFolderKey!: string;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       const result = await feedback.getAll({ pageSize: 1 });
       if (result.items.length === 0) {
         throw new Error('No feedback available for getById tests — create at least one feedback entry first');
       }
       existingFeedbackId = result.items[0].id;
+      existingFolderKey = result.items[0].folderKey!;
     });
 
     it('should retrieve feedback by ID', async () => {
-      const result = await feedback.getById(existingFeedbackId);
+      const result = await feedback.getById(existingFeedbackId, existingFolderKey);
 
       expect(result).toBeDefined();
       expect(result.id).toBe(existingFeedbackId);
     });
 
     it('should have expected fields on the retrieved feedback', async () => {
-      const result: FeedbackGetResponse = await feedback.getById(existingFeedbackId);
+      const result: FeedbackGetResponse = await feedback.getById(existingFeedbackId, existingFolderKey);
 
       expect(result.id).toBeDefined();
       expect(result.traceId).toBeDefined();
@@ -94,7 +96,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should transform API fields — camelCase fields present, raw fields absent', async () => {
-      const result = await feedback.getById(existingFeedbackId);
+      const result = await feedback.getById(existingFeedbackId, existingFolderKey);
 
       expect(result.createdTime).toBeDefined();
       expect(result.updatedTime).toBeDefined();

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { Feedback } from '../../../../src/services/agents/feedback';
-import { FeedbackStatus } from '../../../../src/models/agents/feedback/feedback.types';
+import { FeedbackStatus, FeedbackGetResponse } from '../../../../src/models/agents/feedback/feedback.types';
 
 const modes: InitMode[] = ['v1'];
 
@@ -59,6 +59,47 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
       expect(item.status).toBeDefined();
       expect(item.createdTime).toBeDefined();
       expect(item.updatedTime).toBeDefined();
+    });
+  });
+
+  describe('getById', () => {
+    let existingFeedbackId: string;
+
+    beforeEach(async () => {
+      const result = await feedback.getAll({ pageSize: 1 });
+      if (result.items.length === 0) {
+        throw new Error('No feedback available for getById tests — create at least one feedback entry first');
+      }
+      existingFeedbackId = result.items[0].id;
+    });
+
+    it('should retrieve feedback by ID', async () => {
+      const result = await feedback.getById(existingFeedbackId);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(existingFeedbackId);
+    });
+
+    it('should have expected fields on the retrieved feedback', async () => {
+      const result: FeedbackGetResponse = await feedback.getById(existingFeedbackId);
+
+      expect(result.id).toBeDefined();
+      expect(result.traceId).toBeDefined();
+      expect(result.spanId).toBeDefined();
+      expect(typeof result.isPositive).toBe('boolean');
+      expect(Array.isArray(result.feedbackCategories)).toBe(true);
+      expect(result.status).toBeDefined();
+      expect(result.createdTime).toBeDefined();
+      expect(result.updatedTime).toBeDefined();
+    });
+
+    it('should transform API fields — camelCase fields present, raw fields absent', async () => {
+      const result = await feedback.getById(existingFeedbackId);
+
+      expect(result.createdTime).toBeDefined();
+      expect(result.updatedTime).toBeDefined();
+      expect((result as any).createdAt).toBeUndefined();
+      expect((result as any).updatedAt).toBeUndefined();
     });
   });
 });

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -76,14 +76,14 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should retrieve feedback by ID', async () => {
-      const result = await feedback.getById(existingFeedbackId, existingFolderKey);
+      const result = await feedback.getById(existingFeedbackId, { folderKey: existingFolderKey });
 
       expect(result).toBeDefined();
       expect(result.id).toBe(existingFeedbackId);
     });
 
     it('should have expected fields on the retrieved feedback', async () => {
-      const result: FeedbackGetResponse = await feedback.getById(existingFeedbackId, existingFolderKey);
+      const result: FeedbackGetResponse = await feedback.getById(existingFeedbackId, { folderKey: existingFolderKey });
 
       expect(result.id).toBeDefined();
       expect(result.traceId).toBeDefined();
@@ -96,7 +96,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should transform API fields — camelCase fields present, raw fields absent', async () => {
-      const result = await feedback.getById(existingFeedbackId, existingFolderKey);
+      const result = await feedback.getById(existingFeedbackId, { folderKey: existingFolderKey });
 
       expect(result.createdTime).toBeDefined();
       expect(result.updatedTime).toBeDefined();

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -124,13 +124,9 @@ describe('FeedbackService Unit Tests', () => {
       expect(mockApiClient.get).not.toHaveBeenCalled();
     });
 
-    it('should work without folderKey option', async () => {
-      mockApiClient.get.mockResolvedValue(createMockFeedback());
-
-      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
-
-      expect(result).toBeDefined();
-      expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+    it('should throw ValidationError when folderKey is empty', async () => {
+      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: '' })).rejects.toThrow('folderKey is required');
+      expect(mockApiClient.get).not.toHaveBeenCalled();
     });
 
     it('should throw error when feedback not found', async () => {

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -98,7 +98,7 @@ describe('FeedbackService Unit Tests', () => {
       const mockResponse = createMockFeedback();
       mockApiClient.get.mockResolvedValue(mockResponse);
 
-      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, FEEDBACK_TEST_CONSTANTS.FOLDER_KEY);
 
       expect(result).toBeDefined();
       expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
@@ -111,7 +111,7 @@ describe('FeedbackService Unit Tests', () => {
     it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
       mockApiClient.get.mockResolvedValue(createMockFeedback());
 
-      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, FEEDBACK_TEST_CONSTANTS.FOLDER_KEY);
 
       expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
       expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
@@ -120,7 +120,12 @@ describe('FeedbackService Unit Tests', () => {
     });
 
     it('should throw ValidationError when ID is empty', async () => {
-      await expect(feedbackService.getById('')).rejects.toThrow('Feedback ID is required');
+      await expect(feedbackService.getById('', FEEDBACK_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow('Feedback ID is required');
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when folder key is empty', async () => {
+      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, '')).rejects.toThrow('Folder key is required for getById');
       expect(mockApiClient.get).not.toHaveBeenCalled();
     });
 
@@ -128,7 +133,7 @@ describe('FeedbackService Unit Tests', () => {
       const error = new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
       mockApiClient.get.mockRejectedValue(error);
 
-      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID)).rejects.toThrow(
+      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, FEEDBACK_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(
         FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND
       );
     });

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -98,7 +98,7 @@ describe('FeedbackService Unit Tests', () => {
       const mockResponse = createMockFeedback();
       mockApiClient.get.mockResolvedValue(mockResponse);
 
-      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, FEEDBACK_TEST_CONSTANTS.FOLDER_KEY);
+      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY });
 
       expect(result).toBeDefined();
       expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
@@ -111,7 +111,7 @@ describe('FeedbackService Unit Tests', () => {
     it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
       mockApiClient.get.mockResolvedValue(createMockFeedback());
 
-      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, FEEDBACK_TEST_CONSTANTS.FOLDER_KEY);
+      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY });
 
       expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
       expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
@@ -120,20 +120,24 @@ describe('FeedbackService Unit Tests', () => {
     });
 
     it('should throw ValidationError when ID is empty', async () => {
-      await expect(feedbackService.getById('', FEEDBACK_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow('Feedback ID is required');
+      await expect(feedbackService.getById('', { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY })).rejects.toThrow('Feedback ID is required');
       expect(mockApiClient.get).not.toHaveBeenCalled();
     });
 
-    it('should throw ValidationError when folder key is empty', async () => {
-      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, '')).rejects.toThrow('Folder key is required for getById');
-      expect(mockApiClient.get).not.toHaveBeenCalled();
+    it('should work without folderKey option', async () => {
+      mockApiClient.get.mockResolvedValue(createMockFeedback());
+
+      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
     });
 
     it('should throw error when feedback not found', async () => {
       const error = new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
       mockApiClient.get.mockRejectedValue(error);
 
-      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, FEEDBACK_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(
+      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY })).rejects.toThrow(
         FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND
       );
     });

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -92,4 +92,45 @@ describe('FeedbackService Unit Tests', () => {
       );
     });
   });
+
+  describe('getById', () => {
+    it('should get feedback by ID successfully', async () => {
+      const mockResponse = createMockFeedback();
+      mockApiClient.get.mockResolvedValue(mockResponse);
+
+      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.GET_BY_ID(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID),
+        expect.any(Object)
+      );
+    });
+
+    it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
+      mockApiClient.get.mockResolvedValue(createMockFeedback());
+
+      const result = await feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+
+      expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
+      expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
+      expect((result as any).createdAt).toBeUndefined();
+      expect((result as any).updatedAt).toBeUndefined();
+    });
+
+    it('should throw ValidationError when ID is empty', async () => {
+      await expect(feedbackService.getById('')).rejects.toThrow('Feedback ID is required');
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when feedback not found', async () => {
+      const error = new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
+      mockApiClient.get.mockRejectedValue(error);
+
+      await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID)).rejects.toThrow(
+        FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND
+      );
+    });
+  });
 });

--- a/tests/utils/constants/feedback.ts
+++ b/tests/utils/constants/feedback.ts
@@ -7,6 +7,9 @@ export const FEEDBACK_TEST_CONSTANTS = {
   FEEDBACK_ID: 'feedback-1',
   FEEDBACK_ID_2: 'feedback-2',
 
+  // Folder key for authorization
+  FOLDER_KEY: '00000000-0000-0000-0000-000000000001',
+
   // Agent identifiers (string UUID for feedback API)
   AGENT_UUID: 'agent-789',
 


### PR DESCRIPTION
## Method Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | \`feedback.getById()\` | \`getById(id: string): Promise<FeedbackGetResponse>\` |

## Endpoint Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| \`getById()\` | GET | \`llmopstenant_/api/Feedback/{id}\` | \`Traces.Api\` |

- Extends `BaseService` — authenticated via PAT or OAuth
- Validates that `id` is non-empty, throwing `ValidationError` if missing

## Example Usage

\`\`\`typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { Feedback } from '@uipath/uipath-typescript/feedback';

const sdk = new UiPath({ baseUrl, orgName, tenantName, secret });
const feedback = new Feedback(sdk);

// Get a specific feedback entry
const item = await feedback.getById('<feedbackId>');
console.log(item.isPositive, item.comment, item.status);

// Get feedback ID from getAll, then retrieve details
const allFeedback = await feedback.getAll({ pageSize: 10 });
const feedbackId = allFeedback.items[0].id;
const item2 = await feedback.getById(feedbackId);
\`\`\`

## API Response vs SDK Response

### Transform pipeline
`transformData(response.data, FeedbackMap)`

### Field mapping

| API Response | SDK Response | Change | Reason |
|--------------|--------------|--------|--------|
| `createdAt` | `createdTime` | Rename | Standard SDK time field convention |
| `updatedAt` | `updatedTime` | Rename | Standard SDK time field convention |
| All other fields | unchanged | — | API already returns camelCase |

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/feedback.ts` |
| Models | `src/models/agents/feedback/feedback.models.ts` |
| Service | `src/services/agents/feedback/feedback.ts` |
| Unit tests | `tests/unit/services/agents/feedback.test.ts` (4 new tests) |
| Integration tests | `tests/integration/shared/agents/feedback.integration.test.ts` (3 new tests) |
| Docs | `docs/oauth-scopes.md` |

> **Note:** `getById` returns 403 via `alpha.api.uipath.com` until the Cloudflare worker whitelist is updated to allow `llmopstenant_/api/Feedback/{id}`. The Vite proxy works fine in local dev.

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*