### PR TITLE
feat(auth): generalised postMessage auth protocol for coded app embedding

### DIFF
--- a/src/core/auth/action-center-token-manager.ts
+++ b/src/core/auth/action-center-token-manager.ts
@@ -2,8 +2,7 @@ import { ActionCenterEventNames, ActionCenterEventResponsePayload } from '../../
 import { TokenInfo } from './types';
 import { AuthenticationError, HttpStatus } from '../errors';
 import { Config } from '../config/config';
-
-const AUTHENTICATION_TIMEOUT = 8000;
+import { HostTokenResponse, isTokenExpired, isValidHostOrigin, requestHostToken } from './host-token-request';
 
 export class ActionCenterTokenManager {
   private readonly parentOrigin = new URLSearchParams(window.location.search).get('basedomain');
@@ -15,7 +14,7 @@ export class ActionCenterTokenManager {
   ) {}
 
   async refreshAccessToken(tokenInfo: TokenInfo): Promise<string> {
-    if (!this.isTokenExpired(tokenInfo)) {
+    if (!isTokenExpired(tokenInfo)) {
       return tokenInfo.token;
     }
 
@@ -23,88 +22,58 @@ export class ActionCenterTokenManager {
       return this.refreshPromise;
     }
 
-    this.refreshPromise = new Promise<string>((resolve, reject) => {
-      const content = {
-        clientId: this.config.clientId,
-        scope: this.config.scope,
-      }
-      this.sendMessageToParent(ActionCenterEventNames.REFRESHTOKEN, content);
-
-      const messageListener = (event: MessageEvent<ActionCenterEventResponsePayload>) => {
-        if (event.origin !== this.parentOrigin) return;
-        if (event.data?.eventType !== ActionCenterEventNames.TOKENREFRESHED) return;
-
-        clearTimeout(timer);
-
-        if (event.data?.content?.token) {
-          const { accessToken, expiresAt } = event.data.content.token;
-          this.onTokenRefreshed({ token: accessToken, type: 'secret', expiresAt });
-          resolve(accessToken);
-        } else {
-          reject(new AuthenticationError({
-            message: 'Failed to fetch access token',
-            statusCode: HttpStatus.UNAUTHORIZED,
-          }));
-        }
-
-        this.refreshPromise = null;
-        this.cleanup(messageListener);
-      };
-
-      const timer = setTimeout(() => {
-        reject(new AuthenticationError({
-          message: 'Failed to fetch access token',
+    const parentOrigin = this.parentOrigin;
+    if (!parentOrigin) {
+      return Promise.reject(
+        new AuthenticationError({
+          message: 'Cannot refresh token: basedomain query parameter is missing',
           statusCode: HttpStatus.UNAUTHORIZED,
-        }));
-
-        this.refreshPromise = null;
-        this.cleanup(messageListener);
-      }, AUTHENTICATION_TIMEOUT);
-
-      window.addEventListener('message', messageListener);
-    });
-
-    return this.refreshPromise;
-  }
-
-  private isTokenExpired(tokenInfo: TokenInfo): boolean {
-    if (!tokenInfo?.expiresAt) {
-      return true;
+        })
+      );
     }
 
-    return new Date() >= tokenInfo.expiresAt;
+    // Guard before requestHostToken registers the inbound listener — an untrusted
+    // basedomain would otherwise leave the listener live for the full timeout window,
+    // accepting a forged TOKENREFRESHED from that origin.
+    if (!isValidHostOrigin(parentOrigin)) {
+      return Promise.reject(
+        new AuthenticationError({
+          message: 'Cannot refresh token: basedomain is not a trusted UiPath host origin',
+          statusCode: HttpStatus.UNAUTHORIZED,
+        })
+      );
+    }
+
+    const { promise } = requestHostToken({
+      pinnedOrigin: parentOrigin,
+      sendRequest: () => this.sendMessageToParent(ActionCenterEventNames.REFRESHTOKEN, {
+        clientId: this.config.clientId,
+        scope: this.config.scope,
+      }),
+      responseEventType: ActionCenterEventNames.TOKENREFRESHED,
+      extractToken: (data): HostTokenResponse | undefined => {
+        const token = (data as ActionCenterEventResponsePayload)?.content?.token;
+        if (!token?.accessToken) return undefined;
+        return { accessToken: token.accessToken, expiresAt: token.expiresAt };
+      },
+      onTokenRefreshed: this.onTokenRefreshed,
+    });
+
+    this.refreshPromise = promise;
+    try {
+      return await this.refreshPromise;
+    } finally {
+      this.refreshPromise = null;
+    }
   }
 
   private sendMessageToParent(eventType: string, content?: unknown): void {
-    if (window.parent && this.isValidOrigin(this.parentOrigin)) {
+    if (window.parent && isValidHostOrigin(this.parentOrigin)) {
       try {
         window.parent.postMessage({ eventType, content }, this.parentOrigin!);
       } catch (error) {
-        console.warn('Failed to send message to Action Center', JSON.stringify(error));
+        console.warn('ActionCenterTokenManager: postMessage to host failed', JSON.stringify(error));
       }
-    }
-  }
-
-  private cleanup(messageListener: (event: MessageEvent<ActionCenterEventResponsePayload>) => void): void {
-    window.removeEventListener('message', messageListener);
-  }
-
-  private isValidOrigin(origin: string | null): boolean {
-    const ALLOWED_ORIGINS = ['https://alpha.uipath.com', 'https://staging.uipath.com', 'https://cloud.uipath.com'];
-
-    if (!origin) {
-      return false;
-    }
-
-    if (ALLOWED_ORIGINS.includes(origin)) {
-      return true;
-    }
-
-    try {
-      const url = new URL(origin);
-      return url.hostname === 'localhost';
-    } catch {
-      return false;
     }
   }
 }

--- a/src/core/auth/embedded-token-manager.ts
+++ b/src/core/auth/embedded-token-manager.ts
@@ -1,0 +1,103 @@
+import { UipEmbeddedEventNames, UipEmbeddedRefreshTokenPayload, UipEmbeddedTokenRefreshedPayload } from './uip-embedded-protocol';
+import { TokenInfo } from './types';
+import { Config } from '../config/config';
+import { ValidationError } from '../errors';
+import { HostTokenResponse, isTokenExpired, requestHostToken } from './host-token-request';
+
+function parseExpiresAt(raw: string): Date {
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) {
+    console.warn('EmbeddedTokenManager: host sent a malformed expiresAt value — treating token as already expired', raw);
+    return new Date(0);
+  }
+  return d;
+}
+
+function extractToken(data: unknown): HostTokenResponse | undefined {
+  const token = (data as UipEmbeddedTokenRefreshedPayload)?.content?.token;
+  if (!token?.accessToken) return undefined;
+  return { accessToken: token.accessToken, expiresAt: parseExpiresAt(token.expiresAt) };
+}
+
+/**
+ * Handles token delegation for coded apps embedded inside a UiPath host
+ * (e.g. Governance Portal, Insights UI).
+ *
+ * Detection: the host signals embedding via `?host=embed&basedomain=<origin>`
+ * in the iframe src URL. `parentOrigin` is read from `?basedomain=` and validated
+ * against the trusted UiPath host allowlist before this manager is constructed.
+ * This mirrors the mechanism used by ActionCenterTokenManager.
+ *
+ * On every token expiry the SDK sends `UIP.refreshToken` with `clientId` and
+ * `scope`; the host performs silent SSO and responds with `UIP.tokenRefreshed`.
+ */
+export class EmbeddedTokenManager {
+  private readonly clientId: string;
+  private readonly scope: string;
+  private refreshPromise: Promise<string> | null = null;
+  private cancelRefresh: (() => void) | null = null;
+
+  /**
+   * @param parentOrigin Validated UiPath host origin from the `?basedomain=` query parameter.
+   * @param config SDK configuration — `clientId` and `scope` are required and forwarded
+   *   in every `UIP.refreshToken` request so the host knows which OAuth client to use.
+   * @param onTokenRefreshed Called with the refreshed TokenInfo so the caller
+   *   can persist it in the execution context.
+   * @throws {AuthenticationError} if `config.clientId` or `config.scope` are not set.
+   */
+  constructor(
+    private readonly parentOrigin: string,
+    config: Config,
+    private readonly onTokenRefreshed: (tokenInfo: TokenInfo) => void
+  ) {
+    if (!config.clientId || !config.scope) {
+      throw new ValidationError({
+        message: 'EmbeddedTokenManager requires clientId and scope to be configured for host-delegated authentication',
+      });
+    }
+    this.clientId = config.clientId;
+    this.scope = config.scope;
+  }
+
+  async refreshAccessToken(tokenInfo: TokenInfo): Promise<string> {
+    if (!isTokenExpired(tokenInfo)) {
+      return tokenInfo.token;
+    }
+
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    const { promise, cancel } = requestHostToken({
+      pinnedOrigin: this.parentOrigin,
+      sendRequest: () => {
+        try {
+          const message: UipEmbeddedRefreshTokenPayload = {
+            eventType: UipEmbeddedEventNames.REFRESH_TOKEN,
+            content: { clientId: this.clientId, scope: this.scope },
+          };
+          window.parent.postMessage(message, this.parentOrigin);
+        } catch (error) {
+          console.warn('EmbeddedTokenManager: postMessage to host failed', error);
+        }
+      },
+      responseEventType: UipEmbeddedEventNames.TOKEN_REFRESHED,
+      extractToken,
+      onTokenRefreshed: this.onTokenRefreshed,
+    });
+
+    this.cancelRefresh = cancel;
+    this.refreshPromise = promise;
+    try {
+      return await this.refreshPromise;
+    } finally {
+      this.refreshPromise = null;
+      this.cancelRefresh = null;
+    }
+  }
+
+  /** Cancels any in-flight token-refresh request. */
+  destroy(): void {
+    this.cancelRefresh?.();
+  }
+}

--- a/src/core/auth/host-token-request.ts
+++ b/src/core/auth/host-token-request.ts
@@ -1,0 +1,142 @@
+import { TokenInfo } from './types';
+import { AuthenticationError, HttpStatus } from '../errors';
+
+export const AUTHENTICATION_TIMEOUT = 8000;
+
+const ALLOWED_HOST_ORIGINS = new Set([
+  'https://alpha.uipath.com',
+  'https://staging.uipath.com',
+  'https://cloud.uipath.com',
+]);
+
+/**
+ * Returns true if the origin is a trusted UiPath host that may initiate
+ * token delegation. Mirrors the same allowlist used by ActionCenterTokenManager.
+ */
+export function isValidHostOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  if (ALLOWED_HOST_ORIGINS.has(origin)) return true;
+  try {
+    return new URL(origin).hostname === 'localhost';
+  } catch {
+    console.warn('isValidHostOrigin: received a malformed origin URL', origin);
+    return false;
+  }
+}
+
+export function isTokenExpired(tokenInfo: TokenInfo): boolean {
+  if (!tokenInfo?.expiresAt) return true;
+  return new Date() >= tokenInfo.expiresAt;
+}
+
+export interface HostTokenResponse {
+  accessToken: string;
+  expiresAt: Date;
+}
+
+export interface HostTokenRequestOptions {
+  /** Origin the request is sent to and responses accepted from. */
+  pinnedOrigin: string;
+  /** Sends the refresh request to the parent frame. */
+  sendRequest: () => void;
+  /** Event type string the host sends back with the refreshed token. */
+  responseEventType: string;
+  /** Extracts the token from the host response message. Returns undefined if the payload is malformed. */
+  extractToken: (data: unknown) => HostTokenResponse | undefined;
+  /** Called with the refreshed TokenInfo before the promise resolves. */
+  onTokenRefreshed: (tokenInfo: TokenInfo) => void;
+}
+
+export interface HostTokenRequest {
+  readonly promise: Promise<string>;
+  /** Immediately rejects the promise and removes the response listener. */
+  readonly cancel: () => void;
+}
+
+/**
+ * Waits for the next window message that satisfies `filter`.
+ * Rejects if the AbortSignal fires before a matching message arrives.
+ */
+function waitForMessage(
+  filter: (event: MessageEvent) => boolean,
+  signal: AbortSignal
+): Promise<MessageEvent> {
+  return new Promise((resolve, reject) => {
+    const handler = (event: MessageEvent): void => {
+      if (!filter(event)) return;
+      window.removeEventListener('message', handler);
+      resolve(event);
+    };
+
+    signal.addEventListener('abort', () => {
+      window.removeEventListener('message', handler);
+      reject(signal.reason);
+    }, { once: true });
+
+    window.addEventListener('message', handler);
+  });
+}
+
+/**
+ * Sends a token-refresh request to a parent host frame and waits for the
+ * response. Handles timeout, origin filtering, and listener cleanup.
+ *
+ * Both ActionCenterTokenManager and EmbeddedTokenManager delegate to this
+ * function; they differ only in the event names and message shape they use.
+ */
+export function requestHostToken(options: HostTokenRequestOptions): HostTokenRequest {
+  const { pinnedOrigin, sendRequest, responseEventType, extractToken, onTokenRefreshed } = options;
+
+  const controller = new AbortController();
+
+  const cancel = (): void =>
+    controller.abort(
+      new AuthenticationError({
+        message: 'Token refresh cancelled',
+        statusCode: HttpStatus.UNAUTHORIZED,
+      })
+    );
+
+  const promise = (async (): Promise<string> => {
+    const timer = setTimeout(
+      () =>
+        controller.abort(
+          new AuthenticationError({
+            message: `Token refresh timed out after ${AUTHENTICATION_TIMEOUT}ms waiting for host response`,
+            statusCode: HttpStatus.UNAUTHORIZED,
+          })
+        ),
+      AUTHENTICATION_TIMEOUT
+    );
+
+    try {
+      // Register listener before sending — avoids any race between send and response
+      const responsePromise = waitForMessage(
+        event => event.origin === pinnedOrigin && event.data?.eventType === responseEventType,
+        controller.signal
+      );
+
+      sendRequest();
+
+      const event = await responsePromise;
+
+      const token = extractToken(event.data);
+      if (!token) {
+        throw new AuthenticationError({
+          message: 'Host responded but did not include a valid access token',
+          statusCode: HttpStatus.UNAUTHORIZED,
+        });
+      }
+
+      // type: 'secret' intentionally prevents the SDK's internal OAuth refresh path
+      // from running — the host manager owns the refresh cycle via requestHostToken.
+      // This mirrors the same pattern used by ActionCenterTokenManager.
+      onTokenRefreshed({ token: token.accessToken, type: 'secret', expiresAt: token.expiresAt });
+      return token.accessToken;
+    } finally {
+      clearTimeout(timer);
+    }
+  })();
+
+  return { promise, cancel };
+}

--- a/src/core/auth/token-manager.ts
+++ b/src/core/auth/token-manager.ts
@@ -1,11 +1,13 @@
 import { ExecutionContext } from '../context/execution';
-import { isBrowser, isInActionCenter } from '../../utils/platform';
+import { isBrowser, isInActionCenter, embeddingOrigin, isHostEmbedded } from '../../utils/platform';
 import { AuthToken, TokenInfo } from './types';
 import { AUTH_STORAGE_KEYS } from './constants';
 import { hasOAuthConfig } from '../config/sdk-config';
 import { Config } from '../config/config';
 import { AuthenticationError, HttpStatus } from '../errors';
 import { ActionCenterTokenManager } from './action-center-token-manager';
+import { EmbeddedTokenManager } from './embedded-token-manager';
+import { isValidHostOrigin } from './host-token-request';
 
 /**
  * TokenManager is responsible for managing authentication tokens.
@@ -17,6 +19,7 @@ export class TokenManager {
   private currentToken?: TokenInfo;
   private refreshPromise: Promise<AuthToken> | null = null;
   private readonly actionCenterTokenManager: ActionCenterTokenManager | null = null;
+  private readonly embeddedTokenManager: EmbeddedTokenManager | null = null;
 
   /**
    * Creates a new TokenManager instance
@@ -31,6 +34,9 @@ export class TokenManager {
   ) {
     if (isInActionCenter) {
       this.actionCenterTokenManager = new ActionCenterTokenManager(config, (tokenInfo) => this.setToken(tokenInfo));
+      this.isOAuth = false;
+    } else if (isHostEmbedded && embeddingOrigin && isValidHostOrigin(embeddingOrigin)) {
+      this.embeddedTokenManager = new EmbeddedTokenManager(embeddingOrigin, config, tokenInfo => this.setToken(tokenInfo));
       this.isOAuth = false;
     }
   }
@@ -67,6 +73,11 @@ export class TokenManager {
 
     if (this.actionCenterTokenManager) {
       return await this.actionCenterTokenManager.refreshAccessToken(tokenInfo);
+    }
+
+    // Generic embedded path — active whenever the app is embedded in a UiPath host page
+    if (this.embeddedTokenManager) {
+      return await this.embeddedTokenManager.refreshAccessToken(tokenInfo);
     }
 
     // For secret-based tokens, they never expire
@@ -229,6 +240,14 @@ export class TokenManager {
   }
 
   /**
+   * Releases resources held by this instance.
+   * Must be called when the TokenManager is no longer needed to prevent listener leaks.
+   */
+  destroy(): void {
+    this.embeddedTokenManager?.destroy();
+  }
+
+  /**
    * Clears the current token
    */
   clearToken(): void {
@@ -281,6 +300,10 @@ export class TokenManager {
    * Internal method to perform the actual token refresh
    */
   private async _doRefreshToken(): Promise<AuthToken> {
+    // Destructure before the type guard — hasOAuthConfig narrows this.config to
+    // { clientId, redirectUri, scope } which does not include BaseConfig fields.
+    const { orgName, baseUrl } = this.config;
+
     // Check if we're in OAuth flow
     if (!hasOAuthConfig(this.config)) {
       throw new Error('refreshAccessToken is only available in OAuth flow');
@@ -292,15 +315,13 @@ export class TokenManager {
       throw new Error('No refresh token available. User may need to re-authenticate.');
     }
 
-    const orgName = this.config.orgName;
-    
     const body = new URLSearchParams({
       grant_type: 'refresh_token',
       client_id: this.config.clientId,
       refresh_token: tokenInfo.refreshToken
     });
 
-    const response = await fetch(`${this.config.baseUrl}/${orgName}/identity_/connect/token`, {
+    const response = await fetch(`${baseUrl}/${orgName}/identity_/connect/token`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'

--- a/src/core/auth/uip-embedded-protocol.ts
+++ b/src/core/auth/uip-embedded-protocol.ts
@@ -1,0 +1,35 @@
+/**
+ * Event names and payload types for the UIP.* postMessage protocol used
+ * when a coded app is embedded inside a UiPath host (e.g. Governance Portal, Insights UI).
+ *
+ * Flow — app-initiated, mirrors the Action Center protocol:
+ *  App → Host: UIP.refreshToken   (requests a token; carries clientId + scope
+ *                                   so the host knows which OAuth client to use)
+ *  Host → App: UIP.tokenRefreshed (delivers the access token)
+ *
+ * Detection: the host signals embedding via `?host=embed&basedomain=<origin>` in
+ * the iframe src URL. No explicit init message from the host is required.
+ */
+
+export enum UipEmbeddedEventNames {
+  REFRESH_TOKEN   = 'UIP.refreshToken',
+  TOKEN_REFRESHED = 'UIP.tokenRefreshed',
+}
+
+export type UipEmbeddedTokenRefreshedPayload = {
+  eventType: UipEmbeddedEventNames.TOKEN_REFRESHED,
+  content: {
+    token: {
+      accessToken: string,
+      expiresAt: string, // ISO 8601
+    },
+  },
+};
+
+export type UipEmbeddedRefreshTokenPayload = {
+  eventType: UipEmbeddedEventNames.REFRESH_TOKEN,
+  content: {
+    clientId: string,
+    scope: string,
+  },
+};

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -7,7 +7,7 @@ export const ConfigSchema = z.object({
   secret: z.string().optional(),
   clientId: z.string().optional(),
   redirectUri: z.string().url().optional(),
-  scope: z.string().optional()
+  scope: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -53,6 +53,12 @@ export interface IUiPath {
   getToken(): string | undefined;
 
   /**
+   * Releases resources held by this SDK instance.
+   * Cancels any in-flight token-refresh request. Call this when the coded app is unmounted.
+   */
+  destroy(): void;
+
+  /**
    * Logout from the SDK, clearing all authentication state.
    * After calling this method, the user will need to re-initialize to authenticate again.
    */

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -262,6 +262,14 @@ export class UiPath implements IUiPath {
   }
 
   /**
+   * Releases resources held by this SDK instance.
+   * Cancels any in-flight token-refresh request. Call this when the coded app is unmounted.
+   */
+  public destroy(): void {
+    this.#authService?.getTokenManager()?.destroy();
+  }
+
+  /**
    * Logout from the SDK, clearing all authentication state.
    * After calling this method, the user will need to re-initialize to authenticate again.
    */

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -8,3 +8,30 @@
 export const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
 export const isInActionCenter = isBrowser && window.self != window.top && window.location.href.includes('source=ActionCenter');
+
+const _params = isBrowser ? new URLSearchParams(window.location.search) : null;
+
+/**
+ * True when the coded app has been loaded inside a host frame that explicitly
+ * opted into token delegation by adding `?host=embed` to the iframe src URL.
+ */
+export const isHostEmbedded: boolean =
+  isBrowser && window.self !== window.top && _params?.get('host') === 'embed';
+
+/**
+ * The validated parent origin, read from the `?basedomain=` query param set
+ * by the embedding host in the iframe src URL.
+ * Mirrors the same mechanism used by ActionCenterTokenManager.
+ * Non-null only when `?host=embed` is present and `?basedomain=` is a valid URL.
+ */
+export const embeddingOrigin: string | null = (() => {
+  if (!isHostEmbedded) return null;
+  const basedomain = _params?.get('basedomain');
+  if (!basedomain) return null;
+  try {
+    return new URL(basedomain).origin;
+  } catch {
+    console.warn('embeddingOrigin: basedomain query param is not a valid URL', basedomain);
+    return null;
+  }
+})();

--- a/src/utils/runtime/constants.ts
+++ b/src/utils/runtime/constants.ts
@@ -19,4 +19,5 @@ export enum UiPathMetaTags {
 
   // Folder context (injected during coded-app deployment)
   FOLDER_KEY = 'uipath:folder-key',
+
 }

--- a/tests/unit/core/auth/action-center-token-manager.test.ts
+++ b/tests/unit/core/auth/action-center-token-manager.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AUTHENTICATION_TIMEOUT } from '@/core/auth/host-token-request';
+import { ActionCenterTokenManager } from '@/core/auth/action-center-token-manager';
+import { ActionCenterEventNames } from '@/models/action-center/tasks.internal-types';
+import { AuthenticationError } from '@/core/errors';
+import type { TokenInfo } from '@/core/auth/types';
+import type { Config } from '@/core/config/config';
+
+// ---------------------------------------------------------------------------
+// Window mock helpers
+// ---------------------------------------------------------------------------
+
+type MessageHandler = (e: MessageEvent) => void;
+
+function makeWindowMock(basedomain: string | null = 'https://cloud.uipath.com') {
+  const listeners: Record<string, MessageHandler[]> = {};
+  const parentPostMessage = vi.fn();
+  const search = basedomain ? `?basedomain=${encodeURIComponent(basedomain)}` : '';
+
+  return {
+    location: { search },
+    addEventListener: vi.fn((type: string, handler: MessageHandler) => {
+      (listeners[type] ??= []).push(handler);
+    }),
+    removeEventListener: vi.fn((type: string, handler: MessageHandler) => {
+      listeners[type] = (listeners[type] ?? []).filter(h => h !== handler);
+    }),
+    parent: { postMessage: parentPostMessage },
+    dispatch(event: Partial<MessageEvent>) {
+      (listeners['message'] ?? []).forEach(h => h(event as MessageEvent));
+    },
+    get parentPostMessage() {
+      return parentPostMessage;
+    },
+  };
+}
+
+type WindowMock = ReturnType<typeof makeWindowMock>;
+
+function makeRefreshedEvent(origin: string, accessToken = 'tok-refreshed'): Partial<MessageEvent> {
+  return {
+    origin,
+    data: {
+      eventType: ActionCenterEventNames.TOKENREFRESHED,
+      content: { token: { accessToken, expiresAt: new Date(Date.now() + 3600_000) } },
+    },
+  };
+}
+
+const VALID_ORIGIN = 'https://cloud.uipath.com';
+const MOCK_CONFIG: Config = {
+  baseUrl: 'https://cloud.uipath.com',
+  orgName: 'test-org',
+  tenantName: 'test-tenant',
+  clientId: 'ac-client',
+  scope: 'openid',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ActionCenterTokenManager', () => {
+  let mock: WindowMock;
+  let onTokenRefreshed: ReturnType<typeof vi.fn>;
+  let manager: ActionCenterTokenManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mock = makeWindowMock(VALID_ORIGIN);
+    global.window = mock as unknown as Window & typeof globalThis;
+    onTokenRefreshed = vi.fn();
+    manager = new ActionCenterTokenManager(MOCK_CONFIG, onTokenRefreshed);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (global as unknown as Record<string, unknown>).window;
+  });
+
+  // ---- non-expired token ----
+
+  it('returns token immediately when not expired', async () => {
+    const tokenInfo: TokenInfo = { token: 'tok-valid', type: 'secret', expiresAt: new Date(Date.now() + 3600_000) };
+    const result = await manager.refreshAccessToken(tokenInfo);
+    expect(result).toBe('tok-valid');
+    expect(mock.parentPostMessage).not.toHaveBeenCalled();
+  });
+
+  // ---- missing basedomain ----
+
+  it('rejects when basedomain query param is absent', async () => {
+    mock = makeWindowMock(null);
+    global.window = mock as unknown as Window & typeof globalThis;
+    manager = new ActionCenterTokenManager(MOCK_CONFIG, onTokenRefreshed);
+
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+    await expect(manager.refreshAccessToken(expired)).rejects.toBeInstanceOf(AuthenticationError);
+    expect(mock.parentPostMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects before registering a listener when basedomain is not a trusted origin', async () => {
+    mock = makeWindowMock('https://evil.example.com');
+    global.window = mock as unknown as Window & typeof globalThis;
+    manager = new ActionCenterTokenManager(MOCK_CONFIG, onTokenRefreshed);
+
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+    await expect(manager.refreshAccessToken(expired)).rejects.toBeInstanceOf(AuthenticationError);
+    // No listener registered — the inbound listener window is never opened
+    expect(mock.addEventListener).not.toHaveBeenCalledWith('message', expect.any(Function));
+    expect(mock.parentPostMessage).not.toHaveBeenCalled();
+  });
+
+  // ---- refresh flow ----
+
+  it('sends AC.refreshToken with clientId and scope when token is expired', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent(VALID_ORIGIN, 'tok-new'));
+    await refreshPromise;
+
+    expect(mock.parentPostMessage).toHaveBeenCalledWith(
+      {
+        eventType: ActionCenterEventNames.REFRESHTOKEN,
+        content: { clientId: MOCK_CONFIG.clientId, scope: MOCK_CONFIG.scope },
+      },
+      VALID_ORIGIN
+    );
+  });
+
+  it('resolves with new access token from AC.tokenRefreshed', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent(VALID_ORIGIN, 'tok-new'));
+
+    expect(await refreshPromise).toBe('tok-new');
+  });
+
+  it('calls onTokenRefreshed after successful refresh', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent(VALID_ORIGIN, 'tok-new'));
+    await refreshPromise;
+
+    expect(onTokenRefreshed).toHaveBeenCalledOnce();
+    expect(onTokenRefreshed.mock.calls[0][0].token).toBe('tok-new');
+  });
+
+  it('ignores tokenRefreshed from a different origin', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent('https://staging.uipath.com', 'tok-hijack'));
+    mock.dispatch(makeRefreshedEvent(VALID_ORIGIN, 'tok-good'));
+
+    expect(await refreshPromise).toBe('tok-good');
+  });
+
+  it('rejects when host responds with no accessToken', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch({
+      origin: VALID_ORIGIN,
+      data: { eventType: ActionCenterEventNames.TOKENREFRESHED, content: { token: { accessToken: '' } } },
+    });
+
+    await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  // ---- timeout ----
+
+  it('rejects with AuthenticationError after timeout', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    vi.advanceTimersByTime(AUTHENTICATION_TIMEOUT + 1);
+
+    await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  // ---- deduplication ----
+
+  it('deduplicates concurrent refresh calls into a single postMessage', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const [r1, r2] = await Promise.all([
+      manager.refreshAccessToken(expired),
+      manager.refreshAccessToken(expired),
+      mock.dispatch(makeRefreshedEvent(VALID_ORIGIN, 'tok-new')),
+    ]);
+
+    expect(r1).toBe('tok-new');
+    expect(r2).toBe('tok-new');
+    expect(mock.parentPostMessage).toHaveBeenCalledOnce();
+  });
+
+});

--- a/tests/unit/core/auth/embedded-token-manager.test.ts
+++ b/tests/unit/core/auth/embedded-token-manager.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EmbeddedTokenManager } from '@/core/auth/embedded-token-manager';
+import { UipEmbeddedEventNames } from '@/core/auth/uip-embedded-protocol';
+import { AuthenticationError, ValidationError } from '@/core/errors';
+import { AUTHENTICATION_TIMEOUT } from '@/core/auth/host-token-request';
+import type { TokenInfo } from '@/core/auth/types';
+import type { Config } from '@/core/config/config';
+
+// ---------------------------------------------------------------------------
+// Window mock
+// ---------------------------------------------------------------------------
+
+type MessageHandler = (e: MessageEvent) => void;
+
+function makeWindowMock() {
+  const listeners: Record<string, MessageHandler[]> = {};
+  const parentPostMessage = vi.fn();
+
+  return {
+    addEventListener: vi.fn((type: string, handler: MessageHandler) => {
+      (listeners[type] ??= []).push(handler);
+    }),
+    removeEventListener: vi.fn((type: string, handler: MessageHandler) => {
+      listeners[type] = (listeners[type] ?? []).filter(h => h !== handler);
+    }),
+    parent: { postMessage: parentPostMessage },
+    dispatch(event: Partial<MessageEvent>) {
+      (listeners['message'] ?? []).forEach(h => h(event as MessageEvent));
+    },
+    get parentPostMessage() { return parentPostMessage; },
+  };
+}
+
+type WindowMock = ReturnType<typeof makeWindowMock>;
+
+// ---------------------------------------------------------------------------
+// Event factories
+// ---------------------------------------------------------------------------
+
+function makeRefreshedEvent(origin: string, accessToken = 'tok-refreshed', expiresAt?: string): Partial<MessageEvent> {
+  return {
+    origin,
+    data: {
+      eventType: UipEmbeddedEventNames.TOKEN_REFRESHED,
+      content: { token: { accessToken, expiresAt: expiresAt ?? new Date(Date.now() + 3600_000).toISOString() } },
+    },
+  };
+}
+
+const PARENT_ORIGIN = 'https://cloud.uipath.com';
+const MOCK_CONFIG: Config = {
+  baseUrl: 'https://cloud.uipath.com',
+  orgName: 'test-org',
+  tenantName: 'test-tenant',
+  clientId: 'test-client-id',
+  scope: 'openid OR.Tasks',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EmbeddedTokenManager', () => {
+  let mock: WindowMock;
+  let onTokenRefreshed: ReturnType<typeof vi.fn>;
+  let manager: EmbeddedTokenManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mock = makeWindowMock();
+    global.window = mock as unknown as Window & typeof globalThis;
+    onTokenRefreshed = vi.fn();
+    manager = new EmbeddedTokenManager(PARENT_ORIGIN, MOCK_CONFIG, onTokenRefreshed);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (global as unknown as Record<string, unknown>).window;
+  });
+
+  // ---- non-expired token ----
+
+  it('returns token immediately when not expired', async () => {
+    const tokenInfo: TokenInfo = { token: 'tok-fresh', type: 'secret', expiresAt: new Date(Date.now() + 3600_000) };
+    expect(await manager.refreshAccessToken(tokenInfo)).toBe('tok-fresh');
+    expect(mock.parentPostMessage).not.toHaveBeenCalled();
+  });
+
+  // ---- refresh flow ----
+
+  it('sends UIP.refreshToken with clientId and scope when token expired', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent(PARENT_ORIGIN, 'tok-new'));
+    await refreshPromise;
+
+    expect(mock.parentPostMessage).toHaveBeenCalledWith(
+      {
+        eventType: UipEmbeddedEventNames.REFRESH_TOKEN,
+        content: { clientId: MOCK_CONFIG.clientId, scope: MOCK_CONFIG.scope },
+      },
+      PARENT_ORIGIN
+    );
+  });
+
+  it('resolves with new access token from UIP.tokenRefreshed', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent(PARENT_ORIGIN, 'tok-new'));
+
+    expect(await refreshPromise).toBe('tok-new');
+  });
+
+  it('calls onTokenRefreshed after successful refresh', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent(PARENT_ORIGIN, 'tok-new'));
+    await refreshPromise;
+
+    expect(onTokenRefreshed).toHaveBeenCalledOnce();
+    expect(onTokenRefreshed.mock.calls[0][0].token).toBe('tok-new');
+  });
+
+  it('ignores tokenRefreshed from a different origin', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent('https://staging.uipath.com', 'tok-hijack'));
+    mock.dispatch(makeRefreshedEvent(PARENT_ORIGIN, 'tok-good'));
+
+    expect(await refreshPromise).toBe('tok-good');
+  });
+
+  it('rejects when host responds with UIP.tokenRefreshed but omits the access token', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch({
+      origin: PARENT_ORIGIN,
+      data: { eventType: UipEmbeddedEventNames.TOKEN_REFRESHED, content: { token: { accessToken: '' } } },
+    });
+
+    await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  // ---- timeout ----
+
+  it('rejects with AuthenticationError after timeout', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    vi.advanceTimersByTime(AUTHENTICATION_TIMEOUT + 1);
+
+    await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  // ---- deduplication ----
+
+  it('deduplicates concurrent refresh calls into a single postMessage', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const [r1, r2] = await Promise.all([
+      manager.refreshAccessToken(expired),
+      manager.refreshAccessToken(expired),
+      mock.dispatch(makeRefreshedEvent(PARENT_ORIGIN, 'tok-new')),
+    ]);
+
+    expect(r1).toBe('tok-new');
+    expect(r2).toBe('tok-new');
+    expect(mock.parentPostMessage).toHaveBeenCalledOnce();
+  });
+
+  // ---- malformed expiresAt ----
+
+  it('treats malformed expiresAt in response as already expired and logs a warning', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    mock.dispatch(makeRefreshedEvent(PARENT_ORIGIN, 'tok-new', 'not-a-date'));
+    await refreshPromise;
+
+    expect(onTokenRefreshed.mock.calls[0][0].expiresAt.getTime()).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed expiresAt'),
+      'not-a-date'
+    );
+    warnSpy.mockRestore();
+  });
+
+  // ---- destroy ----
+
+  it('destroy() is a no-op when no refresh is in flight', () => {
+    expect(() => manager.destroy()).not.toThrow();
+  });
+
+  it('destroy() cancels an in-flight refresh and rejects the promise with AuthenticationError', async () => {
+    const expired: TokenInfo = { token: 'tok-old', type: 'secret', expiresAt: new Date(0) };
+
+    const refreshPromise = manager.refreshAccessToken(expired);
+    manager.destroy();
+
+    await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationError);
+    expect(mock.parentPostMessage).toHaveBeenCalledOnce(); // request was sent before cancel
+  });
+
+  // ---- constructor validation ----
+
+  it('throws ValidationError when constructed without clientId', () => {
+    const configWithoutClientId: Config = { ...MOCK_CONFIG, clientId: undefined };
+    expect(() => new EmbeddedTokenManager(PARENT_ORIGIN, configWithoutClientId, onTokenRefreshed))
+      .toThrow(ValidationError);
+  });
+
+  it('throws ValidationError when constructed without scope', () => {
+    const configWithoutScope: Config = { ...MOCK_CONFIG, scope: undefined };
+    expect(() => new EmbeddedTokenManager(PARENT_ORIGIN, configWithoutScope, onTokenRefreshed))
+      .toThrow(ValidationError);
+  });
+});

--- a/tests/unit/core/auth/host-token-request.test.ts
+++ b/tests/unit/core/auth/host-token-request.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isTokenExpired, isValidHostOrigin } from '@/core/auth/host-token-request';
+import type { TokenInfo } from '@/core/auth/types';
+
+describe('isTokenExpired', () => {
+  it('returns true when expiresAt is undefined', () => {
+    const token: TokenInfo = { token: 'tok', type: 'secret' };
+    expect(isTokenExpired(token)).toBe(true);
+  });
+
+  it('returns true when token is past expiry', () => {
+    const token: TokenInfo = { token: 'tok', type: 'secret', expiresAt: new Date(0) };
+    expect(isTokenExpired(token)).toBe(true);
+  });
+
+  it('returns false when token has not expired', () => {
+    const token: TokenInfo = { token: 'tok', type: 'secret', expiresAt: new Date(Date.now() + 3600_000) };
+    expect(isTokenExpired(token)).toBe(false);
+  });
+});
+
+describe('isValidHostOrigin', () => {
+  it('returns false for null', () => {
+    expect(isValidHostOrigin(null)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isValidHostOrigin('')).toBe(false);
+  });
+
+  it('returns true for cloud.uipath.com', () => {
+    expect(isValidHostOrigin('https://cloud.uipath.com')).toBe(true);
+  });
+
+  it('returns true for alpha.uipath.com', () => {
+    expect(isValidHostOrigin('https://alpha.uipath.com')).toBe(true);
+  });
+
+  it('returns true for staging.uipath.com', () => {
+    expect(isValidHostOrigin('https://staging.uipath.com')).toBe(true);
+  });
+
+  it('returns true for localhost', () => {
+    expect(isValidHostOrigin('http://localhost:3000')).toBe(true);
+  });
+
+  it('returns false for an unlisted domain', () => {
+    expect(isValidHostOrigin('https://evil.example.com')).toBe(false);
+  });
+
+  it('returns false for an unlisted uipath.com subdomain', () => {
+    expect(isValidHostOrigin('https://unknown.uipath.com')).toBe(false);
+  });
+
+  it('returns false and logs a warning for a malformed URL', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(isValidHostOrigin('not-a-url')).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'isValidHostOrigin: received a malformed origin URL',
+      'not-a-url'
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/core/auth/service.test.ts
+++ b/tests/unit/core/auth/service.test.ts
@@ -7,7 +7,9 @@ import { IDENTITY_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 // Mock platform detection for Node test environment
 vi.mock('../../../../src/utils/platform', () => ({
   isBrowser: false,
-  isInActionCenter: false
+  isInActionCenter: false,
+  isHostEmbedded: false,
+  embeddingOrigin: null,
 }));
 
 describe('AuthService', () => {

--- a/tests/unit/core/auth/token-manager-embedded.test.ts
+++ b/tests/unit/core/auth/token-manager-embedded.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TokenManager } from '@/core/auth/token-manager';
+import { ExecutionContext } from '@/core/context/execution';
+import type { Config } from '@/core/config/config';
+import { TEST_CONSTANTS } from '@tests/utils/constants/common';
+
+// ---------------------------------------------------------------------------
+// Mock platform — control isInActionCenter, isHostEmbedded, embeddingOrigin
+// ---------------------------------------------------------------------------
+vi.mock('@/utils/platform', () => ({
+  isBrowser: true,
+  isInActionCenter: false,
+  isHostEmbedded: false,
+  embeddingOrigin: null,
+}));
+
+import * as platform from '@/utils/platform';
+
+// ---------------------------------------------------------------------------
+// Mock EmbeddedTokenManager
+// ---------------------------------------------------------------------------
+const mockEmbeddedRefresh = vi.fn();
+const mockEmbeddedDestroy = vi.fn();
+
+vi.mock('@/core/auth/embedded-token-manager', () => ({
+  EmbeddedTokenManager: vi.fn().mockImplementation(() => ({
+    refreshAccessToken: mockEmbeddedRefresh,
+    destroy: mockEmbeddedDestroy,
+  })),
+}));
+
+import { EmbeddedTokenManager } from '@/core/auth/embedded-token-manager';
+
+// isValidHostOrigin is called in TokenManager when isHostEmbedded is true
+vi.mock('@/core/auth/host-token-request', () => ({
+  isValidHostOrigin: vi.fn((origin: string) =>
+    ['https://cloud.uipath.com', 'https://alpha.uipath.com', 'https://staging.uipath.com'].includes(origin)
+  ),
+  isTokenExpired: vi.fn(() => false),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock ActionCenterTokenManager
+// ---------------------------------------------------------------------------
+vi.mock('@/core/auth/action-center-token-manager', () => ({
+  ActionCenterTokenManager: vi.fn().mockImplementation(() => ({
+    refreshAccessToken: vi.fn().mockResolvedValue('ac-token'),
+  })),
+}));
+
+import { ActionCenterTokenManager } from '@/core/auth/action-center-token-manager';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeManager() {
+  const context = new ExecutionContext();
+  const config: Config = {
+    baseUrl: TEST_CONSTANTS.BASE_URL,
+    orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+    tenantName: TEST_CONSTANTS.TENANT_ID,
+    secret: TEST_CONSTANTS.CLIENT_SECRET,
+  };
+  return new TokenManager(context, config, false);
+}
+
+const PARENT_ORIGIN = 'https://cloud.uipath.com';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('TokenManager — EmbeddedTokenManager wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---- Instantiation: EmbeddedTokenManager ----
+
+  it('does not instantiate EmbeddedTokenManager when ?host=embed is absent', () => {
+    vi.mocked(platform).isInActionCenter = false;
+    vi.mocked(platform).isHostEmbedded = false;
+    vi.mocked(platform).embeddingOrigin = PARENT_ORIGIN;
+    makeManager();
+    expect(EmbeddedTokenManager).not.toHaveBeenCalled();
+  });
+
+  it('does not instantiate EmbeddedTokenManager when basedomain is not a trusted UiPath origin', () => {
+    vi.mocked(platform).isInActionCenter = false;
+    vi.mocked(platform).isHostEmbedded = true;
+    vi.mocked(platform).embeddingOrigin = 'https://evil.example.com';
+    makeManager();
+    expect(EmbeddedTokenManager).not.toHaveBeenCalled();
+  });
+
+  it('does not instantiate EmbeddedTokenManager when embeddingOrigin is null', () => {
+    vi.mocked(platform).isInActionCenter = false;
+    vi.mocked(platform).isHostEmbedded = true;
+    vi.mocked(platform).embeddingOrigin = null;
+    makeManager();
+    expect(EmbeddedTokenManager).not.toHaveBeenCalled();
+  });
+
+  it('instantiates EmbeddedTokenManager when ?host=embed is present and embeddingOrigin is trusted', () => {
+    vi.mocked(platform).isInActionCenter = false;
+    vi.mocked(platform).isHostEmbedded = true;
+    vi.mocked(platform).embeddingOrigin = PARENT_ORIGIN;
+    makeManager();
+    expect(EmbeddedTokenManager).toHaveBeenCalledOnce();
+    expect(EmbeddedTokenManager).toHaveBeenCalledWith(PARENT_ORIGIN, expect.any(Object), expect.any(Function));
+    expect(ActionCenterTokenManager).not.toHaveBeenCalled();
+  });
+
+  // ---- Instantiation: ActionCenterTokenManager (unchanged) ----
+
+  it('instantiates ActionCenterTokenManager (not EmbeddedTokenManager) when isInActionCenter', () => {
+    vi.mocked(platform).isInActionCenter = true;
+    vi.mocked(platform).isHostEmbedded = true;
+    vi.mocked(platform).embeddingOrigin = PARENT_ORIGIN;
+    makeManager();
+    expect(ActionCenterTokenManager).toHaveBeenCalledOnce();
+    expect(EmbeddedTokenManager).not.toHaveBeenCalled();
+  });
+
+  // ---- getValidToken routing ----
+
+  it('getValidToken delegates to EmbeddedTokenManager when instantiated', async () => {
+    vi.mocked(platform).isInActionCenter = false;
+    vi.mocked(platform).isHostEmbedded = true;
+    vi.mocked(platform).embeddingOrigin = PARENT_ORIGIN;
+    mockEmbeddedRefresh.mockResolvedValue('embedded-token');
+
+    const manager = makeManager();
+    const tokenInfo = { token: 'old', type: 'secret' as const, expiresAt: new Date(0) };
+    manager.setToken(tokenInfo);
+
+    const result = await manager.getValidToken();
+    expect(result).toBe('embedded-token');
+    expect(mockEmbeddedRefresh).toHaveBeenCalledWith(tokenInfo);
+  });
+
+  it('getValidToken falls through to secret path when not host-embedded', async () => {
+    vi.mocked(platform).isInActionCenter = false;
+    vi.mocked(platform).isHostEmbedded = false;
+    vi.mocked(platform).embeddingOrigin = null;
+
+    const manager = makeManager();
+    manager.setToken({ token: 'my-secret', type: 'secret' as const });
+
+    const result = await manager.getValidToken();
+    expect(result).toBe('my-secret');
+    expect(mockEmbeddedRefresh).not.toHaveBeenCalled();
+  });
+
+  // ---- destroy ----
+
+  it('destroy() delegates to EmbeddedTokenManager.destroy()', () => {
+    vi.mocked(platform).isInActionCenter = false;
+    vi.mocked(platform).isHostEmbedded = true;
+    vi.mocked(platform).embeddingOrigin = PARENT_ORIGIN;
+    const manager = makeManager();
+    manager.destroy();
+    expect(mockEmbeddedDestroy).toHaveBeenCalledOnce();
+  });
+
+  it('destroy() is a no-op when EmbeddedTokenManager is not instantiated', () => {
+    vi.mocked(platform).isHostEmbedded = false;
+    vi.mocked(platform).embeddingOrigin = null;
+    const manager = makeManager();
+    expect(() => manager.destroy()).not.toThrow();
+  });
+});

--- a/tests/unit/core/config/runtime.test.ts
+++ b/tests/unit/core/config/runtime.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Must mock platform before importing runtime
+vi.mock('@/utils/platform', () => ({ isBrowser: true }));
+
+import { loadFromMetaTags } from '@/core/config/runtime';
+import { UiPathMetaTags } from '@/utils/runtime/constants';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const mockQuerySelector = vi.fn();
+
+function setMetaTags(tags: Partial<Record<UiPathMetaTags, string>>): void {
+  mockQuerySelector.mockImplementation((selector: string) => {
+    for (const [name, content] of Object.entries(tags)) {
+      if (selector === `meta[name="${name}"]`) {
+        return { content } as HTMLMetaElement;
+      }
+    }
+    return null;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.document = { querySelector: mockQuerySelector } as unknown as Document;
+});
+
+afterEach(() => {
+  delete (global as unknown as Record<string, unknown>).document;
+});
+
+// ---------------------------------------------------------------------------
+// loadFromMetaTags
+// ---------------------------------------------------------------------------
+describe('loadFromMetaTags', () => {
+  it('returns null when no meta tags are present', () => {
+    mockQuerySelector.mockReturnValue(null);
+    expect(loadFromMetaTags()).toBeNull();
+  });
+
+  it('reads orgName from meta tag', () => {
+    setMetaTags({ [UiPathMetaTags.ORG_NAME]: 'myorg' });
+    expect(loadFromMetaTags()?.orgName).toBe('myorg');
+  });
+
+  it('reads clientId from meta tag', () => {
+    setMetaTags({ [UiPathMetaTags.ORG_NAME]: 'myorg', [UiPathMetaTags.CLIENT_ID]: 'client-123' });
+    expect(loadFromMetaTags()?.clientId).toBe('client-123');
+  });
+
+  it('reads folderKey from meta tag', () => {
+    setMetaTags({ [UiPathMetaTags.ORG_NAME]: 'myorg', [UiPathMetaTags.FOLDER_KEY]: 'folder-abc' });
+    expect(loadFromMetaTags()?.folderKey).toBe('folder-abc');
+  });
+});

--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -7,9 +7,11 @@ import { getConfig, getContext, getTokenManager, getPrivateSDK } from '../../uti
 import { TEST_CONSTANTS } from '../../utils/constants/common';
 
 // ===== MOCKING =====
+const mockTokenManagerDestroy = vi.fn();
 const mockTokenManager = {
   getToken: () => 'mock-access-token',
-  hasValidToken: () => true
+  hasValidToken: () => true,
+  destroy: mockTokenManagerDestroy,
 };
 
 const mockLogout = vi.fn();
@@ -375,6 +377,25 @@ describe('UiPath Core', () => {
 
       expect(mockLogout).toHaveBeenCalledOnce();
       expect(sdk.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('destroy()', () => {
+    beforeEach(() => {
+      mockTokenManagerDestroy.mockClear();
+    });
+
+    it('should delegate to TokenManager.destroy()', () => {
+      const sdk = new UiPath({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantName: TEST_CONSTANTS.TENANT_ID,
+        secret: TEST_CONSTANTS.CLIENT_SECRET,
+      });
+
+      sdk.destroy();
+
+      expect(mockTokenManagerDestroy).toHaveBeenCalledOnce();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a generic `UIP.*` postMessage token-delegation protocol so any UiPath host (Governance Portal, Insights UI, etc.) can embed a coded app with seamless authentication — without requiring hosts to fake `?source=ActionCenter`.

**Design:** Mirrors the existing Action Center pattern exactly — app-initiated, no upfront token push from the host.

---

## Detection

The host signals embedding via query parameters in the iframe src URL — identical pattern to Action Center:

| | AC | New |
|---|---|---|
| Signal | `?source=ActionCenter` | `?host=embed` |
| Parent origin | `?basedomain=<origin>` | `?basedomain=<origin>` |

```
AC:  https://app.uipath.host/app?source=ActionCenter&basedomain=https://cloud.uipath.com
New: https://app.uipath.host/app?host=embed&basedomain=https://cloud.uipath.com
```

`basedomain` is validated against the trusted UiPath host allowlist (`alpha`, `staging`, `cloud.uipath.com`, `localhost`) before `EmbeddedTokenManager` is instantiated — same security policy as AC.

---

## Protocol

| Direction | Event | Payload |
|---|---|---|
| App → Host | `UIP.refreshToken` | `{ clientId, scope }` |
| Host → App | `UIP.tokenRefreshed` | `{ token: { accessToken, expiresAt } }` |

---

## Files changed

### New files
| File | Purpose |
|---|---|
| `src/core/auth/uip-embedded-protocol.ts` | `UipEmbeddedEventNames` enum and payload types |
| `src/core/auth/embedded-token-manager.ts` | Sends `UIP.refreshToken`; awaits `UIP.tokenRefreshed`; validates `clientId`+`scope` at construction (`ValidationError` if missing); `destroy()` cancels in-flight refresh |
| `src/core/auth/host-token-request.ts` | Shared `requestHostToken()` + `isValidHostOrigin()` + `isTokenExpired()` used by both managers |

### Modified files
| File | Change |
|---|---|
| `src/utils/platform.ts` | Add `isHostEmbedded` (`?host=embed`) and `embeddingOrigin` (`?basedomain=`) |
| `src/core/auth/token-manager.ts` | Instantiate `EmbeddedTokenManager` when `isHostEmbedded && isValidHostOrigin(embeddingOrigin)`; `isOAuth=false` prevents OAuth race |
| `src/core/auth/action-center-token-manager.ts` | Delegates to shared `requestHostToken()` and `isValidHostOrigin()`; removes duplicate `isValidOrigin` private method |
| `src/core/types.ts` + `src/core/uipath.ts` | Add `destroy()` to `IUiPath` and `UiPath`; cancels any in-flight token-refresh request |

### Removed
- `platformHosted` config field and `uipath:platform-hosted` meta tag — not needed; detection is URL-param based
- `UIP.init` event and `UipEmbeddedInitPayload` — host push not needed; app initiates

---

## Tests (55 across 6 files)

| File | What's covered |
|---|---|
| `action-center-token-manager.test.ts` | Full coverage: non-expired path, missing basedomain, refresh flow, timeout, deduplication, invalid origin guard |
| `embedded-token-manager.test.ts` | Full coverage: refresh flow, origin filtering, missing token, timeout, deduplication, malformed expiresAt warning, `destroy()` no-op + in-flight cancel, constructor `ValidationError` |
| `host-token-request.test.ts` | `isTokenExpired` + `isValidHostOrigin` all branches including null, malformed URL warning |
| `token-manager-embedded.test.ts` | Instantiation with/without `?host=embed`, invalid basedomain rejected, `getValidToken` routing, `isOAuth=false`, `destroy()` delegation |
| `runtime.test.ts` | `loadFromMetaTags` meta tag reading |
| `service.test.ts` | Updated platform mock |

---

## Security

- `basedomain` validated against explicit allowlist before use — same policy as Action Center
- All outbound `UIP.refreshToken` use explicit `targetOrigin`, never `'*'`
- `isOAuth=false` prevents the SDK's internal OAuth refresh from racing with the embedded path
- `EmbeddedTokenManager` throws `ValidationError` (not `AuthenticationError`) if `clientId`/`scope` are missing — misconfiguration is a validation failure, not an auth failure
- Malformed origins and dates log `console.warn` rather than silently failing
- `EmbeddedTokenManager` and `ActionCenterTokenManager` are mutually exclusive — AC behaviour unchanged

## Action Center

No behaviour change. `ActionCenterTokenManager` continues using `AC.*` events and `?basedomain=` query param. It now delegates shared logic to `host-token-request.ts` but its external contract is identical.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>