### PR TITLE
fix(docs): render deprecated strikethrough in API docs [PLT-100326]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
+  - pymdownx.tilde
   - pymdownx.inlinehilite
   - pymdownx.magiclink
   - pymdownx.snippets


### PR DESCRIPTION
## Summary
- Deprecated members on the API docs site (e.g., `/api/classes/UiPath/`) were showing literal `~~text~~` instead of rendered ~~strikethrough~~
- TypeDoc's markdown plugin wraps `@deprecated` members in `~~tildes~~`, but MkDocs was missing the `pymdownx.tilde` extension to parse them
- Added `pymdownx.tilde` to `mkdocs.yml` so the strikethrough renders correctly

## Test plan
- [ ] Run `npm run docs:api` and `mkdocs serve` locally
- [ ] Verify `/api/classes/UiPath/` shows proper strikethrough on deprecated members instead of raw `~~` characters