### PR TITLE
ci: allow bot-triggered PRs to run claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,6 +41,7 @@ jobs:
         uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude,github-actions[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |


### PR DESCRIPTION
## Summary
- Adds `allowed_bots: 'claude,github-actions[bot]'` to the claude-code-review workflow
- Fixes CI failure when `@claude` on GitHub pushes commits to a PR — the actor is `github-actions[bot]`, which the action rejects as a non-human actor by default

## Test plan
- [ ] Trigger `@claude` on a PR to make a code change and verify the review workflow no longer fails with "non-human actor" error