### PR TITLE
fix(core): throw ServerError instead of NetworkError for non-JSON responses [PLT-102926]

### DIFF
--- a/src/core/http/api-client.ts
+++ b/src/core/http/api-client.ts
@@ -4,6 +4,7 @@ import { RequestSpec } from '../../models/common/request-spec';
 import { TokenManager } from '../auth/token-manager';
 import { errorResponseParser } from '../errors/parser';
 import { ErrorFactory } from '../errors/error-factory';
+import { ServerError } from '../errors/server';
 import { CONTENT_TYPES, RESPONSE_TYPES, TRACEPARENT, UIPATH_TRACEPARENT_ID } from '../../utils/constants/headers';
 
 export interface ApiClientConfig {
@@ -125,14 +126,21 @@ export class ApiClient {
       if (!text) {
         return undefined as T;
       }
-      return JSON.parse(text);
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new ServerError({
+          message: `Server returned non-JSON response (${response.status} ${response.url})`,
+          statusCode: response.status,
+        });
+      }
     } catch (error: any) {
       // If it's already one of our errors, re-throw it
       if (error.type && error.type.includes('Error')) {
         throw error;
       }
-      
-      // Otherwise, it's likely a network error
+
+      // Otherwise, it's a genuine network/fetch failure
       throw ErrorFactory.createNetworkError(error);
     }
 

--- a/src/core/http/api-client.ts
+++ b/src/core/http/api-client.ts
@@ -131,7 +131,6 @@ export class ApiClient {
       } catch {
         throw new ServerError({
           message: `Server returned non-JSON response (${response.status} ${response.url})`,
-          statusCode: response.status,
         });
       }
     } catch (error: any) {

--- a/src/core/http/api-client.ts
+++ b/src/core/http/api-client.ts
@@ -128,11 +128,14 @@ export class ApiClient {
       }
       try {
         return JSON.parse(text);
-      } catch {
-        throw new ServerError({
-          message: `Server returned non-JSON response (${response.status} ${response.url})`,
-          statusCode: response.status,
-        });
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          throw new ServerError({
+            message: `Server returned non-JSON response (${response.status} ${response.url}): ${error.message}`,
+            statusCode: response.status,
+          });
+        }
+        throw error;
       }
     } catch (error: any) {
       // If it's already one of our errors, re-throw it

--- a/src/core/http/api-client.ts
+++ b/src/core/http/api-client.ts
@@ -131,6 +131,7 @@ export class ApiClient {
       } catch {
         throw new ServerError({
           message: `Server returned non-JSON response (${response.status} ${response.url})`,
+          statusCode: response.status,
         });
       }
     } catch (error: any) {

--- a/tests/integration/auth-errors.integration.test.ts
+++ b/tests/integration/auth-errors.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { UiPath } from '../../src';
-import { NetworkError } from '../../src/core/errors/network';
+import { ServerError } from '../../src/core/errors/server';
 import { loadIntegrationConfig } from './config/test-config';
 
 /**
@@ -16,9 +16,8 @@ function isForbiddenError(error: any, keywords: string[] = []): boolean {
     error.statusCode === 401 ||
     error.status === 401 ||
     // Server may return HTML (redirect/error page) for invalid org/tenant,
-    // causing a JSON parse error — this still indicates rejection
-    (error instanceof SyntaxError && error.message?.includes('is not valid JSON')) ||
-    (error instanceof NetworkError && error.message?.includes('is not valid JSON')) ||
+    // causing a non-JSON parse error — this still indicates rejection
+    (error instanceof ServerError && error.message?.includes('non-JSON response')) ||
     allKeywords.some(kw => error.message?.toLowerCase().includes(kw))
   );
 }

--- a/tests/unit/core/http/api-client.test.ts
+++ b/tests/unit/core/http/api-client.test.ts
@@ -117,11 +117,8 @@ describe('ApiClient error handling', () => {
 
     const client = createClient();
     await expect(client.get('/test')).rejects.toMatchObject({
-      message: expect.stringContaining('200'),
+      message: expect.stringContaining(`200 ${testUrl}`),
       statusCode: 200,
-    });
-    await expect(client.get('/test')).rejects.toMatchObject({
-      message: expect.stringContaining(testUrl),
     });
   });
 });

--- a/tests/unit/core/http/api-client.test.ts
+++ b/tests/unit/core/http/api-client.test.ts
@@ -105,7 +105,7 @@ describe('ApiClient error handling', () => {
     await expect(client.get('/test')).rejects.toBeInstanceOf(ServerError);
   });
 
-  it('includes the HTTP status code and URL in the ServerError message', async () => {
+  it('includes the HTTP status and URL in the ServerError message', async () => {
     const testUrl = 'https://example.com/api/test';
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -117,7 +117,10 @@ describe('ApiClient error handling', () => {
 
     const client = createClient();
     await expect(client.get('/test')).rejects.toMatchObject({
-      message: expect.stringContaining('non-JSON response'),
+      message: expect.stringContaining('200'),
+    });
+    await expect(client.get('/test')).rejects.toMatchObject({
+      message: expect.stringContaining(testUrl),
     });
   });
 });

--- a/tests/unit/core/http/api-client.test.ts
+++ b/tests/unit/core/http/api-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ApiClient } from '../../../../src/core/http/api-client';
+import { ServerError } from '../../../../src/core/errors/server';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
 
 const TRACEPARENT_REGEX = /^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/;
@@ -87,5 +88,36 @@ describe('ApiClient traceparent', () => {
     await client.get('/test', { headers: { traceparent: custom } });
 
     expect(capturedHeaders['traceparent']).toBe(custom);
+  });
+});
+
+describe('ApiClient error handling', () => {
+  it('throws ServerError when server returns a non-JSON body on a successful response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: 'https://example.com/api/test',
+      text: () => Promise.resolve('<html>Redirect</html>'),
+      blob: () => Promise.resolve(new Blob()),
+    });
+
+    const client = createClient();
+    await expect(client.get('/test')).rejects.toBeInstanceOf(ServerError);
+  });
+
+  it('includes the HTTP status code and URL in the ServerError message', async () => {
+    const testUrl = 'https://example.com/api/test';
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: testUrl,
+      text: () => Promise.resolve('<html>Error</html>'),
+      blob: () => Promise.resolve(new Blob()),
+    });
+
+    const client = createClient();
+    await expect(client.get('/test')).rejects.toMatchObject({
+      message: expect.stringContaining('non-JSON response'),
+    });
   });
 });

--- a/tests/unit/core/http/api-client.test.ts
+++ b/tests/unit/core/http/api-client.test.ts
@@ -105,7 +105,7 @@ describe('ApiClient error handling', () => {
     await expect(client.get('/test')).rejects.toBeInstanceOf(ServerError);
   });
 
-  it('includes the HTTP status and URL in the ServerError message', async () => {
+  it('includes the HTTP status and URL in the ServerError message and preserves statusCode', async () => {
     const testUrl = 'https://example.com/api/test';
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -118,6 +118,7 @@ describe('ApiClient error handling', () => {
     const client = createClient();
     await expect(client.get('/test')).rejects.toMatchObject({
       message: expect.stringContaining('200'),
+      statusCode: 200,
     });
     await expect(client.get('/test')).rejects.toMatchObject({
       message: expect.stringContaining(testUrl),

--- a/tests/unit/core/http/api-client.test.ts
+++ b/tests/unit/core/http/api-client.test.ts
@@ -98,7 +98,6 @@ describe('ApiClient error handling', () => {
       status: 200,
       url: 'https://example.com/api/test',
       text: () => Promise.resolve('<html>Redirect</html>'),
-      blob: () => Promise.resolve(new Blob()),
     });
 
     const client = createClient();
@@ -112,7 +111,6 @@ describe('ApiClient error handling', () => {
       status: 200,
       url: testUrl,
       text: () => Promise.resolve('<html>Error</html>'),
-      blob: () => Promise.resolve(new Blob()),
     });
 
     const client = createClient();


### PR DESCRIPTION
## Summary

- When a server returns a successful HTTP response with a non-JSON body (e.g. HTML redirect page for invalid org/tenant), `JSON.parse()` was caught by the outer `fetch()` catch block and incorrectly wrapped as `NetworkError`
- Extracted `JSON.parse` into its own inner try/catch that throws `ServerError`, keeping the outer catch exclusively for genuine network/fetch failures
- Removed the `NetworkError`/`SyntaxError` workaround in the auth-errors integration test, replaced with a precise `ServerError` check

## Files

| Area | Files |
|------|-------|
| Core HTTP | `src/core/http/api-client.ts` |
| Integration test | `tests/integration/auth-errors.integration.test.ts` |
| Unit tests | `tests/unit/core/http/api-client.test.ts` (2 new tests) |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — 1529 tests pass
- [ ] Integration: invalid org/tenant now surfaces as `ServerError` (not `NetworkError`) with a descriptive message

🤖 Generated with [Claude Code](https://claude.com/claude-code)