### PR TITLE
Storage bucket: added DeleteFile & GetFiles APIs

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -37,6 +37,8 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getFileMetaData()` | `OR.Buckets` or `OR.Buckets.Read` |
 | `getReadUri()` | `OR.Buckets` or `OR.Buckets.Read` |
 | `uploadFile()` | `OR.Buckets` |
+| `deleteFile()` | `OR.Buckets` or `OR.Buckets.Write` |
+| `getFiles()` | `OR.Buckets` or `OR.Buckets.Read` |
 
 ## Entities
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -117,7 +117,7 @@ console.log(`Total count: ${allAssets.totalCount}`);
 |---------|--------|------------------------|
 | Assets | `getAll()` | ✅ Yes |
 | Buckets | `getAll()` | ✅ Yes |
-| Buckets | `getFiles()` | ❌ No |
+| Buckets | `getFiles()` | ✅ Yes |
 | Jobs | `getAll()` | ✅ Yes |
 | Entities | `getAll()` | ✅ Yes |
 | Entities | `getAllRecords()` | ✅ Yes |

--- a/src/models/orchestrator/buckets.models.ts
+++ b/src/models/orchestrator/buckets.models.ts
@@ -1,4 +1,4 @@
-import { BucketGetAllOptions, BucketGetByIdOptions, BucketGetByNameOptions, BucketGetResponse, BucketGetFileMetaDataWithPaginationOptions, BucketGetReadUriOptions, BucketGetUriResponse, BucketUploadFileOptions, BucketUploadResponse, BlobItem } from './buckets.types';
+import { BucketGetAllOptions, BucketGetByIdOptions, BucketGetByNameOptions, BucketGetResponse, BucketGetFileMetaDataWithPaginationOptions, BucketGetReadUriOptions, BucketGetUriResponse, BucketUploadFileOptions, BucketUploadResponse, BlobItem, BucketGetFilesOptions, BucketFile, BucketDeleteFileOptions } from './buckets.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /**
@@ -188,4 +188,72 @@ export interface BucketServiceModel {
    * ```
    */
   uploadFile(options: BucketUploadFileOptions): Promise<BucketUploadResponse>;
-} 
+
+  /**
+   * Deletes a file from a bucket
+   *
+   * @param bucketId - The ID of the bucket
+   * @param path - The full path to the file to delete
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
+   * @returns Promise resolving when the file is deleted
+   * @example
+   * ```typescript
+   * // Delete a file from a bucket
+   * await buckets.deleteFile(<bucketId>, '/folder/file.pdf', { folderId: <folderId> });
+   * ```
+   */
+  deleteFile(bucketId: number, path: string, options?: BucketDeleteFileOptions): Promise<void>;
+
+  /**
+   * Lists all files in a bucket.
+   *
+   * Returns a flat, recursive listing of all files in the bucket. Supports regex filtering
+   * and filter / orderby / select / expand. {@link BucketFile} entries include
+   * `isDirectory` so callers can distinguish folders from files.
+   *
+   * The method returns either:
+   * - A NonPaginatedResponse with items array (when no pagination parameters are provided)
+   * - A PaginatedResponse with navigation cursors (when any pagination parameter is provided)
+   *
+   * @param bucketId - The ID of the bucket
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional parameters for regex filtering, query options, and pagination
+   * {@link BucketGetFilesOptions}
+   * @returns Promise resolving to either an array of files NonPaginatedResponse<BucketFile> or a PaginatedResponse<BucketFile> when pagination options are used.
+   * {@link BucketFile}
+   * @example
+   * ```typescript
+   * // List all files in the bucket
+   * const files = await buckets.getFiles(<bucketId>, { folderId: <folderId> });
+   *
+   * // Filter by regex pattern
+   * const pdfs = await buckets.getFiles(<bucketId>, {
+   *   folderId: <folderId>,
+   *   fileNameRegex: '.*\\.pdf$'
+   * });
+   *
+   * // First page with pagination
+   * const page1 = await buckets.getFiles(<bucketId>, { folderId: <folderId>, pageSize: 10 });
+   *
+   * // Navigate using cursor
+   * if (page1.hasNextPage) {
+   *   const page2 = await buckets.getFiles(<bucketId>, { folderId: <folderId>, cursor: page1.nextCursor });
+   * }
+   *
+   * // Jump to specific page
+   * const page5 = await buckets.getFiles(<bucketId>, {
+   *   folderId: <folderId>,
+   *   jumpToPage: 5,
+   *   pageSize: 10
+   * });
+   * ```
+   */
+  getFiles<T extends BucketGetFilesOptions = BucketGetFilesOptions>(
+    bucketId: number,
+    options?: T
+  ): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<BucketFile>
+      : NonPaginatedResponse<BucketFile>
+  >;
+}
+

--- a/src/models/orchestrator/buckets.types.ts
+++ b/src/models/orchestrator/buckets.types.ts
@@ -136,22 +136,67 @@ export interface BlobItem {
    * Full path to the blob
    */
   path: string;
-  
+
   /**
    * Content type of the blob
    */
   contentType: string;
-  
+
   /**
    * Size of the blob in bytes
    */
   size: number;
-  
+
   /**
    * Last modified timestamp
    */
   lastModified: string | null;
 }
+
+/**
+ * Represents a file or directory entry in a bucket
+ */
+export interface BucketFile {
+  /**
+   * Full path to the file or directory
+   */
+  path: string;
+
+  /**
+   * Content type of the file (empty for directories)
+   */
+  contentType: string;
+
+  /**
+   * Size of the file in bytes
+   */
+  size: number;
+
+  /**
+   * Whether the entry is a directory
+   */
+  isDirectory: boolean;
+
+  /**
+   * Identifier of the file, when available
+   */
+  id: string | null;
+}
+
+/**
+ * Options for listing files in a bucket directory
+ */
+export type BucketGetFilesOptions = RequestOptions & PaginationOptions & FolderScopedOptions & {
+  /**
+   * Regex pattern to filter file names (e.g., '.*\\.pdf$')
+   */
+  fileNameRegex?: string;
+};
+
+/**
+ * Options for deleting a file from a bucket
+ */
+export interface BucketDeleteFileOptions extends FolderScopedOptions {}
 
 /**
  * Options for uploading files to a bucket

--- a/src/services/orchestrator/buckets/buckets.ts
+++ b/src/services/orchestrator/buckets/buckets.ts
@@ -11,12 +11,16 @@ import {
   BucketUploadFileOptions,
   BucketUploadResponse,
   BlobItem,
-  BucketGetUriOptions
+  BucketGetUriOptions,
+  BucketGetFilesOptions,
+  BucketFile,
+  BucketDeleteFileOptions
 } from '../../../models/orchestrator/buckets.types';
 import { BucketServiceModel } from '../../../models/orchestrator/buckets.models';
 import { pascalToCamelCaseKeys, addPrefixToKeys, transformData, arrayDictionaryToRecord } from '../../../utils/transform';
 import { filterUndefined } from '../../../utils/object';
 import { createHeaders } from '../../../utils/http/headers';
+import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
 import { FOLDER_ID } from '../../../utils/constants/headers';
 import { BUCKET_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX, BUCKET_PAGINATION, ODATA_OFFSET_PARAMS, BUCKET_TOKEN_PARAMS } from '../../../utils/constants/common';
@@ -450,8 +454,144 @@ export class BucketService extends FolderScopedService implements BucketServiceM
   }
 
   /**
+   * Lists all files in a bucket.
+   *
+   * Returns a flat, recursive listing of all files in the bucket. Supports regex filtering
+   * and filter / orderby / select / expand. {@link BucketFile} entries include
+   * `isDirectory` so callers can distinguish folders from files.
+   *
+   * The method returns either:
+   * - A NonPaginatedResponse with items array (when no pagination parameters are provided)
+   * - A PaginatedResponse with navigation cursors (when any pagination parameter is provided)
+   *
+   * @param bucketId - The ID of the bucket
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional parameters for regex filtering, query options, and pagination
+   * @returns Promise resolving to either an array of files NonPaginatedResponse<BucketFile> or a PaginatedResponse<BucketFile> when pagination options are used.
+   *
+   * @example
+   * ```typescript
+   * import { Buckets } from '@uipath/uipath-typescript/buckets';
+   *
+   * const buckets = new Buckets(sdk);
+   *
+   * // List all files in the bucket
+   * const files = await buckets.getFiles(<bucketId>, { folderId: <folderId> });
+   *
+   * // Filter by regex pattern
+   * const pdfs = await buckets.getFiles(<bucketId>, {
+   *   folderId: <folderId>,
+   *   fileNameRegex: '.*\\.pdf$'
+   * });
+   *
+   * // First page with pagination
+   * const page1 = await buckets.getFiles(<bucketId>, { folderId: <folderId>, pageSize: 10 });
+   *
+   * // Navigate using cursor
+   * if (page1.hasNextPage) {
+   *   const page2 = await buckets.getFiles(<bucketId>, { folderId: <folderId>, cursor: page1.nextCursor });
+   * }
+   *
+   * // Jump to specific page
+   * const page5 = await buckets.getFiles(<bucketId>, {
+   *   folderId: <folderId>,
+   *   jumpToPage: 5,
+   *   pageSize: 10
+   * });
+   * ```
+   */
+  @track('Buckets.GetFiles')
+  async getFiles<T extends BucketGetFilesOptions = BucketGetFilesOptions>(
+    bucketId: number,
+    options?: T
+  ): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<BucketFile>
+      : NonPaginatedResponse<BucketFile>
+  > {
+    if (!bucketId) {
+      throw new ValidationError({ message: 'bucketId is required for getFiles' });
+    }
+
+    const { folderId, folderKey, folderPath, ...restOptions } = options ?? {} as BucketGetFilesOptions;
+
+    const headers = resolveFolderHeaders({
+      folderId,
+      folderKey,
+      folderPath,
+      resourceType: 'Buckets.getFiles',
+      fallbackFolderKey: this.config.folderKey,
+    });
+
+    const transformBucketFile = (file: Record<string, unknown>) =>
+      transformData(pascalToCamelCaseKeys(file), BucketMap) as BucketFile;
+
+    return PaginationHelpers.getAll({
+      serviceAccess: this.createPaginationServiceAccess(),
+      getEndpoint: () => BUCKET_ENDPOINTS.GET_FILES(bucketId),
+      transformFn: transformBucketFile,
+      pagination: {
+        paginationType: PaginationType.OFFSET,
+        itemsField: ODATA_PAGINATION.ITEMS_FIELD,
+        totalCountField: ODATA_PAGINATION.TOTAL_COUNT_FIELD,
+        paginationParams: {
+          pageSizeParam: ODATA_OFFSET_PARAMS.PAGE_SIZE_PARAM,
+          offsetParam: ODATA_OFFSET_PARAMS.OFFSET_PARAM,
+          countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM,
+        },
+      },
+      excludeFromPrefix: ['directory', 'recursive', 'fileNameRegex'],
+      headers,
+    }, { ...restOptions, directory: '/', recursive: true }) as any;
+  }
+
+  /**
+   * Deletes a file from a bucket
+   *
+   * @param bucketId - The ID of the bucket
+   * @param path - The full path to the file to delete
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
+   * @returns Promise resolving when the file is deleted
+   *
+   * @example
+   * ```typescript
+   * import { Buckets } from '@uipath/uipath-typescript/buckets';
+   *
+   * const buckets = new Buckets(sdk);
+   *
+   * // Delete a file from a bucket
+   * await buckets.deleteFile(<bucketId>, '/folder/file.pdf', { folderId: <folderId> });
+   * ```
+   */
+  @track('Buckets.DeleteFile')
+  async deleteFile(bucketId: number, path: string, options?: BucketDeleteFileOptions): Promise<void> {
+    if (!bucketId) {
+      throw new ValidationError({ message: 'bucketId is required for deleteFile' });
+    }
+
+    if (!path) {
+      throw new ValidationError({ message: 'path is required for deleteFile' });
+    }
+
+    const headers = resolveFolderHeaders({
+      folderId: options?.folderId,
+      folderKey: options?.folderKey,
+      folderPath: options?.folderPath,
+      resourceType: 'Buckets.deleteFile',
+      fallbackFolderKey: this.config.folderKey,
+    });
+
+    await this.delete(
+      BUCKET_ENDPOINTS.DELETE_FILE(bucketId),
+      {
+        params: { path },
+        headers,
+      }
+    );
+  }
+
+  /**
    * Gets a direct upload URL for a file in the bucket
-   * 
+   *
    * @param options - Contains bucketId, folderId, file path, optional expiry time
    * @returns Promise resolving to blob file access information
    */

--- a/src/utils/constants/endpoints/orchestrator.ts
+++ b/src/utils/constants/endpoints/orchestrator.ts
@@ -34,6 +34,8 @@ export const BUCKET_ENDPOINTS = {
   GET_FILE_META_DATA: (id: number) => `${ORCHESTRATOR_BASE}/api/Buckets/${id}/ListFiles`,
   GET_READ_URI: (id: number) => `${ORCHESTRATOR_BASE}/odata/Buckets(${id})/UiPath.Server.Configuration.OData.GetReadUri`,
   GET_WRITE_URI: (id: number) => `${ORCHESTRATOR_BASE}/odata/Buckets(${id})/UiPath.Server.Configuration.OData.GetWriteUri`,
+  DELETE_FILE: (id: number) => `${ORCHESTRATOR_BASE}/odata/Buckets(${id})/UiPath.Server.Configuration.OData.DeleteFile`,
+  GET_FILES: (id: number) => `${ORCHESTRATOR_BASE}/odata/Buckets(${id})/UiPath.Server.Configuration.OData.GetFiles`,
 } as const;
 
 /**

--- a/src/utils/pagination/helpers.ts
+++ b/src/utils/pagination/helpers.ts
@@ -175,6 +175,7 @@ export class PaginationHelpers {
       serviceAccess,
       getEndpoint,
       folderId,
+      headers: providedHeaders,
       paginationParams,
       additionalParams,
       transformFn,
@@ -183,7 +184,7 @@ export class PaginationHelpers {
     } = params;
 
     const endpoint = getEndpoint(folderId);
-    const headers = folderId ? createHeaders({ [FOLDER_ID]: folderId }) : {};
+    const headers = providedHeaders ?? (folderId ? createHeaders({ [FOLDER_ID]: folderId }) : {});
 
     const paginatedResponse = await serviceAccess.requestWithPagination<T>(
       method,
@@ -227,6 +228,7 @@ export class PaginationHelpers {
       getAllEndpoint,
       getByFolderEndpoint,
       folderId,
+      headers: providedHeaders,
       additionalParams,
       transformFn,
       method = HTTP_METHODS.GET,
@@ -239,7 +241,7 @@ export class PaginationHelpers {
 
     // Determine endpoint and headers based on folderId
     const endpoint = folderId ? getByFolderEndpoint : getAllEndpoint;
-    const headers = folderId ? createHeaders({ [FOLDER_ID]: folderId }) : {};
+    const headers = providedHeaders ?? (folderId ? createHeaders({ [FOLDER_ID]: folderId }) : {});
 
     // Make the API call based on method
     let response: { data: any };
@@ -321,6 +323,7 @@ export class PaginationHelpers {
         serviceAccess: config.serviceAccess,
         getEndpoint: config.getEndpoint,
         folderId,
+        headers: config.headers,
         paginationParams: cursor ? { cursor, pageSize } : jumpToPage ? { jumpToPage, pageSize } : { pageSize },
         additionalParams: prefixedOptions,
         transformFn: config.transformFn,
@@ -339,6 +342,7 @@ export class PaginationHelpers {
       getAllEndpoint: config.getEndpoint(),
       getByFolderEndpoint: byFolderEndpoint,
       folderId,
+      headers: config.headers,
       additionalParams: prefixedOptions,
       transformFn: config.transformFn,
       method: config.method,

--- a/src/utils/pagination/internal-types.ts
+++ b/src/utils/pagination/internal-types.ts
@@ -70,6 +70,8 @@ export interface GetAllPaginatedParams<T, R = T> {
   serviceAccess: PaginationServiceAccess;
   getEndpoint: (folderId?: number) => string;
   folderId?: number;
+  /** Pre-resolved request headers. Overrides the helper's auto-built folder header from `folderId`. */
+  headers?: Record<string, string>;
   paginationParams: PaginationOptions;
   additionalParams: Record<string, any>;
   /**
@@ -101,6 +103,8 @@ export interface GetAllNonPaginatedParams<T, R = T> {
   getAllEndpoint: string;
   getByFolderEndpoint: string;
   folderId?: number;
+  /** Pre-resolved request headers. Overrides the helper's auto-built folder header from `folderId`. */
+  headers?: Record<string, string>;
   additionalParams: Record<string, any>;
   /**
    * Optional function to transform API response items.
@@ -229,4 +233,7 @@ export interface GetAllConfig<TRaw, TTransformed = TRaw> {
 
   /** HTTP method to use for the request (default: 'GET') */
   method?: HttpMethodType;
+
+  /** Pre-resolved request headers. Overrides the helper's auto-built folder header from `folderId`. */
+  headers?: Record<string, string>;
 } 

--- a/tests/integration/config/unified-setup.ts
+++ b/tests/integration/config/unified-setup.ts
@@ -21,6 +21,7 @@ export {
   cleanupTestEntityRecords,
   cleanupTestProcessInstance,
   cleanupTestCaseInstance,
+  cleanupTestBucketFile,
   cleanupAllTestResources,
   registerResource,
 } from '../utils/cleanup';

--- a/tests/integration/shared/orchestrator/buckets.integration.test.ts
+++ b/tests/integration/shared/orchestrator/buckets.integration.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  getServices,
+  getTestConfig,
+  setupUnifiedTests,
+  cleanupTestBucketFile,
+  InitMode,
+} from '../../config/unified-setup';
+import { registerResource } from '../../utils/cleanup';
 import { createTestFileContent } from '../../utils/helpers';
 import { isNotFoundError } from '../../../../src/core/errors';
 
@@ -37,6 +44,24 @@ async function getBucketForTest(testName: string): Promise<{ bucketId: number; f
 
 describe.each(modes)('Orchestrator Buckets - Integration Tests [%s]', (mode) => {
   setupUnifiedTests(mode);
+
+  const uploadedFiles: Array<{ bucketId: number; path: string; folderId: number }> = [];
+
+  function trackUploadedFile(bucketId: number, path: string, folderId: number): void {
+    uploadedFiles.push({ bucketId, path, folderId });
+    registerResource('bucketFiles', { bucketId, path, folderId });
+  }
+
+  function untrackUploadedFile(path: string): void {
+    const idx = uploadedFiles.findIndex((f) => f.path === path);
+    if (idx !== -1) uploadedFiles.splice(idx, 1);
+  }
+
+  afterAll(async () => {
+    for (const file of uploadedFiles.splice(0)) {
+      await cleanupTestBucketFile(file.bucketId, file.path, file.folderId);
+    }
+  });
 
   describe('getAll', () => {
     it('should retrieve all buckets', async () => {
@@ -184,6 +209,7 @@ describe.each(modes)('Orchestrator Buckets - Integration Tests [%s]', (mode) => 
           path: fileName,
           content: buffer,
         });
+        trackUploadedFile(bucket.bucketId, fileName, bucket.folderId);
 
         expect(uploadResult).toBeDefined();
         expect(uploadResult.success).toBe(true);
@@ -221,6 +247,87 @@ describe.each(modes)('Orchestrator Buckets - Integration Tests [%s]', (mode) => 
       expect(result.uri).toBeDefined();
       expect(result.uri).toMatch(/^https?:\/\/.+/);
       console.log(`Got read URI for file: ${fileName}`);
+    });
+
+    it('should upload a file and then delete it', async () => {
+      const { buckets } = getServices();
+      const bucket = await getBucketForTest('delete file test');
+
+      const fileName = `/integration-delete-${mode}-${Date.now()}.txt`;
+      const fileContent = createTestFileContent(fileName);
+      const buffer = Buffer.from(fileContent, 'utf-8');
+
+      const uploadResult = await buckets.uploadFile({
+        bucketId: bucket.bucketId,
+        folderId: bucket.folderId,
+        path: fileName,
+        content: buffer,
+      });
+      trackUploadedFile(bucket.bucketId, fileName, bucket.folderId);
+      expect(uploadResult.success).toBe(true);
+
+      await buckets.deleteFile(bucket.bucketId, fileName, { folderId: bucket.folderId });
+      untrackUploadedFile(fileName);
+
+      const metadata = await buckets.getFileMetaData(bucket.bucketId, bucket.folderId, {
+        prefix: fileName,
+      });
+      const stillPresent = metadata.items.find((f) => f.path === fileName);
+      expect(stillPresent).toBeUndefined();
+    });
+
+    it('should list files via OData GetFiles', async () => {
+      const { buckets } = getServices();
+      const bucket = await getBucketForTest('OData GetFiles test');
+
+      const seedName = `/integration-getfiles-${mode}-${Date.now()}.txt`;
+      await buckets.uploadFile({
+        bucketId: bucket.bucketId,
+        folderId: bucket.folderId,
+        path: seedName,
+        content: Buffer.from(createTestFileContent(seedName), 'utf-8'),
+      });
+      trackUploadedFile(bucket.bucketId, seedName, bucket.folderId);
+
+      const result = await buckets.getFiles(bucket.bucketId, { folderId: bucket.folderId });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
+      expect(result.items.length, 'GetFiles returned an empty listing despite a seeded file').toBeGreaterThan(0);
+
+      const file = result.items[0];
+      expect(file.path).toBeDefined();
+      expect(typeof file.path).toBe('string');
+      expect(typeof file.isDirectory).toBe('boolean');
+      // PascalCase originals must be absent
+      expect((file as any).FullPath).toBeUndefined();
+      expect((file as any).IsDirectory).toBeUndefined();
+
+      await buckets.deleteFile(bucket.bucketId, seedName, { folderId: bucket.folderId });
+      untrackUploadedFile(seedName);
+    });
+
+    it('should paginate getFiles with pageSize', async () => {
+      const { buckets } = getServices();
+      const bucket = await getBucketForTest('OData GetFiles pagination test');
+
+      const page1 = await buckets.getFiles(bucket.bucketId, { folderId: bucket.folderId, pageSize: 2 });
+
+      expect(page1.items.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should filter getFiles by fileNameRegex', async () => {
+      const { buckets } = getServices();
+      const bucket = await getBucketForTest('OData GetFiles regex test');
+
+      const result = await buckets.getFiles(bucket.bucketId, {
+        folderId: bucket.folderId,
+        fileNameRegex: '.*\\.txt$',
+        pageSize: 5,
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
     });
   });
 

--- a/tests/integration/utils/cleanup.ts
+++ b/tests/integration/utils/cleanup.ts
@@ -3,8 +3,9 @@ import { retryWithBackoff } from './helpers';
 
 /**
  * Registry to track created resources for emergency cleanup.
- * Note: Orchestrator services (queues, assets, buckets) are read-only in the SDK.
- * Only services with delete/cancel operations are tracked here.
+ * Note: The SDK exposes no bucket/queue/asset entity deletion, but bucket
+ * files can be deleted, so they are tracked here alongside other deletable
+ * resources.
  */
 interface ResourceRegistry {
   tasks: Array<{ id: number; folderId?: number }>;
@@ -13,6 +14,7 @@ interface ResourceRegistry {
   caseInstances: Array<{ id: string; folderKey?: string }>;
   feedbackEntries: Array<{ id: string; folderKey?: string }>;
   feedbackCategories: Array<{ id: string }>;
+  bucketFiles: Array<{ bucketId: number; path: string; folderId?: number }>;
 }
 
 const resourceRegistry: ResourceRegistry = {
@@ -22,6 +24,7 @@ const resourceRegistry: ResourceRegistry = {
   caseInstances: [],
   feedbackEntries: [],
   feedbackCategories: [],
+  bucketFiles: [],
 };
 
 /**
@@ -153,6 +156,33 @@ export async function cleanupTestFeedbackEntry(
 }
 
 /**
+ * Deletes a test file from a bucket.
+ *
+ * @param bucketId - ID of the bucket containing the file
+ * @param path - Path of the file within the bucket
+ * @param folderId - Optional Orchestrator folder ID
+ */
+export async function cleanupTestBucketFile(
+  bucketId: number,
+  path: string,
+  folderId?: number
+): Promise<void> {
+  try {
+    const { buckets } = getServices();
+    await retryWithBackoff(async () => {
+      await buckets.deleteFile(
+        bucketId,
+        path,
+        folderId !== undefined ? { folderId } : undefined
+      );
+    });
+    console.log(`Cleaned up test bucket file: ${path} (bucket ${bucketId})`);
+  } catch (error) {
+    console.warn(`Failed to cleanup bucket file ${path} in bucket ${bucketId}:`, error);
+  }
+}
+
+/**
  * Deletes a test feedback category.
  *
  * @param id - ID of the feedback category
@@ -207,6 +237,11 @@ export async function cleanupAllTestResources(): Promise<void> {
     await cleanupTestFeedbackCategory(category.id);
   }
 
+  // Cleanup bucket files
+  for (const file of resourceRegistry.bucketFiles) {
+    await cleanupTestBucketFile(file.bucketId, file.path, file.folderId);
+  }
+
   // Clear registry
   resourceRegistry.tasks = [];
   resourceRegistry.entityRecords = [];
@@ -214,6 +249,7 @@ export async function cleanupAllTestResources(): Promise<void> {
   resourceRegistry.caseInstances = [];
   resourceRegistry.feedbackEntries = [];
   resourceRegistry.feedbackCategories = [];
+  resourceRegistry.bucketFiles = [];
 
   console.log('Emergency cleanup completed');
 }
@@ -222,7 +258,9 @@ export async function cleanupAllTestResources(): Promise<void> {
 // the SDK does not provide delete methods for these services:
 // - cleanupTestQueue: sdk.queues has no delete method (read-only)
 // - cleanupTestAsset: sdk.assets has no delete method (read-only)
-// - cleanupTestBucket: sdk.buckets has no delete method (read-only)
+// - cleanupTestBucket: sdk.buckets exposes no method to delete the bucket
+//   entity itself. Files within a bucket can be cleaned up via
+//   cleanupTestBucketFile.
 // - cleanupTestChoiceSet: sdk.choiceSets has no delete method (read-only)
 //
 // These resources must be managed through the UiPath UI or other APIs.

--- a/tests/unit/services/orchestrator/buckets.test.ts
+++ b/tests/unit/services/orchestrator/buckets.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../utils/mocks';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
-import type { BucketGetByIdOptions, BucketGetAllOptions, BucketGetFileMetaDataWithPaginationOptions, BucketGetReadUriOptions, BucketGetResponse, BlobItem } from '../../../../src/models/orchestrator/buckets.types';
+import type { BucketGetByIdOptions, BucketGetAllOptions, BucketGetFileMetaDataWithPaginationOptions, BucketGetReadUriOptions, BucketGetResponse, BlobItem, BucketGetFilesOptions, BucketFile } from '../../../../src/models/orchestrator/buckets.types';
 import { BucketOptions } from '../../../../src/models/orchestrator/buckets.types';
 import { BUCKET_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 
@@ -852,4 +852,250 @@ describe('BucketService Unit Tests', () => {
       })).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
+
+  describe('deleteFile', () => {
+    it('should delete a file from a bucket successfully', async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await bucketService.deleteFile(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        BUCKET_TEST_CONSTANTS.FILE_PATH,
+        { folderId: TEST_CONSTANTS.FOLDER_ID },
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        BUCKET_ENDPOINTS.DELETE_FILE(BUCKET_TEST_CONSTANTS.BUCKET_ID),
+        expect.objectContaining({
+          params: { path: BUCKET_TEST_CONSTANTS.FILE_PATH },
+          headers: expect.objectContaining({
+            [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+          }),
+        }),
+      );
+    });
+
+    it('should resolve folderKey into the FolderKey header', async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await bucketService.deleteFile(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        BUCKET_TEST_CONSTANTS.FILE_PATH,
+        { folderKey: BUCKET_TEST_CONSTANTS.FOLDER_KEY },
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        BUCKET_ENDPOINTS.DELETE_FILE(BUCKET_TEST_CONSTANTS.BUCKET_ID),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: BUCKET_TEST_CONSTANTS.FOLDER_KEY,
+          }),
+        }),
+      );
+    });
+
+    it('should throw ValidationError when bucketId is missing', async () => {
+      await expect(bucketService.deleteFile(
+        null as any,
+        BUCKET_TEST_CONSTANTS.FILE_PATH,
+        { folderId: TEST_CONSTANTS.FOLDER_ID },
+      )).rejects.toThrow('bucketId is required for deleteFile');
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when no folder context is provided', async () => {
+      await expect(bucketService.deleteFile(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        BUCKET_TEST_CONSTANTS.FILE_PATH,
+      )).rejects.toThrow(ValidationError);
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when path is missing', async () => {
+      await expect(bucketService.deleteFile(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        null as any,
+        { folderId: TEST_CONSTANTS.FOLDER_ID },
+      )).rejects.toThrow('path is required for deleteFile');
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.delete.mockRejectedValue(error);
+
+      await expect(bucketService.deleteFile(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        BUCKET_TEST_CONSTANTS.FILE_PATH,
+        { folderId: TEST_CONSTANTS.FOLDER_ID },
+      )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('getFiles', () => {
+    it('should return files without pagination', async () => {
+      const mockFiles: BucketFile[] = [
+        { path: 'file1.txt', contentType: 'text/plain', size: 10, isDirectory: false, id: null },
+        { path: 'folder1', contentType: '', size: 0, isDirectory: true, id: null },
+      ];
+      const mockResponse = { items: mockFiles, totalCount: undefined };
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const result = await bucketService.getFiles(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        { folderId: TEST_CONSTANTS.FOLDER_ID },
+      );
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceAccess: expect.any(Object),
+          getEndpoint: expect.toSatisfy((fn: () => string) =>
+            fn() === BUCKET_ENDPOINTS.GET_FILES(BUCKET_TEST_CONSTANTS.BUCKET_ID),
+          ),
+          transformFn: expect.any(Function),
+          pagination: expect.objectContaining({
+            paginationType: PaginationType.OFFSET,
+            itemsField: ODATA_PAGINATION.ITEMS_FIELD,
+            totalCountField: ODATA_PAGINATION.TOTAL_COUNT_FIELD,
+          }),
+          excludeFromPrefix: ['directory', 'recursive', 'fileNameRegex'],
+          headers: expect.objectContaining({
+            [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+          }),
+        }),
+        expect.objectContaining({
+          directory: '/',
+          recursive: true,
+        }),
+      );
+
+      expect(result).toEqual(mockResponse);
+      expect(result.items).toHaveLength(2);
+    });
+
+    it('should pass fileNameRegex through to the request', async () => {
+      const mockResponse = { items: [], totalCount: undefined };
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const options: BucketGetFilesOptions = {
+        folderId: TEST_CONSTANTS.FOLDER_ID,
+        fileNameRegex: '.*\\.pdf$',
+      };
+
+      await bucketService.getFiles(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        options,
+      );
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeFromPrefix: ['directory', 'recursive', 'fileNameRegex'],
+          headers: expect.objectContaining({
+            [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+          }),
+        }),
+        expect.objectContaining({
+          directory: '/',
+          recursive: true,
+          fileNameRegex: '.*\\.pdf$',
+        }),
+      );
+    });
+
+    it('should resolve folderKey into the FolderKey header', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: undefined });
+
+      await bucketService.getFiles(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        { folderKey: BUCKET_TEST_CONSTANTS.FOLDER_KEY },
+      );
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: BUCKET_TEST_CONSTANTS.FOLDER_KEY,
+          }),
+        }),
+        expect.not.objectContaining({ folderKey: expect.anything() }),
+      );
+    });
+
+    it('should return paginated files when pagination options provided', async () => {
+      const mockFiles: BucketFile[] = [
+        { path: 'a.txt', contentType: 'text/plain', size: 5, isDirectory: false, id: null },
+      ];
+      const mockResponse = {
+        items: mockFiles,
+        totalCount: undefined,
+        hasNextPage: true,
+        nextCursor: TEST_CONSTANTS.NEXT_CURSOR,
+        previousCursor: null,
+        currentPage: 1,
+        totalPages: undefined,
+      };
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const result = await bucketService.getFiles(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        { folderId: TEST_CONSTANTS.FOLDER_ID, pageSize: TEST_CONSTANTS.PAGE_SIZE },
+      ) as PaginatedResponse<BucketFile>;
+
+      expect(result.hasNextPage).toBe(true);
+      expect(result.nextCursor).toBe(TEST_CONSTANTS.NEXT_CURSOR);
+    });
+
+    it('should transform PascalCase API response to camelCase with path rename', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockImplementation(async ({ transformFn }) => {
+        const raw = {
+          FullPath: 'docs/report.pdf',
+          ContentType: 'application/pdf',
+          Size: 12345,
+          IsDirectory: false,
+          Id: null,
+        };
+        const transformed = transformFn?.(raw);
+        return { items: [transformed], totalCount: undefined };
+      });
+
+      const result = await bucketService.getFiles(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        { folderId: TEST_CONSTANTS.FOLDER_ID },
+      );
+
+      const file = result.items[0];
+      expect(file.path).toBe('docs/report.pdf');
+      expect(file.contentType).toBe('application/pdf');
+      expect(file.size).toBe(12345);
+      expect(file.isDirectory).toBe(false);
+      expect(file.id).toBeNull();
+      // PascalCase originals must be absent
+      expect((file as any).FullPath).toBeUndefined();
+      expect((file as any).ContentType).toBeUndefined();
+      expect((file as any).IsDirectory).toBeUndefined();
+      // fullPath (intermediate camelCase) was renamed to path via BucketMap
+      expect((file as any).fullPath).toBeUndefined();
+    });
+
+    it('should throw ValidationError when bucketId is missing', async () => {
+      await expect(bucketService.getFiles(null as any, { folderId: TEST_CONSTANTS.FOLDER_ID }))
+        .rejects.toThrow('bucketId is required for getFiles');
+      expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when no folder context is provided', async () => {
+      await expect(bucketService.getFiles(BUCKET_TEST_CONSTANTS.BUCKET_ID))
+        .rejects.toThrow(ValidationError);
+      expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
+
+      await expect(bucketService.getFiles(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        { folderId: TEST_CONSTANTS.FOLDER_ID },
+      )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
 });
+


### PR DESCRIPTION
https://uipath.atlassian.net/browse/PLT-103904

DeleteFile: deletes a file from storage bucket. Refer [swagger](https://alpha.uipath.com/avinash/addy_test_22/orchestrator_/swagger/index.html#/Buckets/Buckets_DeleteFileByKey) for input and output

GetFiles: return the list of files in a storage bucket. Refer [swagger](https://alpha.uipath.com/avinash/addy_test_22/orchestrator_/swagger/index.html#/Buckets/Buckets_GetFilesByKey)  for input and output