### PR TITLE
feat(insights): add getTopElementFailedCount to MaestroProcesses and Cases [PLT-103283]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -73,7 +73,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getIncidents()` | `PIMS` |
 | `getTopRunCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopFaultedCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getTopElementFailureCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopElementFailedCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getInstanceStatusTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopExecutionDuration()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
@@ -98,7 +98,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getAll()` | `PIMS` |
 | `getTopRunCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopFaultedCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getTopElementFailureCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopElementFailedCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getInstanceStatusTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopExecutionDuration()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -73,6 +73,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getIncidents()` | `PIMS` |
 | `getTopRunCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopFaultedCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopElementFailureCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getInstanceStatusTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopExecutionDuration()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
@@ -97,6 +98,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getAll()` | `PIMS` |
 | `getTopRunCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopFaultedCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopElementFailureCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getInstanceStatusTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getTopExecutionDuration()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 

--- a/src/models/maestro/cases.models.ts
+++ b/src/models/maestro/cases.models.ts
@@ -4,8 +4,7 @@
  */
 
 import { CaseGetAllResponse, CaseGetTopRunCountResponse, CaseGetTopFaultedCountResponse, CaseGetTopDurationResponse } from './cases.types';
-import { TopQueryOptions, InstanceStatusTimelineResponse, TimelineOptions } from './insights.types';
-import { ElementGetTopFailureCountResponse } from './processes.types';
+import { TopQueryOptions, InstanceStatusTimelineResponse, TimelineOptions, ElementGetTopFailedCountResponse } from './insights.types';
 
 /**
  * Service for managing UiPath Maestro Cases
@@ -128,7 +127,7 @@ export interface CasesServiceModel {
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
-   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
    * import { Cases } from '@uipath/uipath-typescript/cases';
@@ -136,17 +135,17 @@ export interface CasesServiceModel {
    * const cases = new Cases(sdk);
    *
    * // Get top failing elements for the last 7 days
-   * const topFailing = await cases.getTopElementFailureCount(
+   * const topFailing = await cases.getTopElementFailedCount(
    *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
    *   new Date()
    * );
    *
    * for (const element of topFailing) {
-   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
    */
-  getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]>;
+  getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]>;
 
   /**
    * Get all instances status counts aggregated by date for case management processes.

--- a/src/models/maestro/cases.models.ts
+++ b/src/models/maestro/cases.models.ts
@@ -5,6 +5,7 @@
 
 import { CaseGetAllResponse, CaseGetTopRunCountResponse, CaseGetTopFaultedCountResponse, CaseGetTopDurationResponse } from './cases.types';
 import { TopQueryOptions, InstanceStatusTimelineResponse, TimelineOptions } from './insights.types';
+import { ElementGetTopFailureCountResponse } from './processes.types';
 
 /**
  * Service for managing UiPath Maestro Cases
@@ -118,6 +119,34 @@ export interface CasesServiceModel {
    * ```
    */
   getTopFaultedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<CaseGetTopFaultedCountResponse[]>;
+
+  /**
+   * Get the top 10 BPMN elements ranked by failure count within a time range.
+   *
+   * Returns an array of up to 10 elements sorted by how many times they failed,
+   * useful for identifying the most error-prone activities in case processes.
+   *
+   * @param startTime - Start of the time range to query
+   * @param endTime - End of the time range to query
+   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @example
+   * ```typescript
+   * import { Cases } from '@uipath/uipath-typescript/cases';
+   *
+   * const cases = new Cases(sdk);
+   *
+   * // Get top failing elements for the last 7 days
+   * const topFailing = await cases.getTopElementFailureCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date()
+   * );
+   *
+   * for (const element of topFailing) {
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   * }
+   * ```
+   */
+  getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]>;
 
   /**
    * Get all instances status counts aggregated by date for case management processes.

--- a/src/models/maestro/cases.models.ts
+++ b/src/models/maestro/cases.models.ts
@@ -127,6 +127,7 @@ export interface CasesServiceModel {
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
+   * @param options - Optional filters (packageId, processKey, version)
    * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
@@ -144,8 +145,18 @@ export interface CasesServiceModel {
    *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Get top failing elements for a specific process
+   * const filtered = await cases.getTopElementFailedCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date(),
+   *   { processKey: '<processKey>' }
+   * );
+   * ```
    */
-  getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]>;
+  getTopElementFailedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<ElementGetTopFailedCountResponse[]>;
 
   /**
    * Get all instances status counts aggregated by date for case management processes.

--- a/src/models/maestro/insights.internal-types.ts
+++ b/src/models/maestro/insights.internal-types.ts
@@ -1,0 +1,14 @@
+/**
+ * Raw API response for TopElementswithFailure endpoint.
+ * The SDK renames `count` to `failedCount` in the public response type.
+ */
+export interface RawElementGetTopFailedCountResponse {
+  /** BPMN element name (falls back to element ID if name is empty) */
+  elementName: string;
+  /** BPMN element type (e.g. ServiceTask, ReceiveTask, IntermediateCatchEvent) */
+  elementType: string;
+  /** The unique process key this element belongs to */
+  processKey: string;
+  /** Number of failed executions */
+  count: number;
+}

--- a/src/models/maestro/insights.types.ts
+++ b/src/models/maestro/insights.types.ts
@@ -43,18 +43,18 @@ export interface GetTopFaultedCountResponse extends GetTopBaseResponse {
 }
 
 /**
- * Response for top elements with failure from the Insights endpoint.
- * Returns BPMN elements ranked by failure count.
+ * SDK response for top elements with failure.
+ * Shared by both MaestroProcesses and Cases — no service-specific enrichment.
  */
-export interface RawElementGetTopFailureCountResponse {
+export interface ElementGetTopFailedCountResponse {
   /** BPMN element name (falls back to element ID if name is empty) */
   elementName: string;
   /** BPMN element type (e.g. ServiceTask, ReceiveTask, IntermediateCatchEvent) */
   elementType: string;
   /** The unique process key this element belongs to */
   processKey: string;
-  /** Number of failed executions */
-  count: number;
+  /** Number of failed executions of this element in the given time range */
+  failedCount: number;
 }
 
 /**

--- a/src/models/maestro/insights.types.ts
+++ b/src/models/maestro/insights.types.ts
@@ -43,6 +43,21 @@ export interface GetTopFaultedCountResponse extends GetTopBaseResponse {
 }
 
 /**
+ * Response for top elements with failure from the Insights endpoint.
+ * Returns BPMN elements ranked by failure count.
+ */
+export interface RawElementGetTopFailureCountResponse {
+  /** BPMN element name (falls back to element ID if name is empty) */
+  elementName: string;
+  /** BPMN element type (e.g. ServiceTask, ReceiveTask, IntermediateCatchEvent) */
+  elementType: string;
+  /** The unique process key this element belongs to */
+  processKey: string;
+  /** Number of failed executions */
+  count: number;
+}
+
+/**
  * Time bucketing granularity for insights time-series queries.
  *
  * Controls how data points are grouped on the time axis.

--- a/src/models/maestro/processes.models.ts
+++ b/src/models/maestro/processes.models.ts
@@ -5,8 +5,7 @@
 
 import { RawMaestroProcessGetAllResponse, ProcessGetTopRunCountResponse, ProcessGetTopFaultedCountResponse, ProcessGetTopDurationResponse } from './processes.types';
 import { ProcessIncidentGetResponse } from './process-incidents.types';
-import { TopQueryOptions, InstanceStatusTimelineResponse, TimelineOptions } from './insights.types';
-import { ElementGetTopFailureCountResponse } from './processes.types';
+import { TopQueryOptions, InstanceStatusTimelineResponse, TimelineOptions, ElementGetTopFailedCountResponse } from './insights.types';
 
 /**
  * Service for managing UiPath Maestro Processes
@@ -155,7 +154,7 @@ export interface MaestroProcessesServiceModel {
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
-   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
    * import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
@@ -163,17 +162,17 @@ export interface MaestroProcessesServiceModel {
    * const maestroProcesses = new MaestroProcesses(sdk);
    *
    * // Get top failing elements for the last 7 days
-   * const topFailing = await maestroProcesses.getTopElementFailureCount(
+   * const topFailing = await maestroProcesses.getTopElementFailedCount(
    *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
    *   new Date()
    * );
    *
    * for (const element of topFailing) {
-   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
    */
-  getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]>;
+  getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]>;
 
   /**
    * Get all instances status counts aggregated by date for maestro processes.

--- a/src/models/maestro/processes.models.ts
+++ b/src/models/maestro/processes.models.ts
@@ -154,6 +154,7 @@ export interface MaestroProcessesServiceModel {
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
+   * @param options - Optional filters (packageId, processKey, version)
    * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
@@ -171,8 +172,18 @@ export interface MaestroProcessesServiceModel {
    *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Get top failing elements for a specific process
+   * const filtered = await maestroProcesses.getTopElementFailedCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date(),
+   *   { processKey: '<processKey>' }
+   * );
+   * ```
    */
-  getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]>;
+  getTopElementFailedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<ElementGetTopFailedCountResponse[]>;
 
   /**
    * Get all instances status counts aggregated by date for maestro processes.

--- a/src/models/maestro/processes.models.ts
+++ b/src/models/maestro/processes.models.ts
@@ -6,6 +6,7 @@
 import { RawMaestroProcessGetAllResponse, ProcessGetTopRunCountResponse, ProcessGetTopFaultedCountResponse, ProcessGetTopDurationResponse } from './processes.types';
 import { ProcessIncidentGetResponse } from './process-incidents.types';
 import { TopQueryOptions, InstanceStatusTimelineResponse, TimelineOptions } from './insights.types';
+import { ElementGetTopFailureCountResponse } from './processes.types';
 
 /**
  * Service for managing UiPath Maestro Processes
@@ -145,6 +146,34 @@ export interface MaestroProcessesServiceModel {
    * ```
    */
   getTopFaultedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<ProcessGetTopFaultedCountResponse[]>;
+
+  /**
+   * Get the top 10 BPMN elements ranked by failure count within a time range.
+   *
+   * Returns an array of up to 10 elements sorted by how many times they failed,
+   * useful for identifying the most error-prone activities in processes.
+   *
+   * @param startTime - Start of the time range to query
+   * @param endTime - End of the time range to query
+   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @example
+   * ```typescript
+   * import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
+   *
+   * const maestroProcesses = new MaestroProcesses(sdk);
+   *
+   * // Get top failing elements for the last 7 days
+   * const topFailing = await maestroProcesses.getTopElementFailureCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date()
+   * );
+   *
+   * for (const element of topFailing) {
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   * }
+   * ```
+   */
+  getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]>;
 
   /**
    * Get all instances status counts aggregated by date for maestro processes.

--- a/src/models/maestro/processes.types.ts
+++ b/src/models/maestro/processes.types.ts
@@ -62,21 +62,6 @@ export interface ProcessGetTopFaultedCountResponse extends GetTopFaultedCountRes
 }
 
 /**
- * SDK response for top elements with failure.
- * Shared by both MaestroProcesses and Cases — no service-specific enrichment.
- */
-export interface ElementGetTopFailureCountResponse {
-  /** BPMN element name (falls back to element ID if name is empty) */
-  elementName: string;
-  /** BPMN element type (e.g. ServiceTask, ReceiveTask, IntermediateCatchEvent) */
-  elementType: string;
-  /** The unique process key this element belongs to */
-  processKey: string;
-  /** Number of failed executions of this element in the given time range */
-  failureCount: number;
-}
-
-/**
  * Response for a single entry in top processes by duration
  */
 export interface ProcessGetTopDurationResponse extends GetTopDurationResponse {

--- a/src/models/maestro/processes.types.ts
+++ b/src/models/maestro/processes.types.ts
@@ -62,10 +62,24 @@ export interface ProcessGetTopFaultedCountResponse extends GetTopFaultedCountRes
 }
 
 /**
+ * SDK response for top elements with failure.
+ * Shared by both MaestroProcesses and Cases — no service-specific enrichment.
+ */
+export interface ElementGetTopFailureCountResponse {
+  /** BPMN element name (falls back to element ID if name is empty) */
+  elementName: string;
+  /** BPMN element type (e.g. ServiceTask, ReceiveTask, IntermediateCatchEvent) */
+  elementType: string;
+  /** The unique process key this element belongs to */
+  processKey: string;
+  /** Number of failed executions of this element in the given time range */
+  failureCount: number;
+}
+
+/**
  * Response for a single entry in top processes by duration
  */
 export interface ProcessGetTopDurationResponse extends GetTopDurationResponse {
   /** Human-readable process name */
   name: string;
 }
-

--- a/src/services/maestro/cases/cases.ts
+++ b/src/services/maestro/cases/cases.ts
@@ -1,4 +1,5 @@
-import { CaseGetAllResponse, CaseGetTopRunCountResponse, CaseGetTopFaultedCountResponse, CaseGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, ElementGetTopFailureCountResponse, RawElementGetTopFailureCountResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
+import { CaseGetAllResponse, CaseGetTopRunCountResponse, CaseGetTopFaultedCountResponse, CaseGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, ElementGetTopFailedCountResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
+import type { RawElementGetTopFailedCountResponse } from '../../../models/maestro/insights.internal-types';
 import type { TimelineOptions, TopQueryOptions } from '../../../models/maestro';
 import { ProcessType } from '../../../models/maestro/cases.internal-types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -104,7 +105,7 @@ export class CasesService extends BaseService implements CasesServiceModel {
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
-   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
    * import { Cases } from '@uipath/uipath-typescript/cases';
@@ -112,19 +113,19 @@ export class CasesService extends BaseService implements CasesServiceModel {
    * const cases = new Cases(sdk);
    *
    * // Get top failing elements for the last 7 days
-   * const topFailing = await cases.getTopElementFailureCount(
+   * const topFailing = await cases.getTopElementFailedCount(
    *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
    *   new Date()
    * );
    *
    * for (const element of topFailing) {
-   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
    */
-  @track('Cases.GetTopElementFailureCount')
-  async getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]> {
-    const { data } = await this.post<RawElementGetTopFailureCountResponse[]>(
+  @track('Cases.GetTopElementFailedCount')
+  async getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]> {
+    const { data } = await this.post<RawElementGetTopFailedCountResponse[]>(
       MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
       buildInsightsTopBody(startTime, endTime, true)
     );
@@ -132,7 +133,7 @@ export class CasesService extends BaseService implements CasesServiceModel {
       elementName: item.elementName,
       elementType: item.elementType,
       processKey: item.processKey,
-      failureCount: item.count,
+      failedCount: item.count,
     }));
   }
 

--- a/src/services/maestro/cases/cases.ts
+++ b/src/services/maestro/cases/cases.ts
@@ -105,6 +105,7 @@ export class CasesService extends BaseService implements CasesServiceModel {
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
+   * @param options - Optional filters (packageId, processKey, version)
    * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
@@ -122,12 +123,22 @@ export class CasesService extends BaseService implements CasesServiceModel {
    *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Get top failing elements for a specific process
+   * const filtered = await cases.getTopElementFailedCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date(),
+   *   { processKey: '<processKey>' }
+   * );
+   * ```
    */
   @track('Cases.GetTopElementFailedCount')
-  async getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]> {
+  async getTopElementFailedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<ElementGetTopFailedCountResponse[]> {
     const { data } = await this.post<RawElementGetTopFailedCountResponse[]>(
       MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
-      buildInsightsTopBody(startTime, endTime, true)
+      buildInsightsTopBody(startTime, endTime, true, options)
     );
     return (data ?? []).map(item => ({
       elementName: item.elementName,

--- a/src/services/maestro/cases/cases.ts
+++ b/src/services/maestro/cases/cases.ts
@@ -1,4 +1,4 @@
-import { CaseGetAllResponse, CaseGetTopRunCountResponse, CaseGetTopFaultedCountResponse, CaseGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
+import { CaseGetAllResponse, CaseGetTopRunCountResponse, CaseGetTopFaultedCountResponse, CaseGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, ElementGetTopFailureCountResponse, RawElementGetTopFailureCountResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
 import type { TimelineOptions, TopQueryOptions } from '../../../models/maestro';
 import { ProcessType } from '../../../models/maestro/cases.internal-types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -94,6 +94,46 @@ export class CasesService extends BaseService implements CasesServiceModel {
       buildInsightsTopBody(startTime, endTime, true, options)
     );
     return (data ?? []).map(process => ({ ...process, name: this.extractCaseName(process.packageId) }));
+  }
+
+  /**
+   * Get the top 10 BPMN elements ranked by failure count within a time range.
+   *
+   * Returns an array of up to 10 elements sorted by how many times they failed,
+   * useful for identifying the most error-prone activities in case processes.
+   *
+   * @param startTime - Start of the time range to query
+   * @param endTime - End of the time range to query
+   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @example
+   * ```typescript
+   * import { Cases } from '@uipath/uipath-typescript/cases';
+   *
+   * const cases = new Cases(sdk);
+   *
+   * // Get top failing elements for the last 7 days
+   * const topFailing = await cases.getTopElementFailureCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date()
+   * );
+   *
+   * for (const element of topFailing) {
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   * }
+   * ```
+   */
+  @track('Cases.GetTopElementFailureCount')
+  async getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]> {
+    const { data } = await this.post<RawElementGetTopFailureCountResponse[]>(
+      MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
+      buildInsightsTopBody(startTime, endTime, true)
+    );
+    return (data ?? []).map(item => ({
+      elementName: item.elementName,
+      elementType: item.elementType,
+      processKey: item.processKey,
+      failureCount: item.count,
+    }));
   }
 
   /**

--- a/src/services/maestro/processes/processes.ts
+++ b/src/services/maestro/processes/processes.ts
@@ -1,4 +1,4 @@
-import { MaestroProcessGetAllResponse, ProcessIncidentGetResponse, ProcessGetTopRunCountResponse, ProcessGetTopFaultedCountResponse, ProcessGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
+import { MaestroProcessGetAllResponse, ProcessIncidentGetResponse, ProcessGetTopRunCountResponse, ProcessGetTopFaultedCountResponse, ProcessGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, ElementGetTopFailureCountResponse, RawElementGetTopFailureCountResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
 import type { TimelineOptions, TopQueryOptions } from '../../../models/maestro';
 import type { IUiPath } from '../../../core/types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -124,6 +124,46 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
       buildInsightsTopBody(startTime, endTime, false, options)
     );
     return (data ?? []).map(process => ({ ...process, name: process.packageId }));
+  }
+
+  /**
+   * Get the top 10 BPMN elements ranked by failure count within a time range.
+   *
+   * Returns an array of up to 10 elements sorted by how many times they failed,
+   * useful for identifying the most error-prone activities in processes.
+   *
+   * @param startTime - Start of the time range to query
+   * @param endTime - End of the time range to query
+   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @example
+   * ```typescript
+   * import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
+   *
+   * const maestroProcesses = new MaestroProcesses(sdk);
+   *
+   * // Get top failing elements for the last 7 days
+   * const topFailing = await maestroProcesses.getTopElementFailureCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date()
+   * );
+   *
+   * for (const element of topFailing) {
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   * }
+   * ```
+   */
+  @track('MaestroProcesses.GetTopElementFailureCount')
+  async getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]> {
+    const { data } = await this.post<RawElementGetTopFailureCountResponse[]>(
+      MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
+      buildInsightsTopBody(startTime, endTime, false)
+    );
+    return (data ?? []).map(item => ({
+      elementName: item.elementName,
+      elementType: item.elementType,
+      processKey: item.processKey,
+      failureCount: item.count,
+    }));
   }
 
   /**

--- a/src/services/maestro/processes/processes.ts
+++ b/src/services/maestro/processes/processes.ts
@@ -135,6 +135,7 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
+   * @param options - Optional filters (packageId, processKey, version)
    * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
@@ -152,12 +153,22 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
    *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Get top failing elements for a specific process
+   * const filtered = await maestroProcesses.getTopElementFailedCount(
+   *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+   *   new Date(),
+   *   { processKey: '<processKey>' }
+   * );
+   * ```
    */
   @track('MaestroProcesses.GetTopElementFailedCount')
-  async getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]> {
+  async getTopElementFailedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<ElementGetTopFailedCountResponse[]> {
     const { data } = await this.post<RawElementGetTopFailedCountResponse[]>(
       MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
-      buildInsightsTopBody(startTime, endTime, false)
+      buildInsightsTopBody(startTime, endTime, false, options)
     );
     return (data ?? []).map(item => ({
       elementName: item.elementName,

--- a/src/services/maestro/processes/processes.ts
+++ b/src/services/maestro/processes/processes.ts
@@ -1,4 +1,5 @@
-import { MaestroProcessGetAllResponse, ProcessIncidentGetResponse, ProcessGetTopRunCountResponse, ProcessGetTopFaultedCountResponse, ProcessGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, ElementGetTopFailureCountResponse, RawElementGetTopFailureCountResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
+import { MaestroProcessGetAllResponse, ProcessIncidentGetResponse, ProcessGetTopRunCountResponse, ProcessGetTopFaultedCountResponse, ProcessGetTopDurationResponse, GetTopRunCountResponse, GetTopDurationResponse, ElementGetTopFailedCountResponse, InstanceStatusTimelineResponse } from '../../../models/maestro';
+import type { RawElementGetTopFailedCountResponse } from '../../../models/maestro/insights.internal-types';
 import type { TimelineOptions, TopQueryOptions } from '../../../models/maestro';
 import type { IUiPath } from '../../../core/types';
 import { MAESTRO_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -134,7 +135,7 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
    *
    * @param startTime - Start of the time range to query
    * @param endTime - End of the time range to query
-   * @returns Promise resolving to an array of {@link ElementGetTopFailureCountResponse}
+   * @returns Promise resolving to an array of {@link ElementGetTopFailedCountResponse}
    * @example
    * ```typescript
    * import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';
@@ -142,19 +143,19 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
    * const maestroProcesses = new MaestroProcesses(sdk);
    *
    * // Get top failing elements for the last 7 days
-   * const topFailing = await maestroProcesses.getTopElementFailureCount(
+   * const topFailing = await maestroProcesses.getTopElementFailedCount(
    *   new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
    *   new Date()
    * );
    *
    * for (const element of topFailing) {
-   *   console.log(`${element.elementName} (${element.elementType}): ${element.failureCount} failures`);
+   *   console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
    * }
    * ```
    */
-  @track('MaestroProcesses.GetTopElementFailureCount')
-  async getTopElementFailureCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailureCountResponse[]> {
-    const { data } = await this.post<RawElementGetTopFailureCountResponse[]>(
+  @track('MaestroProcesses.GetTopElementFailedCount')
+  async getTopElementFailedCount(startTime: Date, endTime: Date): Promise<ElementGetTopFailedCountResponse[]> {
+    const { data } = await this.post<RawElementGetTopFailedCountResponse[]>(
       MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
       buildInsightsTopBody(startTime, endTime, false)
     );
@@ -162,7 +163,7 @@ export class MaestroProcessesService extends BaseService implements MaestroProce
       elementName: item.elementName,
       elementType: item.elementType,
       processKey: item.processKey,
-      failureCount: item.count,
+      failedCount: item.count,
     }));
   }
 

--- a/src/utils/constants/endpoints/maestro.ts
+++ b/src/utils/constants/endpoints/maestro.ts
@@ -41,6 +41,8 @@ export const MAESTRO_ENDPOINTS = {
     TOP_PROCESSES_BY_RUN_COUNT: `${INSIGHTS_RTM_BASE}/agenticInstanceStatus/TopProcessesByRunCount`,
     /** Top processes ranked by failure count */
     TOP_PROCESSES_WITH_FAILURE: `${INSIGHTS_RTM_BASE}/agenticInstanceStatus/TopProcesseswithFailure`,
+    /** Top elements ranked by failure count */
+    TOP_ELEMENTS_WITH_FAILURE: `${INSIGHTS_RTM_BASE}/agenticInstanceStatus/TopElementswithFailure`,
     /** Instance status aggregated by date for time-series charts */
     INSTANCE_STATUS_BY_DATE: `${INSIGHTS_RTM_BASE}/agenticInstanceStatus/InstanceStatusByDate`,
     /** Top processes ranked by total duration */

--- a/tests/integration/shared/maestro/cases.integration.test.ts
+++ b/tests/integration/shared/maestro/cases.integration.test.ts
@@ -120,6 +120,29 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe.skip('getTopElementFailureCount', () => {
+    it('should retrieve top elements by failure count for cases', async () => {
+      const { cases } = getServices();
+      const now = new Date();
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+      const result = await cases.getTopElementFailureCount(sevenDaysAgo, now);
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+
+      if (result.length === 0) {
+        throw new Error('No top elements by failure count returned — cannot validate response structure');
+      }
+
+      const element = result[0];
+      expect(element.elementName).toBeDefined();
+      expect(typeof element.elementName).toBe('string');
+      expect(element.elementType).toBeDefined();
+      expect(typeof element.failureCount).toBe('number');
+    });
+  });
+
   describe.skip('getTopExecutionDuration', () => {
     it('should retrieve top case processes by duration', async () => {
       const { cases } = getServices();

--- a/tests/integration/shared/maestro/cases.integration.test.ts
+++ b/tests/integration/shared/maestro/cases.integration.test.ts
@@ -120,13 +120,13 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopElementFailureCount', () => {
+  describe.skip('getTopElementFailedCount', () => {
     it('should retrieve top elements by failure count for cases', async () => {
       const { cases } = getServices();
       const now = new Date();
       const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
-      const result = await cases.getTopElementFailureCount(sevenDaysAgo, now);
+      const result = await cases.getTopElementFailedCount(sevenDaysAgo, now);
 
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
@@ -139,7 +139,7 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
       expect(element.elementName).toBeDefined();
       expect(typeof element.elementName).toBe('string');
       expect(element.elementType).toBeDefined();
-      expect(typeof element.failureCount).toBe('number');
+      expect(typeof element.failedCount).toBe('number');
     });
   });
 

--- a/tests/integration/shared/maestro/processes.integration.test.ts
+++ b/tests/integration/shared/maestro/processes.integration.test.ts
@@ -171,13 +171,13 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopElementFailureCount', () => {
+  describe.skip('getTopElementFailedCount', () => {
     it('should retrieve top elements by failure count', async () => {
       const { maestroProcesses } = getServices();
       const now = new Date();
       const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
-      const result = await maestroProcesses.getTopElementFailureCount(sevenDaysAgo, now);
+      const result = await maestroProcesses.getTopElementFailedCount(sevenDaysAgo, now);
 
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
@@ -190,7 +190,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
       expect(element.elementName).toBeDefined();
       expect(typeof element.elementName).toBe('string');
       expect(element.elementType).toBeDefined();
-      expect(typeof element.failureCount).toBe('number');
+      expect(typeof element.failedCount).toBe('number');
     });
   });
 

--- a/tests/integration/shared/maestro/processes.integration.test.ts
+++ b/tests/integration/shared/maestro/processes.integration.test.ts
@@ -171,6 +171,29 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe.skip('getTopElementFailureCount', () => {
+    it('should retrieve top elements by failure count', async () => {
+      const { maestroProcesses } = getServices();
+      const now = new Date();
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+      const result = await maestroProcesses.getTopElementFailureCount(sevenDaysAgo, now);
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+
+      if (result.length === 0) {
+        throw new Error('No top elements by failure count returned — cannot validate response structure');
+      }
+
+      const element = result[0];
+      expect(element.elementName).toBeDefined();
+      expect(typeof element.elementName).toBe('string');
+      expect(element.elementType).toBeDefined();
+      expect(typeof element.failureCount).toBe('number');
+    });
+  });
+
   describe.skip('getTopExecutionDuration', () => {
     it('should retrieve top processes by duration', async () => {
       const { maestroProcesses } = getServices();

--- a/tests/unit/services/maestro/cases.test.ts
+++ b/tests/unit/services/maestro/cases.test.ts
@@ -12,6 +12,7 @@ import {
   createMockInstanceStatusTimeline,
   createMockTopFaultedCountResponse,
   createMockTopDurationResponse,
+  createMockTopElementFailureCountResponse,
   createMockError
 } from '../../../utils/mocks';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
@@ -267,6 +268,39 @@ describe('CasesService', () => {
 
       await expect(
         service.getTopFaultedCount(new Date(), new Date())
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('getTopElementFailureCount', () => {
+    it('should retrieve top elements by failure count with isCaseManagement true', async () => {
+      mockApiClient.post.mockResolvedValue([createMockTopElementFailureCountResponse()]);
+
+      const result = await service.getTopElementFailureCount(
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-05-01T00:00:00Z')
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].elementName).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_1);
+      expect(result[0].failureCount).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_1);
+      expect((result[0] as any).count).toBeUndefined();
+      expect(result[0].elementType).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_1);
+      expect(result[0].processKey).toBe(MAESTRO_TEST_CONSTANTS.PROCESS_KEY);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
+        expect.objectContaining({
+          commonParams: expect.objectContaining({ isCaseManagement: true })
+        }),
+        {}
+      );
+    });
+
+    it('should handle API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(
+        service.getTopElementFailureCount(new Date(), new Date())
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });

--- a/tests/unit/services/maestro/cases.test.ts
+++ b/tests/unit/services/maestro/cases.test.ts
@@ -278,7 +278,8 @@ describe('CasesService', () => {
 
       const result = await service.getTopElementFailedCount(
         new Date('2026-04-01T00:00:00Z'),
-        new Date('2026-05-01T00:00:00Z')
+        new Date('2026-05-01T00:00:00Z'),
+        { processKey: MAESTRO_TEST_CONSTANTS.CASE_PROCESS_KEY }
       );
 
       expect(result).toHaveLength(1);
@@ -290,7 +291,10 @@ describe('CasesService', () => {
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
         expect.objectContaining({
-          commonParams: expect.objectContaining({ isCaseManagement: true })
+          commonParams: expect.objectContaining({
+            isCaseManagement: true,
+            processKey: MAESTRO_TEST_CONSTANTS.CASE_PROCESS_KEY,
+          })
         }),
         {}
       );

--- a/tests/unit/services/maestro/cases.test.ts
+++ b/tests/unit/services/maestro/cases.test.ts
@@ -12,7 +12,7 @@ import {
   createMockInstanceStatusTimeline,
   createMockTopFaultedCountResponse,
   createMockTopDurationResponse,
-  createMockTopElementFailureCountResponse,
+  createMockTopElementFailedCountResponse,
   createMockError
 } from '../../../utils/mocks';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
@@ -272,18 +272,18 @@ describe('CasesService', () => {
     });
   });
 
-  describe('getTopElementFailureCount', () => {
+  describe('getTopElementFailedCount', () => {
     it('should retrieve top elements by failure count with isCaseManagement true', async () => {
-      mockApiClient.post.mockResolvedValue([createMockTopElementFailureCountResponse()]);
+      mockApiClient.post.mockResolvedValue([createMockTopElementFailedCountResponse()]);
 
-      const result = await service.getTopElementFailureCount(
+      const result = await service.getTopElementFailedCount(
         new Date('2026-04-01T00:00:00Z'),
         new Date('2026-05-01T00:00:00Z')
       );
 
       expect(result).toHaveLength(1);
       expect(result[0].elementName).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_1);
-      expect(result[0].failureCount).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_1);
+      expect(result[0].failedCount).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_FAILED_COUNT_1);
       expect((result[0] as any).count).toBeUndefined();
       expect(result[0].elementType).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_1);
       expect(result[0].processKey).toBe(MAESTRO_TEST_CONSTANTS.PROCESS_KEY);
@@ -300,7 +300,7 @@ describe('CasesService', () => {
       mockApiClient.post.mockRejectedValue(new Error(TEST_CONSTANTS.ERROR_MESSAGE));
 
       await expect(
-        service.getTopElementFailureCount(new Date(), new Date())
+        service.getTopElementFailedCount(new Date(), new Date())
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });

--- a/tests/unit/services/maestro/processes.test.ts
+++ b/tests/unit/services/maestro/processes.test.ts
@@ -12,6 +12,7 @@ import {
   createMockInstanceStatusTimeline,
   createMockTopFaultedCountResponse,
   createMockTopDurationResponse,
+  createMockTopElementFailureCountResponse,
   createMockError,
   TEST_CONSTANTS
 } from '../../../utils/mocks';
@@ -327,6 +328,53 @@ describe('MaestroProcessesService', () => {
 
       await expect(
         service.getTopFaultedCount(startDate, endDate)
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('getTopElementFailureCount', () => {
+    const mockResponse = [
+      createMockTopElementFailureCountResponse(),
+      createMockTopElementFailureCountResponse({
+        elementName: MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_2,
+        elementType: MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_2,
+        processKey: MAESTRO_TEST_CONSTANTS.PROCESS_KEY_2,
+        count: MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_2,
+      })
+    ];
+
+    const startDate = new Date('2026-04-01T00:00:00Z');
+    const endDate = new Date('2026-05-01T00:00:00Z');
+
+    it('should retrieve top elements by failure count', async () => {
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const result = await service.getTopElementFailureCount(startDate, endDate);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
+        {
+          commonParams: {
+            startTime: startDate.getTime(),
+            endTime: endDate.getTime(),
+            isCaseManagement: false
+          }
+        },
+        {}
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].elementName).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_1);
+      expect(result[0].elementType).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_1);
+      expect(result[0].failureCount).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_1);
+      expect((result[0] as any).count).toBeUndefined();
+      expect(result[0].processKey).toBe(MAESTRO_TEST_CONSTANTS.PROCESS_KEY);
+    });
+
+    it('should handle API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(
+        service.getTopElementFailureCount(startDate, endDate)
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });

--- a/tests/unit/services/maestro/processes.test.ts
+++ b/tests/unit/services/maestro/processes.test.ts
@@ -349,7 +349,9 @@ describe('MaestroProcessesService', () => {
     it('should retrieve top elements by failure count', async () => {
       mockApiClient.post.mockResolvedValue(mockResponse);
 
-      const result = await service.getTopElementFailedCount(startDate, endDate);
+      const result = await service.getTopElementFailedCount(startDate, endDate, {
+        processKey: MAESTRO_TEST_CONSTANTS.PROCESS_KEY,
+      });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
@@ -357,7 +359,8 @@ describe('MaestroProcessesService', () => {
           commonParams: {
             startTime: startDate.getTime(),
             endTime: endDate.getTime(),
-            isCaseManagement: false
+            isCaseManagement: false,
+            processKey: MAESTRO_TEST_CONSTANTS.PROCESS_KEY,
           }
         },
         {}

--- a/tests/unit/services/maestro/processes.test.ts
+++ b/tests/unit/services/maestro/processes.test.ts
@@ -12,7 +12,7 @@ import {
   createMockInstanceStatusTimeline,
   createMockTopFaultedCountResponse,
   createMockTopDurationResponse,
-  createMockTopElementFailureCountResponse,
+  createMockTopElementFailedCountResponse,
   createMockError,
   TEST_CONSTANTS
 } from '../../../utils/mocks';
@@ -332,14 +332,14 @@ describe('MaestroProcessesService', () => {
     });
   });
 
-  describe('getTopElementFailureCount', () => {
+  describe('getTopElementFailedCount', () => {
     const mockResponse = [
-      createMockTopElementFailureCountResponse(),
-      createMockTopElementFailureCountResponse({
+      createMockTopElementFailedCountResponse(),
+      createMockTopElementFailedCountResponse({
         elementName: MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_2,
         elementType: MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_2,
         processKey: MAESTRO_TEST_CONSTANTS.PROCESS_KEY_2,
-        count: MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_2,
+        count: MAESTRO_TEST_CONSTANTS.ELEMENT_FAILED_COUNT_2,
       })
     ];
 
@@ -349,7 +349,7 @@ describe('MaestroProcessesService', () => {
     it('should retrieve top elements by failure count', async () => {
       mockApiClient.post.mockResolvedValue(mockResponse);
 
-      const result = await service.getTopElementFailureCount(startDate, endDate);
+      const result = await service.getTopElementFailedCount(startDate, endDate);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MAESTRO_ENDPOINTS.INSIGHTS.TOP_ELEMENTS_WITH_FAILURE,
@@ -365,7 +365,7 @@ describe('MaestroProcessesService', () => {
       expect(result).toHaveLength(2);
       expect(result[0].elementName).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_1);
       expect(result[0].elementType).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_1);
-      expect(result[0].failureCount).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_1);
+      expect(result[0].failedCount).toBe(MAESTRO_TEST_CONSTANTS.ELEMENT_FAILED_COUNT_1);
       expect((result[0] as any).count).toBeUndefined();
       expect(result[0].processKey).toBe(MAESTRO_TEST_CONSTANTS.PROCESS_KEY);
     });
@@ -374,7 +374,7 @@ describe('MaestroProcessesService', () => {
       mockApiClient.post.mockRejectedValue(new Error(TEST_CONSTANTS.ERROR_MESSAGE));
 
       await expect(
-        service.getTopElementFailureCount(startDate, endDate)
+        service.getTopElementFailedCount(startDate, endDate)
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });

--- a/tests/utils/constants/maestro.ts
+++ b/tests/utils/constants/maestro.ts
@@ -124,6 +124,14 @@ export const MAESTRO_TEST_CONSTANTS = {
   FAULTED_COUNT_PROCESS_2: 508,
   FAULTED_COUNT_CASE: 87,
 
+  // Top element failure count constants
+  ELEMENT_NAME_1: 'Get Email',
+  ELEMENT_TYPE_1: 'ReceiveTask',
+  ELEMENT_FAILURE_COUNT_1: 5,
+  ELEMENT_NAME_2: 'RPA Workflow',
+  ELEMENT_TYPE_2: 'ServiceTask',
+  ELEMENT_FAILURE_COUNT_2: 3,
+
   // Top duration constants (milliseconds)
   DURATION_PROCESS_1: 1058190698729,
   DURATION_PROCESS_2: 749919406366,

--- a/tests/utils/constants/maestro.ts
+++ b/tests/utils/constants/maestro.ts
@@ -127,10 +127,10 @@ export const MAESTRO_TEST_CONSTANTS = {
   // Top element failure count constants
   ELEMENT_NAME_1: 'Get Email',
   ELEMENT_TYPE_1: 'ReceiveTask',
-  ELEMENT_FAILURE_COUNT_1: 5,
+  ELEMENT_FAILED_COUNT_1: 5,
   ELEMENT_NAME_2: 'RPA Workflow',
   ELEMENT_TYPE_2: 'ServiceTask',
-  ELEMENT_FAILURE_COUNT_2: 3,
+  ELEMENT_FAILED_COUNT_2: 3,
 
   // Top duration constants (milliseconds)
   DURATION_PROCESS_1: 1058190698729,

--- a/tests/utils/mocks/maestro.ts
+++ b/tests/utils/mocks/maestro.ts
@@ -626,6 +626,20 @@ export const createMockTopFaultedCountResponse = (overrides: Partial<any> = {}) 
 };
 
 /**
+ * Creates a mock top element failure count response
+ * @param overrides - Optional overrides for specific fields
+ * @returns Mock top element failure count response object
+ */
+export const createMockTopElementFailureCountResponse = (overrides: Partial<any> = {}) => {
+  return createMockBaseResponse({
+    elementName: MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_1,
+    elementType: MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_1,
+    processKey: MAESTRO_TEST_CONSTANTS.PROCESS_KEY,
+    count: MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_1,
+  }, overrides);
+};
+
+/**
  * Creates a mock top duration response for processes
  * @param overrides - Optional overrides for specific fields
  * @returns Mock top duration response object

--- a/tests/utils/mocks/maestro.ts
+++ b/tests/utils/mocks/maestro.ts
@@ -630,12 +630,12 @@ export const createMockTopFaultedCountResponse = (overrides: Partial<any> = {}) 
  * @param overrides - Optional overrides for specific fields
  * @returns Mock top element failure count response object
  */
-export const createMockTopElementFailureCountResponse = (overrides: Partial<any> = {}) => {
+export const createMockTopElementFailedCountResponse = (overrides: Partial<any> = {}) => {
   return createMockBaseResponse({
     elementName: MAESTRO_TEST_CONSTANTS.ELEMENT_NAME_1,
     elementType: MAESTRO_TEST_CONSTANTS.ELEMENT_TYPE_1,
     processKey: MAESTRO_TEST_CONSTANTS.PROCESS_KEY,
-    count: MAESTRO_TEST_CONSTANTS.ELEMENT_FAILURE_COUNT_1,
+    count: MAESTRO_TEST_CONSTANTS.ELEMENT_FAILED_COUNT_1,
   }, overrides);
 };
 


### PR DESCRIPTION
## Method Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service (MaestroProcesses) | `maestroProcesses.getTopElementFailedCount()` | `getTopElementFailedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<ElementGetTopFailedCountResponse[]>` |
| Service (Cases) | `cases.getTopElementFailedCount()` | `getTopElementFailedCount(startTime: Date, endTime: Date, options?: TopQueryOptions): Promise<ElementGetTopFailedCountResponse[]>` |

## Endpoint Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `getTopElementFailedCount()` | POST | `insightsrtm_/agenticInstanceStatus/TopElementswithFailure` | `Insights.RealTimeData` `Insights` `OR.Folders.Read` |

- Reuses shared `buildInsightsTopBody()` helper — same request body pattern
- Returns top **10** BPMN elements ranked by failure count
- Different entity from "top processes" methods — returns elements (activities within processes), not processes
- One shared response type (`ElementGetTopFailedCountResponse`) — no Process/Case variants needed
- Backend returns `count` — SDK renames to `failedCount` (matches backend `Failed` status for elements)
- Raw pre-transform type `RawElementGetTopFailedCountResponse` in `insights.internal-types.ts`
- Supports optional `TopQueryOptions` filters: `packageId`, `processKey`, `version`

## Example Usage

```typescript
import { MaestroProcesses } from '@uipath/uipath-typescript/maestro-processes';

const maestroProcesses = new MaestroProcesses(sdk);

// Get top failing elements for the last 7 days
const topFailing = await maestroProcesses.getTopElementFailedCount(
  new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
  new Date()
);

// Get top failing elements for a specific process
const filtered = await maestroProcesses.getTopElementFailedCount(
  new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
  new Date(),
  { processKey: '<processKey>' }
);

for (const element of topFailing) {
  console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
}
```

```typescript
import { Cases } from '@uipath/uipath-typescript/cases';

const cases = new Cases(sdk);

const topFailing = await cases.getTopElementFailedCount(
  new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
  new Date()
);

// Filter by process
const filtered = await cases.getTopElementFailedCount(
  new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
  new Date(),
  { processKey: '<processKey>' }
);

for (const element of topFailing) {
  console.log(`${element.elementName} (${element.elementType}): ${element.failedCount} failures`);
}
```

## API Response vs SDK Response

### Transform pipeline
No casing transforms. SDK renames `count` → `failedCount`.

### Field mapping
| API Response | SDK Response | Change | Reason |
|-------------|--------------|--------|--------|
| `elementName` | `elementName` | None | Already camelCase |
| `elementType` | `elementType` | None | Already camelCase |
| `processKey` | `processKey` | None | Already camelCase |
| `count` | `failedCount` | Renamed | Matches backend `Failed` status for elements |

### Request transformation
| SDK Input | API Body | Conversion |
|-----------|----------|------------|
| `startTime: Date` | `startTime: number` | `.getTime()` → Unix ms |
| `endTime: Date` | `endTime: number` | `.getTime()` → Unix ms |
| (internal) | `isCaseManagement: boolean` | `true` for Cases, `false` for MaestroProcesses |
| `options.packageId` | `commonParams.packageId` | Forwarded if provided |
| `options.processKey` | `commonParams.processKey` | Forwarded if provided |
| `options.version` | `commonParams.version` | Forwarded if provided |

### Type hierarchy
| Type | Location | Purpose |
|------|----------|---------|
| `RawElementGetTopFailedCountResponse` | `insights.internal-types.ts` | Raw API shape (with `count`) — post generic |
| `ElementGetTopFailedCountResponse` | `insights.types.ts` | SDK response (with `failedCount`) — shared by both services |
| `TopQueryOptions` | `insights.types.ts` | Shared optional filters (packageId, processKey, version) |

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/maestro.ts` |
| Types | `src/models/maestro/insights.types.ts`, `src/models/maestro/insights.internal-types.ts` (new) |
| Models | `src/models/maestro/processes.models.ts`, `src/models/maestro/cases.models.ts` |
| Service | `src/services/maestro/processes/processes.ts`, `src/services/maestro/cases/cases.ts` |
| Unit tests | `tests/unit/services/maestro/processes.test.ts` (2 new), `tests/unit/services/maestro/cases.test.ts` (2 new) |
| Integration tests | `tests/integration/shared/maestro/processes.integration.test.ts` (1 new, skipped), `tests/integration/shared/maestro/cases.integration.test.ts` (1 new, skipped) |
| Test utils | `tests/utils/constants/maestro.ts`, `tests/utils/mocks/maestro.ts` |
| Docs | `docs/oauth-scopes.md` |

Refs PLT-103283

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*