### PR TITLE
fix(maestro-processes): update getExecutionHistory to use element-executions and Traces APIs [PLT-97257]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -78,7 +78,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `PIMS` |
 | `getById()` | `PIMS` |
-| `getExecutionHistory()` | `PIMS` |
+| `getExecutionHistory()` | `PIMS`, `Traces.Api` |
 | `getBpmn()` | `OR.Execution.Read` |
 | `getVariables()` | `PIMS` |
 | `getIncidents()` | `PIMS` |

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -78,7 +78,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `PIMS` |
 | `getById()` | `PIMS` |
-| `getExecutionHistory()` | `PIMS`, `Traces.Api` |
+| `getExecutionHistory()` | `PIMS` `Traces.Api` |
 | `getBpmn()` | `OR.Execution.Read` |
 | `getVariables()` | `PIMS` |
 | `getIncidents()` | `PIMS` |

--- a/src/models/maestro/process-instances.constants.ts
+++ b/src/models/maestro/process-instances.constants.ts
@@ -8,10 +8,3 @@ export const ProcessInstanceMap: { [key: string]: string } = {
   createdAt: 'createdTime',
   updatedAt: 'updatedTime'
 };
-
-/**
- * Maps fields for Process Instance Execution History to ensure consistent naming
- */
-export const ProcessInstanceExecutionHistoryMap: { [key: string]: string } = {
-  startTime: 'startedTime'
-};

--- a/src/models/maestro/process-instances.internal-types.ts
+++ b/src/models/maestro/process-instances.internal-types.ts
@@ -14,3 +14,58 @@ export interface BpmnVariableMetadata {
   elementId: string;
   source: string;
 }
+
+/**
+ * Element run from the element-executions API response
+ * @internal
+ */
+export interface ElementExecutionRun {
+  status: string;
+  startedTimeUtc: string;
+  completedTimeUtc: string | null;
+  elementRunId: string;
+  workflowId: string | null;
+}
+
+/**
+ * Element execution from the element-executions API response
+ * @internal
+ */
+export interface ElementExecution {
+  completedTimeUtc: string | null;
+  elementId: string;
+  elementType: string;
+  elementExtensionType: string | null;
+  parentRunId: string | null;
+  parentElementId: string | null;
+  parentElementRunId: string | null;
+  runId: string;
+  startedTimeUtc: string;
+  status: string;
+  elementRuns: ElementExecutionRun[];
+}
+
+/**
+ * Top-level response from the element-executions API
+ * @internal
+ */
+export interface ElementExecutionsApiResponse {
+  instanceId: string;
+  elementExecutions: ElementExecution[];
+}
+
+/**
+ * Trace span from the LLMOps Traces/spans API
+ * @internal
+ */
+export interface TraceSpan {
+  Id: string;
+  TraceId: string;
+  ParentId: string | null;
+  Name: string;
+  StartTime: string;
+  EndTime: string | null;
+  Attributes: string | null;
+  ExpiryTimeUtc: string | null;
+  UpdatedAt: string;
+}

--- a/src/models/maestro/process-instances.internal-types.ts
+++ b/src/models/maestro/process-instances.internal-types.ts
@@ -51,6 +51,7 @@ export interface ElementExecution {
  */
 export interface ElementExecutionsApiResponse {
   instanceId: string;
+  traceId: string;
   elementExecutions: ElementExecution[];
 }
 

--- a/src/models/maestro/process-instances.models.ts
+++ b/src/models/maestro/process-instances.models.ts
@@ -97,6 +97,7 @@ export interface ProcessInstancesServiceModel {
   /**
    * Get execution history (spans) for a process instance
    * @param instanceId The ID of the instance to get history for
+   * @param options Folder context options (folderKey, folderId, or folderPath)
    * @returns Promise resolving to execution history
    * {@link ProcessInstanceExecutionHistoryResponse}
    * @example
@@ -111,6 +112,7 @@ export interface ProcessInstancesServiceModel {
    * history.forEach(span => {
    *   console.log(`Activity: ${span.name}`);
    *   console.log(`Start: ${span.startedTime}`);
+   *   console.log(`End: ${span.endTime}`);
    * });
    * ```
    */

--- a/src/models/maestro/process-instances.models.ts
+++ b/src/models/maestro/process-instances.models.ts
@@ -102,7 +102,8 @@ export interface ProcessInstancesServiceModel {
    * ```typescript
    * // Get execution history for a process instance
    * const history = await processInstances.getExecutionHistory(
-   *   <instanceId>
+   *   <instanceId>,
+   *   <folderKey>
    * );
    *
    * // Analyze execution timeline
@@ -113,7 +114,7 @@ export interface ProcessInstancesServiceModel {
    * });
    * ```
    */
-  getExecutionHistory(instanceId: string): Promise<ProcessInstanceExecutionHistoryResponse[]>;
+  getExecutionHistory(instanceId: string, folderKey: string): Promise<ProcessInstanceExecutionHistoryResponse[]>;
 
   /**
    * Get BPMN XML file for a process instance
@@ -355,8 +356,9 @@ function createProcessInstanceMethods(instanceData: RawProcessInstanceGetRespons
 
     async getExecutionHistory(): Promise<ProcessInstanceExecutionHistoryResponse[]> {
       if (!instanceData.instanceId) throw new Error('Process instance ID is undefined');
+      if (!instanceData.folderKey) throw new Error('Process instance folder key is undefined');
 
-      return service.getExecutionHistory(instanceData.instanceId);
+      return service.getExecutionHistory(instanceData.instanceId, instanceData.folderKey);
     },
 
     async getBpmn(): Promise<BpmnXmlString> {

--- a/src/models/maestro/process-instances.models.ts
+++ b/src/models/maestro/process-instances.models.ts
@@ -116,7 +116,7 @@ export interface ProcessInstancesServiceModel {
    * });
    * ```
    */
-  getExecutionHistory(instanceId: string, options: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]>;
+  getExecutionHistory(instanceId: string, options?: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]>;
 
   /**
    * Get BPMN XML file for a process instance
@@ -358,9 +358,8 @@ function createProcessInstanceMethods(instanceData: RawProcessInstanceGetRespons
 
     async getExecutionHistory(): Promise<ProcessInstanceExecutionHistoryResponse[]> {
       if (!instanceData.instanceId) throw new Error('Process instance ID is undefined');
-      if (!instanceData.folderKey) throw new Error('Process instance folder key is undefined');
 
-      return service.getExecutionHistory(instanceData.instanceId, { folderKey: instanceData.folderKey });
+      return service.getExecutionHistory(instanceData.instanceId, instanceData.folderKey ? { folderKey: instanceData.folderKey } : undefined);
     },
 
     async getBpmn(): Promise<BpmnXmlString> {

--- a/src/models/maestro/process-instances.models.ts
+++ b/src/models/maestro/process-instances.models.ts
@@ -4,7 +4,6 @@ import type {
   ProcessInstanceOperationOptions,
   ProcessInstanceOperationResponse,
   ProcessInstanceExecutionHistoryResponse,
-  ProcessInstanceGetExecutionHistoryOptions,
   BpmnXmlString,
   ProcessInstanceGetVariablesResponse,
   ProcessInstanceGetVariablesOptions
@@ -97,7 +96,7 @@ export interface ProcessInstancesServiceModel {
   /**
    * Get execution history (spans) for a process instance
    * @param instanceId The ID of the instance to get history for
-   * @param options Folder context options (folderKey, folderId, or folderPath)
+   * @param folderKey The folder key for authorization
    * @returns Promise resolving to execution history
    * {@link ProcessInstanceExecutionHistoryResponse}
    * @example
@@ -105,7 +104,7 @@ export interface ProcessInstancesServiceModel {
    * // Get execution history for a process instance
    * const history = await processInstances.getExecutionHistory(
    *   <instanceId>,
-   *   { folderKey: <folderKey> }
+   *   <folderKey>
    * );
    *
    * // Analyze execution timeline
@@ -116,7 +115,7 @@ export interface ProcessInstancesServiceModel {
    * });
    * ```
    */
-  getExecutionHistory(instanceId: string, options?: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]>;
+  getExecutionHistory(instanceId: string, folderKey: string): Promise<ProcessInstanceExecutionHistoryResponse[]>;
 
   /**
    * Get BPMN XML file for a process instance
@@ -358,8 +357,9 @@ function createProcessInstanceMethods(instanceData: RawProcessInstanceGetRespons
 
     async getExecutionHistory(): Promise<ProcessInstanceExecutionHistoryResponse[]> {
       if (!instanceData.instanceId) throw new Error('Process instance ID is undefined');
+      if (!instanceData.folderKey) throw new Error('Process instance folder key is undefined');
 
-      return service.getExecutionHistory(instanceData.instanceId, instanceData.folderKey ? { folderKey: instanceData.folderKey } : undefined);
+      return service.getExecutionHistory(instanceData.instanceId, instanceData.folderKey);
     },
 
     async getBpmn(): Promise<BpmnXmlString> {

--- a/src/models/maestro/process-instances.models.ts
+++ b/src/models/maestro/process-instances.models.ts
@@ -4,6 +4,7 @@ import type {
   ProcessInstanceOperationOptions,
   ProcessInstanceOperationResponse,
   ProcessInstanceExecutionHistoryResponse,
+  ProcessInstanceGetExecutionHistoryOptions,
   BpmnXmlString,
   ProcessInstanceGetVariablesResponse,
   ProcessInstanceGetVariablesOptions
@@ -103,18 +104,17 @@ export interface ProcessInstancesServiceModel {
    * // Get execution history for a process instance
    * const history = await processInstances.getExecutionHistory(
    *   <instanceId>,
-   *   <folderKey>
+   *   { folderKey: <folderKey> }
    * );
    *
    * // Analyze execution timeline
    * history.forEach(span => {
    *   console.log(`Activity: ${span.name}`);
-   *   console.log(`Start: ${span.startTime}`);
-   *   console.log(`Duration: ${span.duration}ms`);
+   *   console.log(`Start: ${span.startedTime}`);
    * });
    * ```
    */
-  getExecutionHistory(instanceId: string, folderKey: string): Promise<ProcessInstanceExecutionHistoryResponse[]>;
+  getExecutionHistory(instanceId: string, options: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]>;
 
   /**
    * Get BPMN XML file for a process instance
@@ -358,7 +358,7 @@ function createProcessInstanceMethods(instanceData: RawProcessInstanceGetRespons
       if (!instanceData.instanceId) throw new Error('Process instance ID is undefined');
       if (!instanceData.folderKey) throw new Error('Process instance folder key is undefined');
 
-      return service.getExecutionHistory(instanceData.instanceId, instanceData.folderKey);
+      return service.getExecutionHistory(instanceData.instanceId, { folderKey: instanceData.folderKey });
     },
 
     async getBpmn(): Promise<BpmnXmlString> {

--- a/src/models/maestro/process-instances.types.ts
+++ b/src/models/maestro/process-instances.types.ts
@@ -69,7 +69,7 @@ export interface ProcessInstanceExecutionHistoryResponse {
   startedTime: string;
   endTime: string | null;
   attributes: string | null;
-  createdTime: string;
+  createdTime?: string;
   updatedTime?: string;
   expiredTime: string | null;
   // TO Do: Add status and attributes interface

--- a/src/models/maestro/process-instances.types.ts
+++ b/src/models/maestro/process-instances.types.ts
@@ -4,6 +4,7 @@
  */
 
 import { PaginationOptions } from "../../utils/pagination";
+import { FolderScopedOptions } from "../common/types";
 
 /**
  * Response for getting a single process instance
@@ -42,6 +43,11 @@ export interface ProcessInstanceGetAllOptions {
  * Query options for getting process instances with pagination support
  */
 export type ProcessInstanceGetAllWithPaginationOptions = ProcessInstanceGetAllOptions & PaginationOptions;
+
+/**
+ * Options for getting execution history for a process instance
+ */
+export interface ProcessInstanceGetExecutionHistoryOptions extends FolderScopedOptions {}
 
 /**
  * Request for process instance operations (cancel, pause, resume)

--- a/src/models/maestro/process-instances.types.ts
+++ b/src/models/maestro/process-instances.types.ts
@@ -69,8 +69,7 @@ export interface ProcessInstanceExecutionHistoryResponse {
   startedTime: string;
   endTime: string | null;
   attributes: string | null;
-  createdTime?: string;
-  updatedTime?: string;
+  updatedTime: string;
   expiredTime: string | null;
   // TO Do: Add status and attributes interface
 }

--- a/src/models/maestro/process-instances.types.ts
+++ b/src/models/maestro/process-instances.types.ts
@@ -4,7 +4,6 @@
  */
 
 import { PaginationOptions } from "../../utils/pagination";
-import { FolderScopedOptions } from "../common/types";
 
 /**
  * Response for getting a single process instance
@@ -43,11 +42,6 @@ export interface ProcessInstanceGetAllOptions {
  * Query options for getting process instances with pagination support
  */
 export type ProcessInstanceGetAllWithPaginationOptions = ProcessInstanceGetAllOptions & PaginationOptions;
-
-/**
- * Options for getting execution history for a process instance
- */
-export interface ProcessInstanceGetExecutionHistoryOptions extends FolderScopedOptions {}
 
 /**
  * Request for process instance operations (cancel, pause, resume)

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -6,7 +6,6 @@ import {
   ProcessInstanceOperationOptions,
   ProcessInstanceOperationResponse,
   ProcessInstanceExecutionHistoryResponse,
-  ProcessInstanceGetExecutionHistoryOptions,
   ProcessInstancesServiceModel,
   createProcessInstanceWithMethods,
   ProcessInstanceGetVariablesResponse,
@@ -18,7 +17,6 @@ import { BpmnHelpers } from './helpers';
 import { OperationResponse } from '../../../models/common/types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { createHeaders } from '../../../utils/http/headers';
-import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
 import { FOLDER_KEY, CONTENT_TYPES } from '../../../utils/constants/headers';
 import { transformData } from '../../../utils/transform';
 import { ProcessInstanceMap } from '../../../models/maestro/process-instances.constants';
@@ -121,19 +119,12 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
   /**
    * Get execution history (spans) for a process instance
    * @param instanceId The ID of the instance to get history for
-   * @param options Folder context options (folderKey, folderId, or folderPath)
+   * @param folderKey The folder key for authorization
    * @returns Promise<ProcessInstanceExecutionHistoryResponse[]>
    */
   @track('ProcessInstances.GetExecutionHistory')
-  async getExecutionHistory(instanceId: string, options?: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]> {
-    const { folderId, folderKey, folderPath } = options ?? {};
-    const headers = resolveFolderHeaders({
-      folderId,
-      folderKey,
-      folderPath,
-      resourceType: 'ProcessInstances.GetExecutionHistory',
-      fallbackFolderKey: this.config.folderKey,
-    });
+  async getExecutionHistory(instanceId: string, folderKey: string): Promise<ProcessInstanceExecutionHistoryResponse[]> {
+    const headers = createHeaders({ [FOLDER_KEY]: folderKey });
 
     const elementExecResponse = await this.get<ElementExecutionsApiResponse>(
       MAESTRO_ENDPOINTS.INSTANCES.GET_ELEMENT_EXECUTIONS(instanceId),

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -121,6 +121,7 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
   /**
    * Get execution history (spans) for a process instance
    * @param instanceId The ID of the instance to get history for
+   * @param options Folder context options (folderKey, folderId, or folderPath)
    * @returns Promise<ProcessInstanceExecutionHistoryResponse[]>
    */
   @track('ProcessInstances.GetExecutionHistory')

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -19,14 +19,14 @@ import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { createHeaders } from '../../../utils/http/headers';
 import { FOLDER_KEY, CONTENT_TYPES } from '../../../utils/constants/headers';
 import { transformData } from '../../../utils/transform';
-import { ProcessInstanceMap, ProcessInstanceExecutionHistoryMap } from '../../../models/maestro/process-instances.constants';
+import { ProcessInstanceMap } from '../../../models/maestro/process-instances.constants';
 import { BpmnXmlString } from '../../../models/maestro/process-instances.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../../utils/pagination';
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
 import { PROCESS_INSTANCE_PAGINATION, PROCESS_INSTANCE_TOKEN_PARAMS } from '../../../utils/constants/common';
 import { track } from '../../../core/telemetry';
-import { BpmnVariableMetadata } from '../../../models/maestro/process-instances.internal-types';
+import { BpmnVariableMetadata, ElementExecutionsApiResponse, TraceSpan } from '../../../models/maestro/process-instances.internal-types';
 
 
 export class ProcessInstancesService extends BaseService implements ProcessInstancesServiceModel {
@@ -122,11 +122,49 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
    * @returns Promise<ProcessInstanceExecutionHistoryResponse[]>
    */
   @track('ProcessInstances.GetExecutionHistory')
-  async getExecutionHistory(instanceId: string): Promise<ProcessInstanceExecutionHistoryResponse[]> {
-    const response = await this.get<ProcessInstanceExecutionHistoryResponse[]>(MAESTRO_ENDPOINTS.INSTANCES.GET_EXECUTION_HISTORY(instanceId));
-    return response.data.map(historyItem => 
-      transformData(historyItem, ProcessInstanceExecutionHistoryMap)
+  async getExecutionHistory(instanceId: string, folderKey: string): Promise<ProcessInstanceExecutionHistoryResponse[]> {
+    const elementExecResponse = await this.get<ElementExecutionsApiResponse>(
+      MAESTRO_ENDPOINTS.INSTANCES.GET_ELEMENT_EXECUTIONS(instanceId),
+      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
     );
+
+    const traceId = elementExecResponse.data.instanceId;
+
+    const spansResponse = await this.get<TraceSpan[]>(
+      MAESTRO_ENDPOINTS.TRACES.GET_SPANS(traceId),
+      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+    );
+
+    const spanMap = new Map<string, TraceSpan>();
+    for (const span of spansResponse.data) {
+      spanMap.set(span.Id, span);
+    }
+
+    const results: ProcessInstanceExecutionHistoryResponse[] = [];
+    for (const elementExec of elementExecResponse.data.elementExecutions) {
+      for (const run of elementExec.elementRuns) {
+        const span = spanMap.get(run.elementRunId);
+        if (span) {
+          results.push(this.mapSpanToHistory(span));
+        }
+      }
+    }
+
+    return results;
+  }
+
+  private mapSpanToHistory(span: TraceSpan): ProcessInstanceExecutionHistoryResponse {
+    return {
+      id: span.Id,
+      traceId: span.TraceId,
+      parentId: span.ParentId,
+      name: span.Name,
+      startedTime: span.StartTime,
+      endTime: span.EndTime,
+      attributes: span.Attributes,
+      updatedTime: span.UpdatedAt,
+      expiredTime: span.ExpiryTimeUtc,
+    };
   }
 
   /**

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -120,7 +120,23 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
    * Get execution history (spans) for a process instance
    * @param instanceId The ID of the instance to get history for
    * @param folderKey The folder key for authorization
-   * @returns Promise<ProcessInstanceExecutionHistoryResponse[]>
+   * @returns Promise resolving to execution history
+   * {@link ProcessInstanceExecutionHistoryResponse}
+   * @example
+   * ```typescript
+   * // Get execution history for a process instance
+   * const history = await processInstances.getExecutionHistory(
+   *   <instanceId>,
+   *   <folderKey>
+   * );
+   *
+   * // Analyze execution timeline
+   * history.forEach(span => {
+   *   console.log(`Activity: ${span.name}`);
+   *   console.log(`Start: ${span.startedTime}`);
+   *   console.log(`End: ${span.endTime}`);
+   * });
+   * ```
    */
   @track('ProcessInstances.GetExecutionHistory')
   async getExecutionHistory(instanceId: string, folderKey: string): Promise<ProcessInstanceExecutionHistoryResponse[]> {

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -139,16 +139,24 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
       { headers }
     );
 
-    const traceId = elementExecResponse.data.instanceId;
+    const traceId = elementExecResponse.data.traceId;
 
     const spansResponse = await this.get<TraceSpan[]>(
       MAESTRO_ENDPOINTS.TRACES.GET_SPANS(traceId),
       { headers }
     );
 
+    // Build span lookup keyed by elementRunId extracted from Attributes JSON
     const spanMap = new Map<string, TraceSpan>();
     for (const span of spansResponse.data) {
-      spanMap.set(span.Id, span);
+      try {
+        const attrs = span.Attributes ? JSON.parse(span.Attributes) : null;
+        if (attrs?.elementRunId) {
+          spanMap.set(attrs.elementRunId, span);
+        }
+      } catch {
+        // skip spans with unparseable Attributes — they won't match any elementRunId
+      }
     }
 
     const results: ProcessInstanceExecutionHistoryResponse[] = [];

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -124,8 +124,8 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
    * @returns Promise<ProcessInstanceExecutionHistoryResponse[]>
    */
   @track('ProcessInstances.GetExecutionHistory')
-  async getExecutionHistory(instanceId: string, options: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]> {
-    const { folderId, folderKey, folderPath } = options;
+  async getExecutionHistory(instanceId: string, options?: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]> {
+    const { folderId, folderKey, folderPath } = options ?? {};
     const headers = resolveFolderHeaders({
       folderId,
       folderKey,

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -6,6 +6,7 @@ import {
   ProcessInstanceOperationOptions,
   ProcessInstanceOperationResponse,
   ProcessInstanceExecutionHistoryResponse,
+  ProcessInstanceGetExecutionHistoryOptions,
   ProcessInstancesServiceModel,
   createProcessInstanceWithMethods,
   ProcessInstanceGetVariablesResponse,
@@ -17,6 +18,7 @@ import { BpmnHelpers } from './helpers';
 import { OperationResponse } from '../../../models/common/types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { createHeaders } from '../../../utils/http/headers';
+import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
 import { FOLDER_KEY, CONTENT_TYPES } from '../../../utils/constants/headers';
 import { transformData } from '../../../utils/transform';
 import { ProcessInstanceMap } from '../../../models/maestro/process-instances.constants';
@@ -122,17 +124,26 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
    * @returns Promise<ProcessInstanceExecutionHistoryResponse[]>
    */
   @track('ProcessInstances.GetExecutionHistory')
-  async getExecutionHistory(instanceId: string, folderKey: string): Promise<ProcessInstanceExecutionHistoryResponse[]> {
+  async getExecutionHistory(instanceId: string, options: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]> {
+    const { folderId, folderKey, folderPath } = options;
+    const headers = resolveFolderHeaders({
+      folderId,
+      folderKey,
+      folderPath,
+      resourceType: 'ProcessInstances.GetExecutionHistory',
+      fallbackFolderKey: this.config.folderKey,
+    });
+
     const elementExecResponse = await this.get<ElementExecutionsApiResponse>(
       MAESTRO_ENDPOINTS.INSTANCES.GET_ELEMENT_EXECUTIONS(instanceId),
-      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+      { headers }
     );
 
     const traceId = elementExecResponse.data.instanceId;
 
     const spansResponse = await this.get<TraceSpan[]>(
       MAESTRO_ENDPOINTS.TRACES.GET_SPANS(traceId),
-      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+      { headers }
     );
 
     const spanMap = new Map<string, TraceSpan>();

--- a/src/utils/constants/endpoints/maestro.ts
+++ b/src/utils/constants/endpoints/maestro.ts
@@ -2,7 +2,7 @@
  * Maestro Service Endpoints
  */
 
-import { PIMS_BASE, INSIGHTS_RTM_BASE } from './base';
+import { PIMS_BASE, LLMOPS_BASE, INSIGHTS_RTM_BASE } from './base';
 
 /**
  * Maestro Process Service Endpoints
@@ -15,7 +15,7 @@ export const MAESTRO_ENDPOINTS = {
   INSTANCES: {
     GET_ALL: `${PIMS_BASE}/api/v1/instances`,
     GET_BY_ID: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}`,
-    GET_EXECUTION_HISTORY: (instanceId: string) => `${PIMS_BASE}/api/v1/spans/${instanceId}`,
+    GET_ELEMENT_EXECUTIONS: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/element-executions`,
     GET_BPMN: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/bpmn`,
     GET_VARIABLES: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/variables`,
     CANCEL: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/cancel`,
@@ -26,6 +26,9 @@ export const MAESTRO_ENDPOINTS = {
     GET_ALL: `${PIMS_BASE}/api/v1/incidents/summary`,
     GET_BY_PROCESS: (processKey: string) => `${PIMS_BASE}/api/v1/incidents/process/${processKey}`,
     GET_BY_INSTANCE: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/incidents`,
+  },
+  TRACES: {
+    GET_SPANS: (traceId: string) => `${LLMOPS_BASE}/api/Traces/spans?traceId=${traceId}`,
   },
   CASES: {
     GET_CASE_JSON: (instanceId: string) => `${PIMS_BASE}/api/v1/cases/${instanceId}/case-json`,

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -242,25 +242,20 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
     it('should retrieve execution history', async () => {
       if (!testInstanceId) {
-        console.log('No instance ID available for testing');
-        return;
+        throw new Error('No instance ID available for testing');
       }
 
       const { processInstances } = getServices();
       const config = getTestConfig();
 
-      try {
-        const result = await processInstances.getExecutionHistory(testInstanceId, { folderKey: config.folderId || '' });
+      const result = await processInstances.getExecutionHistory(testInstanceId, { folderKey: config.folderId || '' });
 
-        expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
 
-        if (result.length > 0) {
-          const historyItem = result[0];
-          expect(historyItem).toBeDefined();
-        }
-      } catch (error: any) {
-        console.log('Get execution history test failed:', error.message);
+      if (result.length > 0) {
+        const historyItem = result[0];
+        expect(historyItem).toBeDefined();
       }
     });
   });

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -250,7 +250,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
       const config = getTestConfig();
 
       try {
-        const result = await processInstances.getExecutionHistory(testInstanceId, config.folderId || '');
+        const result = await processInstances.getExecutionHistory(testInstanceId, { folderKey: config.folderId || '' });
 
         expect(result).toBeDefined();
         expect(Array.isArray(result)).toBe(true);

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -248,7 +248,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
       const { processInstances } = getServices();
       const config = getTestConfig();
 
-      const result = await processInstances.getExecutionHistory(testInstanceId, { folderKey: config.folderKey || '' });
+      const result = await processInstances.getExecutionHistory(testInstanceId, config.folderKey || '');
 
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -247,9 +247,10 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
       }
 
       const { processInstances } = getServices();
+      const config = getTestConfig();
 
       try {
-        const result = await processInstances.getExecutionHistory(testInstanceId);
+        const result = await processInstances.getExecutionHistory(testInstanceId, config.folderId || '');
 
         expect(result).toBeDefined();
         expect(Array.isArray(result)).toBe(true);

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -248,14 +248,19 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
       const { processInstances } = getServices();
       const config = getTestConfig();
 
-      const result = await processInstances.getExecutionHistory(testInstanceId, { folderKey: config.folderId || '' });
+      const result = await processInstances.getExecutionHistory(testInstanceId, { folderKey: config.folderKey || '' });
 
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
 
       if (result.length > 0) {
         const historyItem = result[0];
-        expect(historyItem).toBeDefined();
+        expect(typeof historyItem.id).toBe('string');
+        expect(typeof historyItem.traceId).toBe('string');
+        expect(typeof historyItem.name).toBe('string');
+        expect(typeof historyItem.startedTime).toBe('string');
+        expect(historyItem.parentId === null || typeof historyItem.parentId === 'string').toBe(true);
+        expect(historyItem.endTime === null || typeof historyItem.endTime === 'string').toBe(true);
       }
     });
   });

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import {
   getServices,
   getTestConfig,
@@ -6,6 +6,7 @@ import {
   InitMode,
 } from '../../config/unified-setup';
 import { registerResource } from '../../utils/cleanup';
+import type { ProcessInstanceExecutionHistoryResponse } from '../../../../src/models/maestro/process-instances.types';
 
 const modes: InitMode[] = ['v0', 'v1'];
 
@@ -240,28 +241,60 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
       }
     });
 
-    it('should retrieve execution history', async () => {
-      if (!testInstanceId) {
-        throw new Error('No instance ID available for testing');
-      }
+    describe('execution history', () => {
+      let executionHistory!: ProcessInstanceExecutionHistoryResponse[];
 
-      const { processInstances } = getServices();
-      const config = getTestConfig();
+      beforeAll(async () => {
+        if (!testInstanceId) {
+          throw new Error('No instance ID available for testing');
+        }
 
-      const result = await processInstances.getExecutionHistory(testInstanceId, config.folderKey || '');
+        const { processInstances } = getServices();
+        const config = getTestConfig();
 
-      expect(result).toBeDefined();
-      expect(Array.isArray(result)).toBe(true);
+        if (!config.folderKey) {
+          throw new Error('No folderKey configured for testing');
+        }
 
-      if (result.length > 0) {
-        const historyItem = result[0];
-        expect(typeof historyItem.id).toBe('string');
-        expect(typeof historyItem.traceId).toBe('string');
-        expect(typeof historyItem.name).toBe('string');
-        expect(typeof historyItem.startedTime).toBe('string');
-        expect(historyItem.parentId === null || typeof historyItem.parentId === 'string').toBe(true);
-        expect(historyItem.endTime === null || typeof historyItem.endTime === 'string').toBe(true);
-      }
+        executionHistory = await processInstances.getExecutionHistory(testInstanceId, config.folderKey);
+      });
+
+      it('should retrieve execution history', () => {
+        expect(executionHistory).toBeDefined();
+        expect(Array.isArray(executionHistory)).toBe(true);
+
+        if (executionHistory.length > 0) {
+          const historyItem = executionHistory[0];
+          expect(typeof historyItem.id).toBe('string');
+          expect(typeof historyItem.traceId).toBe('string');
+          expect(typeof historyItem.name).toBe('string');
+          expect(typeof historyItem.startedTime).toBe('string');
+          expect(historyItem.parentId === null || typeof historyItem.parentId === 'string').toBe(true);
+          expect(historyItem.endTime === null || typeof historyItem.endTime === 'string').toBe(true);
+        }
+      });
+
+      it('should transform execution history fields from PascalCase to camelCase', () => {
+        if (executionHistory.length === 0) {
+          throw new Error('No execution history available to validate transform');
+        }
+
+        const historyItem = executionHistory[0];
+
+        // (a) transformed camelCase fields exist
+        expect(historyItem.id).toBeDefined();
+        expect(historyItem.traceId).toBeDefined();
+        expect(historyItem.name).toBeDefined();
+        expect(historyItem.startedTime).toBeDefined();
+
+        // (b) original PascalCase API fields are absent
+        expect((historyItem as any).Id).toBeUndefined();
+        expect((historyItem as any).TraceId).toBeUndefined();
+        expect((historyItem as any).ParentId).toBeUndefined();
+        expect((historyItem as any).Name).toBeUndefined();
+        expect((historyItem as any).StartTime).toBeUndefined();
+        expect((historyItem as any).EndTime).toBeUndefined();
+      });
     });
   });
 

--- a/tests/unit/models/maestro/process-instances.test.ts
+++ b/tests/unit/models/maestro/process-instances.test.ts
@@ -241,7 +241,7 @@ describe('Process Instance Models', () => {
 
         expect(mockService.getExecutionHistory).toHaveBeenCalledWith(
           MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
-          MAESTRO_TEST_CONSTANTS.FOLDER_KEY
+          { folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY }
         );
         expect(result).toEqual(mockHistory);
       });

--- a/tests/unit/models/maestro/process-instances.test.ts
+++ b/tests/unit/models/maestro/process-instances.test.ts
@@ -230,19 +230,18 @@ describe('Process Instance Models', () => {
     });
 
     describe('processInstance.getExecutionHistory()', () => {
-      it('should call processInstance.getExecutionHistory with bound instanceId', async () => {
+      it('should call processInstance.getExecutionHistory with bound instanceId and folderKey', async () => {
         const mockInstanceData = createMockProcessInstance();
         const instance = createProcessInstanceWithMethods(mockInstanceData, mockService);
-        
+
         const mockHistory = [createMockExecutionHistory()];
         mockService.getExecutionHistory = vi.fn().mockResolvedValue(mockHistory);
 
-        
         const result = await instance.getExecutionHistory();
 
-        
         expect(mockService.getExecutionHistory).toHaveBeenCalledWith(
-          MAESTRO_TEST_CONSTANTS.INSTANCE_ID
+          MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+          MAESTRO_TEST_CONSTANTS.FOLDER_KEY
         );
         expect(result).toEqual(mockHistory);
       });
@@ -252,8 +251,15 @@ describe('Process Instance Models', () => {
         const invalidInstanceData = { ...mockInstanceData, instanceId: undefined as any };
         const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
 
-        
         await expect(invalidInstance.getExecutionHistory()).rejects.toThrow('Process instance ID is undefined');
+      });
+
+      it('should throw error if folderKey is undefined', async () => {
+        const mockInstanceData = createMockProcessInstance();
+        const invalidInstanceData = { ...mockInstanceData, folderKey: undefined as any };
+        const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
+
+        await expect(invalidInstance.getExecutionHistory()).rejects.toThrow('Process instance folder key is undefined');
       });
     });
 

--- a/tests/unit/models/maestro/process-instances.test.ts
+++ b/tests/unit/models/maestro/process-instances.test.ts
@@ -254,12 +254,20 @@ describe('Process Instance Models', () => {
         await expect(invalidInstance.getExecutionHistory()).rejects.toThrow('Process instance ID is undefined');
       });
 
-      it('should throw error if folderKey is undefined', async () => {
+      it('should call getExecutionHistory with undefined options when folderKey is absent', async () => {
         const mockInstanceData = createMockProcessInstance();
-        const invalidInstanceData = { ...mockInstanceData, folderKey: undefined as any };
-        const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
+        const instanceDataWithoutFolderKey = { ...mockInstanceData, folderKey: undefined as any };
+        const instance = createProcessInstanceWithMethods(instanceDataWithoutFolderKey, mockService);
 
-        await expect(invalidInstance.getExecutionHistory()).rejects.toThrow('Process instance folder key is undefined');
+        const mockHistory = [createMockExecutionHistory()];
+        mockService.getExecutionHistory = vi.fn().mockResolvedValue(mockHistory);
+
+        await instance.getExecutionHistory();
+
+        expect(mockService.getExecutionHistory).toHaveBeenCalledWith(
+          MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+          undefined
+        );
       });
     });
 

--- a/tests/unit/models/maestro/process-instances.test.ts
+++ b/tests/unit/models/maestro/process-instances.test.ts
@@ -241,7 +241,7 @@ describe('Process Instance Models', () => {
 
         expect(mockService.getExecutionHistory).toHaveBeenCalledWith(
           MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
-          { folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY }
+          MAESTRO_TEST_CONSTANTS.FOLDER_KEY
         );
         expect(result).toEqual(mockHistory);
       });
@@ -254,20 +254,12 @@ describe('Process Instance Models', () => {
         await expect(invalidInstance.getExecutionHistory()).rejects.toThrow('Process instance ID is undefined');
       });
 
-      it('should call getExecutionHistory with undefined options when folderKey is absent', async () => {
+      it('should throw error if folderKey is undefined', async () => {
         const mockInstanceData = createMockProcessInstance();
-        const instanceDataWithoutFolderKey = { ...mockInstanceData, folderKey: undefined as any };
-        const instance = createProcessInstanceWithMethods(instanceDataWithoutFolderKey, mockService);
+        const invalidInstanceData = { ...mockInstanceData, folderKey: undefined as any };
+        const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
 
-        const mockHistory = [createMockExecutionHistory()];
-        mockService.getExecutionHistory = vi.fn().mockResolvedValue(mockHistory);
-
-        await instance.getExecutionHistory();
-
-        expect(mockService.getExecutionHistory).toHaveBeenCalledWith(
-          MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
-          undefined
-        );
+        await expect(invalidInstance.getExecutionHistory()).rejects.toThrow('Process instance folder key is undefined');
       });
     });
 

--- a/tests/unit/services/maestro/process-instances.test.ts
+++ b/tests/unit/services/maestro/process-instances.test.ts
@@ -10,17 +10,17 @@ import {
   TEST_CONSTANTS,
   createMockProcessInstance,
   createMockBpmnWithVariables,
-  createMockExecutionHistory,
+  createMockElementExecutionsResponse,
+  createMockTraceSpan,
   createMockProcessVariables,
   createMockMaestroApiOperationResponse
 } from '../../../utils/mocks';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
-import type { 
+import type {
   ProcessInstanceGetAllWithPaginationOptions,
   ProcessInstanceOperationOptions,
   ProcessInstanceGetVariablesOptions,
-  RawProcessInstanceGetResponse,
-  ProcessInstanceExecutionHistoryResponse
+  RawProcessInstanceGetResponse
 } from '../../../../src/models/maestro';
 
 // ===== MOCKING =====
@@ -208,33 +208,64 @@ describe('ProcessInstancesService', () => {
 
   describe('getExecutionHistory', () => {
     it('should return execution history for process instance', async () => {
-      
       const instanceId = MAESTRO_TEST_CONSTANTS.INSTANCE_ID;
-      const mockApiResponse: ProcessInstanceExecutionHistoryResponse[] = [createMockExecutionHistory()];
+      const folderKey = MAESTRO_TEST_CONSTANTS.FOLDER_KEY;
 
-      mockApiClient.get.mockResolvedValue(mockApiResponse);
+      mockApiClient.get
+        .mockResolvedValueOnce(createMockElementExecutionsResponse())
+        .mockResolvedValueOnce([createMockTraceSpan()]);
 
-      
-      const result = await service.getExecutionHistory(instanceId);
+      const result = await service.getExecutionHistory(instanceId, folderKey);
 
-      
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        MAESTRO_ENDPOINTS.INSTANCES.GET_EXECUTION_HISTORY(instanceId),
-        {}
+        MAESTRO_ENDPOINTS.INSTANCES.GET_ELEMENT_EXECUTIONS(instanceId),
+        {
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: folderKey
+          })
+        }
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        MAESTRO_ENDPOINTS.TRACES.GET_SPANS(instanceId),
+        {
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: folderKey
+          })
+        }
       );
 
       expect(result).toHaveLength(1);
       expect(result[0]).toHaveProperty('id', MAESTRO_TEST_CONSTANTS.SPAN_ID);
       expect(result[0]).toHaveProperty('traceId', MAESTRO_TEST_CONSTANTS.TRACE_ID);
+      expect(result[0]).toHaveProperty('name', MAESTRO_TEST_CONSTANTS.ACTIVITY_NAME);
+    });
+
+    it('should only include spans matched to elementRuns', async () => {
+      const instanceId = MAESTRO_TEST_CONSTANTS.INSTANCE_ID;
+      const folderKey = MAESTRO_TEST_CONSTANTS.FOLDER_KEY;
+      const unmatchedSpan = createMockTraceSpan({
+        Id: 'nested-agent-span-1',
+        ParentId: MAESTRO_TEST_CONSTANTS.SPAN_ID,
+        Name: 'LangGraph',
+        Attributes: null
+      });
+
+      mockApiClient.get
+        .mockResolvedValueOnce(createMockElementExecutionsResponse())
+        .mockResolvedValueOnce([createMockTraceSpan(), unmatchedSpan]);
+
+      const result = await service.getExecutionHistory(instanceId, folderKey);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('id', MAESTRO_TEST_CONSTANTS.SPAN_ID);
     });
 
     it('should handle API errors', async () => {
-      
       const error = new Error(TEST_CONSTANTS.ERROR_MESSAGE);
       mockApiClient.get.mockRejectedValue(error);
 
-      
-      await expect(service.getExecutionHistory(MAESTRO_TEST_CONSTANTS.INSTANCE_ID)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+      await expect(service.getExecutionHistory(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, MAESTRO_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 

--- a/tests/unit/services/maestro/process-instances.test.ts
+++ b/tests/unit/services/maestro/process-instances.test.ts
@@ -227,7 +227,7 @@ describe('ProcessInstancesService', () => {
       );
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        MAESTRO_ENDPOINTS.TRACES.GET_SPANS(instanceId),
+        MAESTRO_ENDPOINTS.TRACES.GET_SPANS(MAESTRO_TEST_CONSTANTS.TRACE_ID),
         {
           headers: expect.objectContaining({
             [FOLDER_KEY]: folderKey

--- a/tests/unit/services/maestro/process-instances.test.ts
+++ b/tests/unit/services/maestro/process-instances.test.ts
@@ -215,7 +215,7 @@ describe('ProcessInstancesService', () => {
         .mockResolvedValueOnce(createMockElementExecutionsResponse())
         .mockResolvedValueOnce([createMockTraceSpan()]);
 
-      const result = await service.getExecutionHistory(instanceId, { folderKey });
+      const result = await service.getExecutionHistory(instanceId, folderKey);
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
         MAESTRO_ENDPOINTS.INSTANCES.GET_ELEMENT_EXECUTIONS(instanceId),
@@ -255,7 +255,7 @@ describe('ProcessInstancesService', () => {
         .mockResolvedValueOnce(createMockElementExecutionsResponse())
         .mockResolvedValueOnce([createMockTraceSpan(), unmatchedSpan]);
 
-      const result = await service.getExecutionHistory(instanceId, { folderKey });
+      const result = await service.getExecutionHistory(instanceId, folderKey);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toHaveProperty('id', MAESTRO_TEST_CONSTANTS.SPAN_ID);
@@ -265,7 +265,7 @@ describe('ProcessInstancesService', () => {
       const error = new Error(TEST_CONSTANTS.ERROR_MESSAGE);
       mockApiClient.get.mockRejectedValue(error);
 
-      await expect(service.getExecutionHistory(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, { folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY })).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+      await expect(service.getExecutionHistory(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, MAESTRO_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 

--- a/tests/unit/services/maestro/process-instances.test.ts
+++ b/tests/unit/services/maestro/process-instances.test.ts
@@ -241,6 +241,35 @@ describe('ProcessInstancesService', () => {
       expect(result[0]).toHaveProperty('name', MAESTRO_TEST_CONSTANTS.ACTIVITY_NAME);
     });
 
+    it('should transform span fields from PascalCase to camelCase', async () => {
+      const instanceId = MAESTRO_TEST_CONSTANTS.INSTANCE_ID;
+      const folderKey = MAESTRO_TEST_CONSTANTS.FOLDER_KEY;
+
+      mockApiClient.get
+        .mockResolvedValueOnce(createMockElementExecutionsResponse())
+        .mockResolvedValueOnce([createMockTraceSpan()]);
+
+      const result = await service.getExecutionHistory(instanceId, folderKey);
+      const historyItem = result[0];
+
+      // (a) transformed camelCase fields have correct values
+      expect(historyItem.id).toBe(MAESTRO_TEST_CONSTANTS.SPAN_ID);
+      expect(historyItem.traceId).toBe(MAESTRO_TEST_CONSTANTS.TRACE_ID);
+      expect(historyItem.name).toBe(MAESTRO_TEST_CONSTANTS.ACTIVITY_NAME);
+      expect(historyItem.startedTime).toBe(MAESTRO_TEST_CONSTANTS.START_TIME);
+      expect(historyItem.endTime).toBe(MAESTRO_TEST_CONSTANTS.END_TIME);
+      expect(historyItem.updatedTime).toBe(MAESTRO_TEST_CONSTANTS.END_TIME);
+
+      // (b) original PascalCase API fields are absent
+      expect((historyItem as any).Id).toBeUndefined();
+      expect((historyItem as any).TraceId).toBeUndefined();
+      expect((historyItem as any).ParentId).toBeUndefined();
+      expect((historyItem as any).Name).toBeUndefined();
+      expect((historyItem as any).StartTime).toBeUndefined();
+      expect((historyItem as any).EndTime).toBeUndefined();
+      expect((historyItem as any).UpdatedAt).toBeUndefined();
+    });
+
     it('should only include spans matched to elementRuns', async () => {
       const instanceId = MAESTRO_TEST_CONSTANTS.INSTANCE_ID;
       const folderKey = MAESTRO_TEST_CONSTANTS.FOLDER_KEY;

--- a/tests/unit/services/maestro/process-instances.test.ts
+++ b/tests/unit/services/maestro/process-instances.test.ts
@@ -215,7 +215,7 @@ describe('ProcessInstancesService', () => {
         .mockResolvedValueOnce(createMockElementExecutionsResponse())
         .mockResolvedValueOnce([createMockTraceSpan()]);
 
-      const result = await service.getExecutionHistory(instanceId, folderKey);
+      const result = await service.getExecutionHistory(instanceId, { folderKey });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
         MAESTRO_ENDPOINTS.INSTANCES.GET_ELEMENT_EXECUTIONS(instanceId),
@@ -255,7 +255,7 @@ describe('ProcessInstancesService', () => {
         .mockResolvedValueOnce(createMockElementExecutionsResponse())
         .mockResolvedValueOnce([createMockTraceSpan(), unmatchedSpan]);
 
-      const result = await service.getExecutionHistory(instanceId, folderKey);
+      const result = await service.getExecutionHistory(instanceId, { folderKey });
 
       expect(result).toHaveLength(1);
       expect(result[0]).toHaveProperty('id', MAESTRO_TEST_CONSTANTS.SPAN_ID);
@@ -265,7 +265,7 @@ describe('ProcessInstancesService', () => {
       const error = new Error(TEST_CONSTANTS.ERROR_MESSAGE);
       mockApiClient.get.mockRejectedValue(error);
 
-      await expect(service.getExecutionHistory(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, MAESTRO_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+      await expect(service.getExecutionHistory(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, { folderKey: MAESTRO_TEST_CONSTANTS.FOLDER_KEY })).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 

--- a/tests/utils/mocks/maestro.ts
+++ b/tests/utils/mocks/maestro.ts
@@ -100,6 +100,7 @@ export const createMockExecutionHistory = (overrides: Partial<any> = {}) => {
 export const createMockElementExecutionsResponse = (overrides: Partial<any> = {}) => {
   return createMockBaseResponse({
     instanceId: MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+    traceId: MAESTRO_TEST_CONSTANTS.TRACE_ID,
     elementExecutions: [
       {
         elementId: 'Event_start',
@@ -134,7 +135,7 @@ export const createMockTraceSpan = (overrides: Partial<any> = {}) => {
     Name: MAESTRO_TEST_CONSTANTS.ACTIVITY_NAME,
     StartTime: MAESTRO_TEST_CONSTANTS.START_TIME,
     EndTime: MAESTRO_TEST_CONSTANTS.END_TIME,
-    Attributes: MAESTRO_TEST_CONSTANTS.ATTRIBUTES,
+    Attributes: JSON.stringify({ spanType: 'ElementRun', elementRunId: MAESTRO_TEST_CONSTANTS.SPAN_ID }),
     ExpiryTimeUtc: null,
     UpdatedAt: MAESTRO_TEST_CONSTANTS.END_TIME
   }, overrides);

--- a/tests/utils/mocks/maestro.ts
+++ b/tests/utils/mocks/maestro.ts
@@ -89,12 +89,54 @@ export const createMockExecutionHistory = (overrides: Partial<any> = {}) => {
     traceId: MAESTRO_TEST_CONSTANTS.TRACE_ID,
     parentId: null,
     name: MAESTRO_TEST_CONSTANTS.ACTIVITY_NAME,
-    startedTime: new Date().toISOString(),
-    endTime: new Date().toISOString(),
+    startedTime: MAESTRO_TEST_CONSTANTS.START_TIME,
+    endTime: MAESTRO_TEST_CONSTANTS.END_TIME,
     attributes: MAESTRO_TEST_CONSTANTS.ATTRIBUTES,
-    createdTime: new Date().toISOString(),
-    updatedTime: new Date().toISOString(),
+    updatedTime: MAESTRO_TEST_CONSTANTS.END_TIME,
     expiredTime: null
+  }, overrides);
+};
+
+export const createMockElementExecutionsResponse = (overrides: Partial<any> = {}) => {
+  return createMockBaseResponse({
+    instanceId: MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+    elementExecutions: [
+      {
+        elementId: 'Event_start',
+        elementType: 'StartEvent',
+        elementExtensionType: null,
+        status: 'Completed',
+        startedTimeUtc: MAESTRO_TEST_CONSTANTS.START_TIME,
+        completedTimeUtc: MAESTRO_TEST_CONSTANTS.END_TIME,
+        parentRunId: null,
+        parentElementId: null,
+        parentElementRunId: null,
+        runId: '',
+        elementRuns: [
+          {
+            elementRunId: MAESTRO_TEST_CONSTANTS.SPAN_ID,
+            status: 'Completed',
+            startedTimeUtc: MAESTRO_TEST_CONSTANTS.START_TIME,
+            completedTimeUtc: MAESTRO_TEST_CONSTANTS.END_TIME,
+            workflowId: null
+          }
+        ]
+      }
+    ]
+  }, overrides);
+};
+
+export const createMockTraceSpan = (overrides: Partial<any> = {}) => {
+  return createMockBaseResponse({
+    Id: MAESTRO_TEST_CONSTANTS.SPAN_ID,
+    TraceId: MAESTRO_TEST_CONSTANTS.TRACE_ID,
+    ParentId: null,
+    Name: MAESTRO_TEST_CONSTANTS.ACTIVITY_NAME,
+    StartTime: MAESTRO_TEST_CONSTANTS.START_TIME,
+    EndTime: MAESTRO_TEST_CONSTANTS.END_TIME,
+    Attributes: MAESTRO_TEST_CONSTANTS.ATTRIBUTES,
+    ExpiryTimeUtc: null,
+    UpdatedAt: MAESTRO_TEST_CONSTANTS.END_TIME
   }, overrides);
 };
 


### PR DESCRIPTION
## Method Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `processInstances.getExecutionHistory()` | `getExecutionHistory(instanceId: string, options: ProcessInstanceGetExecutionHistoryOptions): Promise<ProcessInstanceExecutionHistoryResponse[]>` |

## Endpoint Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `getExecutionHistory()` | GET | `pims_/api/v1/instances/{instanceId}/element-executions` | PIMS |
| `getExecutionHistory()` | GET | `llmopstenant_/api/Traces/spans?traceId={traceId}` | Traces.Api |

- `options` extends `FolderScopedOptions` (`folderKey`, `folderId`, `folderPath`) — uses `resolveFolderHeaders()` for consistent folder context resolution, matching the pattern from #386
- Both endpoints receive the same resolved folder headers
- Only span entries matched to an `elementRunId` from the element-executions response are returned — the root `ProcessRun` span (covers the whole instance, no `elementRunId`) is dropped automatically


<details>
<summary>Sample SDK response (live API)</summary>

```json
[
  {
    "id": "00000000-0000-0000-0b6a-051ca7aec9ce",
    "traceId": "910e3f56-1fbd-4947-9cee-148355c38d08",
    "parentId": "00000000-0000-0000-9b54-950bbe5a2e63",
    "name": "Start event",
    "startedTime": "2026-05-12T11:48:06.077714Z",
    "endTime": "2026-05-12T11:48:06.8733245Z",
    "attributes": "{\"spanType\":\"ElementRun\",\"status\":\"Completed\",\"elementId\":\"Event_start\",\"elementRunId\":\"88952b06-da40-4ab5-8cf3-2fecfbc53164\",\"elementType\":\"StartEvent\",\"runIndex\":1,...}",
    "updatedTime": "2026-05-12T11:48:07.1584589Z",
    "expiredTime": null
  },
  {
    "id": "00000000-0000-0000-42ef-2088c0ac72ac",
    "traceId": "910e3f56-1fbd-4947-9cee-148355c38d08",
    "parentId": "00000000-0000-0000-9b54-950bbe5a2e63",
    "name": "Activity_tblfOr",
    "startedTime": "2026-05-12T11:48:07.4381836Z",
    "endTime": "2026-05-12T11:48:07.7687194Z",
    "attributes": "{\"spanType\":\"ElementRun\",\"status\":\"Completed\",\"elementId\":\"Activity_tblfOr\",\"elementRunId\":\"c0322c6a-16fb-4232-bee2-8811445c16ca\",\"elementType\":\"Task\",\"runIndex\":1,...}",
    "updatedTime": "2026-05-12T11:48:08.2378818Z",
    "expiredTime": null
  },
  {
    "id": "00000000-0000-0000-38ec-7544ef9d965d",
    "traceId": "910e3f56-1fbd-4947-9cee-148355c38d08",
    "parentId": "00000000-0000-0000-9b54-950bbe5a2e63",
    "name": "Event_lLnUK8",
    "startedTime": "2026-05-12T11:48:08.5335271Z",
    "endTime": "2026-05-12T11:48:09.1996998Z",
    "attributes": "{\"spanType\":\"ElementRun\",\"status\":\"Completed\",\"elementId\":\"Event_lLnUK8\",\"elementRunId\":\"23f305b7-ffbf-4d0b-bba7-5fe2b4127aab\",\"elementType\":\"EndEvent\",\"runIndex\":1,...}",
    "updatedTime": "2026-05-12T11:48:09.4081965Z",
    "expiredTime": null
  }
]
```

</details>

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { ProcessInstances } from '@uipath/uipath-typescript/maestro-processes';

const sdk = new UiPath(config);
await sdk.initialize();
const processInstances = new ProcessInstances(sdk);

// By folder key
const history = await processInstances.getExecutionHistory(
  '<instanceId>',
  { folderKey: '<folderKey>' }
);

// Analyze execution timeline
history.forEach(span => {
  console.log(`Activity: ${span.name}`);
  console.log(`Start: ${span.startedTime}`);
});
```

## API Response vs SDK Response

### Composition flow

```
getExecutionHistory(instanceId, options)
  │
  ├─ resolveFolderHeaders(options) → folder headers
  │
  ├─ GET pims_/api/v1/instances/{instanceId}/element-executions
  │     → ElementExecutionsApiResponse { traceId, elementExecutions[] }
  │
  ├─ GET llmopstenant_/api/Traces/spans?traceId={traceId}
  │     → TraceSpan[] (PascalCase fields; elementRunId inside Attributes JSON)
  │
  └─ Merge: build map of Attributes.elementRunId → span
            for each elementExecution.elementRun, look up by elementRunId
            map matched spans → ProcessInstanceExecutionHistoryResponse[]
            (spans without elementRunId in Attributes dropped — e.g. root ProcessRun span)
```


Fixes https://github.com/UiPath/uipath-typescript/issues/265

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*