### PR TITLE
feat(data-fabric): support explicit expansions in queryRecordsById

### DIFF
--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -354,10 +354,11 @@ export interface EntityServiceModel {
   deleteRecordById(entityId: string, recordId: string): Promise<void>;
 
   /**
-   * Queries entity records with filters, sorting, aggregates, and SDK-managed pagination
+   * Queries entity records with filters, sorting, aggregates, expansion, and SDK-managed pagination
    *
    * @param id - UUID of the entity
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, and pagination
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, expansionLevel,
+   *   expansions, aggregates, groupBy, and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    * @example
@@ -375,6 +376,22 @@ export interface EntityServiceModel {
    *   sortOptions: [{ fieldName: "createdTime", isDescending: true }],
    * });
    * console.log(`Found ${result.totalCount} records`);
+   *
+   * // Auto-expand every foreign-key two levels deep
+   * await entities.queryRecordsById(<id>, { expansionLevel: 2 });
+   *
+   * // Explicit expansions: only `department` (with `manager` inside it) and `avatar`
+   * await entities.queryRecordsById(<id>, {
+   *   expansions: [
+   *     {
+   *       expandedField: "department",
+   *       alias: "dept",
+   *       selectedFields: ["name", "location"],
+   *       expansions: [{ expandedField: "manager", selectedFields: ["fullName", "email"] }],
+   *     },
+   *     { expandedField: "avatar", selectedFields: ["name", "size"] },
+   *   ],
+   * });
    *
    * // With pagination
    * const page1 = await entities.queryRecordsById(<id>, { pageSize: 25 });

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -173,12 +173,39 @@ export interface EntityQueryFilter {
 }
 
 /**
- * A group of query filters combined with a logical operator
+ * A group of query filters combined with a logical operator.
+ *
+ * @example
+ * ```typescript
+ * import { LogicalOperator, QueryFilterOperator } from '@uipath/uipath-typescript/entities';
+ *
+ * // `IsActive = true AND (department = "X" OR department = "Y")`
+ * const filterGroup = {
+ *   logicalOperator: LogicalOperator.And,
+ *   queryFilters: [
+ *     { fieldName: "isActive", operator: QueryFilterOperator.Equals, value: "true" },
+ *   ],
+ *   filterGroups: [
+ *     {
+ *       logicalOperator: LogicalOperator.Or,
+ *       continueLogicalOperator: LogicalOperator.And,
+ *       queryFilters: [
+ *         { fieldName: "department", operator: QueryFilterOperator.Equals, value: "X" },
+ *         { fieldName: "department", operator: QueryFilterOperator.Equals, value: "Y" },
+ *       ],
+ *     },
+ *   ],
+ * };
+ * ```
  */
 export interface EntityQueryFilterGroup {
   /** Logical operator applied between filters in `queryFilters` (default: AND) */
   logicalOperator?: LogicalOperator;
-  /** Logical operator applied between sibling filter groups (default: AND) */
+  /**
+   * Logical operator joining this group to its sibling group(s) within the parent
+   * `filterGroups` array (default: AND). Has no effect on a root group or a group
+   * that has no siblings.
+   */
   continueLogicalOperator?: LogicalOperator;
   /** Array of filter conditions */
   queryFilters?: EntityQueryFilter[];
@@ -223,6 +250,24 @@ export interface EntityAggregate {
 }
 
 /**
+ * Explicit relationship expansion for a query.
+ *
+ * Mutually exclusive with `expansionLevel > 0` on the same query — when both are
+ * provided, the backend silently drops `expansions`, so the SDK rejects that
+ * combination up front.
+ */
+export interface EntityExpansion {
+  /** Name of the relationship (foreign-key) field to follow */
+  expandedField: string;
+  /** Response key for the expanded object (defaults to `expandedField`) */
+  alias?: string;
+  /** Fields to project from the expanded entity (returns all permitted fields if omitted) */
+  selectedFields?: string[];
+  /** Nested expansions to apply to the expanded entity. Recursive. */
+  expansions?: EntityExpansion[];
+}
+
+/**
  * Options for querying entity records with filters, sorting, aggregates, and pagination.
  *
  * Use `pageSize`, `cursor`, or `jumpToPage` for SDK-managed pagination.
@@ -235,8 +280,17 @@ export type EntityQueryRecordsOptions = {
   selectedFields?: string[];
   /** Sort options for the results */
   sortOptions?: EntityQuerySortOption[];
-  /** Level of entity expansion for related fields (default: 0) */
+  /**
+   * Auto-expand every foreign-key field to this depth (default: 0, server-capped at 3).
+   * Mutually exclusive with `expansions` — pass one or the other, not both.
+   */
   expansionLevel?: number;
+  /**
+   * Explicit, per-branch expansions giving fine-grained control over which related
+   * entities are joined and which of their fields are returned. Mutually exclusive
+   * with `expansionLevel > 0`.
+   */
+  expansions?: EntityExpansion[];
   /** Aggregate expressions (COUNT, SUM, AVG, MIN, MAX) to apply across the result set. */
   aggregates?: EntityAggregate[];
   /** Field names to group aggregate results by. */

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -480,10 +480,11 @@ export class EntityService extends BaseService implements EntityServiceModel {
   }
 
   /**
-   * Queries entity records with filters, sorting, aggregates, and pagination
+   * Queries entity records with filters, sorting, aggregates, expansion, and pagination
    *
    * @param id - UUID of the entity
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, and pagination
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, expansionLevel,
+   *   expansions, aggregates, groupBy, and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    *
@@ -504,6 +505,22 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *   sortOptions: [{ fieldName: "created_at", isDescending: true }],
    * });
    * console.log(`Found ${result.totalCount} records`);
+   *
+   * // Auto-expand every foreign-key two levels deep
+   * await entities.queryRecordsById("<entityId>", { expansionLevel: 2 });
+   *
+   * // Explicit expansions: only `department` (with `manager` inside it) and `avatar`
+   * await entities.queryRecordsById("<entityId>", {
+   *   expansions: [
+   *     {
+   *       expandedField: "department",
+   *       alias: "dept",
+   *       selectedFields: ["name", "location"],
+   *       expansions: [{ expandedField: "manager", selectedFields: ["fullName", "email"] }],
+   *     },
+   *     { expandedField: "avatar", selectedFields: ["name", "size"] },
+   *   ],
+   * });
    *
    * // With pagination
    * const page1 = await entities.queryRecordsById("<entityId>", {
@@ -537,6 +554,11 @@ export class EntityService extends BaseService implements EntityServiceModel {
     id: string,
     options?: T
   ): Promise<T extends HasPaginationOptions<T> ? PaginatedResponse<EntityRecord> : NonPaginatedResponse<EntityRecord>> {
+    if (options && (options.expansionLevel ?? 0) > 0 && options.expansions && options.expansions.length > 0) {
+      throw new ValidationError({
+        message: '`expansionLevel` and `expansions` are mutually exclusive on queryRecordsById — pass one or the other.',
+      });
+    }
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_ID(id),
@@ -551,7 +573,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
           countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
         }
       },
-      excludeFromPrefix: ['expansionLevel', 'filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy']
+      excludeFromPrefix: ['expansionLevel', 'expansions', 'filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy']
     }, options);
   }
 

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -761,6 +761,55 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(typeof row.total).toBe('number');
       expect(row.total).toBeGreaterThanOrEqual(0);
     });
+
+    it('should return explicit expansion shape when expansions is provided', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+      if (entityMetadata?.id !== entityId) {
+        entityMetadata = await entities.getById(entityId);
+      }
+      const relationshipField = entityMetadata.fields.find(f => f.isForeignKey && !f.isPrimaryKey);
+      if (!relationshipField) {
+        throw new Error(
+          `Test entity ${entityId} has no relationship (foreign-key) fields — expansions integration test cannot run. ` +
+          `Configure DATA_FABRIC_TEST_ENTITY_ID to point at an entity with at least one RELATIONSHIP field.`,
+        );
+      }
+
+      const result = await entities.queryRecordsById(entityId, {
+        pageSize: 1,
+        expansions: [{ expandedField: relationshipField.name, alias: 'related' }],
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
+      if (result.items.length > 0) {
+        const row = result.items[0] as Record<string, any>;
+        // The expanded field is returned under the alias as an object (or null if no FK target).
+        if (row.related !== null && row.related !== undefined) {
+          expect(typeof row.related).toBe('object');
+        }
+      }
+    });
+
+    it('should reject combining expansionLevel > 0 with a non-empty expansions array', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+      await expect(
+        entities.queryRecordsById(entityId, {
+          expansionLevel: 1,
+          expansions: [{ expandedField: 'irrelevant' }],
+        }),
+      ).rejects.toThrow(/mutually exclusive/);
+    });
   });
 
   // Bulk import requires DataFabric.Data.Write scope — not supported via PAT token yet

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -1516,6 +1516,63 @@ describe("EntityService Unit Tests", () => {
         }),
       );
     });
+
+    it("should pass explicit expansions through to PaginationHelpers.getAll", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      const expansions = [
+        {
+          expandedField: "department",
+          alias: "dept",
+          selectedFields: ["name", "location"],
+          expansions: [
+            { expandedField: "manager", selectedFields: ["fullName", "email"] },
+          ],
+        },
+        { expandedField: "avatar", selectedFields: ["name", "size"] },
+      ];
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, { expansions });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeFromPrefix: expect.arrayContaining(["expansions"]),
+        }),
+        expect.objectContaining({ expansions }),
+      );
+    });
+
+    it("should throw if both expansionLevel > 0 and expansions are provided", async () => {
+      await expect(
+        entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          expansionLevel: 2,
+          expansions: [{ expandedField: "department" }],
+        }),
+      ).rejects.toThrow(/mutually exclusive/);
+      expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
+    });
+
+    it("should allow expansionLevel = 0 alongside expansions", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        expansionLevel: 0,
+        expansions: [{ expandedField: "department" }],
+      });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalled();
+    });
+
+    it("should allow expansionLevel > 0 when expansions is empty", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        expansionLevel: 2,
+        expansions: [],
+      });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalled();
+    });
   });
 
   describe("importRecordsById", () => {


### PR DESCRIPTION
## Summary

- Adds Mode B `expansions` to `queryRecordsById` — per-branch expansion with `expandedField`, `alias`, `selectedFields`, and recursive nested `expansions`. Lets callers pick which FKs to follow and which of their columns to bring back, instead of the all-or-nothing `expansionLevel` knob.
- Rejects the silent-data-loss combo of `expansionLevel > 0` + a non-empty `expansions` array (the backend drops the array otherwise — easy to miss).
- JSDoc: `queryRecordsById` gets two new `@example` blocks (auto-expand vs explicit); `EntityQueryFilterGroup` gets a mixed-AND/OR example using `continueLogicalOperator`.

No behavior change for callers who don't pass the new option.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings
- [x] `npm run test:unit` — 171/171 entities unit tests pass
- [ ] Live API: query an entity with `expansions: [{ expandedField, alias, selectedFields, expansions: [...] }]` and confirm the response has the aliased keys + projected fields only.
- [ ] Live API: pass both `expansionLevel: 2` and `expansions: [...]` and confirm the SDK throws `ValidationError` before the request leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)