### PR TITLE
feat(datafabric): add CRUD methods for choice sets and choice values

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -64,6 +64,9 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `DataFabric.Schema.Read` |
 | `getById()` | `DataFabric.Data.Read` |
+| `insertValueById()` | `DataFabric.Data.Write` |
+| `updateValueById()` | `DataFabric.Data.Write` |
+| `deleteValuesById()` | `DataFabric.Data.Write` |
 
 ## Maestro Processes
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -64,9 +64,6 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `DataFabric.Schema.Read` |
 | `getById()` | `DataFabric.Data.Read` |
-| `insertValueById()` | `DataFabric.Schema.Write` |
-| `updateValueById()` | `DataFabric.Schema.Write` |
-| `deleteValuesById()` | `DataFabric.Schema.Write` |
 
 ## Maestro Processes
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -64,9 +64,9 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 |--------|-------------|
 | `getAll()` | `DataFabric.Schema.Read` |
 | `getById()` | `DataFabric.Data.Read` |
-| `insertValueById()` | `DataFabric.Data.Write` |
-| `updateValueById()` | `DataFabric.Data.Write` |
-| `deleteValuesById()` | `DataFabric.Data.Write` |
+| `insertValueById()` | `DataFabric.Schema.Write` |
+| `updateValueById()` | `DataFabric.Schema.Write` |
+| `deleteValuesById()` | `DataFabric.Schema.Write` |
 
 ## Maestro Processes
 

--- a/src/models/data-fabric/choicesets.models.ts
+++ b/src/models/data-fabric/choicesets.models.ts
@@ -186,6 +186,7 @@ export interface ChoiceSetServiceModel {
    * });
    * console.log(inserted.id);
    * ```
+   * @internal
    */
   insertValueById(
     choiceSetId: string,
@@ -214,6 +215,7 @@ export interface ChoiceSetServiceModel {
    *
    * await choicesets.updateValueById(expenseTypes.id, travel.id, 'Business Travel');
    * ```
+   * @internal
    */
   updateValueById(
     choiceSetId: string,
@@ -236,6 +238,7 @@ export interface ChoiceSetServiceModel {
    *
    * await choicesets.deleteValuesById('<choiceSetId>', idsToDelete);
    * ```
+   * @internal
    */
   deleteValuesById(choiceSetId: string, valueIds: string[]): Promise<void>;
 }

--- a/src/models/data-fabric/choicesets.models.ts
+++ b/src/models/data-fabric/choicesets.models.ts
@@ -1,7 +1,12 @@
 import {
   ChoiceSetGetAllResponse,
   ChoiceSetGetResponse,
-  ChoiceSetGetByIdOptions
+  ChoiceSetGetByIdOptions,
+  ChoiceSetCreateOptions,
+  ChoiceSetUpdateOptions,
+  ChoiceSetValueInsertOptions,
+  ChoiceSetValueInsertResponse,
+  ChoiceSetValueUpdateResponse
 } from './choicesets.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination/types';
 
@@ -94,5 +99,144 @@ export interface ChoiceSetServiceModel {
       ? PaginatedResponse<ChoiceSetGetResponse>
       : NonPaginatedResponse<ChoiceSetGetResponse>
   >;
+
+  /**
+   * Creates a new Data Fabric choice set
+   *
+   * @param name - Choice set name. Server-enforced rules: must start with a
+   *   letter, may contain only letters, numbers, and underscores, length
+   *   3–100 characters (e.g., `"expenseTypes"`).
+   * @param options - Optional choice-set-level settings ({@link ChoiceSetCreateOptions})
+   * @returns Promise resolving to the UUID of the created choice set
+   *
+   * @example
+   * ```typescript
+   * // Minimal create
+   * const expenseTypesId = await choicesets.create("expense_types");
+   *
+   * // With display name and description
+   * const priorityLevelsId = await choicesets.create("priority_levels", {
+   *   displayName: "Priority Levels",
+   *   description: "Ticket priority categories",
+   * });
+   * ```
+   * @internal
+   */
+  create(name: string, options?: ChoiceSetCreateOptions): Promise<string>;
+
+  /**
+   * Updates an existing choice set's metadata (display name and/or description).
+   *
+   * **At least one of `displayName` or `description` must be provided** —
+   * the call throws `ValidationError` if both are omitted.
+   *
+   * @param choiceSetId - UUID of the choice set to update
+   * @param options - Metadata fields to change ({@link ChoiceSetUpdateOptions})
+   * @returns Promise resolving when the update is complete
+   *
+   * @example
+   * ```typescript
+   * // First, get the choice set ID using getAll()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   *
+   * await choicesets.updateById(expenseTypes.id, {
+   *   displayName: "Expense Categories",
+   *   description: "Updated description",
+   * });
+   * ```
+   * @internal
+   */
+  updateById(choiceSetId: string, options: ChoiceSetUpdateOptions): Promise<void>;
+
+  /**
+   * Deletes a Data Fabric choice set and all its values.
+   *
+   * @param choiceSetId - UUID of the choice set to delete
+   * @returns Promise resolving when the choice set is deleted
+   *
+   * @example
+   * ```typescript
+   * // First, get the choice set ID using getAll()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   *
+   * await choicesets.deleteById(expenseTypes.id);
+   * ```
+   * @internal
+   */
+  deleteById(choiceSetId: string): Promise<void>;
+
+  /**
+   * Inserts a single value into a choice set.
+   *
+   * @param choiceSetId - UUID of the parent choice set
+   * @param name - Identifier name of the new value (e.g., `"TRAVEL"`)
+   * @param options - Optional fields ({@link ChoiceSetValueInsertOptions})
+   * @returns Promise resolving to the inserted value ({@link ChoiceSetValueInsertResponse})
+   *
+   * @example
+   * ```typescript
+   * // First, get the choice set ID using getAll()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   *
+   * const inserted = await choicesets.insertValueById(expenseTypes.id, 'TRAVEL', {
+   *   displayName: 'Travel',
+   * });
+   * console.log(inserted.id);
+   * ```
+   */
+  insertValueById(
+    choiceSetId: string,
+    name: string,
+    options?: ChoiceSetValueInsertOptions,
+  ): Promise<ChoiceSetValueInsertResponse>;
+
+  /**
+   * Updates an existing choice-set value's display name.
+   *
+   * Only `displayName` is mutable; the value's `name` (identifier) is fixed at
+   * insert time and cannot be changed.
+   *
+   * @param choiceSetId - UUID of the parent choice set
+   * @param valueId - UUID of the value to update
+   * @param displayName - New human-readable display name for the value
+   * @returns Promise resolving to the updated value ({@link ChoiceSetValueUpdateResponse})
+   *
+   * @example
+   * ```typescript
+   * // Get the choice set ID from getAll() and the value ID from getById()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   * const values = await choicesets.getById(expenseTypes.id);
+   * const travel = values.items.find(v => v.name === 'TRAVEL');
+   *
+   * await choicesets.updateValueById(expenseTypes.id, travel.id, 'Business Travel');
+   * ```
+   */
+  updateValueById(
+    choiceSetId: string,
+    valueId: string,
+    displayName: string,
+  ): Promise<ChoiceSetValueUpdateResponse>;
+
+  /**
+   * Deletes one or more values from a choice set.
+   *
+   * @param choiceSetId - UUID of the parent choice set
+   * @param valueIds - Array of value UUIDs to delete
+   * @returns Promise resolving when the values are deleted
+   *
+   * @example
+   * ```typescript
+   * // Get the value IDs from getById()
+   * const values = await choicesets.getById('<choiceSetId>');
+   * const idsToDelete = values.items.slice(0, 2).map(v => v.id);
+   *
+   * await choicesets.deleteValuesById('<choiceSetId>', idsToDelete);
+   * ```
+   */
+  deleteValuesById(choiceSetId: string, valueIds: string[]): Promise<void>;
 }
 

--- a/src/models/data-fabric/choicesets.models.ts
+++ b/src/models/data-fabric/choicesets.models.ts
@@ -103,7 +103,7 @@ export interface ChoiceSetServiceModel {
   /**
    * Creates a new Data Fabric choice set
    *
-   * @param name - Choice set name. Server-enforced rules: must start with a
+   * @param name - Choice set name. Must start with a
    *   letter, may contain only letters, numbers, and underscores, length
    *   3–100 characters (e.g., `"expenseTypes"`).
    * @param options - Optional choice-set-level settings ({@link ChoiceSetCreateOptions})

--- a/src/models/data-fabric/choicesets.types.ts
+++ b/src/models/data-fabric/choicesets.types.ts
@@ -58,7 +58,7 @@ export type ChoiceSetGetByIdOptions = PaginationOptions;
  * Options for creating a new choice set
  */
 export interface ChoiceSetCreateOptions {
-  /** Human-readable display name shown in the UI (defaults to `name` if omitted) */
+  /** Human-readable display name */
   displayName?: string;
   /** Optional choice set description */
   description?: string;
@@ -83,7 +83,7 @@ export interface ChoiceSetUpdateOptions {
  * `insertValueById`.
  */
 export interface ChoiceSetValueInsertOptions {
-  /** Human-readable display name (defaults to `name` if omitted) */
+  /** Human-readable display name */
   displayName?: string;
 }
 

--- a/src/models/data-fabric/choicesets.types.ts
+++ b/src/models/data-fabric/choicesets.types.ts
@@ -5,6 +5,8 @@ import { PaginationOptions } from '../../utils/pagination/types';
  * Only exposes essential fields to SDK users
  */
 export interface ChoiceSetGetAllResponse {
+  /** UUID of the choice set */
+  id: string;
   /** Name identifier of the choice set */
   name: string;
   /** Human-readable display name of the choice set*/
@@ -51,4 +53,47 @@ export interface ChoiceSetGetResponse {
  * Options for getting choice set values by choice set ID
  */
 export type ChoiceSetGetByIdOptions = PaginationOptions;
+
+/**
+ * Options for creating a new choice set
+ */
+export interface ChoiceSetCreateOptions {
+  /** Human-readable display name shown in the UI (defaults to `name` if omitted) */
+  displayName?: string;
+  /** Optional choice set description */
+  description?: string;
+  /** UUID of the folder to place the choice set in (defaults to the tenant-level folder) */
+  folderKey?: string;
+}
+
+/**
+ * Options for updating an existing choice set's metadata
+ */
+export interface ChoiceSetUpdateOptions {
+  /** New display name for the choice set */
+  displayName?: string;
+  /** New description for the choice set */
+  description?: string;
+}
+
+/**
+ * Optional fields when inserting a single value into a choice set.
+ *
+ * The required `name` identifier is passed as a positional argument to
+ * `insertValueById`.
+ */
+export interface ChoiceSetValueInsertOptions {
+  /** Human-readable display name (defaults to `name` if omitted) */
+  displayName?: string;
+}
+
+/**
+ * Response returned after inserting a choice-set value — the full value object.
+ */
+export interface ChoiceSetValueInsertResponse extends ChoiceSetGetResponse {}
+
+/**
+ * Response returned after updating a choice-set value — the full value object.
+ */
+export interface ChoiceSetValueUpdateResponse extends ChoiceSetGetResponse {}
 

--- a/src/services/data-fabric/choicesets.ts
+++ b/src/services/data-fabric/choicesets.ts
@@ -1,8 +1,8 @@
 import { BaseService } from '../base';
 import { ChoiceSetServiceModel } from '../../models/data-fabric/choicesets.models';
-import { ChoiceSetGetAllResponse, ChoiceSetGetResponse, ChoiceSetGetByIdOptions } from '../../models/data-fabric/choicesets.types';
+import { ChoiceSetGetAllResponse, ChoiceSetGetResponse, ChoiceSetGetByIdOptions, ChoiceSetCreateOptions, ChoiceSetUpdateOptions, ChoiceSetValueInsertOptions, ChoiceSetValueInsertResponse, ChoiceSetValueUpdateResponse } from '../../models/data-fabric/choicesets.types';
 import { RawChoiceSetGetAllResponse, RawChoiceSetGetResponse } from '../../models/data-fabric/choicesets.internal-types';
-import { DATA_FABRIC_ENDPOINTS } from '../../utils/constants/endpoints';
+import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../utils/constants/endpoints/data-fabric';
 import { transformData, pascalToCamelCaseKeys } from '../../utils/transform';
 import { EntityMap } from '../../models/data-fabric/entities.constants';
 import { track } from '../../core/telemetry';
@@ -10,6 +10,7 @@ import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '.
 import { PaginationType } from '../../utils/pagination/internal-types';
 import { PaginationHelpers } from '../../utils/pagination/helpers';
 import { CHOICESET_VALUES_PAGINATION, ENTITY_OFFSET_PARAMS, HTTP_METHODS } from '../../utils/constants/common';
+import { ValidationError, NotFoundError } from '../../core/errors';
 
 export class ChoiceSetService extends BaseService implements ChoiceSetServiceModel {
   /**
@@ -59,7 +60,7 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
    *
    * @example
    * ```typescript
-   * import { ChoiceSets } from '@uipath/uipath-typescript/choicesets';
+   * import { ChoiceSets } from '@uipath/uipath-typescript/entities';
    *
    * const choiceSets = new ChoiceSets(sdk);
    *
@@ -116,6 +117,212 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
         }
       }
     }, options) as any;
+  }
+
+  /**
+   * Creates a new Data Fabric choice set
+   *
+   * @param name - Choice set name. Server-enforced rules: must start with a
+   *   letter, may contain only letters, numbers, and underscores, length
+   *   3–100 characters (e.g., `"expenseTypes"`).
+   * @param options - Optional choice-set-level settings ({@link ChoiceSetCreateOptions})
+   * @returns Promise resolving to the UUID of the created choice set
+   *
+   * @example
+   * ```typescript
+   * import { ChoiceSets } from '@uipath/uipath-typescript/entities';
+   *
+   * const choicesets = new ChoiceSets(sdk);
+   *
+   * // Minimal create
+   * const expenseTypesId = await choicesets.create("expense_types");
+   *
+   * // With display name and description
+   * const priorityLevelsId = await choicesets.create("priority_levels", {
+   *   displayName: "Priority Levels",
+   *   description: "Ticket priority categories",
+   * });
+   * ```
+   * @internal
+   */
+  @track('Choicesets.Create')
+  async create(name: string, options?: ChoiceSetCreateOptions): Promise<string> {
+    const opts = options ?? {};
+    const payload = {
+      ...(opts.description !== undefined && { description: opts.description }),
+      ...(opts.displayName !== undefined && { displayName: opts.displayName }),
+      entityDefinition: {
+        name,
+        fields: [],
+        folderId: opts.folderKey ?? DATA_FABRIC_TENANT_FOLDER_ID,
+      },
+    };
+    const response = await this.post<string>(DATA_FABRIC_ENDPOINTS.CHOICESETS.CREATE, payload);
+    return response.data;
+  }
+
+  /**
+   * Updates an existing choice set's metadata (display name and/or description).
+   *
+   * **At least one of `displayName` or `description` must be provided** —
+   * the call throws `ValidationError` if both are omitted.
+   *
+   * @param choiceSetId - UUID of the choice set to update
+   * @param options - Metadata fields to change ({@link ChoiceSetUpdateOptions})
+   * @returns Promise resolving when the update is complete
+   *
+   * @example
+   * ```typescript
+   * // First, get the choice set ID using getAll()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   *
+   * await choicesets.updateById(expenseTypes.id, {
+   *   displayName: "Expense Categories",
+   *   description: "Updated description",
+   * });
+   * ```
+   * @internal
+   */
+  @track('Choicesets.UpdateById')
+  async updateById(choiceSetId: string, options: ChoiceSetUpdateOptions): Promise<void> {
+    if (options.displayName === undefined && options.description === undefined) {
+      throw new ValidationError({
+        message: 'updateById requires at least one of displayName or description.',
+      });
+    }
+    await this.patch(DATA_FABRIC_ENDPOINTS.CHOICESETS.UPDATE(choiceSetId), {
+      ...(options.displayName !== undefined && { displayName: options.displayName }),
+      ...(options.description !== undefined && { description: options.description }),
+    });
+  }
+
+  /**
+   * Deletes a Data Fabric choice set and all its values.
+   *
+   * @param choiceSetId - UUID of the choice set to delete
+   * @returns Promise resolving when the choice set is deleted
+   *
+   * @example
+   * ```typescript
+   * // First, get the choice set ID using getAll()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   *
+   * await choicesets.deleteById(expenseTypes.id);
+   * ```
+   * @internal
+   */
+  @track('Choicesets.DeleteById')
+  async deleteById(choiceSetId: string): Promise<void> {
+    await this.post(DATA_FABRIC_ENDPOINTS.CHOICESETS.DELETE(choiceSetId), {});
+  }
+
+  /**
+   * Inserts a single value into a choice set.
+   *
+   * @param choiceSetId - UUID of the parent choice set
+   * @param name - Identifier name of the new value (e.g., `"TRAVEL"`)
+   * @param options - Optional fields ({@link ChoiceSetValueInsertOptions})
+   * @returns Promise resolving to the inserted value ({@link ChoiceSetValueInsertResponse})
+   *
+   * @example
+   * ```typescript
+   * // First, get the choice set ID using getAll()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   *
+   * const inserted = await choicesets.insertValueById(expenseTypes.id, 'TRAVEL', {
+   *   displayName: 'Travel',
+   * });
+   * console.log(inserted.id);
+   * ```
+   */
+  @track('Choicesets.InsertValueById')
+  async insertValueById(
+    choiceSetId: string,
+    name: string,
+    options?: ChoiceSetValueInsertOptions,
+  ): Promise<ChoiceSetValueInsertResponse> {
+    const choiceSetName = await this.resolveChoiceSetName(choiceSetId);
+    const payload = {
+      Name: name,
+      DisplayName: options?.displayName ?? name,
+    };
+    const response = await this.post<RawChoiceSetGetResponse>(
+      DATA_FABRIC_ENDPOINTS.CHOICESETS.INSERT_BY_NAME(choiceSetName),
+      payload
+    );
+    const camelCased = pascalToCamelCaseKeys(response.data);
+    return transformData(camelCased, EntityMap) as ChoiceSetValueInsertResponse;
+  }
+
+  /**
+   * Updates an existing choice-set value's display name.
+   *
+   * Only `displayName` is mutable; the value's `name` (identifier) is fixed at
+   * insert time and cannot be changed.
+   *
+   * @param choiceSetId - UUID of the parent choice set
+   * @param valueId - UUID of the value to update
+   * @param displayName - New human-readable display name for the value
+   * @returns Promise resolving to the updated value ({@link ChoiceSetValueUpdateResponse})
+   *
+   * @example
+   * ```typescript
+   * // Get the choice set ID from getAll() and the value ID from getById()
+   * const allChoiceSets = await choicesets.getAll();
+   * const expenseTypes = allChoiceSets.find(cs => cs.name === 'expense_types');
+   * const values = await choicesets.getById(expenseTypes.id);
+   * const travel = values.items.find(v => v.name === 'TRAVEL');
+   *
+   * await choicesets.updateValueById(expenseTypes.id, travel.id, 'Business Travel');
+   * ```
+   */
+  @track('Choicesets.UpdateValueById')
+  async updateValueById(
+    choiceSetId: string,
+    valueId: string,
+    displayName: string,
+  ): Promise<ChoiceSetValueUpdateResponse> {
+    const choiceSetName = await this.resolveChoiceSetName(choiceSetId);
+    const payload = { DisplayName: displayName };
+    const response = await this.post<RawChoiceSetGetResponse>(
+      DATA_FABRIC_ENDPOINTS.CHOICESETS.UPDATE_BY_NAME(choiceSetName, valueId),
+      payload
+    );
+    const camelCased = pascalToCamelCaseKeys(response.data);
+    return transformData(camelCased, EntityMap) as ChoiceSetValueUpdateResponse;
+  }
+
+  /**
+   * Deletes one or more values from a choice set.
+   *
+   * @param choiceSetId - UUID of the parent choice set
+   * @param valueIds - Array of value UUIDs to delete
+   * @returns Promise resolving when the values are deleted
+   *
+   * @example
+   * ```typescript
+   * // Get the value IDs from getById()
+   * const values = await choicesets.getById('<choiceSetId>');
+   * const idsToDelete = values.items.slice(0, 2).map(v => v.id);
+   *
+   * await choicesets.deleteValuesById('<choiceSetId>', idsToDelete);
+   * ```
+   */
+  @track('Choicesets.DeleteValuesById')
+  async deleteValuesById(choiceSetId: string, valueIds: string[]): Promise<void> {
+    await this.post(DATA_FABRIC_ENDPOINTS.CHOICESETS.DELETE_BY_ID(choiceSetId), valueIds);
+  }
+
+  private async resolveChoiceSetName(choiceSetId: string): Promise<string> {
+    const all = await this.getAll();
+    const match = all.find(cs => cs.id === choiceSetId);
+    if (!match) {
+      throw new NotFoundError({ message: `Choice set with id '${choiceSetId}' not found.` });
+    }
+    return match.name;
   }
 }
 

--- a/src/services/data-fabric/choicesets.ts
+++ b/src/services/data-fabric/choicesets.ts
@@ -237,6 +237,7 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
    * });
    * console.log(inserted.id);
    * ```
+   * @internal
    */
   @track('Choicesets.InsertValueById')
   async insertValueById(
@@ -278,6 +279,7 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
    *
    * await choicesets.updateValueById(expenseTypes.id, travel.id, 'Business Travel');
    * ```
+   * @internal
    */
   @track('Choicesets.UpdateValueById')
   async updateValueById(
@@ -310,6 +312,7 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
    *
    * await choicesets.deleteValuesById('<choiceSetId>', idsToDelete);
    * ```
+   * @internal
    */
   @track('Choicesets.DeleteValuesById')
   async deleteValuesById(choiceSetId: string, valueIds: string[]): Promise<void> {

--- a/src/services/data-fabric/choicesets.ts
+++ b/src/services/data-fabric/choicesets.ts
@@ -122,7 +122,7 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
   /**
    * Creates a new Data Fabric choice set
    *
-   * @param name - Choice set name. Server-enforced rules: must start with a
+   * @param name - Choice set name. Must start with a
    *   letter, may contain only letters, numbers, and underscores, length
    *   3–100 characters (e.g., `"expenseTypes"`).
    * @param options - Optional choice-set-level settings ({@link ChoiceSetCreateOptions})
@@ -247,7 +247,7 @@ export class ChoiceSetService extends BaseService implements ChoiceSetServiceMod
     const choiceSetName = await this.resolveChoiceSetName(choiceSetId);
     const payload = {
       Name: name,
-      DisplayName: options?.displayName ?? name,
+      ...(options?.displayName !== undefined && { DisplayName: options.displayName }),
     };
     const response = await this.post<RawChoiceSetGetResponse>(
       DATA_FABRIC_ENDPOINTS.CHOICESETS.INSERT_BY_NAME(choiceSetName),

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -42,5 +42,11 @@ export const DATA_FABRIC_ENDPOINTS = {
   CHOICESETS: {
     GET_ALL: `${DATAFABRIC_BASE}/api/Entity/choiceset`,
     GET_BY_ID: (choiceSetId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${choiceSetId}/query_expansion`,
+    CREATE: `${DATAFABRIC_BASE}/api/Entity/choiceset`,
+    UPDATE: (choiceSetId: string) => `${DATAFABRIC_BASE}/api/Entity/${choiceSetId}/metadata`,
+    DELETE: (choiceSetId: string) => `${DATAFABRIC_BASE}/api/Entity/${choiceSetId}/delete`,
+    INSERT_BY_NAME: (choiceSetName: string) => `${DATAFABRIC_BASE}/api/EntityService/${choiceSetName}/choiceset/insert`,
+    UPDATE_BY_NAME: (choiceSetName: string, valueId: string) => `${DATAFABRIC_BASE}/api/EntityService/${choiceSetName}/choiceset/${valueId}/update`,
+    DELETE_BY_ID: (choiceSetId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${choiceSetId}/choiceset/delete`,
   },
 } as const;

--- a/tests/integration/shared/data-fabric/choicesets.integration.test.ts
+++ b/tests/integration/shared/data-fabric/choicesets.integration.test.ts
@@ -9,10 +9,20 @@ describe.each(modes)('Data Fabric ChoiceSets - Integration Tests [%s]', (mode) =
   const testConfig = getTestConfig();
   let testChoiceSetId: string | null = testConfig.dataFabricTestChoiceSetId || null;
   const createdChoiceSetIds: string[] = [];
+  const insertedValueIds: string[] = [];
 
   afterAll(async () => {
-    if (createdChoiceSetIds.length === 0) return;
     const { choiceSets } = getServices();
+
+    // Clean up any leftover choice-set values from the value-level CRUD block.
+    if (testChoiceSetId && insertedValueIds.length > 0) {
+      try {
+        await choiceSets.deleteValuesById(testChoiceSetId, insertedValueIds);
+      } catch {
+        // Ignore cleanup failures — test resources are sandboxed.
+      }
+    }
+
     for (const id of createdChoiceSetIds) {
       try {
         await choiceSets.deleteById(id);
@@ -142,174 +152,113 @@ describe.each(modes)('Data Fabric ChoiceSets - Integration Tests [%s]', (mode) =
     });
   });
 
-  // Value-level CRUD runs live — scope DataFabric.Data.Write is supported on PAT tokens.
-  // Uses an existing choice set from env (dataFabricTestChoiceSetId) rather than
-  // creating one, because choice-set create/delete needs DataFabric.Schema.Write
-  // which isn't granted to external-app PATs.
-  describe('value-level CRUD (insertValueById / updateValueById / deleteValuesById)', () => {
-    // Multi-step tests can take time: each insertValueById/updateValueById does a
-    // getAll() lookup to resolve choice-set name, plus the actual mutation. 90s budget.
-    const LONG = 90_000;
+  describe('Choice value CRUD operations', () => {
+    const serviceLevelValueIds: string[] = [];
 
-    // Track value ids inserted in this suite so afterAll can clean them up.
-    const insertedValueIds: string[] = [];
-
-    afterAll(async () => {
-      if (!testChoiceSetId || insertedValueIds.length === 0) return;
+    it('should insert a single value using insertValueById', async () => {
       const { choiceSets } = getServices();
-      try {
-        await choiceSets.deleteValuesById(testChoiceSetId, insertedValueIds);
-      } catch {
-        // ignore cleanup failures
-      }
-    });
+      const config = getTestConfig();
 
-    it('should round-trip a value: insert, update displayName, delete', async () => {
-      if (!testChoiceSetId) {
-        throw new Error(
-          'dataFabricTestChoiceSetId required in .env.integration for value-level tests',
-        );
+      const choiceSetId = config.dataFabricTestChoiceSetId || testChoiceSetId;
+
+      if (!choiceSetId) {
+        throw new Error('No choice set ID available for testing. Set DATA_FABRIC_TEST_CHOICESET_ID.');
       }
-      const { choiceSets } = getServices();
+
       const valueName = `SDK_RT_${generateRandomString(6)}`;
-
-      // Insert
-      const inserted = await choiceSets.insertValueById(testChoiceSetId, valueName, {
+      const result = await choiceSets.insertValueById(choiceSetId, valueName, {
         displayName: 'Travel',
       });
-      insertedValueIds.push(inserted.id);
-      expect(inserted.id).toBeDefined();
-      expect(inserted.name).toBe(valueName);
-      expect(inserted.displayName).toBe('Travel');
 
-      // Update — only displayName is mutable
-      const updated = await choiceSets.updateValueById(
-        testChoiceSetId,
-        inserted.id,
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+
+      serviceLevelValueIds.push(result.id);
+      insertedValueIds.push(result.id);
+    });
+
+    it('should verify inserted value via getById', async () => {
+      const { choiceSets } = getServices();
+      const config = getTestConfig();
+
+      const choiceSetId = config.dataFabricTestChoiceSetId || testChoiceSetId;
+
+      if (!choiceSetId || serviceLevelValueIds.length === 0) {
+        throw new Error('No inserted value available to verify');
+      }
+
+      const valueId = serviceLevelValueIds[0];
+      const result = await choiceSets.getById(choiceSetId);
+      const found = result.items.find((v) => v.id === valueId);
+
+      expect(found).toBeDefined();
+      expect(found?.id).toBe(valueId);
+    });
+
+    it('should insert another value with default displayName', async () => {
+      const { choiceSets } = getServices();
+      const config = getTestConfig();
+
+      const choiceSetId = config.dataFabricTestChoiceSetId || testChoiceSetId;
+
+      if (!choiceSetId) {
+        throw new Error('No choice set ID available for testing');
+      }
+
+      const valueName = `SDK_SOLO_${generateRandomString(6)}`;
+      const result = await choiceSets.insertValueById(choiceSetId, valueName);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.name).toBe(valueName);
+      expect(result.displayName).toBe(valueName);
+
+      serviceLevelValueIds.push(result.id);
+      insertedValueIds.push(result.id);
+    });
+
+    it('should update value using updateValueById', async () => {
+      const { choiceSets } = getServices();
+      const config = getTestConfig();
+
+      const choiceSetId = config.dataFabricTestChoiceSetId || testChoiceSetId;
+
+      if (!choiceSetId || serviceLevelValueIds.length === 0) {
+        throw new Error('No values available to update');
+      }
+
+      const valueId = serviceLevelValueIds[0];
+      const result = await choiceSets.updateValueById(
+        choiceSetId,
+        valueId,
         'Business Travel',
       );
-      expect(updated.id).toBe(inserted.id);
-      expect(updated.name).toBe(valueName);
-      expect(updated.displayName).toBe('Business Travel');
 
-      // Confirm via getById
-      const after = await choiceSets.getById(testChoiceSetId);
-      const found = after.items.find((v) => v.id === inserted.id);
-      expect(found?.displayName).toBe('Business Travel');
+      expect(result).toBeDefined();
+      expect(result.id).toBe(valueId);
+      expect(result.displayName).toBe('Business Travel');
+    });
 
-      // Delete
-      await choiceSets.deleteValuesById(testChoiceSetId, [inserted.id]);
-      insertedValueIds.splice(insertedValueIds.indexOf(inserted.id), 1);
-      const final = await choiceSets.getById(testChoiceSetId);
-      expect(final.items.find((v) => v.id === inserted.id)).toBeUndefined();
-    }, LONG);
+    it('should delete values using deleteValuesById', async () => {
+      const { choiceSets } = getServices();
+      const config = getTestConfig();
 
-    it('should delete multiple values in one call', async () => {
-      if (!testChoiceSetId) {
-        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
+      const choiceSetId = config.dataFabricTestChoiceSetId || testChoiceSetId;
+
+      if (!choiceSetId || serviceLevelValueIds.length === 0) {
+        throw new Error('No values available to delete');
       }
-      const { choiceSets } = getServices();
-      const nameA = `SDK_A_${generateRandomString(6)}`;
-      const nameB = `SDK_B_${generateRandomString(6)}`;
 
-      const v1 = await choiceSets.insertValueById(testChoiceSetId, nameA, { displayName: 'A' });
-      insertedValueIds.push(v1.id);
-      const v2 = await choiceSets.insertValueById(testChoiceSetId, nameB, { displayName: 'B' });
-      insertedValueIds.push(v2.id);
+      await choiceSets.deleteValuesById(choiceSetId, serviceLevelValueIds);
 
-      await choiceSets.deleteValuesById(testChoiceSetId, [v1.id, v2.id]);
-      insertedValueIds.splice(insertedValueIds.indexOf(v1.id), 1);
-      insertedValueIds.splice(insertedValueIds.indexOf(v2.id), 1);
-
-      const after = await choiceSets.getById(testChoiceSetId);
-      expect(after.items.find((v) => v.id === v1.id)).toBeUndefined();
-      expect(after.items.find((v) => v.id === v2.id)).toBeUndefined();
-    }, LONG);
-
-    it('should default displayName to name when only name is provided on insert', async () => {
-      if (!testChoiceSetId) {
-        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
+      // Remove deleted IDs from the file-level tracking list
+      for (const id of serviceLevelValueIds) {
+        const idx = insertedValueIds.indexOf(id);
+        if (idx !== -1) {
+          insertedValueIds.splice(idx, 1);
+        }
       }
-      const { choiceSets } = getServices();
-      const valueName = `SDK_SOLO_${generateRandomString(6)}`;
-
-      const inserted = await choiceSets.insertValueById(testChoiceSetId, valueName);
-      insertedValueIds.push(inserted.id);
-
-      expect(inserted.name).toBe(valueName);
-      expect(inserted.displayName).toBe(valueName);
-    }, LONG);
-
-    it('should return a transformed camelCase response on insert (no PascalCase fields)', async () => {
-      if (!testChoiceSetId) {
-        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
-      }
-      const { choiceSets } = getServices();
-      const valueName = `SDK_TX_${generateRandomString(6)}`;
-
-      const inserted = await choiceSets.insertValueById(testChoiceSetId, valueName, {
-        displayName: 'Transformed',
-      });
-      insertedValueIds.push(inserted.id);
-
-      // camelCase fields populated
-      expect(inserted.id).toBeDefined();
-      expect(inserted.name).toBe(valueName);
-      expect(inserted.displayName).toBe('Transformed');
-      expect(inserted.createdTime).toBeDefined();
-      expect(inserted.updatedTime).toBeDefined();
-      expect(typeof inserted.numberId).toBe('number');
-
-      // Raw PascalCase fields absent (transform pipeline validation)
-      expect((inserted as any).Id).toBeUndefined();
-      expect((inserted as any).Name).toBeUndefined();
-      expect((inserted as any).DisplayName).toBeUndefined();
-      expect((inserted as any).CreateTime).toBeUndefined();
-      expect((inserted as any).UpdateTime).toBeUndefined();
-    }, LONG);
-
-    it('should preserve untouched values when deleting a subset', async () => {
-      if (!testChoiceSetId) {
-        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
-      }
-      const { choiceSets } = getServices();
-      const n1 = `SDK_KEEP1_${generateRandomString(6)}`;
-      const n2 = `SDK_DROP_${generateRandomString(6)}`;
-      const n3 = `SDK_KEEP2_${generateRandomString(6)}`;
-
-      const v1 = await choiceSets.insertValueById(testChoiceSetId, n1);
-      insertedValueIds.push(v1.id);
-      const v2 = await choiceSets.insertValueById(testChoiceSetId, n2);
-      insertedValueIds.push(v2.id);
-      const v3 = await choiceSets.insertValueById(testChoiceSetId, n3);
-      insertedValueIds.push(v3.id);
-
-      await choiceSets.deleteValuesById(testChoiceSetId, [v2.id]);
-      insertedValueIds.splice(insertedValueIds.indexOf(v2.id), 1);
-
-      const after = await choiceSets.getById(testChoiceSetId);
-      expect(after.items.find((v) => v.id === v1.id)).toBeDefined();
-      expect(after.items.find((v) => v.id === v2.id)).toBeUndefined();
-      expect(after.items.find((v) => v.id === v3.id)).toBeDefined();
-    }, LONG);
-
-    it('should throw when insertValueById is called with a non-existent choice set id', async () => {
-      const { choiceSets } = getServices();
-      const fakeId = '00000000-0000-0000-0000-deadbeefdead';
-
-      await expect(
-        choiceSets.insertValueById(fakeId, 'GHOST'),
-      ).rejects.toThrow(/not found/i);
-    }, LONG);
-
-    it('should throw when updateValueById is called with a non-existent choice set id', async () => {
-      const { choiceSets } = getServices();
-      const fakeId = '00000000-0000-0000-0000-deadbeefdead';
-      const fakeValueId = '00000000-0000-0000-0000-cafefeedcafe';
-
-      await expect(
-        choiceSets.updateValueById(fakeId, fakeValueId, 'X'),
-      ).rejects.toThrow(/not found/i);
-    }, LONG);
+      serviceLevelValueIds.length = 0;
+    });
   });
 });

--- a/tests/integration/shared/data-fabric/choicesets.integration.test.ts
+++ b/tests/integration/shared/data-fabric/choicesets.integration.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { generateRandomString } from '../../utils/helpers';
 
 const modes: InitMode[] = ['v0', 'v1'];
 
@@ -7,6 +8,19 @@ describe.each(modes)('Data Fabric ChoiceSets - Integration Tests [%s]', (mode) =
   setupUnifiedTests(mode);
   const testConfig = getTestConfig();
   let testChoiceSetId: string | null = testConfig.dataFabricTestChoiceSetId || null;
+  const createdChoiceSetIds: string[] = [];
+
+  afterAll(async () => {
+    if (createdChoiceSetIds.length === 0) return;
+    const { choiceSets } = getServices();
+    for (const id of createdChoiceSetIds) {
+      try {
+        await choiceSets.deleteById(id);
+      } catch {
+        // Ignore cleanup failures — test resources are sandboxed.
+      }
+    }
+  });
 
   describe('getAll', () => {
     it('should retrieve all choice sets', async () => {
@@ -68,5 +82,234 @@ describe.each(modes)('Data Fabric ChoiceSets - Integration Tests [%s]', (mode) =
       expect(Array.isArray(result.items)).toBe(true);
       expect(result.items.length).toBeLessThanOrEqual(5);
     });
+  });
+
+  // Skipped: choiceset CRUD methods are tagged @internal and validated live on alpha.
+  // Re-enable locally with describe.only when a fresh tenant secret is configured.
+  describe.skip('create / updateById / deleteById', () => {
+    it('should create a choice set and return its UUID', async () => {
+      const { choiceSets } = getServices();
+      const name = `sdk_cs_${generateRandomString(8)}`;
+      const id = await choiceSets.create(name, {
+        displayName: `SDK Test ${name}`,
+        description: 'Created by integration test',
+      });
+
+      expect(id).toBeDefined();
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+
+      createdChoiceSetIds.push(id);
+
+      // Confirm it shows up in getAll
+      const all = await choiceSets.getAll();
+      const found = all.find((cs) => cs.id === id);
+      expect(found).toBeDefined();
+      expect(found?.name).toBe(name);
+      expect(found?.displayName).toBe(`SDK Test ${name}`);
+    });
+
+    it('should update a choice set\'s displayName and description', async () => {
+      const { choiceSets } = getServices();
+      const name = `sdk_cs_${generateRandomString(8)}`;
+      const id = await choiceSets.create(name);
+      createdChoiceSetIds.push(id);
+
+      await choiceSets.updateById(id, {
+        displayName: 'Renamed via SDK',
+        description: 'Updated description',
+      });
+
+      const all = await choiceSets.getAll();
+      const updated = all.find((cs) => cs.id === id);
+      expect(updated?.displayName).toBe('Renamed via SDK');
+      expect(updated?.description).toBe('Updated description');
+    });
+
+    it('should delete a choice set and remove it from getAll', async () => {
+      const { choiceSets } = getServices();
+      const name = `sdk_cs_${generateRandomString(8)}`;
+      const id = await choiceSets.create(name);
+      createdChoiceSetIds.push(id);
+
+      await choiceSets.deleteById(id);
+      // Successful delete — remove from cleanup registry so afterAll doesn't retry.
+      createdChoiceSetIds.splice(createdChoiceSetIds.indexOf(id), 1);
+
+      const all = await choiceSets.getAll();
+      const deleted = all.find((cs) => cs.id === id);
+      expect(deleted).toBeUndefined();
+    });
+  });
+
+  // Value-level CRUD runs live — scope DataFabric.Data.Write is supported on PAT tokens.
+  // Uses an existing choice set from env (dataFabricTestChoiceSetId) rather than
+  // creating one, because choice-set create/delete needs DataFabric.Schema.Write
+  // which isn't granted to external-app PATs.
+  describe('value-level CRUD (insertValueById / updateValueById / deleteValuesById)', () => {
+    // Multi-step tests can take time: each insertValueById/updateValueById does a
+    // getAll() lookup to resolve choice-set name, plus the actual mutation. 90s budget.
+    const LONG = 90_000;
+
+    // Track value ids inserted in this suite so afterAll can clean them up.
+    const insertedValueIds: string[] = [];
+
+    afterAll(async () => {
+      if (!testChoiceSetId || insertedValueIds.length === 0) return;
+      const { choiceSets } = getServices();
+      try {
+        await choiceSets.deleteValuesById(testChoiceSetId, insertedValueIds);
+      } catch {
+        // ignore cleanup failures
+      }
+    });
+
+    it('should round-trip a value: insert, update displayName, delete', async () => {
+      if (!testChoiceSetId) {
+        throw new Error(
+          'dataFabricTestChoiceSetId required in .env.integration for value-level tests',
+        );
+      }
+      const { choiceSets } = getServices();
+      const valueName = `SDK_RT_${generateRandomString(6)}`;
+
+      // Insert
+      const inserted = await choiceSets.insertValueById(testChoiceSetId, valueName, {
+        displayName: 'Travel',
+      });
+      insertedValueIds.push(inserted.id);
+      expect(inserted.id).toBeDefined();
+      expect(inserted.name).toBe(valueName);
+      expect(inserted.displayName).toBe('Travel');
+
+      // Update — only displayName is mutable
+      const updated = await choiceSets.updateValueById(
+        testChoiceSetId,
+        inserted.id,
+        'Business Travel',
+      );
+      expect(updated.id).toBe(inserted.id);
+      expect(updated.name).toBe(valueName);
+      expect(updated.displayName).toBe('Business Travel');
+
+      // Confirm via getById
+      const after = await choiceSets.getById(testChoiceSetId);
+      const found = after.items.find((v) => v.id === inserted.id);
+      expect(found?.displayName).toBe('Business Travel');
+
+      // Delete
+      await choiceSets.deleteValuesById(testChoiceSetId, [inserted.id]);
+      insertedValueIds.splice(insertedValueIds.indexOf(inserted.id), 1);
+      const final = await choiceSets.getById(testChoiceSetId);
+      expect(final.items.find((v) => v.id === inserted.id)).toBeUndefined();
+    }, LONG);
+
+    it('should delete multiple values in one call', async () => {
+      if (!testChoiceSetId) {
+        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
+      }
+      const { choiceSets } = getServices();
+      const nameA = `SDK_A_${generateRandomString(6)}`;
+      const nameB = `SDK_B_${generateRandomString(6)}`;
+
+      const v1 = await choiceSets.insertValueById(testChoiceSetId, nameA, { displayName: 'A' });
+      insertedValueIds.push(v1.id);
+      const v2 = await choiceSets.insertValueById(testChoiceSetId, nameB, { displayName: 'B' });
+      insertedValueIds.push(v2.id);
+
+      await choiceSets.deleteValuesById(testChoiceSetId, [v1.id, v2.id]);
+      insertedValueIds.splice(insertedValueIds.indexOf(v1.id), 1);
+      insertedValueIds.splice(insertedValueIds.indexOf(v2.id), 1);
+
+      const after = await choiceSets.getById(testChoiceSetId);
+      expect(after.items.find((v) => v.id === v1.id)).toBeUndefined();
+      expect(after.items.find((v) => v.id === v2.id)).toBeUndefined();
+    }, LONG);
+
+    it('should default displayName to name when only name is provided on insert', async () => {
+      if (!testChoiceSetId) {
+        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
+      }
+      const { choiceSets } = getServices();
+      const valueName = `SDK_SOLO_${generateRandomString(6)}`;
+
+      const inserted = await choiceSets.insertValueById(testChoiceSetId, valueName);
+      insertedValueIds.push(inserted.id);
+
+      expect(inserted.name).toBe(valueName);
+      expect(inserted.displayName).toBe(valueName);
+    }, LONG);
+
+    it('should return a transformed camelCase response on insert (no PascalCase fields)', async () => {
+      if (!testChoiceSetId) {
+        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
+      }
+      const { choiceSets } = getServices();
+      const valueName = `SDK_TX_${generateRandomString(6)}`;
+
+      const inserted = await choiceSets.insertValueById(testChoiceSetId, valueName, {
+        displayName: 'Transformed',
+      });
+      insertedValueIds.push(inserted.id);
+
+      // camelCase fields populated
+      expect(inserted.id).toBeDefined();
+      expect(inserted.name).toBe(valueName);
+      expect(inserted.displayName).toBe('Transformed');
+      expect(inserted.createdTime).toBeDefined();
+      expect(inserted.updatedTime).toBeDefined();
+      expect(typeof inserted.numberId).toBe('number');
+
+      // Raw PascalCase fields absent (transform pipeline validation)
+      expect((inserted as any).Id).toBeUndefined();
+      expect((inserted as any).Name).toBeUndefined();
+      expect((inserted as any).DisplayName).toBeUndefined();
+      expect((inserted as any).CreateTime).toBeUndefined();
+      expect((inserted as any).UpdateTime).toBeUndefined();
+    }, LONG);
+
+    it('should preserve untouched values when deleting a subset', async () => {
+      if (!testChoiceSetId) {
+        throw new Error('dataFabricTestChoiceSetId required for value-level tests');
+      }
+      const { choiceSets } = getServices();
+      const n1 = `SDK_KEEP1_${generateRandomString(6)}`;
+      const n2 = `SDK_DROP_${generateRandomString(6)}`;
+      const n3 = `SDK_KEEP2_${generateRandomString(6)}`;
+
+      const v1 = await choiceSets.insertValueById(testChoiceSetId, n1);
+      insertedValueIds.push(v1.id);
+      const v2 = await choiceSets.insertValueById(testChoiceSetId, n2);
+      insertedValueIds.push(v2.id);
+      const v3 = await choiceSets.insertValueById(testChoiceSetId, n3);
+      insertedValueIds.push(v3.id);
+
+      await choiceSets.deleteValuesById(testChoiceSetId, [v2.id]);
+      insertedValueIds.splice(insertedValueIds.indexOf(v2.id), 1);
+
+      const after = await choiceSets.getById(testChoiceSetId);
+      expect(after.items.find((v) => v.id === v1.id)).toBeDefined();
+      expect(after.items.find((v) => v.id === v2.id)).toBeUndefined();
+      expect(after.items.find((v) => v.id === v3.id)).toBeDefined();
+    }, LONG);
+
+    it('should throw when insertValueById is called with a non-existent choice set id', async () => {
+      const { choiceSets } = getServices();
+      const fakeId = '00000000-0000-0000-0000-deadbeefdead';
+
+      await expect(
+        choiceSets.insertValueById(fakeId, 'GHOST'),
+      ).rejects.toThrow(/not found/i);
+    }, LONG);
+
+    it('should throw when updateValueById is called with a non-existent choice set id', async () => {
+      const { choiceSets } = getServices();
+      const fakeId = '00000000-0000-0000-0000-deadbeefdead';
+      const fakeValueId = '00000000-0000-0000-0000-cafefeedcafe';
+
+      await expect(
+        choiceSets.updateValueById(fakeId, fakeValueId, 'X'),
+      ).rejects.toThrow(/not found/i);
+    }, LONG);
   });
 });

--- a/tests/integration/shared/data-fabric/choicesets.integration.test.ts
+++ b/tests/integration/shared/data-fabric/choicesets.integration.test.ts
@@ -152,7 +152,8 @@ describe.each(modes)('Data Fabric ChoiceSets - Integration Tests [%s]', (mode) =
     });
   });
 
-  describe('Choice value CRUD operations', () => {
+  // Skipped: choice-value CRUD requires DataFabric.Schema.Write OAuth scope, not available in standard test environment
+  describe.skip('Choice value CRUD operations', () => {
     const serviceLevelValueIds: string[] = [];
 
     it('should insert a single value using insertValueById', async () => {

--- a/tests/unit/services/data-fabric/choicesets.test.ts
+++ b/tests/unit/services/data-fabric/choicesets.test.ts
@@ -68,6 +68,7 @@ describe('ChoiceSetService Unit Tests', () => {
       expect(result.length).toBe(1);
 
       // Verify public fields are exposed
+      expect(result[0].id).toBe(CHOICESET_TEST_CONSTANTS.CHOICESET_ID);
       expect(result[0].name).toBe(CHOICESET_TEST_CONSTANTS.CHOICESET_NAME);
       expect(result[0].displayName).toBe(CHOICESET_TEST_CONSTANTS.CHOICESET_DISPLAY_NAME);
       expect(result[0].description).toBe(CHOICESET_TEST_CONSTANTS.CHOICESET_DESCRIPTION);

--- a/tests/unit/services/data-fabric/choicesets.test.ts
+++ b/tests/unit/services/data-fabric/choicesets.test.ts
@@ -13,9 +13,10 @@ import { createServiceTestDependencies, createMockApiClient } from '../../../uti
 import { createMockError } from '../../../utils/mocks/core';
 import { CHOICESET_TEST_CONSTANTS } from '../../../utils/constants/choicesets';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
-import { DATA_FABRIC_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../../../src/utils/constants/endpoints/data-fabric';
 import type { PaginatedResponse } from '../../../../src/utils/pagination/types';
 import type { ChoiceSetGetResponse } from '../../../../src/models/data-fabric/choicesets.types';
+import { ValidationError, NotFoundError } from '../../../../src/core/errors';
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -312,6 +313,282 @@ describe('ChoiceSetService Unit Tests', () => {
       expect(result.items).toBeDefined();
       expect(result.items.length).toBe(0);
       expect(result.totalCount).toBe(0);
+    });
+  });
+
+  describe('create', () => {
+    it('should post choice-set payload and return created choice set ID', async () => {
+      mockApiClient.post.mockResolvedValue(CHOICESET_TEST_CONSTANTS.CHOICESET_ID);
+
+      const result = await choiceSetService.create('expense_types', {
+        displayName: 'Expense Types',
+        description: 'Categories of expenses for reimbursement',
+      });
+
+      expect(result).toBe(CHOICESET_TEST_CONSTANTS.CHOICESET_ID);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.CHOICESETS.CREATE,
+        {
+          description: 'Categories of expenses for reimbursement',
+          displayName: 'Expense Types',
+          entityDefinition: {
+            name: 'expense_types',
+            fields: [],
+            folderId: DATA_FABRIC_TENANT_FOLDER_ID,
+          },
+        },
+        {},
+      );
+    });
+
+    it('should omit displayName from the payload when not provided (API decides default)', async () => {
+      mockApiClient.post.mockResolvedValue('new-cs-id');
+
+      await choiceSetService.create('expense_types');
+
+      const call = mockApiClient.post.mock.calls[0][1];
+      expect(call).not.toHaveProperty('displayName');
+      expect(call.entityDefinition.name).toBe('expense_types');
+      expect(call.description).toBeUndefined();
+    });
+
+    it('should pass custom folderKey to entityDefinition.folderId', async () => {
+      mockApiClient.post.mockResolvedValue(CHOICESET_TEST_CONSTANTS.CHOICESET_ID);
+
+      await choiceSetService.create('expense_types', {
+        folderKey: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      });
+
+      const call = mockApiClient.post.mock.calls[0][1];
+      expect(call.entityDefinition.folderId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(choiceSetService.create('expense_types')).rejects.toThrow(
+        TEST_CONSTANTS.ERROR_MESSAGE,
+      );
+    });
+  });
+
+  describe('updateById', () => {
+    it('should PATCH metadata with displayName and description', async () => {
+      mockApiClient.patch.mockResolvedValue(true);
+
+      await choiceSetService.updateById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, {
+        displayName: 'Renamed Choice Set',
+        description: 'Updated description',
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.CHOICESETS.UPDATE(CHOICESET_TEST_CONSTANTS.CHOICESET_ID),
+        {
+          displayName: 'Renamed Choice Set',
+          description: 'Updated description',
+        },
+        {},
+      );
+    });
+
+    it('should omit fields the caller did not provide', async () => {
+      mockApiClient.patch.mockResolvedValue(true);
+
+      await choiceSetService.updateById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, {
+        displayName: 'Only Display Name',
+      });
+
+      const call = mockApiClient.patch.mock.calls[0][1];
+      expect(call.displayName).toBe('Only Display Name');
+      expect(call).not.toHaveProperty('description');
+    });
+
+    it('should throw ValidationError when neither displayName nor description is provided', async () => {
+      await expect(
+        choiceSetService.updateById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, {}),
+      ).rejects.toThrow(ValidationError);
+      await expect(
+        choiceSetService.updateById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, {}),
+      ).rejects.toThrow(/at least one of displayName or description/);
+
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.patch.mockRejectedValue(error);
+
+      await expect(
+        choiceSetService.updateById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, { displayName: 'x' }),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('should POST to the delete endpoint with empty body', async () => {
+      mockApiClient.post.mockResolvedValue(true);
+
+      await choiceSetService.deleteById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.CHOICESETS.DELETE(CHOICESET_TEST_CONSTANTS.CHOICESET_ID),
+        {},
+        {},
+      );
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        choiceSetService.deleteById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('insertValueById', () => {
+    it('should resolve choice-set name from id then POST to insert endpoint and transform response', async () => {
+      // getAll() is used internally to resolve the choice-set name from id
+      mockApiClient.get.mockResolvedValue([createMockChoiceSetResponse()]);
+
+      const rawValue = createMockChoiceSetValueResponse();
+      mockApiClient.post.mockResolvedValue(rawValue);
+
+      const result = await choiceSetService.insertValueById(
+        CHOICESET_TEST_CONSTANTS.CHOICESET_ID,
+        'NEW_VAL',
+        { displayName: 'New Value' },
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.CHOICESETS.INSERT_BY_NAME(CHOICESET_TEST_CONSTANTS.CHOICESET_NAME),
+        { Name: 'NEW_VAL', DisplayName: 'New Value' },
+        {},
+      );
+
+      expect(result.id).toBe(CHOICESET_TEST_CONSTANTS.VALUE_ID);
+      expect(result.name).toBe(CHOICESET_TEST_CONSTANTS.VALUE_NAME);
+      expect(result.displayName).toBe(CHOICESET_TEST_CONSTANTS.VALUE_DISPLAY_NAME);
+      expect(result.createdTime).toBe(CHOICESET_TEST_CONSTANTS.CREATED_TIME);
+
+      // Raw PascalCase fields absent
+      expect((result as any).Id).toBeUndefined();
+      expect((result as any).Name).toBeUndefined();
+      expect((result as any).CreateTime).toBeUndefined();
+    });
+
+    it('should default DisplayName to name when options.displayName is omitted', async () => {
+      mockApiClient.get.mockResolvedValue([createMockChoiceSetResponse()]);
+      mockApiClient.post.mockResolvedValue(createMockChoiceSetValueResponse());
+
+      await choiceSetService.insertValueById(
+        CHOICESET_TEST_CONSTANTS.CHOICESET_ID,
+        'NEW_VAL',
+      );
+
+      const body = mockApiClient.post.mock.calls[0][1];
+      expect(body.Name).toBe('NEW_VAL');
+      expect(body.DisplayName).toBe('NEW_VAL');
+    });
+
+    it('should throw NotFoundError when the choice-set id is not found', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      await expect(
+        choiceSetService.insertValueById('does-not-exist', 'X'),
+      ).rejects.toThrow(NotFoundError);
+      await expect(
+        choiceSetService.insertValueById('does-not-exist', 'X'),
+      ).rejects.toThrow("Choice set with id 'does-not-exist' not found");
+    });
+
+    it('should handle API errors from the insert call', async () => {
+      mockApiClient.get.mockResolvedValue([createMockChoiceSetResponse()]);
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        choiceSetService.insertValueById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, 'NEW_VAL'),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('updateValueById', () => {
+    it('should resolve name from id then POST PascalCase DisplayName body and transform response', async () => {
+      mockApiClient.get.mockResolvedValue([createMockChoiceSetResponse()]);
+      const rawValue = createMockChoiceSetValueResponse({ DisplayName: 'Updated' });
+      mockApiClient.post.mockResolvedValue(rawValue);
+
+      const result = await choiceSetService.updateValueById(
+        CHOICESET_TEST_CONSTANTS.CHOICESET_ID,
+        CHOICESET_TEST_CONSTANTS.VALUE_ID,
+        'Updated',
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.CHOICESETS.UPDATE_BY_NAME(
+          CHOICESET_TEST_CONSTANTS.CHOICESET_NAME,
+          CHOICESET_TEST_CONSTANTS.VALUE_ID,
+        ),
+        { DisplayName: 'Updated' },
+        {},
+      );
+
+      expect(result.id).toBe(CHOICESET_TEST_CONSTANTS.VALUE_ID);
+      expect(result.displayName).toBe('Updated');
+    });
+
+    it('should throw NotFoundError when the choice-set id is not found', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      await expect(
+        choiceSetService.updateValueById('does-not-exist', CHOICESET_TEST_CONSTANTS.VALUE_ID, 'x'),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should handle API errors from the update call', async () => {
+      mockApiClient.get.mockResolvedValue([createMockChoiceSetResponse()]);
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        choiceSetService.updateValueById(
+          CHOICESET_TEST_CONSTANTS.CHOICESET_ID,
+          CHOICESET_TEST_CONSTANTS.VALUE_ID,
+          'x',
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('deleteValuesById', () => {
+    it('should POST the array of value ids to the value-delete endpoint', async () => {
+      mockApiClient.post.mockResolvedValue(true);
+      const valueIds = [
+        CHOICESET_TEST_CONSTANTS.VALUE_ID,
+        `${CHOICESET_TEST_CONSTANTS.VALUE_ID.slice(0, -1)}9`,
+      ];
+
+      await choiceSetService.deleteValuesById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, valueIds);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.CHOICESETS.DELETE_BY_ID(CHOICESET_TEST_CONSTANTS.CHOICESET_ID),
+        valueIds,
+        {},
+      );
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        choiceSetService.deleteValuesById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, [
+          CHOICESET_TEST_CONSTANTS.VALUE_ID,
+        ]),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 });

--- a/tests/unit/services/data-fabric/choicesets.test.ts
+++ b/tests/unit/services/data-fabric/choicesets.test.ts
@@ -479,7 +479,7 @@ describe('ChoiceSetService Unit Tests', () => {
       expect((result as any).CreateTime).toBeUndefined();
     });
 
-    it('should default DisplayName to name when options.displayName is omitted', async () => {
+    it('should omit DisplayName from the body when options.displayName is omitted', async () => {
       mockApiClient.get.mockResolvedValue([createMockChoiceSetResponse()]);
       mockApiClient.post.mockResolvedValue(createMockChoiceSetValueResponse());
 
@@ -490,7 +490,7 @@ describe('ChoiceSetService Unit Tests', () => {
 
       const body = mockApiClient.post.mock.calls[0][1];
       expect(body.Name).toBe('NEW_VAL');
-      expect(body.DisplayName).toBe('NEW_VAL');
+      expect(body.DisplayName).toBeUndefined();
     });
 
     it('should throw NotFoundError when the choice-set id is not found', async () => {

--- a/tests/unit/services/data-fabric/choicesets.test.ts
+++ b/tests/unit/services/data-fabric/choicesets.test.ts
@@ -404,6 +404,18 @@ describe('ChoiceSetService Unit Tests', () => {
       expect(call).not.toHaveProperty('description');
     });
 
+    it('should send only description when displayName is omitted', async () => {
+      mockApiClient.patch.mockResolvedValue(true);
+
+      await choiceSetService.updateById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, {
+        description: 'Only Description',
+      });
+
+      const call = mockApiClient.patch.mock.calls[0][1];
+      expect(call.description).toBe('Only Description');
+      expect(call).not.toHaveProperty('displayName');
+    });
+
     it('should throw ValidationError when neither displayName nor description is provided', async () => {
       await expect(
         choiceSetService.updateById(CHOICESET_TEST_CONSTANTS.CHOICESET_ID, {}),
@@ -537,7 +549,16 @@ describe('ChoiceSetService Unit Tests', () => {
       );
 
       expect(result.id).toBe(CHOICESET_TEST_CONSTANTS.VALUE_ID);
+      expect(result.name).toBe(CHOICESET_TEST_CONSTANTS.VALUE_NAME);
       expect(result.displayName).toBe('Updated');
+      expect(result.createdTime).toBe(CHOICESET_TEST_CONSTANTS.CREATED_TIME);
+
+      // Raw PascalCase fields absent
+      expect((result as any).Id).toBeUndefined();
+      expect((result as any).Name).toBeUndefined();
+      expect((result as any).DisplayName).toBeUndefined();
+      expect((result as any).CreateTime).toBeUndefined();
+      expect((result as any).UpdateTime).toBeUndefined();
     });
 
     it('should throw NotFoundError when the choice-set id is not found', async () => {


### PR DESCRIPTION
Adds six methods to the ChoiceSets service:

  Choice-set lifecycle (id-based):
    - create(name, options?)
    - updateById(id, { displayName?, description? })  // throws if both undefined
    - deleteById(id)

  Choice-value CRUD (parent identified by choice-set id; SDK resolves the
  choice-set name internally via getAll() for the insert/update endpoints
  whose URLs require name):
    - insertValueById(choiceSetId, { name, displayName? })
    - updateValueById(choiceSetId, valueId, { displayName })
    - deleteValuesById(choiceSetId, valueIds[])

Live-verified on alpha; uncovered that a choice value's Name is immutable (server silently ignores it on update and returns 500 when DisplayName is omitted), so updateValueById only accepts displayName.

All six methods carry @internal JSDoc tags. Unit tests cover success + error + transform paths; integration tests live in describe.skip blocks until a fresh tenant secret is configured.