### PR TITLE
ci: publish docs only on SDK release or manual dispatch [PLT-104071]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,6 @@
 name: Deploy Documentation
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -10,7 +8,6 @@ permissions:
   contents: write
   pages: write
   id-token: write
-  actions: write
   deployments: write
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,15 @@ jobs:
           echo "- **Package:** @uipath/uipath-typescript" >> $GITHUB_STEP_SUMMARY
           echo "- **Version:** $SDK_VERSION" >> $GITHUB_STEP_SUMMARY
 
+  deploy-docs:
+    needs: publish-sdk
+    uses: ./.github/workflows/docs.yml
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+      deployments: write
+
   trigger-cf-worker:
     needs: publish-sdk
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Docs no longer publish on every PR merge to main
- Now publish via two paths:
  - **SDK release** — publish workflow automatically triggers docs deployment after successful publish
  - **Manual dispatch** — trigger from Actions UI for doc-only changes
