### PR TITLE
fix(docs): remove clientid and clientsecret from login cmd flags

### DIFF
--- a/docs/coded-apps/cli-reference.md
+++ b/docs/coded-apps/cli-reference.md
@@ -48,6 +48,9 @@ $ uip login [options]
 | `-t, --tenant` | string | Tenant name (non-interactive mode) | — |
 | `--it, --interactive` | boolean | Interactively select tenant from list | — |
 
+!!! note
+    Publishing and deploying coded apps with `client-id` and `client-secret` based login is not currently supported. Use interactive browser-based user OAuth login only.
+
 **Examples**
 
 <!-- termynal -->

--- a/docs/coded-apps/cli-reference.md
+++ b/docs/coded-apps/cli-reference.md
@@ -44,11 +44,7 @@ $ uip login [options]
 
 | Name | Type | Description | Default |
 |------|------|-------------|---------|
-| `-f, --file` | string | Path to credentials folder | — |
 | `--authority` | string | Custom authority URL | — |
-| `--client-id` | string | Client ID or Application ID | — |
-| `--client-secret` | string | Client secret or Application secret | — |
-| `-s, --scope` | string | Custom scopes (space-separated) | — |
 | `-t, --tenant` | string | Tenant name (non-interactive mode) | — |
 | `--it, --interactive` | boolean | Interactively select tenant from list | — |
 


### PR DESCRIPTION
codedapp publish , deploy cmds cannot be used with clientid and client secret as 
1. it requires apps scope which are internal and not onboarded to external app.
2. current apis are not supported for service.internal token types

[PLT-103329](https://uipath.atlassian.net/browse/PLT-103329)

[PLT-103329]: https://uipath.atlassian.net/browse/PLT-103329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ