### PR TITLE
test(data-fabric): re-enable downloadAttachment integration tests

### DIFF
--- a/tests/integration/shared/data-fabric/attachment.integration.test.ts
+++ b/tests/integration/shared/data-fabric/attachment.integration.test.ts
@@ -133,8 +133,7 @@ describe.skipIf(!hasAttachmentConfig).each(modes)(
       });
     });
 
-    // TODO: skipped due to API bug returning 500 on download — re-enable once fixed
-    describe.skip('downloadAttachment', () => {
+    describe('downloadAttachment', () => {
       it('should upload and then download an attachment via service method', async () => {
         const { entities } = getServices();
 


### PR DESCRIPTION
## Summary

- Re-enables `downloadAttachment` integration tests that were skipped due to an API bug returning HTTP 500 on attachment download
- API bug is now fixed — tests are safe to run again

## Files

| Area | Files |
|------|-------|
| Integration tests | `tests/integration/shared/data-fabric/attachment.integration.test.ts` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)