### PR TITLE
feat(governance): add Governance getOperationSummary service

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -199,6 +199,7 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | Method | OAuth Scope |
 |--------|-------------|
 | `getPolicyTraces()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getOperationSummary()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Processes
 

--- a/src/models/governance/governance.internal-types.ts
+++ b/src/models/governance/governance.internal-types.ts
@@ -21,3 +21,16 @@ export interface RawGovernancePolicyTraceItem {
   processKey?: string;
   jobKey?: string;
 }
+
+/**
+ * Raw governed operation summary response as returned by the Insights RTM
+ * service. Counts are camelCase on the wire and may be absent on auth or
+ * rate-limit error bodies, so each is optional here and coalesced to `0`
+ * in the service.
+ */
+export interface RawGovernanceOperationSummaryResponse {
+  totalEvaluations?: number;
+  allow?: number;
+  deny?: number;
+  noOp?: number;
+}

--- a/src/models/governance/governance.internal-types.ts
+++ b/src/models/governance/governance.internal-types.ts
@@ -23,10 +23,7 @@ export interface RawGovernancePolicyTraceItem {
 }
 
 /**
- * Raw governed operation summary response as returned by the Insights RTM
- * service. Counts are camelCase on the wire and may be absent on auth or
- * rate-limit error bodies, so each is optional here and coalesced to `0`
- * in the service.
+ * Raw governed operation summary response as returned by API before transformation.
  */
 export interface RawGovernanceOperationSummaryResponse {
   totalEvaluations?: number;

--- a/src/models/governance/governance.models.ts
+++ b/src/models/governance/governance.models.ts
@@ -1,6 +1,8 @@
 import type {
   GovernancePolicyTrace,
   GovernancePolicyTraceGetAllOptions,
+  GovernanceFilterOptions,
+  GovernanceOperationSummary,
 } from './governance.types';
 import type {
   PaginatedResponse,
@@ -78,4 +80,38 @@ export interface GovernanceServiceModel {
       ? PaginatedResponse<GovernancePolicyTrace>
       : NonPaginatedResponse<GovernancePolicyTrace>
   >;
+
+  /**
+   * Gets aggregate governance enforcement counts across the requested time range.
+   *
+   * Returns the total number of governance enforcement evaluations along with
+   * how many resolved to `Allow`, `Deny`, or `NoOp`. Counts reflect one row per
+   * AuthZ enforcement verdict, regardless of how many underlying policies fed
+   * into each verdict.
+   *
+   * @param startTime - Inclusive lower bound on the evaluation time. Required.
+   * @param options - Optional `endTime` upper bound and `fullOrganization` flag
+   * @returns Promise resolving to {@link GovernanceOperationSummary}
+   *
+   * @example
+   * ```typescript
+   * import { Governance } from '@uipath/uipath-typescript/governance';
+   *
+   * const governance = new Governance(sdk);
+   *
+   * // Bare minimum — counts from the given start time onward
+   * const summary = await governance.getOperationSummary(new Date('2024-01-01'));
+   * console.log(summary.totalEvaluations, summary.allow, summary.deny, summary.noOp);
+   *
+   * // Bounded range across the whole organization
+   * const ranged = await governance.getOperationSummary(
+   *   new Date('2024-01-01'),
+   *   { endTime: new Date(), fullOrganization: true },
+   * );
+   * ```
+   */
+  getOperationSummary(
+    startTime: Date,
+    options?: GovernanceFilterOptions,
+  ): Promise<GovernanceOperationSummary>;
 }

--- a/src/models/governance/governance.models.ts
+++ b/src/models/governance/governance.models.ts
@@ -84,12 +84,10 @@ export interface GovernanceServiceModel {
   /**
    * Gets aggregate governance enforcement counts across the requested time range.
    *
-   * Returns the total number of governance enforcement evaluations along with
-   * how many resolved to `Allow`, `Deny`, or `NoOp`. Counts reflect one row per
-   * AuthZ enforcement verdict, regardless of how many underlying policies fed
-   * into each verdict.
+   * Returns the total number of evaluations along with how many resolved to
+   * `Allow`, `Deny`, or `NoOp`.
    *
-   * @param startTime - Inclusive lower bound on the evaluation time. Required.
+   * @param startTime - Inclusive lower bound on the evaluation time.
    * @param options - Optional `endTime` upper bound and `fullOrganization` flag
    * @returns Promise resolving to {@link GovernanceOperationSummary}
    *
@@ -99,9 +97,9 @@ export interface GovernanceServiceModel {
    *
    * const governance = new Governance(sdk);
    *
-   * // Bare minimum — counts from the given start time onward
+   * // Get operation summary from the specified start time to right now
    * const summary = await governance.getOperationSummary(new Date('2024-01-01'));
-   * console.log(summary.totalEvaluations, summary.allow, summary.deny, summary.noOp);
+   * console.log(summary.totalEvaluations, summary.allowedCount, summary.deniedCount, summary.noOpCount);
    *
    * // Bounded range across the whole organization
    * const ranged = await governance.getOperationSummary(

--- a/src/models/governance/governance.types.ts
+++ b/src/models/governance/governance.types.ts
@@ -70,7 +70,7 @@ export interface GovernancePolicyTrace {
 export interface GovernanceFilterOptions {
   /**
    * Inclusive upper bound on trace start time. When omitted, the upper bound
-   * is open. 
+   * is open.
    */
   endTime?: Date;
   /**
@@ -111,3 +111,22 @@ export type GovernancePolicyTraceGetAllOptions = PaginationOptions & GovernanceF
   /** Filter by one or more distributed-trace IDs. */
   traceId?: string[];
 };
+
+/**
+ * Aggregate governance enforcement counts returned by
+ * {@link GovernanceServiceModel.getOperationSummary}.
+ *
+ * Each count reflects `governanceEvaluation` spans — one per AuthZ enforcement
+ * verdict — over the requested time range, regardless of how many underlying
+ * policies fed into each verdict.
+ */
+export interface GovernanceOperationSummary {
+  /** Total number of governance enforcement evaluations in range. */
+  totalEvaluations: number;
+  /** Count with a final `Allow` enforcement verdict. */
+  allow: number;
+  /** Count with a final `Deny` enforcement verdict. */
+  deny: number;
+  /** Count with a final `NoOp` (simulated) enforcement verdict. */
+  noOp: number;
+}

--- a/src/models/governance/governance.types.ts
+++ b/src/models/governance/governance.types.ts
@@ -114,19 +114,16 @@ export type GovernancePolicyTraceGetAllOptions = PaginationOptions & GovernanceF
 
 /**
  * Aggregate governance enforcement counts returned by
- * {@link GovernanceServiceModel.getOperationSummary}.
- *
- * Each count reflects `governanceEvaluation` spans — one per AuthZ enforcement
- * verdict — over the requested time range, regardless of how many underlying
- * policies fed into each verdict.
+ * {@link GovernanceServiceModel.getOperationSummary}, covering the requested
+ * time range.
  */
 export interface GovernanceOperationSummary {
   /** Total number of governance enforcement evaluations in range. */
   totalEvaluations: number;
-  /** Count with a final `Allow` enforcement verdict. */
-  allow: number;
-  /** Count with a final `Deny` enforcement verdict. */
-  deny: number;
-  /** Count with a final `NoOp` (simulated) enforcement verdict. */
-  noOp: number;
+  /** Number of evaluations that resolved to `Allow`. */
+  allowedCount: number;
+  /** Number of evaluations that resolved to `Deny`. */
+  deniedCount: number;
+  /** Number of evaluations that resolved to `NoOp` (simulated). */
+  noOpCount: number;
 }

--- a/src/services/governance/governance.ts
+++ b/src/services/governance/governance.ts
@@ -117,12 +117,10 @@ export class GovernanceService extends BaseService implements GovernanceServiceM
   /**
    * Gets aggregate governance enforcement counts across the requested time range.
    *
-   * Returns the total number of governance enforcement evaluations along with
-   * how many resolved to `Allow`, `Deny`, or `NoOp`. Counts reflect one row per
-   * AuthZ enforcement verdict, regardless of how many underlying policies fed
-   * into each verdict.
+   * Returns the total number of evaluations along with how many resolved to
+   * `Allow`, `Deny`, or `NoOp`.
    *
-   * @param startTime - Inclusive lower bound on the evaluation time. Required.
+   * @param startTime - Inclusive lower bound on the evaluation time.
    * @param options - Optional `endTime` upper bound and `fullOrganization` flag
    * @returns Promise resolving to {@link GovernanceOperationSummary}
    *
@@ -132,9 +130,9 @@ export class GovernanceService extends BaseService implements GovernanceServiceM
    *
    * const governance = new Governance(sdk);
    *
-   * // Bare minimum — counts from the given start time onward
+   * // Get operation summary from the specified start time to right now
    * const summary = await governance.getOperationSummary(new Date('2024-01-01'));
-   * console.log(summary.totalEvaluations, summary.allow, summary.deny, summary.noOp);
+   * console.log(summary.totalEvaluations, summary.allowedCount, summary.deniedCount, summary.noOpCount);
    *
    * // Bounded range across the whole organization
    * const ranged = await governance.getOperationSummary(
@@ -163,14 +161,12 @@ export class GovernanceService extends BaseService implements GovernanceServiceM
       body,
     );
 
-    // API returns camelCase keys directly. Error bodies (401/403/429) can omit
-    // counts, so coalesce each to 0 for a stable numeric contract.
     const data = response.data;
     return {
-      totalEvaluations: data?.totalEvaluations ?? 0,
-      allow: data?.allow ?? 0,
-      deny: data?.deny ?? 0,
-      noOp: data?.noOp ?? 0,
+      totalEvaluations: data.totalEvaluations ?? 0,
+      allowedCount: data.allow ?? 0,
+      deniedCount: data.deny ?? 0,
+      noOpCount: data.noOp ?? 0,
     };
   }
 }

--- a/src/services/governance/governance.ts
+++ b/src/services/governance/governance.ts
@@ -14,11 +14,17 @@ import {
 } from '../../utils/pagination';
 import { PaginationHelpers } from '../../utils/pagination/helpers';
 import { PaginationType } from '../../utils/pagination/internal-types';
+import { filterUndefined } from '../../utils/object';
 import {
   GovernancePolicyTrace,
   GovernancePolicyTraceGetAllOptions,
+  GovernanceFilterOptions,
+  GovernanceOperationSummary,
 } from '../../models/governance/governance.types';
 import { GovernanceServiceModel } from '../../models/governance/governance.models';
+import {
+  RawGovernanceOperationSummaryResponse,
+} from '../../models/governance/governance.internal-types';
 
 /**
  * Service for inspecting governance policy enforcement on the UiPath platform.
@@ -106,5 +112,65 @@ export class GovernanceService extends BaseService implements GovernanceServiceM
         ? PaginatedResponse<GovernancePolicyTrace>
         : NonPaginatedResponse<GovernancePolicyTrace>
     >;
+  }
+
+  /**
+   * Gets aggregate governance enforcement counts across the requested time range.
+   *
+   * Returns the total number of governance enforcement evaluations along with
+   * how many resolved to `Allow`, `Deny`, or `NoOp`. Counts reflect one row per
+   * AuthZ enforcement verdict, regardless of how many underlying policies fed
+   * into each verdict.
+   *
+   * @param startTime - Inclusive lower bound on the evaluation time. Required.
+   * @param options - Optional `endTime` upper bound and `fullOrganization` flag
+   * @returns Promise resolving to {@link GovernanceOperationSummary}
+   *
+   * @example
+   * ```typescript
+   * import { Governance } from '@uipath/uipath-typescript/governance';
+   *
+   * const governance = new Governance(sdk);
+   *
+   * // Bare minimum — counts from the given start time onward
+   * const summary = await governance.getOperationSummary(new Date('2024-01-01'));
+   * console.log(summary.totalEvaluations, summary.allow, summary.deny, summary.noOp);
+   *
+   * // Bounded range across the whole organization
+   * const ranged = await governance.getOperationSummary(
+   *   new Date('2024-01-01'),
+   *   { endTime: new Date(), fullOrganization: true },
+   * );
+   * ```
+   */
+  @track('Governance.GetOperationSummary')
+  async getOperationSummary(
+    startTime: Date,
+    options?: GovernanceFilterOptions,
+  ): Promise<GovernanceOperationSummary> {
+    if (!startTime) {
+      throw new ValidationError({ message: 'startTime is required for getOperationSummary' });
+    }
+
+    const body = filterUndefined({
+      startTime: startTime.toISOString(),
+      endTime: options?.endTime?.toISOString(),
+      fullOrganization: options?.fullOrganization,
+    });
+
+    const response = await this.post<RawGovernanceOperationSummaryResponse>(
+      GOVERNANCE_ENDPOINTS.OPERATION.SUMMARY,
+      body,
+    );
+
+    // API returns camelCase keys directly. Error bodies (401/403/429) can omit
+    // counts, so coalesce each to 0 for a stable numeric contract.
+    const data = response.data;
+    return {
+      totalEvaluations: data?.totalEvaluations ?? 0,
+      allow: data?.allow ?? 0,
+      deny: data?.deny ?? 0,
+      noOp: data?.noOp ?? 0,
+    };
   }
 }

--- a/src/utils/constants/endpoints/governance.ts
+++ b/src/utils/constants/endpoints/governance.ts
@@ -13,4 +13,8 @@ export const GOVERNANCE_ENDPOINTS = {
     /** Policy evaluation traces (paginated). */
     TRACES: `${INSIGHTS_RTM_BASE}/Governance/policy/traces`,
   },
+  OPERATION: {
+    /** Aggregate governed-operation enforcement counts. */
+    SUMMARY: `${INSIGHTS_RTM_BASE}/Governance/operation/summary`,
+  },
 } as const;

--- a/tests/integration/shared/governance/governance.integration.test.ts
+++ b/tests/integration/shared/governance/governance.integration.test.ts
@@ -76,9 +76,9 @@ describe.skip.each(modes)('Governance - Integration Tests [%s]', (mode) => {
 
       expect(result).toBeDefined();
       expect(typeof result.totalEvaluations).toBe('number');
-      expect(typeof result.allow).toBe('number');
-      expect(typeof result.deny).toBe('number');
-      expect(typeof result.noOp).toBe('number');
+      expect(typeof result.allowedCount).toBe('number');
+      expect(typeof result.deniedCount).toBe('number');
+      expect(typeof result.noOpCount).toBe('number');
     });
 
     it('should support a bounded range across the whole organization', async () => {

--- a/tests/integration/shared/governance/governance.integration.test.ts
+++ b/tests/integration/shared/governance/governance.integration.test.ts
@@ -69,4 +69,26 @@ describe.skip.each(modes)('Governance - Integration Tests [%s]', (mode) => {
       expect(page2.currentPage).toBe(2);
     });
   });
+
+  describe('getOperationSummary', () => {
+    it('should retrieve aggregate enforcement counts as numbers', async () => {
+      const result = await governance.getOperationSummary(startTime);
+
+      expect(result).toBeDefined();
+      expect(typeof result.totalEvaluations).toBe('number');
+      expect(typeof result.allow).toBe('number');
+      expect(typeof result.deny).toBe('number');
+      expect(typeof result.noOp).toBe('number');
+    });
+
+    it('should support a bounded range across the whole organization', async () => {
+      const result = await governance.getOperationSummary(startTime, {
+        endTime: new Date(),
+        fullOrganization: true,
+      });
+
+      expect(result).toBeDefined();
+      expect(typeof result.totalEvaluations).toBe('number');
+    });
+  });
 });

--- a/tests/unit/services/governance/governance.test.ts
+++ b/tests/unit/services/governance/governance.test.ts
@@ -7,6 +7,7 @@ import { GOVERNANCE_TEST_CONSTANTS, TEST_CONSTANTS } from '../../../utils/consta
 import {
   createMockRawGovernancePolicyTrace,
   createMockRawGovernancePolicyTracesResponse,
+  createMockRawGovernanceOperationSummary,
 } from '../../../utils/mocks/governance';
 import {
   PolicyEvaluationResult,
@@ -232,6 +233,80 @@ describe('GovernanceService Unit Tests', () => {
       mockApiClient.post.mockRejectedValue(new Error(GOVERNANCE_TEST_CONSTANTS.ERROR_GOVERNANCE_REQUEST_FAILED));
 
       await expect(governanceService.getPolicyTraces(startTime)).rejects.toThrow(
+        GOVERNANCE_TEST_CONSTANTS.ERROR_GOVERNANCE_REQUEST_FAILED,
+      );
+    });
+  });
+
+  describe('getOperationSummary - success', () => {
+    it('should return camelCase aggregate counts from the API', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawGovernanceOperationSummary());
+
+      const result = await governanceService.getOperationSummary(startTime);
+
+      expect(result.totalEvaluations).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_TOTAL_EVALUATIONS);
+      expect(result.allow).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_ALLOW);
+      expect(result.deny).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_DENY);
+      expect(result.noOp).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_NOOP);
+    });
+
+    it('should send required startTime and use the operation summary endpoint', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawGovernanceOperationSummary());
+
+      await governanceService.getOperationSummary(startTime);
+
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(GOVERNANCE_ENDPOINTS.OPERATION.SUMMARY);
+      expect(body.startTime).toBe(GOVERNANCE_TEST_CONSTANTS.START_TIME_ISO);
+      expect(body.endTime).toBeUndefined();
+      expect(body.fullOrganization).toBeUndefined();
+    });
+
+    it('should serialize endTime Date to ISO and forward fullOrganization', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawGovernanceOperationSummary());
+
+      const endTime = new Date(GOVERNANCE_TEST_CONSTANTS.END_TIME_ISO);
+      await governanceService.getOperationSummary(startTime, { endTime, fullOrganization: true });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.endTime).toBe(GOVERNANCE_TEST_CONSTANTS.END_TIME_ISO);
+      expect(body.fullOrganization).toBe(true);
+    });
+
+    it('should forward fullOrganization=false rather than dropping it', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawGovernanceOperationSummary());
+
+      await governanceService.getOperationSummary(startTime, { fullOrganization: false });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.fullOrganization).toBe(false);
+    });
+
+    it('should coalesce missing counts to 0 when the API returns an empty body', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await governanceService.getOperationSummary(startTime);
+
+      expect(result).toEqual({ totalEvaluations: 0, allow: 0, deny: 0, noOp: 0 });
+    });
+  });
+
+  describe('getOperationSummary - validation', () => {
+    it('should throw ValidationError when startTime is undefined', async () => {
+      const callWithoutStartTime = governanceService.getOperationSummary.bind(
+        governanceService,
+      ) as (startTime?: Date) => Promise<unknown>;
+      await expect(callWithoutStartTime()).rejects.toThrow('startTime is required');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOperationSummary - error propagation', () => {
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(GOVERNANCE_TEST_CONSTANTS.ERROR_GOVERNANCE_REQUEST_FAILED));
+
+      await expect(governanceService.getOperationSummary(startTime)).rejects.toThrow(
         GOVERNANCE_TEST_CONSTANTS.ERROR_GOVERNANCE_REQUEST_FAILED,
       );
     });

--- a/tests/unit/services/governance/governance.test.ts
+++ b/tests/unit/services/governance/governance.test.ts
@@ -245,9 +245,9 @@ describe('GovernanceService Unit Tests', () => {
       const result = await governanceService.getOperationSummary(startTime);
 
       expect(result.totalEvaluations).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_TOTAL_EVALUATIONS);
-      expect(result.allow).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_ALLOW);
-      expect(result.deny).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_DENY);
-      expect(result.noOp).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_NOOP);
+      expect(result.allowedCount).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_ALLOW);
+      expect(result.deniedCount).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_DENY);
+      expect(result.noOpCount).toBe(GOVERNANCE_TEST_CONSTANTS.SUMMARY_NOOP);
     });
 
     it('should send required startTime and use the operation summary endpoint', async () => {
@@ -288,7 +288,7 @@ describe('GovernanceService Unit Tests', () => {
 
       const result = await governanceService.getOperationSummary(startTime);
 
-      expect(result).toEqual({ totalEvaluations: 0, allow: 0, deny: 0, noOp: 0 });
+      expect(result).toEqual({ totalEvaluations: 0, allowedCount: 0, deniedCount: 0, noOpCount: 0 });
     });
   });
 

--- a/tests/utils/constants/governance.ts
+++ b/tests/utils/constants/governance.ts
@@ -24,4 +24,8 @@ export const GOVERNANCE_TEST_CONSTANTS = {
   EVALUATION_RESULT_DENY: 'Deny',
   EVALUATION_DETAILS: '{"matchedRule":"deny-external-storage"}',
   ERROR_GOVERNANCE_REQUEST_FAILED: 'Governance request failed',
+  SUMMARY_TOTAL_EVALUATIONS: 150,
+  SUMMARY_ALLOW: 90,
+  SUMMARY_DENY: 40,
+  SUMMARY_NOOP: 20,
 } as const;

--- a/tests/utils/mocks/governance.ts
+++ b/tests/utils/mocks/governance.ts
@@ -1,5 +1,8 @@
 import { GOVERNANCE_TEST_CONSTANTS } from '../constants/governance';
-import type { RawGovernancePolicyTraceItem } from '../../../src/models/governance/governance.internal-types';
+import type {
+  RawGovernancePolicyTraceItem,
+  RawGovernanceOperationSummaryResponse,
+} from '../../../src/models/governance/governance.internal-types';
 
 /**
  * Creates a raw policy evaluation trace item (camelCase) matching the live API response shape.
@@ -35,4 +38,18 @@ export const createMockRawGovernancePolicyTracesResponse = (
   items: RawGovernancePolicyTraceItem[] = [createMockRawGovernancePolicyTrace()],
 ): { items: RawGovernancePolicyTraceItem[] } => ({
   items,
+});
+
+/**
+ * Creates a raw governed operation summary response (camelCase) matching the
+ * live API response shape.
+ */
+export const createMockRawGovernanceOperationSummary = (
+  overrides: Partial<RawGovernanceOperationSummaryResponse> = {},
+): RawGovernanceOperationSummaryResponse => ({
+  totalEvaluations: GOVERNANCE_TEST_CONSTANTS.SUMMARY_TOTAL_EVALUATIONS,
+  allow: GOVERNANCE_TEST_CONSTANTS.SUMMARY_ALLOW,
+  deny: GOVERNANCE_TEST_CONSTANTS.SUMMARY_DENY,
+  noOp: GOVERNANCE_TEST_CONSTANTS.SUMMARY_NOOP,
+  ...overrides,
 });


### PR DESCRIPTION
## Method Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `governance.getOperationSummary()` | `getOperationSummary(startTime: Date, options?: GovernanceFilterOptions): Promise<GovernanceOperationSummary>` |

## Endpoint Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `getOperationSummary()` | POST | `insightsrtm_/Governance/operation/summary` | `Insights.RealTimeData Insights OR.Folders.Read` |

- Extends `BaseService` — authenticated POST via `this.post()`.
- No pagination — returns a single aggregate object.
- Required `startTime` is positional; optional `endTime` / `fullOrganization` come from the shared `GovernanceFilterOptions` base (also used by `getPolicyTraces`).
- Org-admin only. The `OR.Folders.Read` scope is required so the org-admin authorization check (which resolves through Orchestrator) passes — verified live; the two Insights scopes alone return 401 on tenants that enforce the Orchestrator-audience admin check.

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { Governance } from '@uipath/uipath-typescript/governance';

const sdk = new UiPath(config);
await sdk.initialize();
const governance = new Governance(sdk);

// Bare minimum — counts from the given start time onward
const summary = await governance.getOperationSummary(new Date('2024-01-01'));
console.log(summary.totalEvaluations, summary.allow, summary.deny, summary.noOp);

// Bounded range across the whole organization
const ranged = await governance.getOperationSummary(
  new Date('2024-01-01'),
  { endTime: new Date(), fullOrganization: true },
);
```

## API Response vs SDK Response

### Transform pipeline
`this.post()` → coalesce each count to `0` (no case transform — API already returns camelCase)

### Field mapping
| API Response | SDK Response | Change | Reason |
|--------------|--------------|--------|--------|
| `totalEvaluations` | `totalEvaluations` | None | API returns camelCase on the wire (verified live), despite the spec describing PascalCase |
| `allow` | `allow` | None | same |
| `deny` | `deny` | None | same |
| `noOp` | `noOp` | None | same |

No `pascalToCamelCaseKeys()` and no field-rename map are applied. Counts are optional on auth/rate-limit (401/403/429) error bodies, so each is coalesced to `0` for a stable numeric contract.

## Sample SDK Response

<details>
<summary><code>getOperationSummary()</code> (fullOrganization: true)</summary>

```json
{
  "totalEvaluations": 4774,
  "allow": 0,
  "deny": 0,
  "noOp": 4774
}
```

</details>

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/governance.ts` |
| Types | `src/models/governance/governance.types.ts` (`GovernanceOperationSummary`) |
| Internal types | `src/models/governance/governance.internal-types.ts` (`RawGovernanceOperationSummaryResponse`) |
| Models | `src/models/governance/governance.models.ts` (ServiceModel method) |
| Service | `src/services/governance/governance.ts` |
| Unit tests | `tests/unit/services/governance/governance.test.ts` (7 new) |
| Integration tests | `tests/integration/shared/governance/governance.integration.test.ts` (2 new) |
| Test utils | `tests/utils/constants/governance.ts`, `tests/utils/mocks/governance.ts` |
| Docs | `docs/oauth-scopes.md` |

Cloudflare whitelist: UiPath/apps-dev-tools#81

*🤖 Auto-generated using onboarding skills*