### PR TITLE
fix: update package-lock.json to use npm registry for @uipath/uipath-typescript resolution

### DIFF
--- a/samples/process-app-v0/package-lock.json
+++ b/samples/process-app-v0/package-lock.json
@@ -1725,7 +1725,7 @@
     },
     "node_modules/@uipath/uipath-typescript": {
       "version": "1.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.1.1/37fff12fd426282749ef2773b82a94aa8e3c228b",
+      "resolved": "https://registry.npmjs.org/@uipath/uipath-typescript/-/uipath-typescript-1.1.1.tgz",
       "integrity": "sha512-b758LoVwqGX2+7MNrDYscj0P5mEWNtNMcxmUkCiCVT3G7JkT5ehWU+Nyt0uuVPTIbzcoGUZc7lIZkXjSsRk8zg==",
       "license": "MIT",
       "dependencies": {

--- a/samples/process-app-v1/package-lock.json
+++ b/samples/process-app-v1/package-lock.json
@@ -1725,7 +1725,7 @@
     },
     "node_modules/@uipath/uipath-typescript": {
       "version": "1.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.1.1/37fff12fd426282749ef2773b82a94aa8e3c228b",
+      "resolved": "https://registry.npmjs.org/@uipath/uipath-typescript/-/uipath-typescript-1.1.1.tgz",
       "integrity": "sha512-b758LoVwqGX2+7MNrDYscj0P5mEWNtNMcxmUkCiCVT3G7JkT5ehWU+Nyt0uuVPTIbzcoGUZc7lIZkXjSsRk8zg==",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Changed the resolved URL for `@uipath/uipath-typescript` package in `package-lock.json` for both `process-app-v0` and `process-app-v1` to point to the npm registry instead of the GitHub package registry.