### PR TITLE
[PLT-92819] feat(maestro): getByName for processes + cases 

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -70,6 +70,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | Method | OAuth Scope |
 |--------|-------------|
 | `getAll()` | `PIMS` |
+| `getByName()` | `PIMS` |
 | `getIncidents()` | `PIMS` |
 
 ## Maestro Process Instances
@@ -91,6 +92,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | Method | OAuth Scope |
 |--------|-------------|
 | `getAll()` | `PIMS` |
+| `getByName()` | `PIMS` |
 
 ## Maestro Case Instances
 

--- a/src/models/common/types.ts
+++ b/src/models/common/types.ts
@@ -47,16 +47,24 @@ export interface RequestOptions extends BaseOptions {
 }
 
 /**
+ * Folder scoping by string identifiers only — `folderKey` (GUID) and
+ * `folderPath` (slash-delimited). Used by services that don't accept the
+ * numeric `folderId`, such as Maestro.
+ */
+export interface FolderKeyPathOptions {
+  /** Folder key (GUID-formatted string). */
+  folderKey?: string;
+  /** Slash-delimited folder path, e.g. `'Shared/Finance'`. */
+  folderPath?: string;
+}
+
+/**
  * Options that scope a name-based lookup (e.g. `getByName`) to a folder.
  * Provide one of `folderId`, `folderKey`, or `folderPath`. When more than
  * one is supplied, all are forwarded; the server applies precedence
  * `folderPath` > `folderKey` > `folderId`.
  */
-export interface FolderScopedOptions extends BaseOptions {
+export interface FolderScopedOptions extends BaseOptions, FolderKeyPathOptions {
   /** Numeric folder ID. */
   folderId?: number;
-  /** Folder key (GUID-formatted string). */
-  folderKey?: string;
-  /** Slash-delimited folder path, e.g. `'Shared/Finance'`. */
-  folderPath?: string;
 }

--- a/src/models/maestro/cases.models.ts
+++ b/src/models/maestro/cases.models.ts
@@ -3,7 +3,7 @@
  * Model classes for Maestro cases
  */
 
-import { CaseGetAllResponse} from './cases.types';
+import { CaseGetAllResponse, CaseGetByNameOptions } from './cases.types';
 
 /**
  * Service for managing UiPath Maestro Cases
@@ -39,4 +39,23 @@ export interface CasesServiceModel {
    * ```
    */
   getAll(): Promise<CaseGetAllResponse[]>;
+
+  /**
+   * Retrieves a single case management process by name.
+   *
+   * @param name - Case process name to search for
+   * @param options - Folder scoping (`folderKey` / `folderPath`)
+   * @returns Promise resolving to a single case management process
+   * {@link CaseGetAllResponse}
+   * @throws ValidationError when the name is empty; NotFoundError when no match
+   * @example
+   * ```typescript
+   * // By folder key (GUID)
+   * await cases.getByName('OnboardingCase', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await cases.getByName('OnboardingCase', { folderPath: 'Shared/Onboarding' });
+   * ```
+   */
+  getByName(name: string, options?: CaseGetByNameOptions): Promise<CaseGetAllResponse>;
 }

--- a/src/models/maestro/cases.types.ts
+++ b/src/models/maestro/cases.types.ts
@@ -3,19 +3,26 @@
  * Types and interfaces for Maestro case management
  */
 
+import { FolderKeyPathOptions } from '../common/types';
+
+/**
+ * Options for looking up a single case management process by name.
+ */
+export interface CaseGetByNameOptions extends FolderKeyPathOptions {}
+
 /**
  * Case information with instance statistics
  */
 export interface CaseGetAllResponse {
-  /** Unique key identifying the case process */
+  /** Unique key identifying the case management process */
   processKey: string;
   /** Package identifier */
   packageId: string;
   /** Case name */
   name: string;
-  /** Folder key of the folder where case process is located */
+  /** Folder key of the folder where case management process is located */
   folderKey: string;
-  /** Name of the folder where case process is located */
+  /** Name of the folder where case management process is located */
   folderName: string;
   /** Available package versions */
   packageVersions: string[];

--- a/src/models/maestro/processes.models.ts
+++ b/src/models/maestro/processes.models.ts
@@ -3,7 +3,7 @@
  * Model classes for Maestro processes
  */
 
-import { RawMaestroProcessGetAllResponse } from './processes.types';
+import { MaestroProcessGetByNameOptions, RawMaestroProcessGetAllResponse } from './processes.types';
 import { ProcessIncidentGetResponse } from './process-incidents.types';
 
 /**
@@ -44,6 +44,25 @@ export interface MaestroProcessesServiceModel {
    * ```
    */
   getAll(): Promise<MaestroProcessGetAllResponse[]>;
+
+  /**
+   * Retrieves a single Maestro process by name.
+   *
+   * @param name - Process name to search for
+   * @param options - Folder scoping (`folderKey` / `folderPath`)
+   * @returns Promise resolving to a single Maestro process with bound methods
+   * {@link MaestroProcessGetAllResponse}
+   * @throws ValidationError when the name is empty; NotFoundError when no match
+   * @example
+   * ```typescript
+   * // By folder key (GUID)
+   * await maestroProcesses.getByName('MyMaestroProcess', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await maestroProcesses.getByName('MyMaestroProcess', { folderPath: 'Shared/Finance' });
+   * ```
+   */
+  getByName(name: string, options?: MaestroProcessGetByNameOptions): Promise<MaestroProcessGetAllResponse>;
 
   /**
    * Get incidents for a specific process

--- a/src/models/maestro/processes.types.ts
+++ b/src/models/maestro/processes.types.ts
@@ -3,6 +3,13 @@
  * Types and interfaces for Maestro process management
  */
 
+import { FolderKeyPathOptions } from '../common/types';
+
+/**
+ * Options for looking up a single Maestro process by name.
+ */
+export interface MaestroProcessGetByNameOptions extends FolderKeyPathOptions {}
+
 /**
  * Process information with instance statistics
  */

--- a/src/services/maestro/cases/cases.ts
+++ b/src/services/maestro/cases/cases.ts
@@ -1,10 +1,13 @@
 import { CaseGetAllResponse } from '../../../models/maestro';
+import { CaseGetByNameOptions } from '../../../models/maestro/cases.types';
 import { ProcessType } from '../../../models/maestro/cases.internal-types';
 import { BaseService } from '../../base';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
 import type { CasesServiceModel } from '../../../models/maestro/cases.models';
 import { track } from '../../../core/telemetry';
 import { createParams } from '../../../utils/http/params';
+import { findMaestroResourceByName, MaestroResourceType } from '../helpers/get-by-name';
+import { validateName } from '../../../utils/validation/name-validator';
 
 /**
  * Service for interacting with UiPath Maestro Cases
@@ -57,16 +60,51 @@ export class CasesService extends BaseService implements CasesServiceModel {
   private extractCaseName(packageId: string): string {
     // Check if packageId contains "CaseManagement."
     const caseManagementIndex = packageId.indexOf('CaseManagement.');
-    
+
     if (caseManagementIndex !== -1) {
       // Extract everything after "CaseManagement."
       const afterCaseManagement = packageId.substring(caseManagementIndex + 'CaseManagement.'.length);
-      
+
       // Replace hyphens with spaces for better readability
       return afterCaseManagement.replace(/-/g, ' ');
     }
-    
+
     // If no "CaseManagement.", return the whole packageId
     return packageId;
+  }
+
+  /**
+   * Retrieves a single case management process by name.
+   *
+   * @param name - Case process name to search for
+   * @param options - Folder scoping (`folderKey` / `folderPath`)
+   * @returns Promise resolving to a single case management process
+   * @throws ValidationError when the name is empty; NotFoundError when no match
+   *
+   * @example
+   * ```typescript
+   * import { Cases } from '@uipath/uipath-typescript/cases';
+   *
+   * const cases = new Cases(sdk);
+   *
+   * // By folder key (GUID)
+   * await cases.getByName('OnboardingCase', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await cases.getByName('OnboardingCase', { folderPath: 'Shared/Onboarding' });
+   * ```
+   */
+  @track('Cases.GetByName')
+  async getByName(
+    name: string,
+    options: CaseGetByNameOptions = {},
+  ): Promise<CaseGetAllResponse> {
+    const validatedName = validateName(MaestroResourceType.Case, name);
+    const all = await this.getAll();
+    return findMaestroResourceByName(MaestroResourceType.Case, all, validatedName, {
+      folderPath: options.folderPath,
+      folderKey: options.folderKey,
+      fallbackFolderKey: this.config.folderKey,
+    });
   }
 }

--- a/src/services/maestro/helpers/get-by-name.ts
+++ b/src/services/maestro/helpers/get-by-name.ts
@@ -1,0 +1,102 @@
+import { NotFoundError, ValidationError } from '../../../core/errors';
+
+/**
+ * Resource labels recognised by the shared Maestro `getByName` helper.
+ * Drives the prefix in `NotFoundError` messages, e.g.
+ * `"MaestroProcess 'X' not found in folder 'Shared/Finance'."`.
+ */
+export enum MaestroResourceType {
+  MaestroProcess = 'MaestroProcess',
+  Case = 'Case',
+}
+
+/**
+ * Options accepted by the shared Maestro `getByName` helper.
+ */
+export interface MaestroGetByNameOptions {
+  /** Folder path that scopes the lookup. Matched against `folderName`. */
+  folderPath?: string;
+  /** Folder key (GUID) that scopes the lookup. */
+  folderKey?: string;
+  /**
+   * Init-time folderKey from `BaseService.config.folderKey` (e.g. seeded by
+   * the `uipath:folder-key` meta tag). Used only when the caller didn't supply
+   * any folder context.
+   */
+  fallbackFolderKey?: string;
+}
+
+/**
+ * Minimum shape required from a Maestro item for name-based lookup.
+ * `getAll()` responses for both processes and cases already satisfy this.
+ */
+interface MaestroItemForLookup {
+  name: string;
+  folderName: string;
+  folderKey: string;
+}
+
+/**
+ * Shared client-side filter used by Maestro `getByName` implementations.
+ *
+ * Maestro's `/processes/summary` endpoint has no name-based lookup or filter
+ * parameter, so callers must `getAll()` and filter client-side. This helper
+ * standardises the matching rules across MaestroProcesses and Cases:
+ *
+ * - Name must match exactly (caller is responsible for trimming via
+ *   `validateName` before invoking `getAll()` so input errors fail fast).
+ * - `folderPath` matches against `folderName`.
+ * - `folderKey` matches against `folderKey`.
+ * - When the caller didn't supply any folder context, falls back to the
+ *   init-time folderKey (e.g. from the `uipath:folder-key` meta tag).
+ * - When neither explicit context nor the init-time fallback resolves, a
+ *   `ValidationError` is thrown — mirroring the Orchestrator getByName
+ *   contract (see `resolveFolderHeaders`).
+ *
+ * @param resourceType - Resource label used in error messages
+ * @param items - Result of the caller's `getAll()`
+ * @param validatedName - Pre-validated, trimmed resource name
+ * @param options - Folder scoping + init-time fallback key
+ * @throws ValidationError when no folder context can be resolved; NotFoundError when no item matches
+ */
+export function findMaestroResourceByName<T extends MaestroItemForLookup>(
+  resourceType: MaestroResourceType,
+  items: T[],
+  validatedName: string,
+  options: MaestroGetByNameOptions,
+): T {
+  const { folderPath, folderKey, fallbackFolderKey } = options;
+
+  const trimmedKey = folderKey?.trim();
+  const trimmedPath = folderPath?.trim();
+  if (!trimmedKey && !trimmedPath && !fallbackFolderKey) {
+    throw new ValidationError({
+      message: `${resourceType}.getByName requires folder context: pass \`folderKey\` or \`folderPath\`, or initialize the SDK with a folder context.`,
+    });
+  }
+
+  const effectiveFolderKey =
+    trimmedKey ?? (trimmedPath ? undefined : fallbackFolderKey);
+
+  const match = items.find(
+    (item) =>
+      item.name === validatedName &&
+      (trimmedPath ? item.folderName === trimmedPath : true) &&
+      (effectiveFolderKey ? item.folderKey === effectiveFolderKey : true),
+  );
+
+  if (!match) {
+    throw new NotFoundError({
+      message: `${resourceType} '${validatedName}' not found${describeFolderHint(trimmedPath, effectiveFolderKey)}.`,
+    });
+  }
+  return match;
+}
+
+function describeFolderHint(folderPath: string | undefined, folderKey: string | undefined): string {
+  const path = folderPath;
+  if (path) return ` in folder '${path}'`;
+  const key = folderKey?.trim();
+  if (key) return ` in folder (key: ${key})`;
+  return '';
+}

--- a/src/services/maestro/processes/processes.ts
+++ b/src/services/maestro/processes/processes.ts
@@ -1,4 +1,5 @@
 import { MaestroProcessGetAllResponse, ProcessIncidentGetResponse } from '../../../models/maestro';
+import { MaestroProcessGetByNameOptions } from '../../../models/maestro/processes.types';
 import { BaseService } from '../../base';
 import type { IUiPath } from '../../../core/types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -9,6 +10,8 @@ import { track } from '../../../core/telemetry';
 import { createHeaders } from '../../../utils/http/headers';
 import { FOLDER_KEY } from '../../../utils/constants/headers';
 import { ProcessInstancesService } from './process-instances';
+import { findMaestroResourceByName, MaestroResourceType } from '../helpers/get-by-name';
+import { validateName } from '../../../utils/validation/name-validator';
 
 /**
  * Service for interacting with Maestro Processes
@@ -60,6 +63,41 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
 
     // Add methods to each process
     return processesWithName.map(process => createProcessWithMethods(process, this));
+  }
+
+  /**
+   * Retrieves a single Maestro process by name.
+   *
+   * @param name - Process name to search for
+   * @param options - Folder scoping (`folderKey` / `folderPath`)
+   * @returns Promise resolving to a single Maestro process with bound methods
+   * @throws ValidationError when the name is empty; NotFoundError when no match
+   *
+   * @example
+   * ```typescript
+   * import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
+   *
+   * const maestroProcesses = new MaestroProcesses(sdk);
+   *
+   * // By folder key (GUID)
+   * await maestroProcesses.getByName('MyMaestroProcess', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await maestroProcesses.getByName('MyMaestroProcess', { folderPath: 'Shared/Finance' });
+   * ```
+   */
+  @track('MaestroProcesses.GetByName')
+  async getByName(
+    name: string,
+    options: MaestroProcessGetByNameOptions = {},
+  ): Promise<MaestroProcessGetAllResponse> {
+    const validatedName = validateName(MaestroResourceType.MaestroProcess, name);
+    const all = await this.getAll();
+    return findMaestroResourceByName(MaestroResourceType.MaestroProcess, all, validatedName, {
+      folderPath: options.folderPath,
+      folderKey: options.folderKey,
+      fallbackFolderKey: this.config.folderKey,
+    });
   }
 
   /**

--- a/tests/integration/shared/maestro/cases.integration.test.ts
+++ b/tests/integration/shared/maestro/cases.integration.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { isNotFoundError } from '../../../../src/core/errors';
 
 const modes: InitMode[] = ['v0', 'v1'];
 
@@ -91,6 +92,58 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
       expect(services.caseInstances).toBeDefined();
       expect(services.maestroProcesses).toBeDefined();
       expect(services.sdk.isAuthenticated()).toBe(true);
+    });
+  });
+
+  describe('getByName', () => {
+    let existing!: { name: string; folderKey: string; folderName: string };
+    let folderKey!: string;
+
+    beforeAll(async () => {
+      const config = getTestConfig();
+      if (!config.folderKey) {
+        throw new Error('INTEGRATION_TEST_FOLDER_KEY must be configured for Cases getByName tests');
+      }
+      folderKey = config.folderKey;
+
+      const { cases } = getServices();
+      const all = await cases.getAll();
+      const match = all.find((c) => c.folderKey === folderKey);
+      if (!match) {
+        throw new Error(
+          `No Maestro cases found in folder ${folderKey} — seed at least one for getByName tests`,
+        );
+      }
+      existing = { name: match.name, folderKey: match.folderKey, folderName: match.folderName };
+    });
+
+    it('should retrieve a case by name using folderKey', async () => {
+      const { cases } = getServices();
+
+      const result = await cases.getByName(existing.name, { folderKey });
+
+      expect(result).toBeDefined();
+      expect(result.name).toBe(existing.name);
+      expect(result.folderKey).toBe(folderKey);
+    });
+
+    it('should retrieve a case by name using folderPath', async () => {
+      const { cases } = getServices();
+
+      const result = await cases.getByName(existing.name, { folderPath: existing.folderName });
+
+      expect(result).toBeDefined();
+      expect(result.name).toBe(existing.name);
+      expect(result.folderName).toBe(existing.folderName);
+    });
+
+    it('should throw NotFoundError for a nonexistent case name', async () => {
+      const { cases } = getServices();
+
+      const missingName = `__uipath-sdk-nonexistent-case-${Date.now()}`;
+      await expect(
+        cases.getByName(missingName, { folderKey }),
+      ).rejects.toSatisfy(isNotFoundError);
     });
   });
 });

--- a/tests/integration/shared/maestro/processes.integration.test.ts
+++ b/tests/integration/shared/maestro/processes.integration.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { isNotFoundError } from '../../../../src/core/errors';
 
 const modes: InitMode[] = ['v0', 'v1'];
 
@@ -166,6 +167,58 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
         }
         throw error;
       }
+    });
+  });
+
+  describe('getByName', () => {
+    let existing!: { name: string; folderKey: string; folderName: string };
+    let folderKey!: string;
+
+    beforeAll(async () => {
+      const config = getTestConfig();
+      if (!config.folderKey) {
+        throw new Error('INTEGRATION_TEST_FOLDER_KEY must be configured for Maestro getByName tests');
+      }
+      folderKey = config.folderKey;
+
+      const { maestroProcesses } = getServices();
+      const all = await maestroProcesses.getAll();
+      const match = all.find((p) => p.folderKey === folderKey);
+      if (!match) {
+        throw new Error(
+          `No Maestro processes found in folder ${folderKey} — seed at least one for getByName tests`,
+        );
+      }
+      existing = { name: match.name, folderKey: match.folderKey, folderName: match.folderName };
+    });
+
+    it('should retrieve a process by name using folderKey', async () => {
+      const { maestroProcesses } = getServices();
+
+      const result = await maestroProcesses.getByName(existing.name, { folderKey });
+
+      expect(result).toBeDefined();
+      expect(result.name).toBe(existing.name);
+      expect(result.folderKey).toBe(folderKey);
+    });
+
+    it('should retrieve a process by name using folderPath', async () => {
+      const { maestroProcesses } = getServices();
+
+      const result = await maestroProcesses.getByName(existing.name, { folderPath: existing.folderName });
+
+      expect(result).toBeDefined();
+      expect(result.name).toBe(existing.name);
+      expect(result.folderName).toBe(existing.folderName);
+    });
+
+    it('should throw NotFoundError for a nonexistent process name', async () => {
+      const { maestroProcesses } = getServices();
+
+      const missingName = `__uipath-sdk-nonexistent-process-${Date.now()}`;
+      await expect(
+        maestroProcesses.getByName(missingName, { folderKey }),
+      ).rejects.toSatisfy(isNotFoundError);
     });
   });
 });

--- a/tests/unit/services/maestro/cases.test.ts
+++ b/tests/unit/services/maestro/cases.test.ts
@@ -3,15 +3,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CasesService } from '../../../../src/services/maestro/cases';
 import { MAESTRO_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { ApiClient } from '../../../../src/core/http/api-client';
-import { 
+import {
   MAESTRO_TEST_CONSTANTS,
   TEST_CONSTANTS,
-  createMockCase, 
+  createMockCase,
   createMockCasesGetAllApiResponse,
-  createMockError 
+  createMockError
 } from '../../../utils/mocks';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { ProcessType } from '../../../../src/models/maestro/cases.internal-types';
+import { NotFoundError, ValidationError } from '../../../../src/core/errors';
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -150,7 +151,7 @@ describe('CasesService', () => {
     });
 
     it('should extract case name from packageId without CaseManagement prefix', async () => {
-      
+
       const mockApiResponse = createMockCasesGetAllApiResponse([
         createMockCase({
           processKey: MAESTRO_TEST_CONSTANTS.CASE_PROCESS_KEY,
@@ -160,10 +161,76 @@ describe('CasesService', () => {
 
       mockApiClient.get.mockResolvedValue(mockApiResponse);
 
-      
+
       const result = await service.getAll();
 
       expect(result[0].name).toBe(MAESTRO_TEST_CONSTANTS.EXTRACTED_NAME_WITHOUT_PREFIX);
+    });
+  });
+
+  describe('getByName', () => {
+    it('should match against the name extracted from packageId by getAll', async () => {
+      mockApiClient.get.mockResolvedValue(
+        createMockCasesGetAllApiResponse([
+          createMockCase({
+            processKey: MAESTRO_TEST_CONSTANTS.CASE_PROCESS_KEY,
+            packageId: MAESTRO_TEST_CONSTANTS.CASE_PACKAGE_ID,
+          }),
+        ]),
+      );
+
+      const result = await service.getByName(MAESTRO_TEST_CONSTANTS.EXTRACTED_NAME_DEFAULT, {
+        folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+      });
+
+      expect(result.name).toBe(MAESTRO_TEST_CONSTANTS.EXTRACTED_NAME_DEFAULT);
+      expect(result.processKey).toBe(MAESTRO_TEST_CONSTANTS.CASE_PROCESS_KEY);
+    });
+
+    it('should throw ValidationError without calling getAll when the name is empty', async () => {
+      await expect(service.getByName('   ')).rejects.toBeInstanceOf(ValidationError);
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should propagate NotFoundError from the shared filter when no case matches', async () => {
+      mockApiClient.get.mockResolvedValue(createMockCasesGetAllApiResponse([createMockCase()]));
+
+      await expect(
+        service.getByName(MAESTRO_TEST_CONSTANTS.MISSING_CASE_NAME, {
+          folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+        }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('should wire the init-time folderKey into the fallback chain', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY });
+      vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+      const scopedService = new CasesService(instance);
+
+      mockApiClient.get.mockResolvedValue(
+        createMockCasesGetAllApiResponse([
+          createMockCase({
+            packageId: MAESTRO_TEST_CONSTANTS.CASE_PACKAGE_ID,
+            folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY_OTHER,
+          }),
+          createMockCase({
+            packageId: MAESTRO_TEST_CONSTANTS.CASE_PACKAGE_ID,
+            folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+          }),
+        ]),
+      );
+
+      const result = await scopedService.getByName(MAESTRO_TEST_CONSTANTS.EXTRACTED_NAME_DEFAULT);
+
+      expect(result.folderKey).toBe(MAESTRO_TEST_CONSTANTS.FOLDER_KEY);
+    });
+
+    it('should propagate API errors from getAll', async () => {
+      mockApiClient.get.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(
+        service.getByName(MAESTRO_TEST_CONSTANTS.EXTRACTED_NAME_DEFAULT),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 });

--- a/tests/unit/services/maestro/get-by-name.test.ts
+++ b/tests/unit/services/maestro/get-by-name.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findMaestroResourceByName,
+  MaestroResourceType,
+} from '../../../../src/services/maestro/helpers/get-by-name';
+import { NotFoundError, ValidationError } from '../../../../src/core/errors';
+import { MAESTRO_TEST_CONSTANTS } from '../../../utils/mocks';
+
+const RESOURCE = MaestroResourceType.MaestroProcess;
+
+interface TestItem {
+  name: string;
+  folderName: string;
+  folderKey: string;
+  marker: string;
+}
+
+const makeItem = (overrides: Partial<TestItem> = {}): TestItem => ({
+  name: 'Alpha',
+  folderName: 'Shared/Finance',
+  folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+  marker: '',
+  ...overrides,
+});
+
+describe('findMaestroResourceByName', () => {
+  it('throws ValidationError when no folder context can be resolved', () => {
+    expect(() => findMaestroResourceByName(RESOURCE, [makeItem()], 'Alpha', {})).toThrowError(
+      ValidationError,
+    );
+  });
+
+  it('filters by folderKey when multiple items share a name', () => {
+    const items = [
+      makeItem({ name: 'Alpha', folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY_OTHER, marker: 'other' }),
+      makeItem({ name: 'Alpha', folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY, marker: 'wanted' }),
+    ];
+
+    const result = findMaestroResourceByName(RESOURCE,items, 'Alpha', {
+      folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+    });
+
+    expect(result.marker).toBe('wanted');
+  });
+
+  it('filters by folderPath against the folderName field', () => {
+    const items = [
+      makeItem({ name: 'Alpha', folderName: MAESTRO_TEST_CONSTANTS.FOLDER_PATH_OTHER, marker: 'other' }),
+      makeItem({ name: 'Alpha', folderName: MAESTRO_TEST_CONSTANTS.FOLDER_PATH, marker: 'wanted' }),
+    ];
+
+    const result = findMaestroResourceByName(RESOURCE,items, 'Alpha', {
+      folderPath: MAESTRO_TEST_CONSTANTS.FOLDER_PATH,
+    });
+
+    expect(result.marker).toBe('wanted');
+  });
+
+  it('falls back to fallbackFolderKey when no explicit folder is supplied', () => {
+    const items = [
+      makeItem({ name: 'Alpha', folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY_OTHER, marker: 'other' }),
+      makeItem({ name: 'Alpha', folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY, marker: 'wanted' }),
+    ];
+
+    const result = findMaestroResourceByName(RESOURCE,items, 'Alpha', {
+      fallbackFolderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+    });
+
+    expect(result.marker).toBe('wanted');
+  });
+
+  it('suppresses fallbackFolderKey when folderPath is supplied', () => {
+    const items = [
+      makeItem({
+        name: 'Alpha',
+        folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY_OTHER,
+        folderName: MAESTRO_TEST_CONSTANTS.FOLDER_PATH,
+        marker: 'wanted',
+      }),
+    ];
+
+    const result = findMaestroResourceByName(RESOURCE,items, 'Alpha', {
+      folderPath: MAESTRO_TEST_CONSTANTS.FOLDER_PATH,
+      fallbackFolderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+    });
+
+    expect(result.marker).toBe('wanted');
+  });
+
+  it('throws NotFoundError when no item matches', () => {
+    expect(() =>
+      findMaestroResourceByName(RESOURCE, [makeItem()], 'Missing', {
+        folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+      }),
+    ).toThrowError(NotFoundError);
+  });
+
+  it('includes folderPath in the NotFoundError message when supplied', () => {
+    expect(() =>
+      findMaestroResourceByName(RESOURCE,[makeItem()], 'Missing', {
+        folderPath: MAESTRO_TEST_CONSTANTS.FOLDER_PATH,
+      }),
+    ).toThrowError(`in folder '${MAESTRO_TEST_CONSTANTS.FOLDER_PATH}'`);
+  });
+
+  it('includes folderKey in the NotFoundError message when supplied', () => {
+    expect(() =>
+      findMaestroResourceByName(RESOURCE,[makeItem()], 'Missing', {
+        folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+      }),
+    ).toThrowError(`in folder (key: ${MAESTRO_TEST_CONSTANTS.FOLDER_KEY})`);
+  });
+
+});

--- a/tests/unit/services/maestro/processes.test.ts
+++ b/tests/unit/services/maestro/processes.test.ts
@@ -3,14 +3,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MaestroProcessesService } from '../../../../src/services/maestro/processes';
 import { MAESTRO_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { ApiClient } from '../../../../src/core/http/api-client';
-import { 
+import {
   MAESTRO_TEST_CONSTANTS,
-  createMockProcess, 
+  createMockProcess,
   createMockProcessesApiResponse,
-  createMockError, 
+  createMockError,
   TEST_CONSTANTS
 } from '../../../utils/mocks';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
+import { NotFoundError, ValidationError } from '../../../../src/core/errors';
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -136,7 +137,7 @@ describe('MaestroProcessesService', () => {
     });
 
     it('should set name field to packageId for each process', async () => {
-      
+
       const mockApiResponse = createMockProcessesApiResponse([
         createMockProcess({
           processKey: MAESTRO_TEST_CONSTANTS.CUSTOM_PROCESS_KEY,
@@ -146,11 +147,74 @@ describe('MaestroProcessesService', () => {
 
       mockApiClient.get.mockResolvedValue(mockApiResponse);
 
-      
+
       const result = await service.getAll();
 
-      
+
       expect(result[0].name).toBe(MAESTRO_TEST_CONSTANTS.CUSTOM_PACKAGE_ID);
+    });
+  });
+
+  describe('getByName', () => {
+    it('should return a matching process with bound methods (delegates to getAll + helper)', async () => {
+      mockApiClient.get.mockResolvedValue(
+        createMockProcessesApiResponse([
+          createMockProcess({ name: MAESTRO_TEST_CONSTANTS.PACKAGE_ID }),
+        ]),
+      );
+
+      const result = await service.getByName(MAESTRO_TEST_CONSTANTS.PACKAGE_ID, {
+        folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+      });
+
+      expect(result.name).toBe(MAESTRO_TEST_CONSTANTS.PACKAGE_ID);
+      expect(typeof result.getIncidents).toBe('function');
+    });
+
+    it('should throw ValidationError without calling getAll when the name is empty', async () => {
+      await expect(service.getByName('   ')).rejects.toBeInstanceOf(ValidationError);
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should propagate NotFoundError from the shared filter when no process matches', async () => {
+      mockApiClient.get.mockResolvedValue(createMockProcessesApiResponse([createMockProcess()]));
+
+      await expect(
+        service.getByName(MAESTRO_TEST_CONSTANTS.MISSING_PROCESS_NAME, {
+          folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+        }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('should wire the init-time folderKey into the fallback chain', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY });
+      vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+      const scopedService = new MaestroProcessesService(instance);
+
+      mockApiClient.get.mockResolvedValue(
+        createMockProcessesApiResponse([
+          createMockProcess({
+            name: MAESTRO_TEST_CONSTANTS.PACKAGE_ID,
+            folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY_OTHER,
+          }),
+          createMockProcess({
+            name: MAESTRO_TEST_CONSTANTS.PACKAGE_ID,
+            folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+          }),
+        ]),
+      );
+
+      const result = await scopedService.getByName(MAESTRO_TEST_CONSTANTS.PACKAGE_ID);
+
+      expect(result.folderKey).toBe(MAESTRO_TEST_CONSTANTS.FOLDER_KEY);
+    });
+
+    it('should propagate API errors from getAll', async () => {
+      mockApiClient.get.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(
+        service.getByName(MAESTRO_TEST_CONSTANTS.PACKAGE_ID),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 });

--- a/tests/utils/constants/maestro.ts
+++ b/tests/utils/constants/maestro.ts
@@ -42,6 +42,13 @@ export const MAESTRO_TEST_CONSTANTS = {
   CUSTOM_PACKAGE_ID: 'custom-package',
   OTHER_PROPERTY: 'value',
 
+  // getByName test data
+  FOLDER_KEY_OTHER: 'other-folder-key',
+  FOLDER_PATH: 'Shared/Finance',
+  FOLDER_PATH_OTHER: 'Shared/HR',
+  MISSING_PROCESS_NAME: 'NonexistentMaestroProcess',
+  MISSING_CASE_NAME: 'NonexistentCase',
+
   // Variable types
   VARIABLE_TYPE: 'string',
 


### PR DESCRIPTION
## Summary
- Adds `maestroProcesses.getByName(name, options?)` and `cases.getByName(name, options?)`
- Both accept `{ folderPath?, folderKey? }` for API parity with the Orchestrator `getByName` services and fall back to the init-time folderKey (e.g. `uipath:folder-key` meta tag) when no folder context is supplied
- Maestro has no name-based lookup endpoint, so both methods filter `getAll()` client-side. Shared filter logic lives in [src/services/maestro/get-by-name.ts](src/services/maestro/get-by-name.ts) so processes and cases stay in sync
- `ValidationError` fires before the network call when the name is empty; `NotFoundError` fires when no record matches
Sample response
{
  "processKey": "16888728-348a-4668-86b2-3c0defbf6993",
  "packageId": "timer.CaseManagement.Agentic.case",
  "folderKey": "69400db2-3102-4851-9496-16f64be02196",
  "folderName": "Shared/timer",
  "releaseName": "Agentic case",
  "packageVersions": [
    "1.0.0"
  ],
  "versionCount": 1,
  "pendingCount": 0,
  "runningCount": 17,
  "completedCount": 0,
  "pausedCount": 0,
  "cancelledCount": 0,
  "faultedCount": 0,
  "retryingCount": 0,
  "resumingCount": 0,
  "pausingCount": 0,
  "cancelingCount": 0,
  "name": "Agentic.case"
}

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — 1492 tests passing (includes new maestro getByName unit tests)
- [x] `npm run build` — produces `dist/maestro-processes/*` and `dist/cases/*` with `.getByName`
- [ ] Integration tests in `tests/integration/shared/maestro/{processes,cases}-get-by-name.integration.test.ts` (require `INTEGRATION_TEST_FOLDER_KEY` + seeded process/case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)