### PR TITLE
fix(tests): enable orchestrator attachment integration tests [PLT-103332]

### DIFF
--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     include: ["tests/integration/**/*.integration.test.ts"],
     exclude: [
       "tests/integration/shared/maestro/**",
-      "tests/integration/shared/orchestrator/attachments.integration.test.ts",
     ],
     testTimeout: 30000,
     hookTimeout: 30000,


### PR DESCRIPTION
## Summary
- Remove orchestrator attachment test exclusion from `vitest.integration.config.ts` now that `ORCHESTRATOR_ATTACHMENT_ID` env variable is configured
- All 5 attachment integration tests pass against the live API

## Test plan
- [x] Verified all 5 orchestrator attachment integration tests pass
- [x] No other tests affected