### PR TITLE
feat(datafabric): add aggregate query support to entities

### DIFF
--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -354,15 +354,15 @@ export interface EntityServiceModel {
   deleteRecordById(entityId: string, recordId: string): Promise<void>;
 
   /**
-   * Queries entity records with filters, sorting, and SDK-managed pagination
+   * Queries entity records with filters, sorting, aggregates, and SDK-managed pagination
    *
    * @param id - UUID of the entity
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, and pagination
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    * @example
    * ```typescript
-   * import { Entities, LogicalOperator, QueryFilterOperator } from '@uipath/uipath-typescript/entities';
+   * import { Entities, LogicalOperator, QueryFilterOperator, EntityAggregateFunction } from '@uipath/uipath-typescript/entities';
    *
    * const entities = new Entities(sdk);
    *
@@ -381,6 +381,23 @@ export interface EntityServiceModel {
    * if (page1.hasNextPage) {
    *   const page2 = await entities.queryRecordsById(<id>, { cursor: page1.nextCursor });
    * }
+   *
+   * // Aggregate: count of records per status
+   * await entities.queryRecordsById(<id>, {
+   *   selectedFields: ["status"],
+   *   groupBy: ["status"],
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
+   *   ],
+   * });
+   *
+   * // Aggregate: total sum and average across all records (no grouping)
+   * await entities.queryRecordsById(<id>, {
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Sum, field: "amount", alias: "totalAmount" },
+   *     { function: EntityAggregateFunction.Avg, field: "amount", alias: "avgAmount" },
+   *   ],
+   * });
    * ```
    */
   queryRecordsById<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(id: string, options?: T): Promise<
@@ -760,13 +777,17 @@ export interface EntityMethods {
   batchInsert(data: Record<string, any>[], options?: EntityBatchInsertOptions): Promise<EntityBatchInsertResponse>;
 
   /**
-   * Queries records in this entity with filters, sorting, and SDK-managed pagination
+   * Queries records in this entity with filters, sorting, aggregates, and SDK-managed pagination
    *
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, and pagination
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    * @example
    * ```typescript
+   * import { Entities, LogicalOperator, QueryFilterOperator, EntityAggregateFunction } from '@uipath/uipath-typescript/entities';
+   *
+   * const entities = new Entities(sdk);
+   *
    * const entity = await entities.getById(<entityId>);
    * const result = await entity.queryRecords({
    *   filterGroup: {
@@ -776,6 +797,23 @@ export interface EntityMethods {
    *   sortOptions: [{ fieldName: "createdTime", isDescending: true }],
    * });
    * console.log(`Found ${result.totalCount} records`);
+   *
+   * // Aggregate: count of records per status
+   * await entity.queryRecords({
+   *   selectedFields: ["status"],
+   *   groupBy: ["status"],
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
+   *   ],
+   * });
+   *
+   * // Aggregate: total sum and average across all records (no grouping)
+   * await entity.queryRecords({
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Sum, field: "amount", alias: "totalAmount" },
+   *     { function: EntityAggregateFunction.Avg, field: "amount", alias: "avgAmount" },
+   *   ],
+   * });
    * ```
    */
   queryRecords<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(options?: T): Promise<

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -197,7 +197,33 @@ export interface EntityQuerySortOption {
 }
 
 /**
- * Options for querying entity records with filters, sorting, and pagination.
+ * Aggregate functions supported by the Data Fabric query API.
+ */
+export enum EntityAggregateFunction {
+  Count = 'COUNT',
+  Sum = 'SUM',
+  Avg = 'AVG',
+  Min = 'MIN',
+  Max = 'MAX',
+}
+
+/**
+ * A single aggregate expression to apply during a query.
+ *
+ * Aggregate results are returned as fields on each item in the response,
+ * keyed by `alias` when provided.
+ */
+export interface EntityAggregate {
+  /** Aggregate function to apply */
+  function: EntityAggregateFunction;
+  /** Field to aggregate on. For `COUNT`, any non-null field works (typically `Id`). */
+  field: string;
+  /** Optional alias for the aggregate result column. */
+  alias?: string;
+}
+
+/**
+ * Options for querying entity records with filters, sorting, aggregates, and pagination.
  *
  * Use `pageSize`, `cursor`, or `jumpToPage` for SDK-managed pagination.
  * The SDK computes and manages offset parameters automatically.
@@ -211,6 +237,10 @@ export type EntityQueryRecordsOptions = {
   sortOptions?: EntityQuerySortOption[];
   /** Level of entity expansion for related fields (default: 0) */
   expansionLevel?: number;
+  /** Aggregate expressions (COUNT, SUM, AVG, MIN, MAX) to apply across the result set. */
+  aggregates?: EntityAggregate[];
+  /** Field names to group aggregate results by. */
+  groupBy?: string[];
 } & PaginationOptions;
 
 /**

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -480,16 +480,16 @@ export class EntityService extends BaseService implements EntityServiceModel {
   }
 
   /**
-   * Queries entity records with filters, sorting, and pagination
+   * Queries entity records with filters, sorting, aggregates, and pagination
    *
    * @param id - UUID of the entity
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, and pagination
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    *
    * @example
    * ```typescript
-   * import { Entities, LogicalOperator, QueryFilterOperator } from '@uipath/uipath-typescript/entities';
+   * import { Entities, LogicalOperator, QueryFilterOperator, EntityAggregateFunction } from '@uipath/uipath-typescript/entities';
    *
    * const entities = new Entities(sdk);
    *
@@ -513,6 +513,23 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * if (page1.hasNextPage) {
    *   const page2 = await entities.queryRecordsById("<entityId>", { cursor: page1.nextCursor });
    * }
+   *
+   * // Aggregate: count of records per status
+   * await entities.queryRecordsById("<entityId>", {
+   *   selectedFields: ["status"],
+   *   groupBy: ["status"],
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
+   *   ],
+   * });
+   *
+   * // Aggregate: total sum and average across all records (no grouping)
+   * await entities.queryRecordsById("<entityId>", {
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Sum, field: "amount", alias: "totalAmount" },
+   *     { function: EntityAggregateFunction.Avg, field: "amount", alias: "avgAmount" },
+   *   ],
+   * });
    * ```
    */
   @track('Entities.QueryRecordsById')
@@ -534,7 +551,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
           countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
         }
       },
-      excludeFromPrefix: ['expansionLevel', 'filterGroup', 'selectedFields', 'sortOptions']
+      excludeFromPrefix: ['expansionLevel', 'filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy']
     }, options);
   }
 

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -9,6 +9,7 @@ import {
 import { registerResource } from '../../utils/cleanup';
 import { generateRandomString, generateRandomInt, generateRandomFloat, hasValidPagination } from '../../utils/helpers';
 import {
+  EntityAggregateFunction,
   EntityFieldDataType,
   EntityRecord,
   FieldDisplayType,
@@ -738,6 +739,27 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(Array.isArray(result.items)).toBe(true);
       expect(result.items.length).toBeLessThanOrEqual(2);
       expect(hasValidPagination(result)).toBe(true);
+    });
+
+    it('should return aggregate count when aggregates is provided without groupBy', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+      const result = await entities.queryRecordsById(entityId, {
+        aggregates: [
+          { function: EntityAggregateFunction.Count, field: 'Id', alias: 'total' },
+        ],
+      });
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
+      expect(result.items.length).toBe(1);
+      const row = result.items[0] as Record<string, any>;
+      expect(row.total).toBeDefined();
+      expect(typeof row.total).toBe('number');
+      expect(row.total).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -14,6 +14,7 @@ import {
   createMockBlob,
 } from "../../../utils/mocks/entities";
 import { ENTITY_TEST_CONSTANTS } from "../../../utils/constants/entities";
+import { EntityAggregateFunction } from "../../../../src/models/data-fabric/entities.types";
 import type { EntityUpdateByIdOptions } from "../../../../src/models/data-fabric/entities.types";
 
 // ===== TEST SUITE =====
@@ -586,6 +587,59 @@ describe("Entity Models", () => {
             expect(record.RecordOwner).toHaveProperty("id");
           }
         });
+      });
+    });
+
+    describe("entity.queryRecords()", () => {
+      it("should call queryRecordsById with entity id and no options", async () => {
+        const entityData = createBasicEntity();
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        const mockResponse = { items: createMockEntityRecords(2), totalCount: 2 };
+        mockService.queryRecordsById = vi.fn().mockResolvedValue(mockResponse);
+
+        const result = await entity.queryRecords();
+
+        expect(mockService.queryRecordsById).toHaveBeenCalledWith(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          undefined,
+        );
+        expect(result).toEqual(mockResponse);
+      });
+
+      it("should throw error if entity id is undefined", async () => {
+        const entityData = createBasicEntity({ id: undefined as any });
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        await expect(entity.queryRecords()).rejects.toThrow(
+          ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_ENTITY_ID_UNDEFINED,
+        );
+      });
+
+      it("should call queryRecordsById with aggregates and groupBy options", async () => {
+        const entityData = createBasicEntity();
+        const entity = createEntityWithMethods(entityData, mockService);
+
+        const options = {
+          selectedFields: ["status"],
+          groupBy: ["status"],
+          aggregates: [
+            { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
+          ],
+        };
+        const mockResponse = {
+          items: [{ status: "active", total: 12 }, { status: "closed", total: 5 }],
+          totalCount: 2,
+        };
+        mockService.queryRecordsById = vi.fn().mockResolvedValue(mockResponse);
+
+        const result = await entity.queryRecords(options);
+
+        expect(mockService.queryRecordsById).toHaveBeenCalledWith(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          options,
+        );
+        expect(result).toEqual(mockResponse);
       });
     });
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -35,6 +35,7 @@ import type {
 } from "../../../../src/models/data-fabric/entities.types";
 import {
   EntityFieldDataType,
+  EntityAggregateFunction,
   ExternalField,
   FieldDisplayType,
   QueryFilterOperator,
@@ -1443,6 +1444,77 @@ describe("EntityService Unit Tests", () => {
       await expect(
         entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID),
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should pass aggregates and groupBy through to PaginationHelpers.getAll", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({
+        items: [{ status: "active", total: 12 }, { status: "closed", total: 5 }],
+        totalCount: 2,
+      });
+
+      const options = {
+        selectedFields: ["status"],
+        groupBy: ["status"],
+        aggregates: [
+          { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
+        ],
+      };
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, options);
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          selectedFields: options.selectedFields,
+          groupBy: options.groupBy,
+          aggregates: options.aggregates,
+        }),
+      );
+    });
+
+    it("should include aggregates and groupBy in excludeFromPrefix so OData $ prefix is not added", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        aggregates: [
+          { function: EntityAggregateFunction.Sum, field: "amount", alias: "totalAmount" },
+        ],
+        groupBy: ["region"],
+      });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeFromPrefix: expect.arrayContaining(["aggregates", "groupBy"]),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("should send aggregate function values as uppercase enum strings", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        aggregates: [
+          { function: EntityAggregateFunction.Count, field: "Id" },
+          { function: EntityAggregateFunction.Avg, field: "score", alias: "avgScore" },
+          { function: EntityAggregateFunction.Min, field: "score" },
+          { function: EntityAggregateFunction.Max, field: "score" },
+          { function: EntityAggregateFunction.Sum, field: "amount" },
+        ],
+      });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          aggregates: [
+            { function: "COUNT", field: "Id" },
+            { function: "AVG",   field: "score", alias: "avgScore" },
+            { function: "MIN",   field: "score" },
+            { function: "MAX",   field: "score" },
+            { function: "SUM",   field: "amount" },
+          ],
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Adds minimal, server-aligned aggregate query support to `entities.queryRecordsById()`, exposing what the Data Fabric `/query` API ships in Phase 1.

- New `EntityAggregateFunction` enum (`Count` / `Sum` / `Avg` / `Min` / `Max`) and `EntityAggregate` interface
- Two new optional fields on `EntityQueryRecordsOptions`: `aggregates?: EntityAggregate[]` and `groupBy?: string[]`
- `queryRecordsById` adds both fields to `excludeFromPrefix` so the OData `$` prefix is not applied
- Wire format matches the CEP `EntityDataQueryRequest` / `AggregateRequest` contract: `{ aggregates: [{ function: "COUNT", field: "Id", alias: "total" }], groupBy: ["status"] }`
- Server-enforced limits (max 5 aggregates / 5 groupBy fields, root-entity-only) are not duplicated client-side

## Out of scope 

- `having` clause
- `Binnings` (numeric / date bucketing)
- `Joins` (multi-entity queries)
- `isAggregate` flag on `sortOptions`

## Jira

[DS-8357](https://uipath.atlassian.net/browse/DS-8357)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm run test:unit` — 1411/1411 passing, including 3 new aggregate tests in `entities.test.ts`
- [x] `npm run build` — Rollup green; `EntityAggregateFunction` present in `dist/entities/index.mjs`
- [x] Live aggregate query verified against a seeded entity on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DS-8357]: https://uipath.atlassian.net/browse/DS-8357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ