### PR TITLE
feat(feedback): add create, updateById, deleteById methods

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -154,6 +154,9 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 |--------|-------------|
 | `getAll()` | `Traces.Api` |
 | `getById()` | `Traces.Api` |
+| `submit()` | `Traces.Api` |
+| `updateById()` | `Traces.Api` |
+| `deleteById()` | `Traces.Api` |
 
 ## Processes
 

--- a/src/models/agents/feedback/feedback.internal-types.ts
+++ b/src/models/agents/feedback/feedback.internal-types.ts
@@ -4,7 +4,7 @@ import { FeedbackCategory, FeedbackStatus } from './feedback.types';
  * Raw feedback response shape as returned by the API, before the transform pipeline
  * renames createdAt → createdTime and updatedAt → updatedTime.
  */
-export interface RawFeedbackGetResponse {
+export interface RawFeedbackResponse {
   id: string;
   traceId: string;
   spanId: string;

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -103,7 +103,7 @@ export interface FeedbackServiceModel {
    *
    * const feedback = new Feedback(sdk);
    *
-   * const item = await feedback.create({
+   * const item = await feedback.submit({
    *   traceId: '<traceId>',
    *   spanId: '<spanId>',
    *   isPositive: true,
@@ -113,7 +113,7 @@ export interface FeedbackServiceModel {
    * console.log(item.id, item.status);
    * ```
    */
-  create(options: FeedbackCreateOptions): Promise<FeedbackGetResponse>;
+  submit(options: FeedbackCreateOptions): Promise<FeedbackGetResponse>;
 
   /**
    * Updates an existing feedback entry.

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -1,8 +1,8 @@
 import type {
-  FeedbackGetResponse,
+  FeedbackResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
-  FeedbackCreateOptions,
+  FeedbackSubmitOptions,
   FeedbackUpdateOptions,
 } from './feedback.types';
 import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
@@ -34,7 +34,7 @@ export interface FeedbackServiceModel {
    * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
-   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackGetResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackGetResponse} when pagination options are used.
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback, FeedbackStatus } from '@uipath/uipath-typescript/feedback';
@@ -66,8 +66,8 @@ export interface FeedbackServiceModel {
    */
   getAll<T extends FeedbackGetAllOptions = FeedbackGetAllOptions>(options?: T): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackGetResponse>
-      : NonPaginatedResponse<FeedbackGetResponse>
+      ? PaginatedResponse<FeedbackResponse>
+      : NonPaginatedResponse<FeedbackResponse>
   >;
 
   /**
@@ -75,7 +75,7 @@ export interface FeedbackServiceModel {
    *
    * @param id - Feedback ID (GUID) of the feedback entry
    * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
-   * @returns Promise resolving to {@link FeedbackGetResponse}
+   * @returns Promise resolving to {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -86,56 +86,62 @@ export interface FeedbackServiceModel {
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
    * const folderKey = allFeedback.items[0].folderKey;
+   * 
    * const item = await feedback.getById(feedbackId, { folderKey });
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
-  getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse>;
+  getById(id: string, options: FeedbackOptions): Promise<FeedbackResponse>;
 
   /**
-   * Creates a feedback entry.
+   * Submits a feedback entry.
    *
-   * @param options - Feedback data and folderKey for authorization {@link FeedbackCreateOptions}
-   * @returns Promise resolving to the created {@link FeedbackGetResponse}
+   * @param traceId - Trace identifier linking feedback to a specific agent execution
+   * @param isPositive - Whether the feedback is positive (thumbs up) or negative (thumbs down)
+   * @param options - Additional feedback data and folderKey for authorization {@link FeedbackSubmitOptions}
+   * @returns Promise resolving to the submitted {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
    *
    * const feedback = new Feedback(sdk);
    *
-   * const item = await feedback.submit({
-   *   traceId: '<traceId>',
-   *   spanId: '<spanId>',
-   *   isPositive: true,
-   *   comment: 'Great response!',
-   *   folderKey: '<folderKey>',
-   * });
+   * // Obtain traceId and folderKey from an existing feedback entry
+   * const allFeedback = await feedback.getAll({ pageSize: 1 });
+   * const traceId = allFeedback.items[0].traceId;
+   * const folderKey = allFeedback.items[0].folderKey!;
+   *
+   * const item = await feedback.submit(traceId, true, { folderKey });
    * console.log(item.id, item.status);
    * ```
    */
-  submit(options: FeedbackCreateOptions): Promise<FeedbackGetResponse>;
+  submit(traceId: string, isPositive: boolean, options: FeedbackSubmitOptions): Promise<FeedbackResponse>;
 
   /**
-   * Updates an existing feedback entry.
+   * Updates already submitted feedback.
    *
    * @param id - Feedback ID (GUID) of the entry to update
+   * @param isPositive - Whether the feedback is positive (thumbs up) or negative (thumbs down)
    * @param options - Updated feedback data and folderKey for authorization {@link FeedbackUpdateOptions}
-   * @returns Promise resolving to the updated {@link FeedbackGetResponse}
+   * @returns Promise resolving to the updated {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
    *
    * const feedback = new Feedback(sdk);
    *
-   * const updated = await feedback.updateById('<feedbackId>', {
-   *   isPositive: false,
+   * const allFeedback = await feedback.getAll({ pageSize: 1 });
+   * const feedbackId = allFeedback.items[0].id;
+   * const folderKey = allFeedback.items[0].folderKey!;
+   *
+   * const updated = await feedback.updateById(feedbackId, false, {
    *   comment: 'On reflection, not great.',
-   *   folderKey: '<folderKey>',
+   *   folderKey,
    * });
    * console.log(updated.isPositive, updated.comment);
    * ```
    */
-  updateById(id: string, options: FeedbackUpdateOptions): Promise<FeedbackGetResponse>;
+  updateById(id: string, isPositive: boolean, options: FeedbackUpdateOptions): Promise<FeedbackResponse>;
 
   /**
    * Deletes a feedback entry by its ID.
@@ -149,7 +155,11 @@ export interface FeedbackServiceModel {
    *
    * const feedback = new Feedback(sdk);
    *
-   * await feedback.deleteById('<feedbackId>', { folderKey: '<folderKey>' });
+   * const allFeedback = await feedback.getAll({ pageSize: 1 });
+   * const feedbackId = allFeedback.items[0].id;
+   * const folderKey = allFeedback.items[0].folderKey!;
+   *
+   * await feedback.deleteById(feedbackId, { folderKey });
    * ```
    */
   deleteById(id: string, options: FeedbackOptions): Promise<void>;

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -1,6 +1,5 @@
 import type {
   FeedbackResponse,
-  FeedbackGetResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
@@ -35,7 +34,7 @@ export interface FeedbackServiceModel {
    * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
-   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackGetResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackGetResponse} when pagination options are used.
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback, FeedbackStatus } from '@uipath/uipath-typescript/feedback';
@@ -67,8 +66,8 @@ export interface FeedbackServiceModel {
    */
   getAll<T extends FeedbackGetAllOptions = FeedbackGetAllOptions>(options?: T): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackGetResponse>
-      : NonPaginatedResponse<FeedbackGetResponse>
+      ? PaginatedResponse<FeedbackResponse>
+      : NonPaginatedResponse<FeedbackResponse>
   >;
 
   /**
@@ -76,7 +75,7 @@ export interface FeedbackServiceModel {
    *
    * @param id - Feedback ID (GUID) of the feedback entry
    * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
-   * @returns Promise resolving to {@link FeedbackGetResponse}
+   * @returns Promise resolving to {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -92,7 +91,7 @@ export interface FeedbackServiceModel {
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
-  getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse>;
+  getById(id: string, options: FeedbackOptions): Promise<FeedbackResponse>;
 
   /**
    * Submits a feedback entry.

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -2,6 +2,8 @@ import type {
   FeedbackGetResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
+  FeedbackCreateOptions,
+  FeedbackUpdateOptions,
 } from './feedback.types';
 import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 
@@ -89,4 +91,66 @@ export interface FeedbackServiceModel {
    * ```
    */
   getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse>;
+
+  /**
+   * Creates a feedback entry.
+   *
+   * @param options - Feedback data and folderKey for authorization {@link FeedbackCreateOptions}
+   * @returns Promise resolving to the created {@link FeedbackGetResponse}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * const item = await feedback.create({
+   *   traceId: '<traceId>',
+   *   spanId: '<spanId>',
+   *   isPositive: true,
+   *   comment: 'Great response!',
+   *   folderKey: '<folderKey>',
+   * });
+   * console.log(item.id, item.status);
+   * ```
+   */
+  create(options: FeedbackCreateOptions): Promise<FeedbackGetResponse>;
+
+  /**
+   * Updates an existing feedback entry.
+   *
+   * @param id - Feedback ID (GUID) of the entry to update
+   * @param options - Updated feedback data and folderKey for authorization {@link FeedbackUpdateOptions}
+   * @returns Promise resolving to the updated {@link FeedbackGetResponse}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * const updated = await feedback.updateById('<feedbackId>', {
+   *   isPositive: false,
+   *   comment: 'On reflection, not great.',
+   *   folderKey: '<folderKey>',
+   * });
+   * console.log(updated.isPositive, updated.comment);
+   * ```
+   */
+  updateById(id: string, options: FeedbackUpdateOptions): Promise<FeedbackGetResponse>;
+
+  /**
+   * Deletes a feedback entry by its ID.
+   *
+   * @param id - Feedback ID (GUID) of the entry to delete
+   * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
+   * @returns Promise resolving to void on success
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * await feedback.deleteById('<feedbackId>', { folderKey: '<folderKey>' });
+   * ```
+   */
+  deleteById(id: string, options: FeedbackOptions): Promise<void>;
 }

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -1,5 +1,6 @@
 import type {
   FeedbackResponse,
+  FeedbackGetResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
@@ -34,7 +35,7 @@ export interface FeedbackServiceModel {
    * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
-   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackGetResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackGetResponse} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback, FeedbackStatus } from '@uipath/uipath-typescript/feedback';
@@ -66,8 +67,8 @@ export interface FeedbackServiceModel {
    */
   getAll<T extends FeedbackGetAllOptions = FeedbackGetAllOptions>(options?: T): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackResponse>
-      : NonPaginatedResponse<FeedbackResponse>
+      ? PaginatedResponse<FeedbackGetResponse>
+      : NonPaginatedResponse<FeedbackGetResponse>
   >;
 
   /**
@@ -75,7 +76,7 @@ export interface FeedbackServiceModel {
    *
    * @param id - Feedback ID (GUID) of the feedback entry
    * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
-   * @returns Promise resolving to {@link FeedbackResponse}
+   * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -86,12 +87,12 @@ export interface FeedbackServiceModel {
    * const allFeedback = await feedback.getAll({ pageSize: 10 });
    * const feedbackId = allFeedback.items[0].id;
    * const folderKey = allFeedback.items[0].folderKey;
-   * 
+   *
    * const item = await feedback.getById(feedbackId, { folderKey });
    * console.log(item.isPositive, item.comment, item.status);
    * ```
    */
-  getById(id: string, options: FeedbackOptions): Promise<FeedbackResponse>;
+  getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse>;
 
   /**
    * Submits a feedback entry.

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -66,10 +66,10 @@ export interface FeedbackGetResponse {
 }
 
 /**
- * Options shared across feedback operations requiring folder-level authorization
+ * Options shared across feedback operations
  */
 export interface FeedbackOptions {
-  /** Folder key (GUID) of the folder the feedback belongs to, required for authorization */
+  /** Folder key for authorization */
   folderKey: string;
 }
 

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -99,7 +99,7 @@ export interface FeedbackSubmitOptions extends FeedbackOptions {
   agentId?: string;
   /** Version of the agent at the time the feedback was given (max 100 characters) */
   agentVersion?: string;
-  /** Span type (e.g., 'agentRun', 'llm', 'tool', 'retriever') */
+  /** Span type (e.g., 'agentRun', 'llm', 'tool', 'retriever') (max 100 characters) */
   spanType?: string;
   /** Optional text comment provided by the user (max 4000 characters) */
   comment?: string;

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -34,7 +34,7 @@ export enum FeedbackStatus {
 /**
  * Complete feedback object returned from the API
  */
-export interface FeedbackGetResponse {
+export interface FeedbackResponse {
   /** Unique identifier of the feedback entry */
   id: string;
   /** Trace identifier linking feedback to a specific agent execution */
@@ -79,30 +79,26 @@ export interface FeedbackOptions {
 export interface FeedbackCategoryInput {
   /** Unique identifier of the category */
   id: string;
-  /** Category name */
+  /** Category name (e.g., 'Output', 'Agent Error', 'Agent Plan Execution') */
   category: string;
 }
 
 /**
- * Options for creating a new feedback entry
+ * Options for submitting a new feedback entry
  */
-export interface FeedbackCreateOptions extends FeedbackOptions {
-  /** Trace identifier linking feedback to a specific agent execution */
-  traceId: string;
+export interface FeedbackSubmitOptions extends FeedbackOptions {
   /** Span identifier representing a specific operation within the trace */
   spanId?: string;
   /** Identifier of the agent that generated the response being reviewed */
   agentId?: string;
   /** Version of the agent at the time the feedback was given (max 100 characters) */
   agentVersion?: string;
-  /** Span type (e.g., agent, llm) */
+  /** Span type (e.g., 'agentRun', 'llm', 'tool', 'retriever') */
   spanType?: string;
   /** Optional text comment provided by the user (max 4000 characters) */
   comment?: string;
   /** Optional metadata string associated with the feedback (max 4000 characters) */
   metadata?: string;
-  /** Whether the feedback is positive (thumbs up) or negative (thumbs down) */
-  isPositive: boolean;
   /** Categories to associate with this feedback entry */
   categories?: FeedbackCategoryInput[];
 }
@@ -115,8 +111,6 @@ export interface FeedbackUpdateOptions extends FeedbackOptions {
   comment?: string;
   /** Optional metadata string associated with the feedback (max 4000 characters) */
   metadata?: string;
-  /** Whether the feedback is positive (thumbs up) or negative (thumbs down) */
-  isPositive: boolean;
   /** Categories to associate with this feedback entry */
   categories?: FeedbackCategoryInput[];
 }

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -66,6 +66,12 @@ export interface FeedbackResponse {
 }
 
 /**
+ * Feedback object returned by getAll and getById.
+ * Extends {@link FeedbackResponse} — use this type for getAll/getById return values.
+ */
+export interface FeedbackGetResponse extends FeedbackResponse {}
+
+/**
  * Options shared across feedback operations
  */
 export interface FeedbackOptions {

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -66,11 +66,59 @@ export interface FeedbackGetResponse {
 }
 
 /**
- * Options shared across feedback operations
+ * Options shared across feedback operations requiring folder-level authorization
  */
 export interface FeedbackOptions {
-  /** Folder key for authorization */
+  /** Folder key (GUID) of the folder the feedback belongs to, required for authorization */
   folderKey: string;
+}
+
+/**
+ * A category reference used when creating or updating feedback
+ */
+export interface FeedbackCategoryInput {
+  /** Unique identifier of the category */
+  id: string;
+  /** Category name */
+  category: string;
+}
+
+/**
+ * Options for creating a new feedback entry
+ */
+export interface FeedbackCreateOptions extends FeedbackOptions {
+  /** Trace identifier linking feedback to a specific agent execution */
+  traceId: string;
+  /** Span identifier representing a specific operation within the trace */
+  spanId?: string;
+  /** Identifier of the agent that generated the response being reviewed */
+  agentId?: string;
+  /** Version of the agent at the time the feedback was given (max 100 characters) */
+  agentVersion?: string;
+  /** Span type (e.g., agent, llm) */
+  spanType?: string;
+  /** Optional text comment provided by the user (max 4000 characters) */
+  comment?: string;
+  /** Optional metadata string associated with the feedback (max 4000 characters) */
+  metadata?: string;
+  /** Whether the feedback is positive (thumbs up) or negative (thumbs down) */
+  isPositive: boolean;
+  /** Categories to associate with this feedback entry */
+  categories?: FeedbackCategoryInput[];
+}
+
+/**
+ * Options for updating an existing feedback entry
+ */
+export interface FeedbackUpdateOptions extends FeedbackOptions {
+  /** Optional text comment provided by the user (max 4000 characters) */
+  comment?: string;
+  /** Optional metadata string associated with the feedback (max 4000 characters) */
+  metadata?: string;
+  /** Whether the feedback is positive (thumbs up) or negative (thumbs down) */
+  isPositive: boolean;
+  /** Categories to associate with this feedback entry */
+  categories?: FeedbackCategoryInput[];
 }
 
 /**

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -131,7 +131,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    *
    * const feedback = new Feedback(sdk);
    *
-   * const item = await feedback.create({
+   * const item = await feedback.submit({
    *   traceId: '<traceId>',
    *   spanId: '<spanId>',
    *   isPositive: true,
@@ -141,14 +141,14 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * console.log(item.id, item.status);
    * ```
    */
-  @track('Feedback.Create')
-  async create(options: FeedbackCreateOptions): Promise<FeedbackGetResponse> {
-    if (!options.traceId) throw new ValidationError({ message: 'traceId is required for create' });
-    if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for create' });
+  @track('Feedback.Submit')
+  async submit(options: FeedbackCreateOptions): Promise<FeedbackGetResponse> {
+    if (!options.traceId) throw new ValidationError({ message: 'traceId is required for submit' });
+    if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for submit' });
 
     const { folderKey, ...request } = options;
     const response = await this.post<RawFeedbackGetResponse>(
-      FEEDBACK_ENDPOINTS.CREATE,
+      FEEDBACK_ENDPOINTS.SUBMIT,
       request,
       { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
     );
@@ -209,7 +209,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for deleteById' });
     if (!options?.folderKey) throw new ValidationError({ message: 'folderKey is required for deleteById' });
 
-    await super.delete(
+    await this.delete(
       FEEDBACK_ENDPOINTS.DELETE(id),
       { headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
     );

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -3,6 +3,8 @@ import {
   FeedbackGetResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
+  FeedbackCreateOptions,
+  FeedbackUpdateOptions,
 } from '../../../models/agents/feedback/feedback.types';
 import { FeedbackServiceModel } from '../../../models/agents/feedback/feedback.models';
 import { FeedbackMap } from '../../../models/agents/feedback/feedback.constants';
@@ -116,5 +118,100 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
       { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
     );
     return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
+  }
+
+  /**
+   * Creates a feedback entry.
+   *
+   * @param options - Feedback data and folderKey for authorization {@link FeedbackCreateOptions}
+   * @returns Promise resolving to the created {@link FeedbackGetResponse}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * const item = await feedback.create({
+   *   traceId: '<traceId>',
+   *   spanId: '<spanId>',
+   *   isPositive: true,
+   *   comment: 'Great response!',
+   *   folderKey: '<folderKey>',
+   * });
+   * console.log(item.id, item.status);
+   * ```
+   */
+  @track('Feedback.Create')
+  async create(options: FeedbackCreateOptions): Promise<FeedbackGetResponse> {
+    if (!options.traceId) throw new ValidationError({ message: 'traceId is required for create' });
+    if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for create' });
+
+    const { folderKey, ...request } = options;
+    const response = await this.post<RawFeedbackGetResponse>(
+      FEEDBACK_ENDPOINTS.CREATE,
+      request,
+      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+    );
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
+  }
+
+  /**
+   * Updates an existing feedback entry.
+   *
+   * @param id - Feedback ID (GUID) of the entry to update
+   * @param options - Updated feedback data and folderKey for authorization {@link FeedbackUpdateOptions}
+   * @returns Promise resolving to the updated {@link FeedbackGetResponse}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * const updated = await feedback.updateById('<feedbackId>', {
+   *   isPositive: false,
+   *   comment: 'On reflection, not great.',
+   *   folderKey: '<folderKey>',
+   * });
+   * console.log(updated.isPositive, updated.comment);
+   * ```
+   */
+  @track('Feedback.UpdateById')
+  async updateById(id: string, options: FeedbackUpdateOptions): Promise<FeedbackGetResponse> {
+    if (!id) throw new ValidationError({ message: 'Feedback ID is required for updateById' });
+    if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for updateById' });
+
+    const { folderKey, ...request } = options;
+    const response = await this.post<RawFeedbackGetResponse>(
+      FEEDBACK_ENDPOINTS.UPDATE(id),
+      request,
+      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+    );
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
+  }
+
+  /**
+   * Deletes a feedback entry by its ID.
+   *
+   * @param id - Feedback ID (GUID) of the entry to delete
+   * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
+   * @returns Promise resolving to void on success
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * await feedback.deleteById('<feedbackId>', { folderKey: '<folderKey>' });
+   * ```
+   */
+  @track('Feedback.DeleteById')
+  async deleteById(id: string, options: FeedbackOptions): Promise<void> {
+    if (!id) throw new ValidationError({ message: 'Feedback ID is required for deleteById' });
+    if (!options?.folderKey) throw new ValidationError({ message: 'folderKey is required for deleteById' });
+
+    await super.delete(
+      FEEDBACK_ENDPOINTS.DELETE(id),
+      { headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
   }
 }

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -1,14 +1,14 @@
 import { BaseService } from '../../base';
 import {
-  FeedbackGetResponse,
+  FeedbackResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
-  FeedbackCreateOptions,
+  FeedbackSubmitOptions,
   FeedbackUpdateOptions,
 } from '../../../models/agents/feedback/feedback.types';
 import { FeedbackServiceModel } from '../../../models/agents/feedback/feedback.models';
 import { FeedbackMap } from '../../../models/agents/feedback/feedback.constants';
-import { RawFeedbackGetResponse } from '../../../models/agents/feedback/feedback.internal-types';
+import { RawFeedbackResponse } from '../../../models/agents/feedback/feedback.internal-types';
 import { transformData } from '../../../utils/transform';
 import { FEEDBACK_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { FEEDBACK_OFFSET_PARAMS } from '../../../utils/constants/common';
@@ -31,7 +31,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
-   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackGetResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackGetResponse} when pagination options are used.
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback, FeedbackStatus } from '@uipath/uipath-typescript/feedback';
@@ -66,13 +66,13 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     options?: T
   ): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackGetResponse>
-      : NonPaginatedResponse<FeedbackGetResponse>
+      ? PaginatedResponse<FeedbackResponse>
+      : NonPaginatedResponse<FeedbackResponse>
   > {
-    const transformFeedbackResponse = (item: RawFeedbackGetResponse): FeedbackGetResponse =>
-      transformData(item, FeedbackMap) as unknown as FeedbackGetResponse;
+    const transformFeedbackResponse = (item: RawFeedbackResponse): FeedbackResponse =>
+      transformData(item, FeedbackMap) as unknown as FeedbackResponse;
 
-    return PaginationHelpers.getAll<T, RawFeedbackGetResponse, FeedbackGetResponse>({
+    return PaginationHelpers.getAll<T, RawFeedbackResponse, FeedbackResponse>({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => FEEDBACK_ENDPOINTS.GET_ALL,
       transformFn: transformFeedbackResponse,
@@ -93,7 +93,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    *
    * @param id - Feedback ID (GUID) of the feedback entry
    * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
-   * @returns Promise resolving to {@link FeedbackGetResponse}
+   * @returns Promise resolving to {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -109,84 +109,89 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * ```
    */
   @track('Feedback.GetById')
-  async getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse> {
+  async getById(id: string, options: FeedbackOptions): Promise<FeedbackResponse> {
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for getById' });
-    if (!options?.folderKey) throw new ValidationError({ message: 'folderKey is required for getById' });
+    if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for getById' });
 
-    const response = await this.get<RawFeedbackGetResponse>(
+    const response = await this.get<RawFeedbackResponse>(
       FEEDBACK_ENDPOINTS.GET_BY_ID(id),
       { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
     );
-    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackResponse;
   }
 
   /**
-   * Creates a feedback entry.
+   * Submits a feedback entry.
    *
-   * @param options - Feedback data and folderKey for authorization {@link FeedbackCreateOptions}
-   * @returns Promise resolving to the created {@link FeedbackGetResponse}
+   * @param traceId - Trace identifier linking feedback to a specific agent execution
+   * @param isPositive - Whether the feedback is positive (thumbs up) or negative (thumbs down)
+   * @param options - Additional feedback data and folderKey for authorization {@link FeedbackSubmitOptions}
+   * @returns Promise resolving to the submitted {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
    *
    * const feedback = new Feedback(sdk);
    *
-   * const item = await feedback.submit({
-   *   traceId: '<traceId>',
-   *   spanId: '<spanId>',
-   *   isPositive: true,
-   *   comment: 'Great response!',
-   *   folderKey: '<folderKey>',
-   * });
+   * // Obtain traceId and folderKey from an existing feedback entry
+   * const allFeedback = await feedback.getAll({ pageSize: 1 });
+   * const traceId = allFeedback.items[0].traceId;
+   * const folderKey = allFeedback.items[0].folderKey!;
+   *
+   * const item = await feedback.submit(traceId, true, { folderKey });
    * console.log(item.id, item.status);
    * ```
    */
   @track('Feedback.Submit')
-  async submit(options: FeedbackCreateOptions): Promise<FeedbackGetResponse> {
-    if (!options.traceId) throw new ValidationError({ message: 'traceId is required for submit' });
+  async submit(traceId: string, isPositive: boolean, options: FeedbackSubmitOptions): Promise<FeedbackResponse> {
+    if (!traceId) throw new ValidationError({ message: 'traceId is required for submit' });
     if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for submit' });
 
-    const { folderKey, ...request } = options;
-    const response = await this.post<RawFeedbackGetResponse>(
+    const { folderKey, ...rest } = options;
+    const response = await this.post<RawFeedbackResponse>(
       FEEDBACK_ENDPOINTS.SUBMIT,
-      request,
+      { traceId, isPositive, ...rest },
       { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
     );
-    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackResponse;
   }
 
   /**
-   * Updates an existing feedback entry.
+   * Updates already submitted feedback.
    *
    * @param id - Feedback ID (GUID) of the entry to update
+   * @param isPositive - Whether the feedback is positive (thumbs up) or negative (thumbs down)
    * @param options - Updated feedback data and folderKey for authorization {@link FeedbackUpdateOptions}
-   * @returns Promise resolving to the updated {@link FeedbackGetResponse}
+   * @returns Promise resolving to the updated {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
    *
    * const feedback = new Feedback(sdk);
    *
-   * const updated = await feedback.updateById('<feedbackId>', {
-   *   isPositive: false,
+   * const allFeedback = await feedback.getAll({ pageSize: 1 });
+   * const feedbackId = allFeedback.items[0].id;
+   * const folderKey = allFeedback.items[0].folderKey!;
+   *
+   * const updated = await feedback.updateById(feedbackId, false, {
    *   comment: 'On reflection, not great.',
-   *   folderKey: '<folderKey>',
+   *   folderKey,
    * });
    * console.log(updated.isPositive, updated.comment);
    * ```
    */
   @track('Feedback.UpdateById')
-  async updateById(id: string, options: FeedbackUpdateOptions): Promise<FeedbackGetResponse> {
+  async updateById(id: string, isPositive: boolean, options: FeedbackUpdateOptions): Promise<FeedbackResponse> {
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for updateById' });
     if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for updateById' });
 
-    const { folderKey, ...request } = options;
-    const response = await this.post<RawFeedbackGetResponse>(
+    const { folderKey, ...rest } = options;
+    const response = await this.post<RawFeedbackResponse>(
       FEEDBACK_ENDPOINTS.UPDATE(id),
-      request,
+      { isPositive, ...rest },
       { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
     );
-    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackResponse;
   }
 
   /**
@@ -201,13 +206,17 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    *
    * const feedback = new Feedback(sdk);
    *
-   * await feedback.deleteById('<feedbackId>', { folderKey: '<folderKey>' });
+   * const allFeedback = await feedback.getAll({ pageSize: 1 });
+   * const feedbackId = allFeedback.items[0].id;
+   * const folderKey = allFeedback.items[0].folderKey!;
+   *
+   * await feedback.deleteById(feedbackId, { folderKey });
    * ```
    */
   @track('Feedback.DeleteById')
   async deleteById(id: string, options: FeedbackOptions): Promise<void> {
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for deleteById' });
-    if (!options?.folderKey) throw new ValidationError({ message: 'folderKey is required for deleteById' });
+    if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for deleteById' });
 
     await this.delete(
       FEEDBACK_ENDPOINTS.DELETE(id),

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -1,6 +1,7 @@
 import { BaseService } from '../../base';
 import {
   FeedbackResponse,
+  FeedbackGetResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
@@ -31,7 +32,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
-   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackGetResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackGetResponse} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback, FeedbackStatus } from '@uipath/uipath-typescript/feedback';
@@ -66,13 +67,13 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     options?: T
   ): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackResponse>
-      : NonPaginatedResponse<FeedbackResponse>
+      ? PaginatedResponse<FeedbackGetResponse>
+      : NonPaginatedResponse<FeedbackGetResponse>
   > {
-    const transformFeedbackResponse = (item: RawFeedbackResponse): FeedbackResponse =>
-      transformData(item, FeedbackMap) as unknown as FeedbackResponse;
+    const transformFeedbackResponse = (item: RawFeedbackResponse): FeedbackGetResponse =>
+      transformData(item, FeedbackMap) as unknown as FeedbackGetResponse;
 
-    return PaginationHelpers.getAll<T, RawFeedbackResponse, FeedbackResponse>({
+    return PaginationHelpers.getAll<T, RawFeedbackResponse, FeedbackGetResponse>({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => FEEDBACK_ENDPOINTS.GET_ALL,
       transformFn: transformFeedbackResponse,
@@ -93,7 +94,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    *
    * @param id - Feedback ID (GUID) of the feedback entry
    * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
-   * @returns Promise resolving to {@link FeedbackResponse}
+   * @returns Promise resolving to {@link FeedbackGetResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -109,7 +110,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * ```
    */
   @track('Feedback.GetById')
-  async getById(id: string, options: FeedbackOptions): Promise<FeedbackResponse> {
+  async getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse> {
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for getById' });
     if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for getById' });
 
@@ -117,7 +118,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
       FEEDBACK_ENDPOINTS.GET_BY_ID(id),
       { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
     );
-    return transformData(response.data, FeedbackMap) as unknown as FeedbackResponse;
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
   }
 
   /**

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -1,7 +1,6 @@
 import { BaseService } from '../../base';
 import {
   FeedbackResponse,
-  FeedbackGetResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
@@ -32,7 +31,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
-   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackGetResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackGetResponse} when pagination options are used.
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback, FeedbackStatus } from '@uipath/uipath-typescript/feedback';
@@ -67,13 +66,13 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     options?: T
   ): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackGetResponse>
-      : NonPaginatedResponse<FeedbackGetResponse>
+      ? PaginatedResponse<FeedbackResponse>
+      : NonPaginatedResponse<FeedbackResponse>
   > {
-    const transformFeedbackResponse = (item: RawFeedbackResponse): FeedbackGetResponse =>
-      transformData(item, FeedbackMap) as unknown as FeedbackGetResponse;
+    const transformFeedbackResponse = (item: RawFeedbackResponse): FeedbackResponse =>
+      transformData(item, FeedbackMap) as unknown as FeedbackResponse;
 
-    return PaginationHelpers.getAll<T, RawFeedbackResponse, FeedbackGetResponse>({
+    return PaginationHelpers.getAll<T, RawFeedbackResponse, FeedbackResponse>({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => FEEDBACK_ENDPOINTS.GET_ALL,
       transformFn: transformFeedbackResponse,
@@ -94,7 +93,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    *
    * @param id - Feedback ID (GUID) of the feedback entry
    * @param options - Required options including folderKey for folder-level authorization {@link FeedbackOptions}
-   * @returns Promise resolving to {@link FeedbackGetResponse}
+   * @returns Promise resolving to {@link FeedbackResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -110,7 +109,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * ```
    */
   @track('Feedback.GetById')
-  async getById(id: string, options: FeedbackOptions): Promise<FeedbackGetResponse> {
+  async getById(id: string, options: FeedbackOptions): Promise<FeedbackResponse> {
     if (!id) throw new ValidationError({ message: 'Feedback ID is required for getById' });
     if (!options.folderKey) throw new ValidationError({ message: 'folderKey is required for getById' });
 
@@ -118,7 +117,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
       FEEDBACK_ENDPOINTS.GET_BY_ID(id),
       { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
     );
-    return transformData(response.data, FeedbackMap) as unknown as FeedbackGetResponse;
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackResponse;
   }
 
   /**

--- a/src/utils/constants/endpoints/feedback.ts
+++ b/src/utils/constants/endpoints/feedback.ts
@@ -6,4 +6,7 @@ import { LLMOPS_BASE } from './base';
 export const FEEDBACK_ENDPOINTS = {
   GET_ALL: `${LLMOPS_BASE}/api/Feedback`,
   GET_BY_ID: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
+  CREATE: `${LLMOPS_BASE}/api/Feedback`,
+  UPDATE: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
+  DELETE: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
 } as const;

--- a/src/utils/constants/endpoints/feedback.ts
+++ b/src/utils/constants/endpoints/feedback.ts
@@ -6,7 +6,7 @@ import { LLMOPS_BASE } from './base';
 export const FEEDBACK_ENDPOINTS = {
   GET_ALL: `${LLMOPS_BASE}/api/Feedback`,
   GET_BY_ID: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
-  CREATE: `${LLMOPS_BASE}/api/Feedback`,
+  SUBMIT: `${LLMOPS_BASE}/api/Feedback`,
   UPDATE: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
   DELETE: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
 } as const;

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -110,7 +110,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('create / updateById / deleteById', () => {
+  describe('submit / updateById / deleteById', () => {
     let traceId!: string;
     let folderKey!: string;
     const createdIds: string[] = [];
@@ -134,8 +134,8 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
       }
     });
 
-    it('should create a feedback entry', async () => {
-      const result = await feedback.create({ traceId, isPositive: true, comment: 'Integration test feedback', folderKey });
+    it('should submit a feedback entry', async () => {
+      const result = await feedback.submit({ traceId, isPositive: true, comment: 'Integration test feedback', folderKey });
 
       createdIds.push(result.id);
       registerResource('feedbackEntries', { id: result.id, folderKey });
@@ -151,7 +151,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should update a feedback entry', async () => {
-      const created = await feedback.create({ traceId, isPositive: true, comment: 'Before update', folderKey });
+      const created = await feedback.submit({ traceId, isPositive: true, comment: 'Before update', folderKey });
       createdIds.push(created.id);
       registerResource('feedbackEntries', { id: created.id, folderKey });
 
@@ -168,9 +168,12 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should delete a feedback entry', async () => {
-      const created = await feedback.create({ traceId, isPositive: true, comment: 'To be deleted', folderKey });
+      const created = await feedback.submit({ traceId, isPositive: true, comment: 'To be deleted', folderKey });
+      createdIds.push(created.id);
+      registerResource('feedbackEntries', { id: created.id, folderKey });
 
       await feedback.deleteById(created.id, { folderKey });
+      createdIds.splice(createdIds.indexOf(created.id), 1);
     });
   });
 });

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { Feedback } from '../../../../src/services/agents/feedback';
-import { FeedbackStatus, FeedbackGetResponse } from '../../../../src/models/agents/feedback/feedback.types';
+import { FeedbackStatus, FeedbackResponse } from '../../../../src/models/agents/feedback/feedback.types';
 import { registerResource } from '../../utils/cleanup';
 
 const modes: InitMode[] = ['v1'];
@@ -88,7 +88,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should have expected fields on the retrieved feedback', async () => {
-      const result: FeedbackGetResponse = await feedback.getById(existingFeedbackId, { folderKey: existingFolderKey });
+      const result: FeedbackResponse = await feedback.getById(existingFeedbackId, { folderKey: existingFolderKey });
 
       expect(result.id).toBeDefined();
       expect(result.traceId).toBeDefined();
@@ -122,7 +122,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
         throw new Error('No existing feedback — need at least one entry to obtain a valid traceId and folderKey');
       }
       if (!result.items[0].folderKey) {
-        throw new Error('Feedback entry missing folderKey — cannot run create/update/delete tests');
+        throw new Error('Feedback entry missing folderKey — cannot run submit/update/delete tests');
       }
       traceId = result.items[0].traceId;
       folderKey = result.items[0].folderKey;
@@ -134,8 +134,8 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
       }
     });
 
-    it('should submit a feedback entry', async () => {
-      const result = await feedback.submit({ traceId, isPositive: true, comment: 'Integration test feedback', folderKey });
+    it('should submit a feedback entry with minimum required fields', async () => {
+      const result = await feedback.submit(traceId, true, { folderKey });
 
       createdIds.push(result.id);
       registerResource('feedbackEntries', { id: result.id, folderKey });
@@ -151,11 +151,11 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should update a feedback entry', async () => {
-      const created = await feedback.submit({ traceId, isPositive: true, comment: 'Before update', folderKey });
+      const created = await feedback.submit(traceId, true, { comment: 'Before update', folderKey });
       createdIds.push(created.id);
       registerResource('feedbackEntries', { id: created.id, folderKey });
 
-      const updated = await feedback.updateById(created.id, { isPositive: false, comment: 'After update', folderKey });
+      const updated = await feedback.updateById(created.id, false, { comment: 'After update', folderKey });
 
       expect(updated).toBeDefined();
       expect(updated.id).toBe(created.id);
@@ -168,7 +168,7 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     });
 
     it('should delete a feedback entry', async () => {
-      const created = await feedback.submit({ traceId, isPositive: true, comment: 'To be deleted', folderKey });
+      const created = await feedback.submit(traceId, true, { comment: 'To be deleted', folderKey });
       createdIds.push(created.id);
       registerResource('feedbackEntries', { id: created.id, folderKey });
 

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { Feedback } from '../../../../src/services/agents/feedback';
 import { FeedbackStatus, FeedbackGetResponse } from '../../../../src/models/agents/feedback/feedback.types';
+import { registerResource } from '../../utils/cleanup';
 
 const modes: InitMode[] = ['v1'];
 
@@ -106,6 +107,70 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
       expect(result.updatedTime).toBeDefined();
       expect((result as any).createdAt).toBeUndefined();
       expect((result as any).updatedAt).toBeUndefined();
+    });
+  });
+
+  describe('create / updateById / deleteById', () => {
+    let traceId!: string;
+    let folderKey!: string;
+    const createdIds: string[] = [];
+
+    beforeAll(async () => {
+      feedback = getServices().feedback!;
+      const result = await feedback.getAll({ pageSize: 1 });
+      if (result.items.length === 0) {
+        throw new Error('No existing feedback — need at least one entry to obtain a valid traceId and folderKey');
+      }
+      if (!result.items[0].folderKey) {
+        throw new Error('Feedback entry missing folderKey — cannot run create/update/delete tests');
+      }
+      traceId = result.items[0].traceId;
+      folderKey = result.items[0].folderKey;
+    });
+
+    afterAll(async () => {
+      for (const id of createdIds) {
+        await feedback.deleteById(id, { folderKey });
+      }
+    });
+
+    it('should create a feedback entry', async () => {
+      const result = await feedback.create({ traceId, isPositive: true, comment: 'Integration test feedback', folderKey });
+
+      createdIds.push(result.id);
+      registerResource('feedbackEntries', { id: result.id, folderKey });
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.traceId).toBe(traceId);
+      expect(result.isPositive).toBe(true);
+      expect(result.createdTime).toBeDefined();
+      expect(result.updatedTime).toBeDefined();
+      expect((result as any).createdAt).toBeUndefined();
+      expect((result as any).updatedAt).toBeUndefined();
+    });
+
+    it('should update a feedback entry', async () => {
+      const created = await feedback.create({ traceId, isPositive: true, comment: 'Before update', folderKey });
+      createdIds.push(created.id);
+      registerResource('feedbackEntries', { id: created.id, folderKey });
+
+      const updated = await feedback.updateById(created.id, { isPositive: false, comment: 'After update', folderKey });
+
+      expect(updated).toBeDefined();
+      expect(updated.id).toBe(created.id);
+      expect(updated.isPositive).toBe(false);
+      expect(updated.comment).toBe('After update');
+      expect(updated.createdTime).toBeDefined();
+      expect(updated.updatedTime).toBeDefined();
+      expect((updated as any).createdAt).toBeUndefined();
+      expect((updated as any).updatedAt).toBeUndefined();
+    });
+
+    it('should delete a feedback entry', async () => {
+      const created = await feedback.create({ traceId, isPositive: true, comment: 'To be deleted', folderKey });
+
+      await feedback.deleteById(created.id, { folderKey });
     });
   });
 });

--- a/tests/integration/utils/cleanup.ts
+++ b/tests/integration/utils/cleanup.ts
@@ -140,8 +140,9 @@ export async function cleanupTestFeedbackEntry(
   try {
     const { feedback } = getServices();
     if (!feedback) return;
+    if (!folderKey) return;
     await retryWithBackoff(async () => {
-      await feedback.deleteById(id, { folderKey: folderKey! });
+      await feedback.deleteById(id, { folderKey });
     });
     console.log(`Cleaned up test feedback entry: ${id}`);
   } catch (error) {

--- a/tests/integration/utils/cleanup.ts
+++ b/tests/integration/utils/cleanup.ts
@@ -11,6 +11,7 @@ interface ResourceRegistry {
   entityRecords: Array<{ entityId: string; recordIds: string[] }>;
   processInstances: Array<{ id: string; folderKey?: string }>;
   caseInstances: Array<{ id: string; folderKey?: string }>;
+  feedbackEntries: Array<{ id: string; folderKey?: string }>;
 }
 
 const resourceRegistry: ResourceRegistry = {
@@ -18,6 +19,7 @@ const resourceRegistry: ResourceRegistry = {
   entityRecords: [],
   processInstances: [],
   caseInstances: [],
+  feedbackEntries: [],
 };
 
 /**
@@ -126,6 +128,28 @@ export async function cleanupTestCaseInstance(
 }
 
 /**
+ * Deletes a test feedback entry.
+ *
+ * @param id - ID of the feedback entry
+ * @param folderKey - Optional folder key
+ */
+export async function cleanupTestFeedbackEntry(
+  id: string,
+  folderKey?: string
+): Promise<void> {
+  try {
+    const { feedback } = getServices();
+    if (!feedback) return;
+    await retryWithBackoff(async () => {
+      await feedback.deleteById(id, { folderKey: folderKey! });
+    });
+    console.log(`Cleaned up test feedback entry: ${id}`);
+  } catch (error) {
+    console.warn(`Failed to cleanup feedback entry ${id}:`, error);
+  }
+}
+
+/**
  * Emergency cleanup function that attempts to delete all registered resources.
  * Should be called as a last resort in afterAll hooks.
  */
@@ -152,11 +176,17 @@ export async function cleanupAllTestResources(): Promise<void> {
     await cleanupTestCaseInstance(caseInstance.id, caseInstance.folderKey);
   }
 
+  // Cleanup feedback entries
+  for (const entry of resourceRegistry.feedbackEntries) {
+    await cleanupTestFeedbackEntry(entry.id, entry.folderKey);
+  }
+
   // Clear registry
   resourceRegistry.tasks = [];
   resourceRegistry.entityRecords = [];
   resourceRegistry.processInstances = [];
   resourceRegistry.caseInstances = [];
+  resourceRegistry.feedbackEntries = [];
 
   console.log('Emergency cleanup completed');
 }

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -6,7 +6,7 @@ import { createServiceTestDependencies, createMockApiClient } from '../../../uti
 import { FEEDBACK_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { TEST_CONSTANTS, FEEDBACK_TEST_CONSTANTS, CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../../../utils/constants';
 import { createMockFeedback } from '../../../utils/mocks/feedback';
-import { FeedbackCreateOptions, FeedbackUpdateOptions } from '../../../../src/models/agents/feedback/feedback.types';
+import { FeedbackSubmitOptions, FeedbackUpdateOptions } from '../../../../src/models/agents/feedback/feedback.types';
 
 // ===== MOCKING =====
 vi.mock('../../../../src/core/http/api-client');
@@ -141,24 +141,22 @@ describe('FeedbackService Unit Tests', () => {
   });
 
   describe('submit', () => {
-    const createOptions: FeedbackCreateOptions = {
-      traceId: FEEDBACK_TEST_CONSTANTS.TRACE_ID,
+    const submitOptions: FeedbackSubmitOptions = {
       spanId: FEEDBACK_TEST_CONSTANTS.SPAN_ID,
-      isPositive: true,
       comment: 'Great response!',
       folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY,
     };
 
-    it('should create feedback successfully', async () => {
+    it('should submit feedback successfully', async () => {
       mockApiClient.post.mockResolvedValue(createMockFeedback());
 
-      const result = await feedbackService.submit(createOptions);
+      const result = await feedbackService.submit(FEEDBACK_TEST_CONSTANTS.TRACE_ID, true, submitOptions);
 
       expect(result).toBeDefined();
       expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
       expect(mockApiClient.post).toHaveBeenCalledWith(
         FEEDBACK_ENDPOINTS.SUBMIT,
-        expect.objectContaining({ traceId: FEEDBACK_TEST_CONSTANTS.TRACE_ID }),
+        expect.objectContaining({ traceId: FEEDBACK_TEST_CONSTANTS.TRACE_ID, isPositive: true }),
         expect.objectContaining({ headers: expect.objectContaining({ 'X-UIPATH-FolderKey': FEEDBACK_TEST_CONSTANTS.FOLDER_KEY }) })
       );
       expect(mockApiClient.post.mock.calls[0][1]).not.toHaveProperty('folderKey');
@@ -167,7 +165,7 @@ describe('FeedbackService Unit Tests', () => {
     it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
       mockApiClient.post.mockResolvedValue(createMockFeedback());
 
-      const result = await feedbackService.submit(createOptions);
+      const result = await feedbackService.submit(FEEDBACK_TEST_CONSTANTS.TRACE_ID, true, submitOptions);
 
       expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
       expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
@@ -176,13 +174,13 @@ describe('FeedbackService Unit Tests', () => {
     });
 
     it('should throw ValidationError when traceId is empty', async () => {
-      await expect(feedbackService.submit({ ...createOptions, traceId: '' }))
+      await expect(feedbackService.submit('', true, submitOptions))
         .rejects.toThrow('traceId is required');
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
 
     it('should throw ValidationError when folderKey is empty', async () => {
-      await expect(feedbackService.submit({ ...createOptions, folderKey: '' }))
+      await expect(feedbackService.submit(FEEDBACK_TEST_CONSTANTS.TRACE_ID, true, { ...submitOptions, folderKey: '' }))
         .rejects.toThrow('folderKey is required');
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
@@ -190,14 +188,13 @@ describe('FeedbackService Unit Tests', () => {
     it('should throw error when API call fails', async () => {
       mockApiClient.post.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND));
 
-      await expect(feedbackService.submit(createOptions))
+      await expect(feedbackService.submit(FEEDBACK_TEST_CONSTANTS.TRACE_ID, true, submitOptions))
         .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
     });
   });
 
   describe('updateById', () => {
     const updateOptions: FeedbackUpdateOptions = {
-      isPositive: false,
       comment: 'On reflection, not great.',
       folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY,
     };
@@ -205,7 +202,7 @@ describe('FeedbackService Unit Tests', () => {
     it('should update feedback successfully', async () => {
       mockApiClient.post.mockResolvedValue(createMockFeedback({ isPositive: false, comment: 'On reflection, not great.' }));
 
-      const result = await feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, updateOptions);
+      const result = await feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, false, updateOptions);
 
       expect(result).toBeDefined();
       expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
@@ -220,7 +217,7 @@ describe('FeedbackService Unit Tests', () => {
     it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
       mockApiClient.post.mockResolvedValue(createMockFeedback());
 
-      const result = await feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, updateOptions);
+      const result = await feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, false, updateOptions);
 
       expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
       expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
@@ -229,13 +226,13 @@ describe('FeedbackService Unit Tests', () => {
     });
 
     it('should throw ValidationError when ID is empty', async () => {
-      await expect(feedbackService.updateById('', updateOptions))
+      await expect(feedbackService.updateById('', false, updateOptions))
         .rejects.toThrow('Feedback ID is required');
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
 
     it('should throw ValidationError when folderKey is empty', async () => {
-      await expect(feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { ...updateOptions, folderKey: '' }))
+      await expect(feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, false, { ...updateOptions, folderKey: '' }))
         .rejects.toThrow('folderKey is required');
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
@@ -243,7 +240,7 @@ describe('FeedbackService Unit Tests', () => {
     it('should throw error when feedback not found', async () => {
       mockApiClient.post.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND));
 
-      await expect(feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, updateOptions))
+      await expect(feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, false, updateOptions))
         .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
     });
   });

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -140,7 +140,7 @@ describe('FeedbackService Unit Tests', () => {
     });
   });
 
-  describe('create', () => {
+  describe('submit', () => {
     const createOptions: FeedbackCreateOptions = {
       traceId: FEEDBACK_TEST_CONSTANTS.TRACE_ID,
       spanId: FEEDBACK_TEST_CONSTANTS.SPAN_ID,
@@ -152,21 +152,22 @@ describe('FeedbackService Unit Tests', () => {
     it('should create feedback successfully', async () => {
       mockApiClient.post.mockResolvedValue(createMockFeedback());
 
-      const result = await feedbackService.create(createOptions);
+      const result = await feedbackService.submit(createOptions);
 
       expect(result).toBeDefined();
       expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        FEEDBACK_ENDPOINTS.CREATE,
+        FEEDBACK_ENDPOINTS.SUBMIT,
         expect.objectContaining({ traceId: FEEDBACK_TEST_CONSTANTS.TRACE_ID }),
-        expect.any(Object)
+        expect.objectContaining({ headers: expect.objectContaining({ 'X-UIPATH-FolderKey': FEEDBACK_TEST_CONSTANTS.FOLDER_KEY }) })
       );
+      expect(mockApiClient.post.mock.calls[0][1]).not.toHaveProperty('folderKey');
     });
 
     it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
       mockApiClient.post.mockResolvedValue(createMockFeedback());
 
-      const result = await feedbackService.create(createOptions);
+      const result = await feedbackService.submit(createOptions);
 
       expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
       expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
@@ -175,13 +176,13 @@ describe('FeedbackService Unit Tests', () => {
     });
 
     it('should throw ValidationError when traceId is empty', async () => {
-      await expect(feedbackService.create({ ...createOptions, traceId: '' }))
+      await expect(feedbackService.submit({ ...createOptions, traceId: '' }))
         .rejects.toThrow('traceId is required');
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
 
     it('should throw ValidationError when folderKey is empty', async () => {
-      await expect(feedbackService.create({ ...createOptions, folderKey: '' }))
+      await expect(feedbackService.submit({ ...createOptions, folderKey: '' }))
         .rejects.toThrow('folderKey is required');
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
@@ -189,7 +190,7 @@ describe('FeedbackService Unit Tests', () => {
     it('should throw error when API call fails', async () => {
       mockApiClient.post.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND));
 
-      await expect(feedbackService.create(createOptions))
+      await expect(feedbackService.submit(createOptions))
         .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
     });
   });
@@ -211,8 +212,9 @@ describe('FeedbackService Unit Tests', () => {
       expect(mockApiClient.post).toHaveBeenCalledWith(
         FEEDBACK_ENDPOINTS.UPDATE(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID),
         expect.objectContaining({ isPositive: false }),
-        expect.any(Object)
+        expect.objectContaining({ headers: expect.objectContaining({ 'X-UIPATH-FolderKey': FEEDBACK_TEST_CONSTANTS.FOLDER_KEY }) })
       );
+      expect(mockApiClient.post.mock.calls[0][1]).not.toHaveProperty('folderKey');
     });
 
     it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
@@ -254,7 +256,7 @@ describe('FeedbackService Unit Tests', () => {
 
       expect(mockApiClient.delete).toHaveBeenCalledWith(
         FEEDBACK_ENDPOINTS.DELETE(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID),
-        expect.any(Object)
+        expect.objectContaining({ headers: expect.objectContaining({ 'X-UIPATH-FolderKey': FEEDBACK_TEST_CONSTANTS.FOLDER_KEY }) })
       );
     });
 

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -6,6 +6,7 @@ import { createServiceTestDependencies, createMockApiClient } from '../../../uti
 import { FEEDBACK_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { TEST_CONSTANTS, FEEDBACK_TEST_CONSTANTS, CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../../../utils/constants';
 import { createMockFeedback } from '../../../utils/mocks/feedback';
+import { FeedbackCreateOptions, FeedbackUpdateOptions } from '../../../../src/models/agents/feedback/feedback.types';
 
 // ===== MOCKING =====
 vi.mock('../../../../src/core/http/api-client');
@@ -136,6 +137,144 @@ describe('FeedbackService Unit Tests', () => {
       await expect(feedbackService.getById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY })).rejects.toThrow(
         FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND
       );
+    });
+  });
+
+  describe('create', () => {
+    const createOptions: FeedbackCreateOptions = {
+      traceId: FEEDBACK_TEST_CONSTANTS.TRACE_ID,
+      spanId: FEEDBACK_TEST_CONSTANTS.SPAN_ID,
+      isPositive: true,
+      comment: 'Great response!',
+      folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY,
+    };
+
+    it('should create feedback successfully', async () => {
+      mockApiClient.post.mockResolvedValue(createMockFeedback());
+
+      const result = await feedbackService.create(createOptions);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.CREATE,
+        expect.objectContaining({ traceId: FEEDBACK_TEST_CONSTANTS.TRACE_ID }),
+        expect.any(Object)
+      );
+    });
+
+    it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
+      mockApiClient.post.mockResolvedValue(createMockFeedback());
+
+      const result = await feedbackService.create(createOptions);
+
+      expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
+      expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
+      expect((result as any).createdAt).toBeUndefined();
+      expect((result as any).updatedAt).toBeUndefined();
+    });
+
+    it('should throw ValidationError when traceId is empty', async () => {
+      await expect(feedbackService.create({ ...createOptions, traceId: '' }))
+        .rejects.toThrow('traceId is required');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when folderKey is empty', async () => {
+      await expect(feedbackService.create({ ...createOptions, folderKey: '' }))
+        .rejects.toThrow('folderKey is required');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when API call fails', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND));
+
+      await expect(feedbackService.create(createOptions))
+        .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
+    });
+  });
+
+  describe('updateById', () => {
+    const updateOptions: FeedbackUpdateOptions = {
+      isPositive: false,
+      comment: 'On reflection, not great.',
+      folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY,
+    };
+
+    it('should update feedback successfully', async () => {
+      mockApiClient.post.mockResolvedValue(createMockFeedback({ isPositive: false, comment: 'On reflection, not great.' }));
+
+      const result = await feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, updateOptions);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.UPDATE(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID),
+        expect.objectContaining({ isPositive: false }),
+        expect.any(Object)
+      );
+    });
+
+    it('should transform createdAt and updatedAt to createdTime and updatedTime', async () => {
+      mockApiClient.post.mockResolvedValue(createMockFeedback());
+
+      const result = await feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, updateOptions);
+
+      expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
+      expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
+      expect((result as any).createdAt).toBeUndefined();
+      expect((result as any).updatedAt).toBeUndefined();
+    });
+
+    it('should throw ValidationError when ID is empty', async () => {
+      await expect(feedbackService.updateById('', updateOptions))
+        .rejects.toThrow('Feedback ID is required');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when folderKey is empty', async () => {
+      await expect(feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { ...updateOptions, folderKey: '' }))
+        .rejects.toThrow('folderKey is required');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when feedback not found', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND));
+
+      await expect(feedbackService.updateById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, updateOptions))
+        .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('should delete feedback successfully', async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await feedbackService.deleteById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY });
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.DELETE(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID),
+        expect.any(Object)
+      );
+    });
+
+    it('should throw ValidationError when ID is empty', async () => {
+      await expect(feedbackService.deleteById('', { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY }))
+        .rejects.toThrow('Feedback ID is required');
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when folderKey is empty', async () => {
+      await expect(feedbackService.deleteById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: '' }))
+        .rejects.toThrow('folderKey is required');
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when feedback not found', async () => {
+      mockApiClient.delete.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND));
+
+      await expect(feedbackService.deleteById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY }))
+        .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
     });
   });
 });

--- a/tests/utils/constants/feedback.ts
+++ b/tests/utils/constants/feedback.ts
@@ -13,6 +13,10 @@ export const FEEDBACK_TEST_CONSTANTS = {
   // Agent identifiers (string UUID for feedback API)
   AGENT_UUID: 'agent-789',
 
+  // Trace / span identifiers
+  TRACE_ID: 'trace-abc-123',
+  SPAN_ID: 'span-def-456',
+
   // Feedback category identifiers
   CATEGORY_ID: 'category-1',
   CATEGORY_NAME: 'Output',

--- a/tests/utils/mocks/feedback.ts
+++ b/tests/utils/mocks/feedback.ts
@@ -1,5 +1,5 @@
 import { FeedbackCategory, FeedbackStatus } from '../../../src/models/agents/feedback/feedback.types';
-import { RawFeedbackGetResponse } from '../../../src/models/agents/feedback/feedback.internal-types';
+import { RawFeedbackResponse } from '../../../src/models/agents/feedback/feedback.internal-types';
 import { FEEDBACK_TEST_CONSTANTS } from '../constants/feedback';
 import { CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../constants/conversational-agent';
 
@@ -25,7 +25,7 @@ export const createMockFeedbackCategory = (overrides: Partial<FeedbackCategory> 
  * @param overrides - Optional overrides for specific fields
  * @returns Mock feedback data
  */
-export const createMockFeedback = (overrides: Partial<RawFeedbackGetResponse> = {}): RawFeedbackGetResponse => ({
+export const createMockFeedback = (overrides: Partial<RawFeedbackResponse> = {}): RawFeedbackResponse => ({
   id: FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID,
   traceId: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_TRACE_ID,
   spanId: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_SPAN_ID,


### PR DESCRIPTION
## Summary

- Adds `create`, `updateById`, and `deleteById` methods to `FeedbackService`
- Consolidates options types — `FeedbackCreateOptions` and `FeedbackUpdateOptions` both extend a shared `FeedbackOptions` base (with required `folderKey`)
- `folderKey` is destructured out before the POST body is sent — it goes in the `X-UiPath-FolderKey` header, not the request body
- Validation errors thrown for missing `id`, `traceId`, and `folderKey`
- OAuth scope: `Traces.Api` (all three methods)

## API responses (live)

**`feedback.create({ traceId, isPositive, comment, folderKey })`**
```json
{
  "id": "5b3b31b4-f24e-4d00-9300-1e20e67301ef",
  "traceId": "a09b8232-09f7-4386-92e3-8a9f2e72d8e2",
  "spanId": "00000000-0000-0000-6044-b04baf471192",
  "comment": "PR demo: create",
  "isPositive": true,
  "folderKey": "2fc1d938-7a49-4544-b333-1aaad674c4e1",
  "feedbackCategories": [],
  "userEmail": "motatisarath.reddy@uipath.com",
  "status": 1,
  "createdTime": "2026-05-06T12:12:58.8788446Z",
  "updatedTime": "2026-05-06T12:12:58.8788446Z"
}
```

**`feedback.updateById(id, { isPositive, comment, folderKey })`**
```json
{
  "id": "5b3b31b4-f24e-4d00-9300-1e20e67301ef",
  "traceId": "a09b8232-09f7-4386-92e3-8a9f2e72d8e2",
  "spanId": "00000000-0000-0000-6044-b04baf471192",
  "comment": "PR demo: updated",
  "isPositive": false,
  "folderKey": "2fc1d938-7a49-4544-b333-1aaad674c4e1",
  "feedbackCategories": [],
  "userEmail": "motatisarath.reddy@uipath.com",
  "status": 1,
  "createdTime": "2026-05-06T12:12:58.8788446Z",
  "updatedTime": "2026-05-06T12:12:59.5602914Z"
}
```

**`feedback.deleteById(id, { folderKey })`** — returns `void`

## Test plan
- [x] Unit tests: `npm run test:unit`
- [x] Integration tests: `npm run test:integration` (all feedback tests pass)