### PR TITLE
[PLT-103926] feat(processes): support folderKey/folderPath in start()

### DIFF
--- a/src/models/orchestrator/processes.models.ts
+++ b/src/models/orchestrator/processes.models.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from '../common/types';
-import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions, ProcessGetByNameOptions } from './processes.types';
+import { ProcessGetAllOptions, ProcessGetResponse, ProcessStartRequest, ProcessStartResponse, ProcessGetByIdOptions, ProcessGetByNameOptions, ProcessStartOptions } from './processes.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -104,25 +104,44 @@ export interface ProcessServiceModel {
   getByName(name: string, options?: ProcessGetByNameOptions): Promise<ProcessGetResponse>;
 
   /**
-   * Starts a process with the specified configuration
+   * Starts a process with the specified configuration.
+   *
+   * Folder context can be supplied as `folderId`, `folderKey`, or `folderPath`
+   * inside the options.
    *
    * @param request - Process start configuration
-   * @param folderId - Required folder ID
-   * @param options - Optional request options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional query parameters (`expand`, `select`, `filter`, `orderby`)
    * @returns Promise resolving to array of started process instances
    * {@link ProcessStartResponse}
    * @example
    * ```typescript
-   * // Start a process by process key
-   * const result = await processes.start({
-   *   processKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-   * }, <folderId>); // folderId is required
+   * // By folder ID
+   * await processes.start({ processKey: '<processKey>' }, { folderId: <folderId> });
    *
-   * // Start a process by name with specific robots
-   * const result = await processes.start({
-   *   processName: "MyProcess"
-   * }, <folderId>); // folderId is required
+   * // By folder key (GUID)
+   * await processes.start({ processKey: '<processKey>' }, { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await processes.start({ processKey: '<processKey>' }, { folderPath: 'Shared/Finance' });
+   *
+   * // Start by process name (instead of processKey)
+   * await processes.start({ processName: 'MyProcess' }, { folderId: <folderId> });
+   *
+   * // With additional options
+   * await processes.start({ processKey: '<processKey>' }, { folderId: <folderId>, expand: 'Robot' });
    * ```
+   */
+  start(request: ProcessStartRequest, options?: ProcessStartOptions): Promise<ProcessStartResponse[]>;
+  /**
+   * Starts a process — positional `folderId` form.
+   *
+   * @deprecated Use the options-object form: `start(request, { folderId })`. See {@link ProcessStartOptions} for the supported options.
+   *
+   * @param request - Process start configuration
+   * @param folderId - Required folder ID (numeric)
+   * @param options - Optional request options
+   * @returns Promise resolving to array of started process instances
+   * {@link ProcessStartResponse}
    */
   start(request: ProcessStartRequest, folderId: number, options?: RequestOptions): Promise<ProcessStartResponse[]>;
 }

--- a/src/models/orchestrator/processes.types.ts
+++ b/src/models/orchestrator/processes.types.ts
@@ -386,3 +386,14 @@ export interface ProcessGetByIdOptions extends BaseOptions {}
  */
 export interface ProcessGetByNameOptions extends FolderScopedOptions {}
 
+/**
+ * Options for starting a process. Combines folder scoping
+ * (`folderId` / `folderKey` / `folderPath`) with the OData query options
+ * (`expand`, `select`, `filter`, `orderby`) accepted by the start endpoint.
+ *
+ * Folder scoping is optional in the type — the SDK falls back to the
+ * init-time folderKey (e.g. `<meta name="uipath:folder-key">` in coded-app
+ * deployments). A `ValidationError` is raised when neither is provided.
+ */
+export interface ProcessStartOptions extends FolderScopedOptions, RequestOptions {}
+

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -7,6 +7,7 @@ import {
   ProcessStartResponse,
   ProcessGetByIdOptions,
   ProcessGetByNameOptions,
+  ProcessStartOptions,
 } from '../../../models/orchestrator/processes.types';
 import { ProcessServiceModel } from '../../../models/orchestrator/processes.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest } from '../../../utils/transform';
@@ -19,6 +20,7 @@ import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '.
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
 import { track } from '../../../core/telemetry';
+import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
 
 /**
  * Service for interacting with UiPath Orchestrator Processes API
@@ -99,12 +101,15 @@ export class ProcessService extends FolderScopedService implements ProcessServic
   }
 
   /**
-   * Starts a process execution (job)
+   * Starts a process with the specified configuration.
    *
-   * @param request - Process start request body
-   * @param folderId - Required folder ID
-   * @param options - Optional query parameters
-   * @returns Promise resolving to the created jobs
+   * Folder context can be supplied as `folderId`, `folderKey`, or `folderPath`
+   * inside the options.
+   *
+   * @param request - Process start configuration
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional query parameters (`expand`, `select`, `filter`, `orderby`)
+   * @returns Promise resolving to array of started process instances
+   * {@link ProcessStartResponse}
    *
    * @example
    * ```typescript
@@ -112,20 +117,67 @@ export class ProcessService extends FolderScopedService implements ProcessServic
    *
    * const processes = new Processes(sdk);
    *
-   * // Start a process by process key
-   * const jobs = await processes.start({
-   *   processKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-   * }, 123); // folderId is required
+   * // By folder ID
+   * await processes.start({ processKey: '<processKey>' }, { folderId: <folderId> });
    *
-   * // Start a process by name with specific robots
-   * const jobs = await processes.start({
-   *   processName: "MyProcess"
-   * }, 123); // folderId is required
+   * // By folder key (GUID)
+   * await processes.start({ processKey: '<processKey>' }, { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+   *
+   * // By folder path
+   * await processes.start({ processKey: '<processKey>' }, { folderPath: 'Shared/Finance' });
+   *
+   * // Start by process name (instead of processKey)
+   * await processes.start({ processName: 'MyProcess' }, { folderId: <folderId> });
+   *
+   * // With additional options
+   * await processes.start({ processKey: '<processKey>' }, { folderId: <folderId>, expand: 'Robot' });
    * ```
    */
+  start(request: ProcessStartRequest, options?: ProcessStartOptions): Promise<ProcessStartResponse[]>;
+  /**
+   * Starts a process — positional `folderId` form.
+   *
+   * @deprecated Use the options-object form: `start(request, { folderId })`. See {@link ProcessStartOptions} for the supported options.
+   *
+   * @param request - Process start configuration
+   * @param folderId - Required folder ID (numeric)
+   * @param options - Optional request options
+   * @returns Promise resolving to array of started process instances
+   * {@link ProcessStartResponse}
+   */
+  start(request: ProcessStartRequest, folderId: number, options?: RequestOptions): Promise<ProcessStartResponse[]>;
   @track('Processes.Start')
-  async start(request: ProcessStartRequest, folderId: number, options: RequestOptions = {}): Promise<ProcessStartResponse[]> {
-    const headers = createHeaders({ [FOLDER_ID]: folderId });
+  async start(
+    request: ProcessStartRequest,
+    optionsOrFolderId?: ProcessStartOptions | number,
+    legacyOptions?: RequestOptions,
+  ): Promise<ProcessStartResponse[]> {
+    // Normalize the two overload forms into a single internal shape.
+    let folderId: number | undefined;
+    let folderKey: string | undefined;
+    let folderPath: string | undefined;
+    let queryOptions: RequestOptions;
+
+    if (typeof optionsOrFolderId === 'number') {
+      // Deprecated positional form: start(request, folderId, options?)
+      folderId = optionsOrFolderId;
+      queryOptions = legacyOptions ?? {};
+    } else {
+      // Preferred form: start(request, options?)
+      const { folderId: fid, folderKey: fkey, folderPath: fpath, ...rest } = optionsOrFolderId ?? {};
+      folderId = fid;
+      folderKey = fkey;
+      folderPath = fpath;
+      queryOptions = rest;
+    }
+
+    const headers = resolveFolderHeaders({
+      folderId,
+      folderKey,
+      folderPath,
+      resourceType: 'processes.start',
+      fallbackFolderKey: this.config.folderKey,
+    });
 
     // Transform SDK field names to API field names (e.g., processKey → releaseKey)
     const apiRequest = transformRequest(request, ProcessMap);
@@ -136,8 +188,8 @@ export class ProcessService extends FolderScopedService implements ProcessServic
     };
 
     // Prefix all query parameter keys with '$' for OData
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
+    const keysToPrefix = Object.keys(queryOptions);
+    const apiOptions = addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix);
 
     const response = await this.post<CollectionResponse<ProcessStartResponse>>(
       PROCESS_ENDPOINTS.START_PROCESS,

--- a/tests/integration/shared/orchestrator/processes.integration.test.ts
+++ b/tests/integration/shared/orchestrator/processes.integration.test.ts
@@ -138,6 +138,25 @@ describe.each(modes)('Orchestrator Processes - Integration Tests [%s]', (mode) =
         expect(result[0].id).toBeDefined();
       }
     });
+
+    it('should start a process using the options-object form with folderKey', async () => {
+      const { processes } = getServices();
+      const config = getTestConfig();
+
+      expect(config.orchestratorTestProcessKey, 'ORCHESTRATOR_TEST_PROCESS_KEY must be configured').toBeDefined();
+      expect(config.folderKey, 'INTEGRATION_TEST_FOLDER_KEY must be configured').toBeDefined();
+
+      const result = await processes.start(
+        { processKey: config.orchestratorTestProcessKey! },
+        { folderKey: config.folderKey },
+      );
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      if (result.length > 0) {
+        expect(result[0].id).toBeDefined();
+      }
+    });
   });
 
   describe('getByName', () => {

--- a/tests/unit/services/orchestrator/processes.test.ts
+++ b/tests/unit/services/orchestrator/processes.test.ts
@@ -342,6 +342,95 @@ describe('ProcessService Unit Tests', () => {
       await expect(service.start(request, TEST_CONSTANTS.FOLDER_ID))
         .rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
+
+    it('should accept the new options-object form with folderId', async () => {
+      const mockResponse = createMockProcessStartApiResponse([createMockProcessStartResponse()]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await service.start(request, { folderId: TEST_CONSTANTS.FOLDER_ID });
+
+      const [, , requestSpec] = mockApiClient.post.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+      });
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should route folderKey from the options object to X-UIPATH-FolderKey', async () => {
+      const mockResponse = createMockProcessStartApiResponse([createMockProcessStartResponse()]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await service.start(request, { folderKey: PROCESS_TEST_CONSTANTS.FOLDER_KEY });
+
+      const [, , requestSpec] = mockApiClient.post.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_KEY]: PROCESS_TEST_CONSTANTS.FOLDER_KEY,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+    });
+
+    it('should route folderPath from the options object to X-UIPATH-FolderPath-Encoded', async () => {
+      const mockResponse = createMockProcessStartApiResponse([createMockProcessStartResponse()]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await service.start(request, { folderPath: PROCESS_TEST_CONSTANTS.FOLDER_PATH_WITH_SPACE });
+
+      const [, , requestSpec] = mockApiClient.post.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_PATH_ENCODED]: PROCESS_TEST_CONSTANTS.FOLDER_PATH_WITH_SPACE_ENCODED,
+      });
+      expect(requestSpec.headers[FOLDER_ID]).toBeUndefined();
+      expect(requestSpec.headers[FOLDER_KEY]).toBeUndefined();
+    });
+
+    it('should pass OData query options when using the new options-object form', async () => {
+      const mockResponse = createMockProcessStartApiResponse([createMockProcessStartResponse()]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await service.start(request, {
+        folderId: TEST_CONSTANTS.FOLDER_ID,
+        expand: PROCESS_TEST_CONSTANTS.EXPAND_ROBOT,
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.START_PROCESS,
+        expect.any(Object),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$expand': PROCESS_TEST_CONSTANTS.EXPAND_ROBOT,
+          }),
+        }),
+      );
+    });
+
+    it('should fall back to the SDK init-time folderKey when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: PROCESS_TEST_CONSTANTS.FOLDER_KEY });
+      vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
+      const scopedService = new ProcessService(instance);
+
+      const mockResponse = createMockProcessStartApiResponse([createMockProcessStartResponse()]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await scopedService.start(request);
+
+      const [, , requestSpec] = mockApiClient.post.mock.calls[0];
+      expect(requestSpec.headers).toMatchObject({
+        [FOLDER_KEY]: PROCESS_TEST_CONSTANTS.FOLDER_KEY,
+      });
+    });
+
+    it('should throw ValidationError when no folder context can be resolved', async () => {
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await expect(service.start(request)).rejects.toBeInstanceOf(ValidationError);
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
   });
 
   describe('getByName', () => {


### PR DESCRIPTION
## Summary
- Adds an options-object overload to [`processes.start()`](src/services/orchestrator/processes/processes.ts) so callers can supply `folderKey` or `folderPath` in addition to the existing numeric `folderId`
- New form reuses `resolveFolderHeaders` for header routing, falls back to the init-time folderKey (e.g. `uipath:folder-key` meta tag) when nothing is supplied, and throws `ValidationError` if no context resolves
- Existing positional form `start(req, folderId, options?)` retained and marked `@deprecated` — zero breaking changes for v1.x consumers
- Implements the design agreed in [Confluence: Support folderKey/Path in existing methods](https://uipath.atlassian.net/wiki/spaces/CLD/pages/90651034942/Support+folderKey+Path+in+existing+methods)

## API shape
```ts
// Preferred — matches getByName style
start(request, options?: ProcessStartOptions): Promise<ProcessStartResponse[]>;

/** @deprecated Use the options-object form: start(request, { folderId }) */
start(request, folderId: number, options?: RequestOptions): Promise<ProcessStartResponse[]>;
```

`ProcessStartOptions extends FolderScopedOptions, RequestOptions` (folderId/folderKey/folderPath + expand/select/filter/orderby).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — 1533 passing (existing positional-form tests preserved as backward-compat coverage; 6 new tests cover folderId/folderKey/folderPath options form, OData query options, init-fallback, and ValidationError)
- [x] `npm run build` — produces dist/ output
- [ ] Integration test added in `tests/integration/shared/orchestrator/processes.integration.test.ts` — requires `INTEGRATION_TEST_FOLDER_KEY` + `ORCHESTRATOR_TEST_PROCESS_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)