### PR TITLE
feat(skills): add sdk-review skill for local convention review before PR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr create:*)",
+            "command": "jq -r '.tool_input.command' | grep -q 'gh pr create' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"STOP: You must run /sdk-review before creating a PR. If sdk-review has NOT been run in this session, abort this PR creation and run /sdk-review first. Only proceed with gh pr create after the review passes.\"}}'",
+            "statusMessage": "Checking pre-PR review requirement..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/onboard-api/SKILL.md
+++ b/.claude/skills/onboard-api/SKILL.md
@@ -29,8 +29,9 @@ Single skill that handles the full onboarding lifecycle for new SDK endpoints �
 - [ ] Step 4g: Docs updated (oauth-scopes.md, pagination.md, mkdocs.yml if new service)
 - [ ] Step 5: npm run typecheck + lint + test:unit + build — ALL four pass
 - [ ] Step 6: E2E app scaffolded, tested in browser, cleaned up
-- [ ] Step 7: Cloudflare whitelist added (or explicitly noted as skipped)
-- [ ] Step 8: Committed & PR raised
+- [ ] Step 7: Convention review — sdk-review loop clean
+- [ ] Step 8: Cloudflare whitelist added (or explicitly noted as skipped)
+- [ ] Step 9: Committed & PR raised
 ```
 
 **For Composite tickets (with or without reference):**
@@ -52,13 +53,14 @@ Single skill that handles the full onboarding lifecycle for new SDK endpoints �
 - [ ] Step 4h: Docs updated (oauth-scopes.md, pagination.md, mkdocs.yml if new service)
 - [ ] Step 5: npm run typecheck + lint + test:unit + build — ALL four pass
 - [ ] Step 6: E2E app scaffolded, tested in browser, cleaned up
-- [ ] Step 7: Cloudflare whitelist for ALL internal endpoints (or explicitly noted as skipped)
-- [ ] Step 8: Committed & PR raised
+- [ ] Step 7: Convention review — sdk-review loop clean
+- [ ] Step 8: Cloudflare whitelist for ALL internal endpoints (or explicitly noted as skipped)
+- [ ] Step 9: Committed & PR raised
 ```
 
 Use the appropriate checklist based on the ticket type detected in Step 1. You may detect the type first, then create the checklist.
 
-**If a step is skipped**, mark it with a note explaining why (e.g., "Step 7: skipped — Cloudflare Workers not accessible"). Do NOT leave items unmarked.
+**If a step is skipped**, mark it with a note explaining why (e.g., "Step 8: skipped — Cloudflare Workers not accessible"). Do NOT leave items unmarked.
 
 **If a step fails**, stop and resolve before proceeding. Do NOT mark as complete and move on.
 
@@ -171,11 +173,27 @@ If `sdk-verify` reports failures:
 3. Re-invoke `sdk-verify`
 4. Repeat until all checks pass
 
-Do not proceed to Step 7-8 until verification passes.
+Do not proceed to Step 7 until verification passes.
 
 ---
 
-## Step 7-8: Ship (Cloudflare + Commit + PR)
+## Step 7: Convention Review
+
+Invoke the `sdk-review` skill. It reviews all changes on the branch against CLAUDE.md and agent_docs/ conventions, fixes critical and important issues, and re-reviews in a loop (max 3 iterations) until clean.
+
+### Fix loop
+
+If `sdk-review` reports issues it could not auto-fix:
+1. Read the remaining issues
+2. Fix them manually
+3. Re-invoke `sdk-review`
+4. Repeat until clean
+
+Do not proceed to Step 8-9 until the review is clean.
+
+---
+
+## Step 8-9: Ship (Cloudflare + Commit + PR)
 
 Invoke the `sdk-ship` skill. It handles Cloudflare whitelisting, committing, and PR creation.
 

--- a/.claude/skills/onboard-api/SKILL.md
+++ b/.claude/skills/onboard-api/SKILL.md
@@ -142,7 +142,7 @@ Without a real response, you cannot reliably decide: which fields are optional, 
 
 **If Composite:** Make the five design decisions: flow decomposition, response composition, intermediate type design, error handling strategy, and implementation pattern. **MANDATORY — Read** [`references/composite-methods.md`](references/composite-methods.md) before proceeding. Also read [`references/onboarding.md`](references/onboarding.md) for any sub-endpoints within the composite flow that need standard transform pipelines.
 
-**Do NOT load** `e2e-testing.md` or `cloudflare-whitelist.md` yet — those are for Steps 6-7.
+**Do NOT load** `e2e-testing.md` or `cloudflare-whitelist.md` yet — those are for Steps 6 and 8.
 
 ---
 

--- a/.claude/skills/sdk-review/SKILL.md
+++ b/.claude/skills/sdk-review/SKILL.md
@@ -31,24 +31,22 @@ digraph review_loop {
     "Fix critical + important" [shape=box];
     "typecheck + lint" [shape=box];
     "iteration < 3?" [shape=diamond];
-    "Files modified?" [shape=diamond];
     "Commit fixes" [shape=box];
-    "Report clean" [shape=doublecircle];
     "Report" [shape=doublecircle];
 
     "Detect changed files" -> "Run review agent";
     "Run review agent" -> "Issues found?";
-    "Issues found?" -> "Files modified?" [label="no — clean"];
+    "Issues found?" -> "Report" [label="no — clean, nothing to commit"];
     "Issues found?" -> "Fix critical + important" [label="yes"];
     "Fix critical + important" -> "typecheck + lint";
     "typecheck + lint" -> "iteration < 3?";
     "iteration < 3?" -> "Run review agent" [label="yes"];
-    "iteration < 3?" -> "Files modified?" [label="no — max reached"];
-    "Files modified?" -> "Commit fixes" [label="yes"];
-    "Files modified?" -> "Report clean" [label="no — nothing to commit"];
+    "iteration < 3?" -> "Commit fixes" [label="no — max reached"];
     "Commit fixes" -> "Report";
 }
 ```
+
+When the review finds no issues, the loop exits immediately — no commit needed. Commit only happens when fixes were made (either after a clean re-review or after max iterations).
 
 ---
 
@@ -91,19 +89,12 @@ After fixing, run `npm run typecheck` and `npm run lint`. If either fails, fix b
 
 ## Step 3: Commit
 
-After the loop ends, check if any files were actually modified during the fix iterations:
+Only reached when fixes were made. Stage and commit:
 
 ```bash
-git diff --name-only        # unstaged changes from fixes
-git diff --name-only --cached  # staged changes from fixes
+git add <fixed files>
+git commit -m "fix: address convention review comments"
 ```
-
-- **If files were modified** → stage and commit:
-  ```bash
-  git add <fixed files>
-  git commit -m "fix: address convention review comments"
-  ```
-- **If no files were modified** (review was clean from the start, or all issues were suggestions) → skip commit, nothing to do.
 
 **Do NOT push.** The user or calling skill (e.g., sdk-ship) decides when to push.
 

--- a/.claude/skills/sdk-review/SKILL.md
+++ b/.claude/skills/sdk-review/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: sdk-review
+description: Use when reviewing and fixing local code changes against CLAUDE.md and agent_docs conventions. Reviews committed, staged, and unstaged changes against main in a loop, fixes issues, and commits. Triggers on "review my changes", "fix review comments", "run code review", "sdk-review".
+---
+
+# SDK Review
+
+Review and fix all local changes (committed + staged + unstaged vs main) against project conventions. Loops up to 3 times until clean, then commits fixes.
+
+---
+
+## Detect Changes
+
+```bash
+git diff --name-only main...HEAD   # committed
+git diff --name-only --cached       # staged
+git diff --name-only                # unstaged
+```
+
+Merge all three into one deduplicated set of changed files. If empty, report "Nothing to review" and stop.
+
+---
+
+## Review-Fix Loop (max 3 iterations)
+
+```dot
+digraph review_loop {
+    "Detect changed files" [shape=box];
+    "Run review agent" [shape=box];
+    "Issues found?" [shape=diamond];
+    "Fix critical + important" [shape=box];
+    "typecheck + lint" [shape=box];
+    "iteration < 3?" [shape=diamond];
+    "Commit fixes" [shape=box];
+    "Report" [shape=doublecircle];
+
+    "Detect changed files" -> "Run review agent";
+    "Run review agent" -> "Issues found?";
+    "Issues found?" -> "Commit fixes" [label="no — clean"];
+    "Issues found?" -> "Fix critical + important" [label="yes"];
+    "Fix critical + important" -> "typecheck + lint";
+    "typecheck + lint" -> "iteration < 3?";
+    "iteration < 3?" -> "Run review agent" [label="yes"];
+    "iteration < 3?" -> "Commit fixes" [label="no — max reached"];
+    "Commit fixes" -> "Report";
+}
+```
+
+---
+
+## Step 1: Review
+
+Launch an agent to review all changed files against project conventions. The agent must:
+
+1. **Read conventions** — CLAUDE.md, Agents.md, agent_docs/architecture.md, agent_docs/conventions.md, agent_docs/rules.md
+2. **Get the full diff** — combine `git diff main...HEAD`, `git diff --cached`, and `git diff`
+3. **Read each changed file in full** for context beyond the diff
+4. **Review against conventions**, including:
+   - Type naming (Response, Options, Raw types)
+   - Service conventions (BaseService, `@track`, constructor JSDoc)
+   - Endpoint constants (`as const`, parameterized functions, grouping)
+   - Export conventions (barrel exports, subpath exports)
+   - Test conventions (Arrange-Act-Assert, constants, mock factories, error scenarios)
+   - Transform pipeline correctness
+   - JSDoc quality (ServiceModel, `@example`, `@param`, `@returns`, synced with service class)
+   - Code hygiene (no unused code, no `any`, no `as unknown as`)
+   - Pagination and documentation updates
+5. **Classify** each issue as **Critical**, **Important**, or **Suggestion**
+6. **Return** file path, line number, violated rule (cite agent_docs), and recommended fix
+
+---
+
+## Step 2: Fix
+
+Fix issues in priority order:
+
+1. **Critical** — convention violations, bugs, missing required elements
+2. **Important** — quality concerns, sync issues, redundant code
+
+**Do NOT fix:**
+- **Suggestions** — report to user (may involve design decisions)
+- **Issues in files not changed on this branch** — pre-existing, out of scope
+
+After fixing, run `npm run typecheck` and `npm run lint`. If either fails, fix before next iteration.
+
+---
+
+## Step 3: Commit
+
+After the loop ends (clean or max iterations reached), if any files were modified:
+
+```bash
+git add <fixed files>
+git commit -m "fix: address convention review comments"
+```
+
+**Do NOT push.** The user or calling skill (e.g., sdk-ship) decides when to push.
+
+---
+
+## Step 4: Report
+
+```markdown
+## SDK Review Summary
+
+**Iterations:** X/3
+**Status:** Clean | X issues remaining
+
+### Fixed (Y items)
+- [file:line] Brief description
+
+### Remaining (if any)
+- [file:line] Brief description — why not auto-fixed
+
+### Suggestions (not auto-fixed)
+- [file:line] Brief description — user decision needed
+```

--- a/.claude/skills/sdk-review/SKILL.md
+++ b/.claude/skills/sdk-review/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: sdk-review
-description: Use when reviewing and fixing local code changes against CLAUDE.md and agent_docs conventions. Reviews committed, staged, and unstaged changes against main in a loop, fixes issues, and commits. Triggers on "review my changes", "fix review comments", "run code review", "sdk-review".
+description: Use when local changes need convention compliance checking before committing or raising a PR. Also use after receiving PR review comments to fix them locally. Triggers on "review my changes", "fix review comments", "run code review", "sdk-review", "check conventions".
 ---
 
 # SDK Review
 
-Review and fix all local changes (committed + staged + unstaged vs main) against project conventions. Loops up to 3 times until clean, then commits fixes.
+Review and fix local changes (committed + staged + unstaged vs main) against project conventions in a loop until clean.
+
+**Core principle:** The review agent reads CLAUDE.md/agent_docs — don't re-teach conventions here. This skill's value is the loop mechanics, prioritization rules, and expert knowledge about what review agents get wrong.
 
 ---
 
@@ -17,7 +19,7 @@ git diff --name-only --cached       # staged
 git diff --name-only                # unstaged
 ```
 
-Merge all three into one deduplicated set of changed files. If empty, report "Nothing to review" and stop.
+Merge into one deduplicated set. If empty, report "Nothing to review" and stop.
 
 ---
 
@@ -25,65 +27,70 @@ Merge all three into one deduplicated set of changed files. If empty, report "No
 
 ```dot
 digraph review_loop {
-    "Detect changed files" [shape=box];
     "Run review agent" [shape=box];
     "Issues found?" [shape=diamond];
     "Fix critical + important" [shape=box];
-    "typecheck + lint" [shape=box];
+    "typecheck + lint pass?" [shape=diamond];
+    "Fix build errors" [shape=box];
     "iteration < 3?" [shape=diamond];
     "Commit fixes" [shape=box];
     "Report" [shape=doublecircle];
 
-    "Detect changed files" -> "Run review agent";
     "Run review agent" -> "Issues found?";
-    "Issues found?" -> "Report" [label="no — clean, nothing to commit"];
+    "Issues found?" -> "Report" [label="no — clean"];
     "Issues found?" -> "Fix critical + important" [label="yes"];
-    "Fix critical + important" -> "typecheck + lint";
-    "typecheck + lint" -> "iteration < 3?";
+    "Fix critical + important" -> "typecheck + lint pass?";
+    "typecheck + lint pass?" -> "iteration < 3?" [label="yes"];
+    "typecheck + lint pass?" -> "Fix build errors" [label="no"];
+    "Fix build errors" -> "iteration < 3?";
     "iteration < 3?" -> "Run review agent" [label="yes"];
     "iteration < 3?" -> "Commit fixes" [label="no — max reached"];
     "Commit fixes" -> "Report";
 }
 ```
 
-When the review finds no issues, the loop exits immediately — no commit needed. Commit only happens when fixes were made (either after a clean re-review or after max iterations).
-
 ---
 
 ## Step 1: Review
 
-Launch an agent to review all changed files against project conventions. The agent must:
+Launch an agent that reads CLAUDE.md (which loads Agents.md and agent_docs/ via `@` references), gets the full diff (`git diff main...HEAD` + `git diff --cached` + `git diff`), reads each changed file in full, and returns a structured report classifying issues as **Critical**, **Important**, or **Suggestion** with file:line, violated rule, and recommended fix.
 
-1. **Read conventions** — CLAUDE.md, Agents.md, agent_docs/architecture.md, agent_docs/conventions.md, agent_docs/rules.md
-2. **Get the full diff** — combine `git diff main...HEAD`, `git diff --cached`, and `git diff`
-3. **Read each changed file in full** for context beyond the diff
-4. **Review against conventions**, including:
-   - Type naming (Response, Options, Raw types)
-   - Service conventions (BaseService, `@track`, constructor JSDoc)
-   - Endpoint constants (`as const`, parameterized functions, grouping)
-   - Export conventions (barrel exports, subpath exports)
-   - Test conventions (Arrange-Act-Assert, constants, mock factories, error scenarios)
-   - Transform pipeline correctness
-   - JSDoc quality (ServiceModel, `@example`, `@param`, `@returns`, synced with service class)
-   - Code hygiene (no unused code, no `any`, no `as unknown as`)
-   - Pagination and documentation updates
-5. **Classify** each issue as **Critical**, **Important**, or **Suggestion**
-6. **Return** file path, line number, violated rule (cite agent_docs), and recommended fix
+### Review agent calibration — what agents get wrong in this codebase
+
+The conventions in agent_docs are comprehensive, but review agents consistently misjudge these areas:
+
+**Over-reported (false positives to ignore):**
+- JSDoc style preferences on existing methods not touched in the diff
+- Suggesting `interface extends` when `type` intersection is the correct pattern per conventions.md
+- Flagging `param || {}` on genuinely optional parameters (only flag on required params)
+- Reporting missing tests for private helper methods — only public methods need tests
+- Flagging field map entries that look like "case-only" renames but are actually semantic renames
+
+**Under-reported (agents miss these — explicitly check):**
+- `@track` decorator missing on new public methods — agents skip this 50% of the time
+- JSDoc on ServiceModel not synced with service class implementation
+- `export type * from` in barrel files instead of `export * from` (drops runtime values silently)
+- Mock factories typed as `{Entity}GetResponse` instead of `Raw{Entity}GetResponse`
+- Missing `docs/oauth-scopes.md` entry for new methods
+
+**Ambiguous (ask user, don't auto-fix):**
+- Whether a new method should have bound methods (depends on entity lifecycle)
+- Endpoint grouping structure for new API domains
+- Whether a field is optional or required in the response type (needs live API check)
 
 ---
 
 ## Step 2: Fix
 
-Fix issues in priority order:
+Fix in priority order: **Critical** first, then **Important**.
 
-1. **Critical** — convention violations, bugs, missing required elements
-2. **Important** — quality concerns, sync issues, redundant code
+**NEVER fix:**
+- **Suggestions** — report to user, may involve design decisions
+- **Files not in the diff** — pre-existing issues are out of scope
+- **Public API type signatures** — changing return types or parameter types can break consumers; report instead
+- **Test assertions** — changing what tests assert can mask real failures; report instead
 
-**Do NOT fix:**
-- **Suggestions** — report to user (may involve design decisions)
-- **Issues in files not changed on this branch** — pre-existing, out of scope
-
-After fixing, run `npm run typecheck` and `npm run lint`. If either fails, fix before next iteration.
+After fixing, run `npm run typecheck` and `npm run lint`. If either fails, fix the build error before the next review iteration. If a build error persists after 2 attempts, stop and report it — don't loop on the same failure.
 
 ---
 
@@ -96,7 +103,7 @@ git add <fixed files>
 git commit -m "fix: address convention review comments"
 ```
 
-**Do NOT push.** The user or calling skill (e.g., sdk-ship) decides when to push.
+**Do NOT push.** The user or calling skill (sdk-ship) decides when to push.
 
 ---
 
@@ -117,3 +124,14 @@ git commit -m "fix: address convention review comments"
 ### Suggestions (not auto-fixed)
 - [file:line] Brief description — user decision needed
 ```
+
+---
+
+## NEVER
+
+- **NEVER review files not in the diff** — pre-existing issues are not this skill's job
+- **NEVER fix and re-review in the same iteration** — fix first, THEN re-run the review agent fresh
+- **NEVER auto-fix the same issue differently across iterations** — if iteration 1 fixed X one way and iteration 2 flags X again, stop and report; don't oscillate
+- **NEVER suppress typecheck/lint failures** — if a fix breaks the build, the fix is wrong
+- **NEVER commit if no files were modified** — if review is clean from the start, skip commit entirely
+- **NEVER continue past 3 iterations** — if issues remain, report them; infinite loops waste tokens and patience

--- a/.claude/skills/sdk-review/SKILL.md
+++ b/.claude/skills/sdk-review/SKILL.md
@@ -31,17 +31,21 @@ digraph review_loop {
     "Fix critical + important" [shape=box];
     "typecheck + lint" [shape=box];
     "iteration < 3?" [shape=diamond];
+    "Files modified?" [shape=diamond];
     "Commit fixes" [shape=box];
+    "Report clean" [shape=doublecircle];
     "Report" [shape=doublecircle];
 
     "Detect changed files" -> "Run review agent";
     "Run review agent" -> "Issues found?";
-    "Issues found?" -> "Commit fixes" [label="no — clean"];
+    "Issues found?" -> "Files modified?" [label="no — clean"];
     "Issues found?" -> "Fix critical + important" [label="yes"];
     "Fix critical + important" -> "typecheck + lint";
     "typecheck + lint" -> "iteration < 3?";
     "iteration < 3?" -> "Run review agent" [label="yes"];
-    "iteration < 3?" -> "Commit fixes" [label="no — max reached"];
+    "iteration < 3?" -> "Files modified?" [label="no — max reached"];
+    "Files modified?" -> "Commit fixes" [label="yes"];
+    "Files modified?" -> "Report clean" [label="no — nothing to commit"];
     "Commit fixes" -> "Report";
 }
 ```
@@ -87,12 +91,19 @@ After fixing, run `npm run typecheck` and `npm run lint`. If either fails, fix b
 
 ## Step 3: Commit
 
-After the loop ends (clean or max iterations reached), if any files were modified:
+After the loop ends, check if any files were actually modified during the fix iterations:
 
 ```bash
-git add <fixed files>
-git commit -m "fix: address convention review comments"
+git diff --name-only        # unstaged changes from fixes
+git diff --name-only --cached  # staged changes from fixes
 ```
+
+- **If files were modified** → stage and commit:
+  ```bash
+  git add <fixed files>
+  git commit -m "fix: address convention review comments"
+  ```
+- **If no files were modified** (review was clean from the start, or all issues were suggestions) → skip commit, nothing to do.
 
 **Do NOT push.** The user or calling skill (e.g., sdk-ship) decides when to push.
 

--- a/.claude/skills/sdk-review/SKILL.md
+++ b/.claude/skills/sdk-review/SKILL.md
@@ -30,21 +30,24 @@ digraph review_loop {
     "Run review agent" [shape=box];
     "Issues found?" [shape=diamond];
     "Fix critical + important" [shape=box];
-    "typecheck + lint pass?" [shape=diamond];
+    "typecheck + lint + test pass?" [shape=diamond];
     "Fix build errors" [shape=box];
     "iteration < 3?" [shape=diamond];
+    "Fixes made in any iteration?" [shape=diamond];
     "Commit fixes" [shape=box];
     "Report" [shape=doublecircle];
 
     "Run review agent" -> "Issues found?";
-    "Issues found?" -> "Report" [label="no — clean"];
+    "Issues found?" -> "Fixes made in any iteration?" [label="no — clean"];
     "Issues found?" -> "Fix critical + important" [label="yes"];
-    "Fix critical + important" -> "typecheck + lint pass?";
-    "typecheck + lint pass?" -> "iteration < 3?" [label="yes"];
-    "typecheck + lint pass?" -> "Fix build errors" [label="no"];
+    "Fix critical + important" -> "typecheck + lint + test pass?";
+    "typecheck + lint + test pass?" -> "iteration < 3?" [label="yes"];
+    "typecheck + lint + test pass?" -> "Fix build errors" [label="no"];
     "Fix build errors" -> "iteration < 3?";
     "iteration < 3?" -> "Run review agent" [label="yes"];
     "iteration < 3?" -> "Commit fixes" [label="no — max reached"];
+    "Fixes made in any iteration?" -> "Commit fixes" [label="yes"];
+    "Fixes made in any iteration?" -> "Report" [label="no — nothing to commit"];
     "Commit fixes" -> "Report";
 }
 ```
@@ -92,7 +95,7 @@ Fix in priority order: **Critical** first, then **Important**.
 - **Public API type signatures** — changing return types or parameter types can break consumers; report instead
 - **Test assertions** — changing what tests assert can mask real failures; report instead
 
-After fixing, run `npm run typecheck` and `npm run lint`. If either fails, fix the build error before the next review iteration. If a build error persists after 2 attempts, stop and report it — don't loop on the same failure.
+After fixing, run `npm run typecheck`, `npm run lint`, and `npm run test:unit`. If any fail, fix the error before the next review iteration. If an error persists after 2 attempts, stop and report it — don't loop on the same failure.
 
 ---
 
@@ -134,6 +137,6 @@ git commit -m "fix: address convention review comments"
 - **NEVER review files not in the diff** — pre-existing issues are not this skill's job
 - **NEVER fix and re-review in the same iteration** — fix first, THEN re-run the review agent fresh
 - **NEVER auto-fix the same issue differently across iterations** — if iteration 1 fixed X one way and iteration 2 flags X again, stop and report; don't oscillate
-- **NEVER suppress typecheck/lint failures** — if a fix breaks the build, the fix is wrong
-- **NEVER commit if no files were modified** — if review is clean from the start, skip commit entirely
+- **NEVER suppress typecheck/lint/test failures** — if a fix breaks the build or tests, the fix is wrong
+- **NEVER commit if no files were modified** — if review is clean and no fixes were made in any iteration, skip commit entirely
 - **NEVER continue past 3 iterations** — if issues remain, report them; infinite loops waste tokens and patience

--- a/.claude/skills/sdk-review/SKILL.md
+++ b/.claude/skills/sdk-review/SKILL.md
@@ -53,7 +53,9 @@ digraph review_loop {
 
 ## Step 1: Review
 
-Launch an agent that reads CLAUDE.md (which loads Agents.md and agent_docs/ via `@` references), gets the full diff (`git diff main...HEAD` + `git diff --cached` + `git diff`), reads each changed file in full, and returns a structured report classifying issues as **Critical**, **Important**, or **Suggestion** with file:line, violated rule, and recommended fix.
+Launch an agent that reads CLAUDE.md (which loads Agents.md and agent_docs/ via `@` references), gets the full diff (`git diff main...HEAD` + `git diff --cached` + `git diff`), and returns a structured report classifying issues as **Critical**, **Important**, or **Suggestion** with file:line, violated rule, and recommended fix.
+
+**Review scope: diff lines only.** Read full files for context (imports, class structure, surrounding code) but ONLY flag issues on lines that appear in the diff. Pre-existing issues on unchanged lines are out of scope — even if they violate conventions.
 
 ### Review agent calibration — what agents get wrong in this codebase
 


### PR DESCRIPTION
## Summary

- Adds `sdk-review` skill that reviews local changes against CLAUDE.md/agent_docs conventions **before code reaches a PR**, reducing Claude Code Review noise on ready PRs
- Reviews committed + staged + unstaged changes in a loop (max 3 iterations), fixes critical and important issues, commits fixes locally
- Includes expert calibration for this codebase: known false positives to ignore, under-reported issues agents miss, ambiguous cases to escalate
- Updates `onboard-api` skill to run sdk-review as Step 7 (after verify, before ship)

## Motivation

Claude Code Review workflow comments on every PR push. Many comments are convention violations that could be caught and fixed locally before the PR is even raised. This skill shifts review feedback left — catch issues during development, not during review.

## Usage

- **Standalone:** `/sdk-review` on any feature branch
- **onboard-api flow:** runs automatically as Step 7 (verify → review → ship)
- **After PR feedback:** checkout branch, run `/sdk-review`, push when ready

## Files

| File | Change |
|------|--------|
| `.claude/skills/sdk-review/SKILL.md` | New skill |
| `.claude/skills/onboard-api/SKILL.md` | Added Step 7 (convention review), renumbered Steps 8-9 |