### PR TITLE
feat(feedback): add createCategory, getCategories, deleteCategory methods

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -165,6 +165,9 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `submit()` | `Traces.Api` |
 | `updateById()` | `Traces.Api` |
 | `deleteById()` | `Traces.Api` |
+| `createCategory()` | `Traces.Api` |
+| `getCategories()` | `Traces.Api` |
+| `deleteCategory()` | `Traces.Api` |
 
 ## Processes
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -132,3 +132,4 @@ console.log(`Total count: ${allAssets.totalCount}`);
 | ConversationalAgent.conversations | `getAll()` | ❌ No |
 | ConversationalAgent.exchanges | `getAll()` | ❌ No |
 | Feedback | `getAll()` | ✅ Yes |
+| Feedback | `getCategories()` | ✅ Yes |

--- a/src/models/agents/feedback/feedback.internal-types.ts
+++ b/src/models/agents/feedback/feedback.internal-types.ts
@@ -1,6 +1,26 @@
 import { FeedbackCategory, FeedbackStatus } from './feedback.types';
 
 /**
+ * Raw shape of the GET /api/Feedback/category response
+ */
+export interface RawFeedbackCategoryListResponse {
+  categories: RawFeedbackCategory[];
+  totalCount: number;
+}
+
+/**
+ * Raw category shape before createdAt → createdTime rename
+ */
+export interface RawFeedbackCategory {
+  id: string;
+  category: string;
+  createdAt: string;
+  isDefault: boolean;
+  isPositive: boolean;
+  isNegative: boolean;
+}
+
+/**
  * Raw feedback response shape as returned by the API, before the transform pipeline
  * renames createdAt → createdTime and updatedAt → updatedTime.
  */

--- a/src/models/agents/feedback/feedback.internal-types.ts
+++ b/src/models/agents/feedback/feedback.internal-types.ts
@@ -9,7 +9,7 @@ export interface RawFeedbackCategoryListResponse {
 }
 
 /**
- * Raw category shape before createdAt → createdTime rename
+ * Raw category shape as returned by the API (used by getCategories / createCategory before transform)
  */
 export interface RawFeedbackCategory {
   id: string;
@@ -22,7 +22,7 @@ export interface RawFeedbackCategory {
 
 /**
  * Raw feedback response shape as returned by the API, before the transform pipeline
- * renames createdAt → createdTime and updatedAt → updatedTime.
+ * renames createdAt → createdTime, updatedAt → updatedTime.
  */
 export interface RawFeedbackResponse {
   id: string;

--- a/src/models/agents/feedback/feedback.internal-types.ts
+++ b/src/models/agents/feedback/feedback.internal-types.ts
@@ -22,7 +22,7 @@ export interface RawFeedbackCategory {
 
 /**
  * Raw feedback response shape as returned by the API, before the transform pipeline
- * renames createdAt → createdTime, updatedAt → updatedTime.
+ * renames createdAt → createdTime and updatedAt → updatedTime.
  */
 export interface RawFeedbackResponse {
   id: string;

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -173,9 +173,10 @@ export interface FeedbackServiceModel {
    *
    * Custom categories can be used to label feedback entries beyond the default system categories.
    * Once created, reference the category by its `id` when submitting or updating feedback.
+   * If `isPositive` and `isNegative` are omitted, the backend defaults both to `true`.
    *
    * @param category - Name of the category to create (max 256 characters, unique per tenant)
-   * @param options - Whether the category applies to positive and/or negative feedback {@link FeedbackCreateCategoryOptions}
+   * @param options - Optional flags controlling whether the category applies to positive and/or negative feedback {@link FeedbackCreateCategoryOptions}
    * @returns Promise resolving to the created {@link FeedbackCategory}
    * @example
    * ```typescript
@@ -183,14 +184,18 @@ export interface FeedbackServiceModel {
    *
    * const feedback = new Feedback(sdk);
    *
-   * const category = await feedback.createCategory('Hallucination', {
+   * // Minimum — applies to both positive and negative feedback by default
+   * const category = await feedback.createCategory('Hallucination');
+   * console.log(category.id, category.category);
+   *
+   * // With explicit flags
+   * const negativeOnly = await feedback.createCategory('Off-topic', {
    *   isPositive: false,
    *   isNegative: true,
    * });
-   * console.log(category.id, category.category);
    * ```
    */
-  createCategory(category: string, options: FeedbackCreateCategoryOptions): Promise<FeedbackCategory>;
+  createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategory>;
 
   /**
    * Gets all feedback categories for the tenant.

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -35,7 +35,7 @@ export interface FeedbackServiceModel {
    * Gets all feedback across all agents in the tenant, with optional filters.
    *
    * Retrieves a list of feedback entries, optionally filtered by agent, trace, span, status, or agent version.
-   * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
+   * When no pagination options are provided, the SDK returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
@@ -202,7 +202,7 @@ export interface FeedbackServiceModel {
    *
    * Returns both system default categories (Output, Agent Error, Agent Plan Execution)
    * and any custom categories created for this tenant.
-   * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
+   * When no pagination options are provided, the SDK returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional filters and pagination options {@link FeedbackGetCategoriesOptions}
    * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackCategoryResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackCategoryResponse} when pagination options are used.

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -250,10 +250,10 @@ export interface FeedbackServiceModel {
    * const customCategory = categories.items.find(c => !c.isDefault);
    * if (customCategory) {
    *   await feedback.deleteCategory(customCategory.id);
-   * }
    *
-   * // Force-delete a custom category that has associated feedback entries
-   * await feedback.deleteCategory(customCategory.id, { forceDelete: true });
+   *   // Force-delete a custom category that has associated feedback entries
+   *   await feedback.deleteCategory(customCategory.id, { forceDelete: true });
+   * }
    * ```
    */
   deleteCategory(id: string, options?: FeedbackDeleteCategoryOptions): Promise<void>;

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -250,8 +250,14 @@ export interface FeedbackServiceModel {
    * const customCategory = categories.items.find(c => !c.isDefault);
    * if (customCategory) {
    *   await feedback.deleteCategory(customCategory.id);
-   *
-   *   // Force-delete a custom category that has associated feedback entries
+   * }
+   * ```
+   * @example
+   * ```typescript
+   * // Force-delete a custom category that has associated feedback entries
+   * const categories = await feedback.getCategories();
+   * const customCategory = categories.items.find(c => !c.isDefault);
+   * if (customCategory) {
    *   await feedback.deleteCategory(customCategory.id, { forceDelete: true });
    * }
    * ```

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -2,6 +2,7 @@ import type {
   FeedbackResponse,
   FeedbackCategory,
   FeedbackGetAllOptions,
+  FeedbackGetCategoriesOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
   FeedbackUpdateOptions,
@@ -196,19 +197,32 @@ export interface FeedbackServiceModel {
    *
    * Returns both system default categories (Output, Agent Error, Agent Plan Execution)
    * and any custom categories created for this tenant.
+   * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
-   * @returns Promise resolving to an array of {@link FeedbackCategory}
+   * @param options - Optional filters and pagination options {@link FeedbackGetCategoriesOptions}
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackCategory} without pagination options, or {@link PaginatedResponse} of {@link FeedbackCategory} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
    *
    * const feedback = new Feedback(sdk);
    *
+   * // Get all categories
    * const categories = await feedback.getCategories();
-   * console.log(categories.map(c => c.category));
+   * console.log(categories.items.map(c => c.category));
+   *
+   * // Get only categories applicable to negative feedback
+   * const negativeCategories = await feedback.getCategories({ isNegative: true });
+   *
+   * // Paginated
+   * const page1 = await feedback.getCategories({ pageSize: 10 });
    * ```
    */
-  getCategories(): Promise<FeedbackCategory[]>;
+  getCategories<T extends FeedbackGetCategoriesOptions = FeedbackGetCategoriesOptions>(options?: T): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<FeedbackCategory>
+      : NonPaginatedResponse<FeedbackCategory>
+  >;
 
   /**
    * Deletes a feedback category by its ID.

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -1,6 +1,6 @@
 import type {
   FeedbackResponse,
-  FeedbackCategory,
+  FeedbackCategoryResponse,
   FeedbackGetAllOptions,
   FeedbackGetCategoriesOptions,
   FeedbackOptions,
@@ -177,7 +177,7 @@ export interface FeedbackServiceModel {
    *
    * @param category - Name of the category to create (max 256 characters, unique per tenant)
    * @param options - Optional flags controlling whether the category applies to positive and/or negative feedback {@link FeedbackCreateCategoryOptions}
-   * @returns Promise resolving to the created {@link FeedbackCategory}
+   * @returns Promise resolving to the created {@link FeedbackCategoryResponse}
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -195,7 +195,7 @@ export interface FeedbackServiceModel {
    * });
    * ```
    */
-  createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategory>;
+  createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategoryResponse>;
 
   /**
    * Gets all feedback categories for the tenant.
@@ -205,7 +205,7 @@ export interface FeedbackServiceModel {
    * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional filters and pagination options {@link FeedbackGetCategoriesOptions}
-   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackCategory} without pagination options, or {@link PaginatedResponse} of {@link FeedbackCategory} when pagination options are used.
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackCategoryResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackCategoryResponse} when pagination options are used.
    * @example
    * ```typescript
    * import { Feedback } from '@uipath/uipath-typescript/feedback';
@@ -225,15 +225,16 @@ export interface FeedbackServiceModel {
    */
   getCategories<T extends FeedbackGetCategoriesOptions = FeedbackGetCategoriesOptions>(options?: T): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackCategory>
-      : NonPaginatedResponse<FeedbackCategory>
+      ? PaginatedResponse<FeedbackCategoryResponse>
+      : NonPaginatedResponse<FeedbackCategoryResponse>
   >;
 
   /**
    * Deletes a feedback category by its ID.
    *
-   * Default system categories cannot be deleted. Use `forceDelete` to delete a category
-   * that already has feedback entries associated with it.
+   * System default categories (Output, Agent Error, Agent Plan Execution) cannot be deleted —
+   * attempting to do so throws a `409 Conflict` error.
+   * Use `forceDelete` to delete a custom category that already has feedback entries associated with it.
    *
    * @param id - Category ID (GUID) of the category to delete
    * @param options - Optional deletion options {@link FeedbackDeleteCategoryOptions}
@@ -244,12 +245,15 @@ export interface FeedbackServiceModel {
    *
    * const feedback = new Feedback(sdk);
    *
-   * // Get categories to obtain the ID of the one to delete
+   * // Only custom categories (isDefault: false) can be deleted
    * const categories = await feedback.getCategories();
-   * const customCategory = categories.find(c => !c.isDefault);
+   * const customCategory = categories.items.find(c => !c.isDefault);
    * if (customCategory) {
    *   await feedback.deleteCategory(customCategory.id);
    * }
+   *
+   * // Force-delete a custom category that has associated feedback entries
+   * await feedback.deleteCategory(customCategory.id, { forceDelete: true });
    * ```
    */
   deleteCategory(id: string, options?: FeedbackDeleteCategoryOptions): Promise<void>;

--- a/src/models/agents/feedback/feedback.models.ts
+++ b/src/models/agents/feedback/feedback.models.ts
@@ -1,9 +1,12 @@
 import type {
   FeedbackResponse,
+  FeedbackCategory,
   FeedbackGetAllOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
   FeedbackUpdateOptions,
+  FeedbackCreateCategoryOptions,
+  FeedbackDeleteCategoryOptions,
 } from './feedback.types';
 import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 
@@ -163,4 +166,72 @@ export interface FeedbackServiceModel {
    * ```
    */
   deleteById(id: string, options: FeedbackOptions): Promise<void>;
+
+  /**
+   * Creates a new feedback category.
+   *
+   * Custom categories can be used to label feedback entries beyond the default system categories.
+   * Once created, reference the category by its `id` when submitting or updating feedback.
+   *
+   * @param category - Name of the category to create (max 256 characters, unique per tenant)
+   * @param options - Whether the category applies to positive and/or negative feedback {@link FeedbackCreateCategoryOptions}
+   * @returns Promise resolving to the created {@link FeedbackCategory}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * const category = await feedback.createCategory('Hallucination', {
+   *   isPositive: false,
+   *   isNegative: true,
+   * });
+   * console.log(category.id, category.category);
+   * ```
+   */
+  createCategory(category: string, options: FeedbackCreateCategoryOptions): Promise<FeedbackCategory>;
+
+  /**
+   * Gets all feedback categories for the tenant.
+   *
+   * Returns both system default categories (Output, Agent Error, Agent Plan Execution)
+   * and any custom categories created for this tenant.
+   *
+   * @returns Promise resolving to an array of {@link FeedbackCategory}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * const categories = await feedback.getCategories();
+   * console.log(categories.map(c => c.category));
+   * ```
+   */
+  getCategories(): Promise<FeedbackCategory[]>;
+
+  /**
+   * Deletes a feedback category by its ID.
+   *
+   * Default system categories cannot be deleted. Use `forceDelete` to delete a category
+   * that already has feedback entries associated with it.
+   *
+   * @param id - Category ID (GUID) of the category to delete
+   * @param options - Optional deletion options {@link FeedbackDeleteCategoryOptions}
+   * @returns Promise resolving to void on success
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * // Get categories to obtain the ID of the one to delete
+   * const categories = await feedback.getCategories();
+   * const customCategory = categories.find(c => !c.isDefault);
+   * if (customCategory) {
+   *   await feedback.deleteCategory(customCategory.id);
+   * }
+   * ```
+   */
+  deleteCategory(id: string, options?: FeedbackDeleteCategoryOptions): Promise<void>;
 }

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -168,7 +168,8 @@ export interface FeedbackCreateCategoryOptions {
 }
 
 /**
- * Options for deleting a feedback category
+ * Options for deleting a feedback category.
+ * Note: system default categories (Output, Agent Error, Agent Plan Execution) cannot be deleted — attempting to do so returns a 409 Conflict.
  */
 export interface FeedbackDeleteCategoryOptions {
   /** When true, deletes the category even if it has associated feedback entries */

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -154,3 +154,13 @@ export interface FeedbackDeleteCategoryOptions {
   /** When true, deletes the category even if it has associated feedback entries */
   forceDelete?: boolean;
 }
+
+/**
+ * Options for retrieving feedback categories
+ */
+export type FeedbackGetCategoriesOptions = PaginationOptions & {
+  /** Filter by whether the category applies to positive feedback */
+  isPositive?: boolean;
+  /** Filter by whether the category applies to negative feedback */
+  isNegative?: boolean;
+}

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -10,7 +10,7 @@ export interface FeedbackCategory {
   /** Category name (max 256 characters, unique per tenant) */
   category: string;
   /** Timestamp when the category was created */
-  createdAt: string;
+  createdTime: string;
   /** Whether this is a system default category (e.g., Output, Agent Error, Agent Plan Execution) */
   isDefault: boolean;
   /** Whether this category applies to positive feedback */
@@ -135,4 +135,22 @@ export type FeedbackGetAllOptions = PaginationOptions & {
   traceId?: string;
   /** Filter by OpenTelemetry span identifier */
   spanId?: string;
+}
+
+/**
+ * Options for creating a new feedback category
+ */
+export interface FeedbackCreateCategoryOptions {
+  /** Whether the category applies to positive feedback */
+  isPositive: boolean;
+  /** Whether the category applies to negative feedback */
+  isNegative: boolean;
+}
+
+/**
+ * Options for deleting a feedback category
+ */
+export interface FeedbackDeleteCategoryOptions {
+  /** When true, deletes the category even if it has associated feedback entries */
+  forceDelete?: boolean;
 }

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -141,10 +141,10 @@ export type FeedbackGetAllOptions = PaginationOptions & {
  * Options for creating a new feedback category
  */
 export interface FeedbackCreateCategoryOptions {
-  /** Whether the category applies to positive feedback */
-  isPositive: boolean;
-  /** Whether the category applies to negative feedback */
-  isNegative: boolean;
+  /** Whether the category applies to positive feedback (defaults to true) */
+  isPositive?: boolean;
+  /** Whether the category applies to negative feedback (defaults to true) */
+  isNegative?: boolean;
 }
 
 /**

--- a/src/models/agents/feedback/feedback.types.ts
+++ b/src/models/agents/feedback/feedback.types.ts
@@ -3,8 +3,28 @@ import { PaginationOptions } from '../../../utils/pagination';
 /**
  * Represents a category that can be associated with feedback.
  * Default categories (Output, Agent Error, Agent Plan Execution) are auto-created per tenant.
+ * Used as nested objects inside {@link FeedbackResponse}.
  */
 export interface FeedbackCategory {
+  /** Unique identifier of the feedback category */
+  id: string;
+  /** Category name (max 256 characters, unique per tenant) */
+  category: string;
+  /** Timestamp when the category was created */
+  createdAt: string;
+  /** Whether this is a system default category (e.g., Output, Agent Error, Agent Plan Execution) */
+  isDefault: boolean;
+  /** Whether this category applies to positive feedback */
+  isPositive: boolean;
+  /** Whether this category applies to negative feedback */
+  isNegative: boolean;
+}
+
+/**
+ * A feedback category returned by {@link FeedbackServiceModel.getCategories}, {@link FeedbackServiceModel.createCategory}.
+ * Fields are transformed to camelCase SDK conventions (createdAt → createdTime).
+ */
+export interface FeedbackCategoryResponse {
   /** Unique identifier of the feedback category */
   id: string;
   /** Category name (max 256 characters, unique per tenant) */

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -32,7 +32,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * Gets all feedback across all agents in the tenant, with optional filters.
    *
    * Retrieves a list of feedback entries, optionally filtered by agent, trace, span, status, or agent version.
-   * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
+   * When no pagination options are provided, the SDK returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional query parameters for filtering and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackResponse} when pagination options are used.
@@ -275,7 +275,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    *
    * Returns both system default categories (Output, Agent Error, Agent Plan Execution)
    * and any custom categories created for this tenant.
-   * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
+   * When no pagination options are provided, the SDK returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
    *
    * @param options - Optional filters and pagination options {@link FeedbackGetCategoriesOptions}
    * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackCategoryResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackCategoryResponse} when pagination options are used.

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -228,6 +228,33 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     );
   }
 
+  /**
+   * Creates a new feedback category.
+   *
+   * Custom categories can be used to label feedback entries beyond the default system categories.
+   * Once created, reference the category by its `id` when submitting or updating feedback.
+   * If `isPositive` and `isNegative` are omitted, the backend defaults both to `true`.
+   *
+   * @param category - Name of the category to create (max 256 characters, unique per tenant)
+   * @param options - Optional flags controlling whether the category applies to positive and/or negative feedback {@link FeedbackCreateCategoryOptions}
+   * @returns Promise resolving to the created {@link FeedbackCategoryResponse}
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * // Minimum — applies to both positive and negative feedback by default
+   * const category = await feedback.createCategory('Hallucination');
+   * console.log(category.id, category.category);
+   *
+   * // With explicit flags
+   * const negativeOnly = await feedback.createCategory('Off-topic', {
+   *   isPositive: false,
+   *   isNegative: true,
+   * });
+   * ```
+   */
   @track('Feedback.CreateCategory')
   async createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategoryResponse> {
     if (!category) throw new ValidationError({ message: 'category name is required for createCategory' });
@@ -243,6 +270,32 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     return transformData(response.data, FeedbackMap) as unknown as FeedbackCategoryResponse;
   }
 
+  /**
+   * Gets all feedback categories for the tenant.
+   *
+   * Returns both system default categories (Output, Agent Error, Agent Plan Execution)
+   * and any custom categories created for this tenant.
+   * When no pagination options are provided, the API returns up to 100 items. When pagination options are provided without a pageSize, the SDK defaults to 50 items per page.
+   *
+   * @param options - Optional filters and pagination options {@link FeedbackGetCategoriesOptions}
+   * @returns Promise resolving to {@link NonPaginatedResponse} of {@link FeedbackCategoryResponse} without pagination options, or {@link PaginatedResponse} of {@link FeedbackCategoryResponse} when pagination options are used.
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * // Get all categories
+   * const categories = await feedback.getCategories();
+   * console.log(categories.items.map(c => c.category));
+   *
+   * // Get only categories applicable to negative feedback
+   * const negativeCategories = await feedback.getCategories({ isNegative: true });
+   *
+   * // Paginated
+   * const page1 = await feedback.getCategories({ pageSize: 10 });
+   * ```
+   */
   @track('Feedback.GetCategories')
   async getCategories<T extends FeedbackGetCategoriesOptions = FeedbackGetCategoriesOptions>(
     options?: T

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -3,6 +3,7 @@ import {
   FeedbackResponse,
   FeedbackCategory,
   FeedbackGetAllOptions,
+  FeedbackGetCategoriesOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
   FeedbackUpdateOptions,
@@ -11,10 +12,10 @@ import {
 } from '../../../models/agents/feedback/feedback.types';
 import { FeedbackServiceModel } from '../../../models/agents/feedback/feedback.models';
 import { FeedbackMap } from '../../../models/agents/feedback/feedback.constants';
-import { RawFeedbackResponse, RawFeedbackCategory, RawFeedbackCategoryListResponse } from '../../../models/agents/feedback/feedback.internal-types';
+import { RawFeedbackResponse, RawFeedbackCategory } from '../../../models/agents/feedback/feedback.internal-types';
 import { transformData } from '../../../utils/transform';
 import { FEEDBACK_ENDPOINTS } from '../../../utils/constants/endpoints';
-import { FEEDBACK_OFFSET_PARAMS } from '../../../utils/constants/common';
+import { FEEDBACK_OFFSET_PARAMS, FEEDBACK_CATEGORY_PAGINATION } from '../../../utils/constants/common';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
@@ -239,13 +240,32 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
   }
 
   @track('Feedback.GetCategories')
-  async getCategories(): Promise<FeedbackCategory[]> {
-    const response = await this.get<RawFeedbackCategoryListResponse>(
-      FEEDBACK_ENDPOINTS.CATEGORY.GET_ALL
-    );
-    return response.data.categories.map(
-      (item) => transformData(item, FeedbackMap) as unknown as FeedbackCategory
-    );
+  async getCategories<T extends FeedbackGetCategoriesOptions = FeedbackGetCategoriesOptions>(
+    options?: T
+  ): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<FeedbackCategory>
+      : NonPaginatedResponse<FeedbackCategory>
+  > {
+    const transformCategory = (item: RawFeedbackCategory): FeedbackCategory =>
+      transformData(item, FeedbackMap) as unknown as FeedbackCategory;
+
+    return PaginationHelpers.getAll<T, RawFeedbackCategory, FeedbackCategory>({
+      serviceAccess: this.createPaginationServiceAccess(),
+      getEndpoint: () => FEEDBACK_ENDPOINTS.CATEGORY.GET_ALL,
+      transformFn: transformCategory,
+      pagination: {
+        paginationType: PaginationType.OFFSET,
+        itemsField: FEEDBACK_CATEGORY_PAGINATION.ITEMS_FIELD,
+        totalCountField: FEEDBACK_CATEGORY_PAGINATION.TOTAL_COUNT_FIELD,
+        paginationParams: {
+          pageSizeParam: FEEDBACK_OFFSET_PARAMS.PAGE_SIZE_PARAM,
+          offsetParam: FEEDBACK_OFFSET_PARAMS.OFFSET_PARAM,
+          countParam: FEEDBACK_OFFSET_PARAMS.COUNT_PARAM,
+        },
+      },
+      excludeFromPrefix: Object.keys(options || {}),
+    }, options);
   }
 
   @track('Feedback.DeleteCategory')

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -346,10 +346,10 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * const customCategory = categories.items.find(c => !c.isDefault);
    * if (customCategory) {
    *   await feedback.deleteCategory(customCategory.id);
-   * }
    *
-   * // Force-delete a custom category that has associated feedback entries
-   * await feedback.deleteCategory(customCategory.id, { forceDelete: true });
+   *   // Force-delete a custom category that has associated feedback entries
+   *   await feedback.deleteCategory(customCategory.id, { forceDelete: true });
+   * }
    * ```
    */
   @track('Feedback.DeleteCategory')

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -229,12 +229,16 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
   }
 
   @track('Feedback.CreateCategory')
-  async createCategory(category: string, options: FeedbackCreateCategoryOptions): Promise<FeedbackCategory> {
+  async createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategory> {
     if (!category) throw new ValidationError({ message: 'category name is required for createCategory' });
+
+    const body: Record<string, unknown> = { category };
+    if (options?.isPositive !== undefined) body.isPositive = options.isPositive;
+    if (options?.isNegative !== undefined) body.isNegative = options.isNegative;
 
     const response = await this.post<RawFeedbackCategory>(
       FEEDBACK_ENDPOINTS.CATEGORY.CREATE,
-      { category, isPositive: options.isPositive, isNegative: options.isNegative }
+      body
     );
     return transformData(response.data, FeedbackMap) as unknown as FeedbackCategory;
   }

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -1,7 +1,7 @@
 import { BaseService } from '../../base';
 import {
   FeedbackResponse,
-  FeedbackCategory,
+  FeedbackCategoryResponse,
   FeedbackGetAllOptions,
   FeedbackGetCategoriesOptions,
   FeedbackOptions,
@@ -229,7 +229,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
   }
 
   @track('Feedback.CreateCategory')
-  async createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategory> {
+  async createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategoryResponse> {
     if (!category) throw new ValidationError({ message: 'category name is required for createCategory' });
 
     const body: Record<string, unknown> = { category };
@@ -240,7 +240,7 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
       FEEDBACK_ENDPOINTS.CATEGORY.CREATE,
       body
     );
-    return transformData(response.data, FeedbackMap) as unknown as FeedbackCategory;
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackCategoryResponse;
   }
 
   @track('Feedback.GetCategories')
@@ -248,13 +248,13 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     options?: T
   ): Promise<
     T extends HasPaginationOptions<T>
-      ? PaginatedResponse<FeedbackCategory>
-      : NonPaginatedResponse<FeedbackCategory>
+      ? PaginatedResponse<FeedbackCategoryResponse>
+      : NonPaginatedResponse<FeedbackCategoryResponse>
   > {
-    const transformCategory = (item: RawFeedbackCategory): FeedbackCategory =>
-      transformData(item, FeedbackMap) as unknown as FeedbackCategory;
+    const transformCategory = (item: RawFeedbackCategory): FeedbackCategoryResponse =>
+      transformData(item, FeedbackMap) as unknown as FeedbackCategoryResponse;
 
-    return PaginationHelpers.getAll<T, RawFeedbackCategory, FeedbackCategory>({
+    return PaginationHelpers.getAll<T, RawFeedbackCategory, FeedbackCategoryResponse>({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => FEEDBACK_ENDPOINTS.CATEGORY.GET_ALL,
       transformFn: transformCategory,
@@ -272,6 +272,33 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     }, options);
   }
 
+  /**
+   * Deletes a feedback category by its ID.
+   *
+   * System default categories (Output, Agent Error, Agent Plan Execution) cannot be deleted —
+   * attempting to do so throws a `409 Conflict` error.
+   * Use `forceDelete` to delete a custom category that already has feedback entries associated with it.
+   *
+   * @param id - Category ID (GUID) of the category to delete
+   * @param options - Optional deletion options {@link FeedbackDeleteCategoryOptions}
+   * @returns Promise resolving to void on success
+   * @example
+   * ```typescript
+   * import { Feedback } from '@uipath/uipath-typescript/feedback';
+   *
+   * const feedback = new Feedback(sdk);
+   *
+   * // Only custom categories (isDefault: false) can be deleted
+   * const categories = await feedback.getCategories();
+   * const customCategory = categories.items.find(c => !c.isDefault);
+   * if (customCategory) {
+   *   await feedback.deleteCategory(customCategory.id);
+   * }
+   *
+   * // Force-delete a custom category that has associated feedback entries
+   * await feedback.deleteCategory(customCategory.id, { forceDelete: true });
+   * ```
+   */
   @track('Feedback.DeleteCategory')
   async deleteCategory(id: string, options?: FeedbackDeleteCategoryOptions): Promise<void> {
     if (!id) throw new ValidationError({ message: 'Category ID is required for deleteCategory' });

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -1,14 +1,17 @@
 import { BaseService } from '../../base';
 import {
   FeedbackResponse,
+  FeedbackCategory,
   FeedbackGetAllOptions,
   FeedbackOptions,
   FeedbackSubmitOptions,
   FeedbackUpdateOptions,
+  FeedbackCreateCategoryOptions,
+  FeedbackDeleteCategoryOptions,
 } from '../../../models/agents/feedback/feedback.types';
 import { FeedbackServiceModel } from '../../../models/agents/feedback/feedback.models';
 import { FeedbackMap } from '../../../models/agents/feedback/feedback.constants';
-import { RawFeedbackResponse } from '../../../models/agents/feedback/feedback.internal-types';
+import { RawFeedbackResponse, RawFeedbackCategory, RawFeedbackCategoryListResponse } from '../../../models/agents/feedback/feedback.internal-types';
 import { transformData } from '../../../utils/transform';
 import { FEEDBACK_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { FEEDBACK_OFFSET_PARAMS } from '../../../utils/constants/common';
@@ -221,6 +224,38 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
     await this.delete(
       FEEDBACK_ENDPOINTS.DELETE(id),
       { headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
+  }
+
+  @track('Feedback.CreateCategory')
+  async createCategory(category: string, options: FeedbackCreateCategoryOptions): Promise<FeedbackCategory> {
+    if (!category) throw new ValidationError({ message: 'category name is required for createCategory' });
+
+    const response = await this.post<RawFeedbackCategory>(
+      FEEDBACK_ENDPOINTS.CATEGORY.CREATE,
+      { category, isPositive: options.isPositive, isNegative: options.isNegative }
+    );
+    return transformData(response.data, FeedbackMap) as unknown as FeedbackCategory;
+  }
+
+  @track('Feedback.GetCategories')
+  async getCategories(): Promise<FeedbackCategory[]> {
+    const response = await this.get<RawFeedbackCategoryListResponse>(
+      FEEDBACK_ENDPOINTS.CATEGORY.GET_ALL
+    );
+    return response.data.categories.map(
+      (item) => transformData(item, FeedbackMap) as unknown as FeedbackCategory
+    );
+  }
+
+  @track('Feedback.DeleteCategory')
+  async deleteCategory(id: string, options?: FeedbackDeleteCategoryOptions): Promise<void> {
+    if (!id) throw new ValidationError({ message: 'Category ID is required for deleteCategory' });
+
+    const params = options?.forceDelete !== undefined ? { forceDelete: options.forceDelete } : undefined;
+    await this.delete(
+      FEEDBACK_ENDPOINTS.CATEGORY.DELETE(id),
+      { params }
     );
   }
 }

--- a/src/services/agents/feedback/feedback.ts
+++ b/src/services/agents/feedback/feedback.ts
@@ -346,8 +346,14 @@ export class FeedbackService extends BaseService implements FeedbackServiceModel
    * const customCategory = categories.items.find(c => !c.isDefault);
    * if (customCategory) {
    *   await feedback.deleteCategory(customCategory.id);
-   *
-   *   // Force-delete a custom category that has associated feedback entries
+   * }
+   * ```
+   * @example
+   * ```typescript
+   * // Force-delete a custom category that has associated feedback entries
+   * const categories = await feedback.getCategories();
+   * const customCategory = categories.items.find(c => !c.isDefault);
+   * if (customCategory) {
    *   await feedback.deleteCategory(customCategory.id, { forceDelete: true });
    * }
    * ```

--- a/src/utils/constants/common.ts
+++ b/src/utils/constants/common.ts
@@ -93,17 +93,6 @@ export const ODATA_OFFSET_PARAMS = {
 };
 
 /**
- * Feedback pagination response shape constants
- */
-export const FEEDBACK_PAGINATION = {
-  /** Field name for items in feedback response */
-  ITEMS_FIELD: 'items',
-
-  /** Field name for total count in feedback response */
-  TOTAL_COUNT_FIELD: 'totalCount'
-};
-
-/**
  * Feedback category pagination response shape constants
  */
 export const FEEDBACK_CATEGORY_PAGINATION = {

--- a/src/utils/constants/common.ts
+++ b/src/utils/constants/common.ts
@@ -93,6 +93,28 @@ export const ODATA_OFFSET_PARAMS = {
 };
 
 /**
+ * Feedback pagination response shape constants
+ */
+export const FEEDBACK_PAGINATION = {
+  /** Field name for items in feedback response */
+  ITEMS_FIELD: 'items',
+
+  /** Field name for total count in feedback response */
+  TOTAL_COUNT_FIELD: 'totalCount'
+};
+
+/**
+ * Feedback category pagination response shape constants
+ */
+export const FEEDBACK_CATEGORY_PAGINATION = {
+  /** Field name for items in feedback category response */
+  ITEMS_FIELD: 'categories',
+
+  /** Field name for total count in feedback category response */
+  TOTAL_COUNT_FIELD: 'totalCount'
+};
+
+/**
  * Feedback OFFSET pagination parameter names (take/skip style)
  */
 export const FEEDBACK_OFFSET_PARAMS = {

--- a/src/utils/constants/endpoints/feedback.ts
+++ b/src/utils/constants/endpoints/feedback.ts
@@ -9,4 +9,9 @@ export const FEEDBACK_ENDPOINTS = {
   SUBMIT: `${LLMOPS_BASE}/api/Feedback`,
   UPDATE: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
   DELETE: (id: string) => `${LLMOPS_BASE}/api/Feedback/${id}`,
+  CATEGORY: {
+    GET_ALL: `${LLMOPS_BASE}/api/Feedback/category`,
+    CREATE: `${LLMOPS_BASE}/api/Feedback/category`,
+    DELETE: (id: string) => `${LLMOPS_BASE}/api/Feedback/category/${id}`,
+  },
 } as const;

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -124,14 +124,15 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
       const result = await feedback.getCategories();
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result)).toBe(true);
+      expect(result.items).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
     });
 
     it('should include default categories in results', async () => {
       const result = await feedback.getCategories();
 
       const defaultNames = ['Output', 'Agent Error', 'Agent Plan Execution'];
-      const names = result.map((c) => c.category);
+      const names = result.items.map((c) => c.category);
       for (const name of defaultNames) {
         expect(names).toContain(name);
       }
@@ -140,9 +141,9 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     it('should have expected fields on each category', async () => {
       const result = await feedback.getCategories();
 
-      if (result.length === 0) throw new Error('No categories returned');
+      if (result.items.length === 0) throw new Error('No categories returned');
 
-      const item = result[0];
+      const item = result.items[0];
       expect(item.id).toBeDefined();
       expect(item.category).toBeDefined();
       expect(item.createdTime).toBeDefined();
@@ -154,10 +155,17 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
     it('should transform API fields — createdTime present, createdAt absent', async () => {
       const result = await feedback.getCategories();
 
-      if (result.length === 0) throw new Error('No categories returned');
+      if (result.items.length === 0) throw new Error('No categories returned');
 
-      expect(result[0].createdTime).toBeDefined();
-      expect((result[0] as any).createdAt).toBeUndefined();
+      expect(result.items[0].createdTime).toBeDefined();
+      expect((result.items[0] as any).createdAt).toBeUndefined();
+    });
+
+    it('should support isNegative filter', async () => {
+      const result = await feedback.getCategories({ isNegative: true });
+
+      expect(result.items).toBeDefined();
+      expect(result.items.every((c) => c.isNegative)).toBe(true);
     });
 
     it('should create a category with minimum required fields', async () => {

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -168,21 +168,34 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
       expect(result.items.every((c) => c.isNegative)).toBe(true);
     });
 
-    it('should create a category with minimum required fields', async () => {
+    it('should create a category with no options — defaults to isPositive and isNegative both true', async () => {
       const name = `TestCategory_${generateRandomString(6)}`;
-      const result = await feedback.createCategory(name, { isPositive: true, isNegative: false });
+      const result = await feedback.createCategory(name);
 
       createdCategoryIds.push(result.id);
+      registerResource('feedbackCategories', { id: result.id });
 
       expect(result).toBeDefined();
       expect(result.id).toBeDefined();
       expect(result.category).toBe(name);
       expect(result.isPositive).toBe(true);
-      expect(result.isNegative).toBe(false);
+      expect(result.isNegative).toBe(true);
       expect(result.isDefault).toBe(false);
       expect(result.createdTime).toBeDefined();
       expect((result as any).createdAt).toBeUndefined();
     });
+
+    it('should create a category with explicit options', async () => {
+      const name = `TestCategory_${generateRandomString(6)}`;
+      const result = await feedback.createCategory(name, { isPositive: true, isNegative: false });
+
+      createdCategoryIds.push(result.id);
+      registerResource('feedbackCategories', { id: result.id });
+
+      expect(result.isPositive).toBe(true);
+      expect(result.isNegative).toBe(false);
+    });
+
 
     it('should delete a custom category', async () => {
       const name = `TestCategory_${generateRandomString(6)}`;

--- a/tests/integration/shared/agents/feedback.integration.test.ts
+++ b/tests/integration/shared/agents/feedback.integration.test.ts
@@ -3,6 +3,7 @@ import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-s
 import { Feedback } from '../../../../src/services/agents/feedback';
 import { FeedbackStatus, FeedbackResponse } from '../../../../src/models/agents/feedback/feedback.types';
 import { registerResource } from '../../utils/cleanup';
+import { generateRandomString } from '../../utils/helpers';
 
 const modes: InitMode[] = ['v1'];
 
@@ -107,6 +108,81 @@ describe.each(modes)('Agent Feedback - Integration Tests [%s]', (mode) => {
       expect(result.updatedTime).toBeDefined();
       expect((result as any).createdAt).toBeUndefined();
       expect((result as any).updatedAt).toBeUndefined();
+    });
+  });
+
+  describe('createCategory / getCategories / deleteCategory', () => {
+    const createdCategoryIds: string[] = [];
+
+    afterAll(async () => {
+      for (const id of createdCategoryIds) {
+        await feedback.deleteCategory(id);
+      }
+    });
+
+    it('should retrieve all categories', async () => {
+      const result = await feedback.getCategories();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should include default categories in results', async () => {
+      const result = await feedback.getCategories();
+
+      const defaultNames = ['Output', 'Agent Error', 'Agent Plan Execution'];
+      const names = result.map((c) => c.category);
+      for (const name of defaultNames) {
+        expect(names).toContain(name);
+      }
+    });
+
+    it('should have expected fields on each category', async () => {
+      const result = await feedback.getCategories();
+
+      if (result.length === 0) throw new Error('No categories returned');
+
+      const item = result[0];
+      expect(item.id).toBeDefined();
+      expect(item.category).toBeDefined();
+      expect(item.createdTime).toBeDefined();
+      expect(typeof item.isDefault).toBe('boolean');
+      expect(typeof item.isPositive).toBe('boolean');
+      expect(typeof item.isNegative).toBe('boolean');
+    });
+
+    it('should transform API fields — createdTime present, createdAt absent', async () => {
+      const result = await feedback.getCategories();
+
+      if (result.length === 0) throw new Error('No categories returned');
+
+      expect(result[0].createdTime).toBeDefined();
+      expect((result[0] as any).createdAt).toBeUndefined();
+    });
+
+    it('should create a category with minimum required fields', async () => {
+      const name = `TestCategory_${generateRandomString(6)}`;
+      const result = await feedback.createCategory(name, { isPositive: true, isNegative: false });
+
+      createdCategoryIds.push(result.id);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.category).toBe(name);
+      expect(result.isPositive).toBe(true);
+      expect(result.isNegative).toBe(false);
+      expect(result.isDefault).toBe(false);
+      expect(result.createdTime).toBeDefined();
+      expect((result as any).createdAt).toBeUndefined();
+    });
+
+    it('should delete a custom category', async () => {
+      const name = `TestCategory_${generateRandomString(6)}`;
+      const created = await feedback.createCategory(name, { isPositive: false, isNegative: true });
+      createdCategoryIds.push(created.id);
+
+      await feedback.deleteCategory(created.id);
+      createdCategoryIds.splice(createdCategoryIds.indexOf(created.id), 1);
     });
   });
 

--- a/tests/integration/utils/cleanup.ts
+++ b/tests/integration/utils/cleanup.ts
@@ -12,6 +12,7 @@ interface ResourceRegistry {
   processInstances: Array<{ id: string; folderKey?: string }>;
   caseInstances: Array<{ id: string; folderKey?: string }>;
   feedbackEntries: Array<{ id: string; folderKey?: string }>;
+  feedbackCategories: Array<{ id: string }>;
 }
 
 const resourceRegistry: ResourceRegistry = {
@@ -20,6 +21,7 @@ const resourceRegistry: ResourceRegistry = {
   processInstances: [],
   caseInstances: [],
   feedbackEntries: [],
+  feedbackCategories: [],
 };
 
 /**
@@ -151,6 +153,24 @@ export async function cleanupTestFeedbackEntry(
 }
 
 /**
+ * Deletes a test feedback category.
+ *
+ * @param id - ID of the feedback category
+ */
+export async function cleanupTestFeedbackCategory(id: string): Promise<void> {
+  try {
+    const { feedback } = getServices();
+    if (!feedback) return;
+    await retryWithBackoff(async () => {
+      await feedback.deleteCategory(id);
+    });
+    console.log(`Cleaned up test feedback category: ${id}`);
+  } catch (error) {
+    console.warn(`Failed to cleanup feedback category ${id}:`, error);
+  }
+}
+
+/**
  * Emergency cleanup function that attempts to delete all registered resources.
  * Should be called as a last resort in afterAll hooks.
  */
@@ -182,12 +202,18 @@ export async function cleanupAllTestResources(): Promise<void> {
     await cleanupTestFeedbackEntry(entry.id, entry.folderKey);
   }
 
+  // Cleanup feedback categories
+  for (const category of resourceRegistry.feedbackCategories) {
+    await cleanupTestFeedbackCategory(category.id);
+  }
+
   // Clear registry
   resourceRegistry.tasks = [];
   resourceRegistry.entityRecords = [];
   resourceRegistry.processInstances = [];
   resourceRegistry.caseInstances = [];
   resourceRegistry.feedbackEntries = [];
+  resourceRegistry.feedbackCategories = [];
 
   console.log('Emergency cleanup completed');
 }

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -6,7 +6,7 @@ import { createServiceTestDependencies, createMockApiClient } from '../../../uti
 import { FEEDBACK_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { TEST_CONSTANTS, FEEDBACK_TEST_CONSTANTS, CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../../../utils/constants';
 import { createMockFeedback, createMockRawFeedbackCategory, createMockRawCategoryListResponse } from '../../../utils/mocks/feedback';
-import { FeedbackSubmitOptions, FeedbackUpdateOptions, FeedbackCreateCategoryOptions } from '../../../../src/models/agents/feedback/feedback.types';
+import { FeedbackSubmitOptions, FeedbackUpdateOptions } from '../../../../src/models/agents/feedback/feedback.types';
 
 // ===== MOCKING =====
 vi.mock('../../../../src/core/http/api-client');
@@ -278,12 +278,24 @@ describe('FeedbackService Unit Tests', () => {
   });
 
   describe('createCategory', () => {
-    const createOptions: FeedbackCreateCategoryOptions = {
-      isPositive: false,
-      isNegative: true,
-    };
+    it('should create a category with no options — only category name sent in body', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawFeedbackCategory({
+        category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM,
+        isDefault: false,
+      }));
 
-    it('should create a category successfully', async () => {
+      const result = await feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM);
+
+      expect(result).toBeDefined();
+      expect(result.category).toBe(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.CATEGORY.CREATE,
+        { category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM },
+        expect.any(Object)
+      );
+    });
+
+    it('should create a category with explicit isPositive and isNegative', async () => {
       mockApiClient.post.mockResolvedValue(createMockRawFeedbackCategory({
         category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM,
         isDefault: false,
@@ -291,10 +303,12 @@ describe('FeedbackService Unit Tests', () => {
         isNegative: true,
       }));
 
-      const result = await feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM, createOptions);
+      const result = await feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM, {
+        isPositive: false,
+        isNegative: true,
+      });
 
       expect(result).toBeDefined();
-      expect(result.category).toBe(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM);
       expect(mockApiClient.post).toHaveBeenCalledWith(
         FEEDBACK_ENDPOINTS.CATEGORY.CREATE,
         expect.objectContaining({
@@ -309,22 +323,21 @@ describe('FeedbackService Unit Tests', () => {
     it('should transform createdAt to createdTime', async () => {
       mockApiClient.post.mockResolvedValue(createMockRawFeedbackCategory());
 
-      const result = await feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME, createOptions);
+      const result = await feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME);
 
       expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
       expect((result as any).createdAt).toBeUndefined();
     });
 
     it('should throw ValidationError when category name is empty', async () => {
-      await expect(feedbackService.createCategory('', createOptions))
-        .rejects.toThrow('category name is required');
+      await expect(feedbackService.createCategory('')).rejects.toThrow('category name is required');
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
 
     it('should throw error when API call fails', async () => {
       mockApiClient.post.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_CATEGORY_NOT_FOUND));
 
-      await expect(feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM, createOptions))
+      await expect(feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM))
         .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_CATEGORY_NOT_FOUND);
     });
   });

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -5,8 +5,8 @@ import { ApiClient } from '../../../../src/core/http/api-client';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { FEEDBACK_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { TEST_CONSTANTS, FEEDBACK_TEST_CONSTANTS, CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../../../utils/constants';
-import { createMockFeedback } from '../../../utils/mocks/feedback';
-import { FeedbackSubmitOptions, FeedbackUpdateOptions } from '../../../../src/models/agents/feedback/feedback.types';
+import { createMockFeedback, createMockRawFeedbackCategory, createMockRawCategoryListResponse } from '../../../utils/mocks/feedback';
+import { FeedbackSubmitOptions, FeedbackUpdateOptions, FeedbackCreateCategoryOptions } from '../../../../src/models/agents/feedback/feedback.types';
 
 // ===== MOCKING =====
 vi.mock('../../../../src/core/http/api-client');
@@ -274,6 +274,133 @@ describe('FeedbackService Unit Tests', () => {
 
       await expect(feedbackService.deleteById(FEEDBACK_TEST_CONSTANTS.FEEDBACK_ID, { folderKey: FEEDBACK_TEST_CONSTANTS.FOLDER_KEY }))
         .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
+    });
+  });
+
+  describe('createCategory', () => {
+    const createOptions: FeedbackCreateCategoryOptions = {
+      isPositive: false,
+      isNegative: true,
+    };
+
+    it('should create a category successfully', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawFeedbackCategory({
+        category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM,
+        isDefault: false,
+        isPositive: false,
+        isNegative: true,
+      }));
+
+      const result = await feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM, createOptions);
+
+      expect(result).toBeDefined();
+      expect(result.category).toBe(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.CATEGORY.CREATE,
+        expect.objectContaining({
+          category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM,
+          isPositive: false,
+          isNegative: true,
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('should transform createdAt to createdTime', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawFeedbackCategory());
+
+      const result = await feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME, createOptions);
+
+      expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
+      expect((result as any).createdAt).toBeUndefined();
+    });
+
+    it('should throw ValidationError when category name is empty', async () => {
+      await expect(feedbackService.createCategory('', createOptions))
+        .rejects.toThrow('category name is required');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when API call fails', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_CATEGORY_NOT_FOUND));
+
+      await expect(feedbackService.createCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME_CUSTOM, createOptions))
+        .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_CATEGORY_NOT_FOUND);
+    });
+  });
+
+  describe('getCategories', () => {
+    it('should get all categories successfully', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawCategoryListResponse());
+
+      const result = await feedbackService.getCategories();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.CATEGORY.GET_ALL,
+        expect.any(Object)
+      );
+    });
+
+    it('should transform createdAt to createdTime on each category', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawCategoryListResponse());
+
+      const result = await feedbackService.getCategories();
+
+      expect(result[0].createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
+      expect((result[0] as any).createdAt).toBeUndefined();
+    });
+
+    it('should return empty array when no categories exist', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawCategoryListResponse({ categories: [], totalCount: 0 }));
+
+      const result = await feedbackService.getCategories();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw error when API call fails', async () => {
+      mockApiClient.get.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND));
+
+      await expect(feedbackService.getCategories()).rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_FEEDBACK_NOT_FOUND);
+    });
+  });
+
+  describe('deleteCategory', () => {
+    it('should delete a category successfully', async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await feedbackService.deleteCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_ID);
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.CATEGORY.DELETE(FEEDBACK_TEST_CONSTANTS.CATEGORY_ID),
+        expect.objectContaining({ params: undefined })
+      );
+    });
+
+    it('should pass forceDelete param when provided', async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await feedbackService.deleteCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_ID, { forceDelete: true });
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.CATEGORY.DELETE(FEEDBACK_TEST_CONSTANTS.CATEGORY_ID),
+        expect.objectContaining({ params: { forceDelete: true } })
+      );
+    });
+
+    it('should throw ValidationError when ID is empty', async () => {
+      await expect(feedbackService.deleteCategory('')).rejects.toThrow('Category ID is required');
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when category not found', async () => {
+      mockApiClient.delete.mockRejectedValue(new Error(FEEDBACK_TEST_CONSTANTS.ERROR_CATEGORY_NOT_FOUND));
+
+      await expect(feedbackService.deleteCategory(FEEDBACK_TEST_CONSTANTS.CATEGORY_ID))
+        .rejects.toThrow(FEEDBACK_TEST_CONSTANTS.ERROR_CATEGORY_NOT_FOUND);
     });
   });
 });

--- a/tests/unit/services/agents/feedback.test.ts
+++ b/tests/unit/services/agents/feedback.test.ts
@@ -336,8 +336,9 @@ describe('FeedbackService Unit Tests', () => {
       const result = await feedbackService.getCategories();
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBe(1);
+      expect(result.items).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
+      expect(result.items.length).toBe(1);
       expect(mockApiClient.get).toHaveBeenCalledWith(
         FEEDBACK_ENDPOINTS.CATEGORY.GET_ALL,
         expect.any(Object)
@@ -349,16 +350,28 @@ describe('FeedbackService Unit Tests', () => {
 
       const result = await feedbackService.getCategories();
 
-      expect(result[0].createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
-      expect((result[0] as any).createdAt).toBeUndefined();
+      expect(result.items[0].createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
+      expect((result.items[0] as any).createdAt).toBeUndefined();
     });
 
-    it('should return empty array when no categories exist', async () => {
+    it('should return empty items when no categories exist', async () => {
       mockApiClient.get.mockResolvedValue(createMockRawCategoryListResponse({ categories: [], totalCount: 0 }));
 
       const result = await feedbackService.getCategories();
 
-      expect(result).toEqual([]);
+      expect(result.items).toEqual([]);
+    });
+
+    it('should get paginated categories', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawCategoryListResponse());
+
+      const result = await feedbackService.getCategories({ pageSize: TEST_CONSTANTS.PAGE_SIZE });
+
+      expect(result.items).toBeDefined();
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        FEEDBACK_ENDPOINTS.CATEGORY.GET_ALL,
+        expect.objectContaining({ params: expect.objectContaining({ take: TEST_CONSTANTS.PAGE_SIZE }) })
+      );
     });
 
     it('should throw error when API call fails', async () => {

--- a/tests/utils/constants/feedback.ts
+++ b/tests/utils/constants/feedback.ts
@@ -23,4 +23,8 @@ export const FEEDBACK_TEST_CONSTANTS = {
 
   // Error messages
   ERROR_FEEDBACK_NOT_FOUND: 'Feedback not found',
+  ERROR_CATEGORY_NOT_FOUND: 'Category not found',
+
+  // Category name for create tests
+  CATEGORY_NAME_CUSTOM: 'Hallucination',
 } as const;

--- a/tests/utils/mocks/feedback.ts
+++ b/tests/utils/mocks/feedback.ts
@@ -1,4 +1,4 @@
-import { FeedbackCategory, FeedbackCategoryResponse, FeedbackStatus } from '../../../src/models/agents/feedback/feedback.types';
+import { FeedbackCategory, FeedbackStatus } from '../../../src/models/agents/feedback/feedback.types';
 import { RawFeedbackResponse, RawFeedbackCategory, RawFeedbackCategoryListResponse } from '../../../src/models/agents/feedback/feedback.internal-types';
 import { FEEDBACK_TEST_CONSTANTS } from '../constants/feedback';
 import { CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../constants/conversational-agent';
@@ -34,20 +34,6 @@ export const createMockFeedbackCategory = (overrides: Partial<FeedbackCategory> 
   id: FEEDBACK_TEST_CONSTANTS.CATEGORY_ID,
   category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME,
   createdAt: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT,
-  isDefault: true,
-  isPositive: true,
-  isNegative: false,
-  ...overrides,
-});
-
-/**
- * Creates a mock feedback get-category response (post-transform, has createdTime).
- * Used for createCategory / getCategories method assertions.
- */
-export const createMockFeedbackCategoryResponse = (overrides: Partial<FeedbackCategoryResponse> = {}): FeedbackCategoryResponse => ({
-  id: FEEDBACK_TEST_CONSTANTS.CATEGORY_ID,
-  category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME,
-  createdTime: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT,
   isDefault: true,
   isPositive: true,
   isNegative: false,

--- a/tests/utils/mocks/feedback.ts
+++ b/tests/utils/mocks/feedback.ts
@@ -1,7 +1,31 @@
 import { FeedbackCategory, FeedbackStatus } from '../../../src/models/agents/feedback/feedback.types';
-import { RawFeedbackResponse } from '../../../src/models/agents/feedback/feedback.internal-types';
+import { RawFeedbackResponse, RawFeedbackCategory, RawFeedbackCategoryListResponse } from '../../../src/models/agents/feedback/feedback.internal-types';
 import { FEEDBACK_TEST_CONSTANTS } from '../constants/feedback';
 import { CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../constants/conversational-agent';
+
+/**
+ * Creates a mock raw feedback category (pre-transform, with createdAt).
+ */
+export const createMockRawFeedbackCategory = (overrides: Partial<RawFeedbackCategory> = {}): RawFeedbackCategory => ({
+  id: FEEDBACK_TEST_CONSTANTS.CATEGORY_ID,
+  category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME,
+  createdAt: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT,
+  isDefault: true,
+  isPositive: true,
+  isNegative: false,
+  ...overrides,
+});
+
+/**
+ * Creates a mock raw category list response (pre-transform).
+ */
+export const createMockRawCategoryListResponse = (
+  overrides: Partial<RawFeedbackCategoryListResponse> = {}
+): RawFeedbackCategoryListResponse => ({
+  categories: [createMockRawFeedbackCategory()],
+  totalCount: 1,
+  ...overrides,
+});
 
 /**
  * Creates a mock feedback category.
@@ -12,7 +36,7 @@ import { CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../constants/conversational
 export const createMockFeedbackCategory = (overrides: Partial<FeedbackCategory> = {}): FeedbackCategory => ({
   id: FEEDBACK_TEST_CONSTANTS.CATEGORY_ID,
   category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME,
-  createdAt: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT,
+  createdTime: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT,
   isDefault: true,
   isPositive: true,
   isNegative: false,

--- a/tests/utils/mocks/feedback.ts
+++ b/tests/utils/mocks/feedback.ts
@@ -1,4 +1,4 @@
-import { FeedbackCategory, FeedbackStatus } from '../../../src/models/agents/feedback/feedback.types';
+import { FeedbackCategory, FeedbackCategoryResponse, FeedbackStatus } from '../../../src/models/agents/feedback/feedback.types';
 import { RawFeedbackResponse, RawFeedbackCategory, RawFeedbackCategoryListResponse } from '../../../src/models/agents/feedback/feedback.internal-types';
 import { FEEDBACK_TEST_CONSTANTS } from '../constants/feedback';
 import { CONVERSATIONAL_AGENT_TEST_CONSTANTS } from '../constants/conversational-agent';
@@ -28,12 +28,23 @@ export const createMockRawCategoryListResponse = (
 });
 
 /**
- * Creates a mock feedback category.
- *
- * @param overrides - Optional overrides for specific fields
- * @returns Mock feedback category data
+ * Creates a mock feedback category (nested inside FeedbackResponse, has createdAt).
  */
 export const createMockFeedbackCategory = (overrides: Partial<FeedbackCategory> = {}): FeedbackCategory => ({
+  id: FEEDBACK_TEST_CONSTANTS.CATEGORY_ID,
+  category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME,
+  createdAt: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT,
+  isDefault: true,
+  isPositive: true,
+  isNegative: false,
+  ...overrides,
+});
+
+/**
+ * Creates a mock feedback get-category response (post-transform, has createdTime).
+ * Used for createCategory / getCategories method assertions.
+ */
+export const createMockFeedbackCategoryResponse = (overrides: Partial<FeedbackCategoryResponse> = {}): FeedbackCategoryResponse => ({
   id: FEEDBACK_TEST_CONSTANTS.CATEGORY_ID,
   category: FEEDBACK_TEST_CONSTANTS.CATEGORY_NAME,
   createdTime: CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT,


### PR DESCRIPTION
## Methods Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `feedback.createCategory()` | `createCategory(category: string, options?: FeedbackCreateCategoryOptions): Promise<FeedbackCategoryResponse>` |
| Service | `feedback.getCategories()` | `getCategories(options?: FeedbackGetCategoriesOptions): Promise<NonPaginatedResponse<FeedbackCategoryResponse> \| PaginatedResponse<FeedbackCategoryResponse>>` |
| Service | `feedback.deleteCategory()` | `deleteCategory(id: string, options?: FeedbackDeleteCategoryOptions): Promise<void>` |

## Endpoints Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `createCategory()` | POST | `/llmops_/api/Feedback/category` | `Traces.Api` |
| `getCategories()` | GET | `/llmops_/api/Feedback/category` | `Traces.Api` |
| `deleteCategory()` | DELETE | `/llmops_/api/Feedback/category/{id}` | `Traces.Api` |

- Categories are tenant-scoped — no `folderKey` required on any category endpoint
- `createCategory` omits `isPositive`/`isNegative` from the request body when not provided; backend defaults both to `true`
- `getCategories` uses offset pagination (`take`/`skip`) with custom response shape (`categories` array, `totalCount` field); supports `pageSize`, `cursor`, `jumpToPage`, `isPositive`/`isNegative` filters
- `deleteCategory` passes `forceDelete` as a query param; system default categories (Output, Agent Error, Agent Plan Execution) always reject with `409 Conflict`

## Example Usage

```typescript
import { Feedback } from '@uipath/uipath-typescript/feedback';

const feedback = new Feedback(sdk);

// Create a category — isPositive and isNegative both default to true
const category = await feedback.createCategory('Hallucination');
console.log(category.id, category.category);

// Create with explicit flags
const negativeOnly = await feedback.createCategory('Off-topic', {
  isPositive: false,
  isNegative: true,
});

// Get all categories
const categories = await feedback.getCategories();
console.log(categories.items.map(c => c.category));

// Get only categories applicable to negative feedback
const negativeCategories = await feedback.getCategories({ isNegative: true });

// Paginated
const page1 = await feedback.getCategories({ pageSize: 3 });
if (page1.hasNextPage) {
  const page2 = await feedback.getCategories({ cursor: page1.nextCursor });
}

// Delete a custom category (system defaults cannot be deleted)
const customCategory = categories.items.find(c => !c.isDefault);
if (customCategory) {
  await feedback.deleteCategory(customCategory.id);
}

// Force-delete a custom category that has associated feedback entries
await feedback.deleteCategory(customCategory.id, { forceDelete: true });
```

## API Response vs SDK Response

### Transform pipeline
`RawFeedbackCategory` → `transformData(item, FeedbackMap)` → `FeedbackCategoryResponse`

### Field mapping

| API Response | SDK Response | Change | Reason |
|---|---|---|---|
| `createdAt` | `createdTime` | Rename | Consistent SDK time field naming |
| all others | unchanged | — | Already camelCase from API |

### Type split: `FeedbackCategory` vs `FeedbackCategoryResponse`

`FeedbackCategory` (with `createdAt`) is used as the nested type inside `FeedbackResponse.feedbackCategories` — no transform is applied there (shallow transform on the parent). `FeedbackCategoryResponse` (with `createdTime`) is returned by `createCategory` and `getCategories` where the transform is applied directly.

### Live API responses

**`createCategory('TestCategory_75f023', { isPositive: true, isNegative: false })`**
```json
{
  "id": "10df751b-e9ea-4fb0-aa58-b0b17ac72a1e",
  "category": "TestCategory_75f023",
  "isDefault": false,
  "isPositive": true,
  "isNegative": false,
  "createdTime": "2026-05-11T11:01:45.4898094Z"
}
```

**`getCategories({ pageSize: 3 })`**
```json
{
  "items": [
    { "id": "00000000-0000-0000-0000-000000000000", "category": "Output", "isDefault": true, "isPositive": true, "isNegative": true, "createdTime": "0001-01-01T00:00:00Z" },
    { "id": "00000000-0000-0000-0000-000000000000", "category": "Agent Error", "isDefault": true, "isPositive": false, "isNegative": true, "createdTime": "0001-01-01T00:00:00Z" },
    { "id": "00000000-0000-0000-0000-000000000000", "category": "Agent Plan Execution", "isDefault": true, "isPositive": true, "isNegative": true, "createdTime": "0001-01-01T00:00:00Z" }
  ],
  "totalCount": 6,
  "hasNextPage": true,
  "nextCursor": { "value": "eyJ0eXBlIjoib2Zmc2V0IiwicGFnZVNpemUiOjMsInBhZ2VOdW1iZXIiOjJ9" },
  "currentPage": 1,
  "totalPages": 2,
  "supportsPageJump": true
}
```

**`deleteCategory(id)`** — returns `void` (no response body)

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/feedback.ts` |
| Types | `src/models/agents/feedback/feedback.types.ts` |
| Internal types | `src/models/agents/feedback/feedback.internal-types.ts` |
| Constants | `src/utils/constants/common.ts` |
| Models | `src/models/agents/feedback/feedback.models.ts` |
| Service | `src/services/agents/feedback/feedback.ts` |
| Unit tests | `tests/unit/services/agents/feedback.test.ts` (43 tests) |
| Integration tests | `tests/integration/shared/agents/feedback.integration.test.ts` (21 tests) |
| Test utils | `tests/utils/mocks/feedback.ts`, `tests/utils/constants/feedback.ts`, `tests/integration/utils/cleanup.ts` |
| Docs | `docs/oauth-scopes.md`, `docs/pagination.md` |

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*