### PR TITLE
[PLT-104923] feat(coded-apps): inject all uipath.json keys as meta tags in local dev

### DIFF
--- a/packages/plugins/coded-apps/src/constants.ts
+++ b/packages/plugins/coded-apps/src/constants.ts
@@ -26,10 +26,35 @@ export const CONFIG_FILE_NAME = 'uipath.json'
 export const PACKAGE_JSON_FILE_NAME = 'package.json'
 
 /**
- * Mapping from config keys to meta tag names
+ * Prefix for all injected meta tags: `<meta name="uipath:..." ...>`
  */
 export const META_TAG_PREFIX = 'uipath'
 
+/**
+ * Well-known SDK configuration keys and their meta tag suffixes.
+ *
+ * These are the keys the UiPath SDK reads at runtime. The plugin uses this
+ * mapping for exact suffix names; any key NOT listed here is still injected
+ * — its suffix is derived by converting camelCase to kebab-case automatically
+ * (e.g. `folderKey` → `uipath:folder-key`).
+ *
+ * ----- Deployment-time meta tags (server-side injection) -----
+ * At deployment, the Apps Service (process-coded-app-package.ts) injects
+ * the following meta tags into the published index.html:
+ *
+ *   uipath:client-id      — OAuth client ID (from uipath.json in the .nupkg)
+ *   uipath:scope           — OAuth scopes (from uipath.json in the .nupkg)
+ *   uipath:org-name        — Organization ID
+ *   uipath:tenant-name     — Tenant ID
+ *   uipath:base-url        — Portal base URL
+ *   uipath:redirect-uri    — OAuth redirect URI (computed from routing name)
+ *   uipath:cdn-base        — CDN base path (computed: /{systemName}/{folderKey}/{deployVersion}/)
+ *   uipath:app-base        — App base path (computed from routing name or legacy path)
+ *   uipath:folder-key      — Folder identifier where the app is deployed
+ *
+ * The plugin mirrors this for local dev: anything in uipath.json is injected
+ * so the SDK can read the same meta tags locally as it would in production.
+ */
 export const UIPATH_META_TAGS: Record<ValidConfigKey, string> = {
   clientId: 'client-id',
   scope: 'scope',
@@ -64,7 +89,6 @@ export const MESSAGES = {
   // Validation errors
   INVALID_KEY_FORMAT: (key: string, suggestion: string) =>
     `❌ Invalid key "${key}" - use camelCase: "${suggestion}"`,
-  UNKNOWN_KEY: (key: string) => `⚠️  Unknown key "${key}" will be ignored by the SDK`,
 
   // Validation warnings
   MISSING_DEV_KEYS: (keys: string[]) =>

--- a/packages/plugins/coded-apps/src/constants.ts
+++ b/packages/plugins/coded-apps/src/constants.ts
@@ -44,8 +44,8 @@ export const META_TAG_PREFIX = 'uipath'
  *
  *   uipath:client-id      — OAuth client ID (from uipath.json in the .nupkg)
  *   uipath:scope           — OAuth scopes (from uipath.json in the .nupkg)
- *   uipath:org-name        — Organization ID
- *   uipath:tenant-name     — Tenant ID
+ *   uipath:org-name        — Organization name
+ *   uipath:tenant-name     — Tenant name
  *   uipath:base-url        — Portal base URL
  *   uipath:redirect-uri    — OAuth redirect URI (computed from routing name)
  *   uipath:cdn-base        — CDN base path (computed: /{systemName}/{folderKey}/{deployVersion}/)

--- a/packages/plugins/coded-apps/src/core/config-reader.ts
+++ b/packages/plugins/coded-apps/src/core/config-reader.ts
@@ -135,7 +135,6 @@ function validateKeyFormats(
       // Known SDK key in wrong format (e.g. client_id → clientId)
       collector.addError(MESSAGES.INVALID_KEY_FORMAT(key, matchingKey))
     }
-    // Unknown keys are allowed — they are injected as uipath:<kebab-case> meta tags
   }
 }
 

--- a/packages/plugins/coded-apps/src/core/config-reader.ts
+++ b/packages/plugins/coded-apps/src/core/config-reader.ts
@@ -132,10 +132,10 @@ function validateKeyFormats(
     const matchingKey = findMatchingKey(key)
 
     if (matchingKey && matchingKey !== key) {
+      // Known SDK key in wrong format (e.g. client_id → clientId)
       collector.addError(MESSAGES.INVALID_KEY_FORMAT(key, matchingKey))
-    } else if (!matchingKey) {
-      collector.addWarning(MESSAGES.UNKNOWN_KEY(key))
     }
+    // Unknown keys are allowed — they are injected as uipath:<kebab-case> meta tags
   }
 }
 

--- a/packages/plugins/coded-apps/src/core/meta-tag-generator.ts
+++ b/packages/plugins/coded-apps/src/core/meta-tag-generator.ts
@@ -1,22 +1,24 @@
 import { META_TAG_PREFIX, UIPATH_META_TAGS } from '../constants'
-import { isValidKey } from './utils'
+import { isValidKey, camelToKebab } from './utils'
 import type { UiPathConfig, ViteMetaTag } from '../types'
 
 /**
  * Generate meta tags in Vite format (for Vite's transformIndexHtml hook).
+ *
+ * Every key in the config is injected as a `<meta name="uipath:..." content="...">` tag.
+ * Well-known SDK keys use the predefined suffix from UIPATH_META_TAGS; all other keys
+ * are converted from camelCase to kebab-case automatically.
  */
 export function generateMetaTagsForVite(config: UiPathConfig): ViteMetaTag[] {
   const tags: ViteMetaTag[] = []
 
   for (const [key, value] of Object.entries(config)) {
-    const metaName = getMetaTagName(key)
-    if (metaName && value) {
-      tags.push({
-        tag: 'meta',
-        attrs: { name: metaName, content: String(value) },
-        injectTo: 'head',
-      })
-    }
+    if (!value) continue
+    tags.push({
+      tag: 'meta',
+      attrs: { name: getMetaTagName(key), content: String(value) },
+      injectTo: 'head',
+    })
   }
 
   return tags
@@ -24,22 +26,30 @@ export function generateMetaTagsForVite(config: UiPathConfig): ViteMetaTag[] {
 
 /**
  * Generate meta tags as HTML string (for Webpack, Rollup, esbuild).
+ *
+ * Every key in the config is injected as a `<meta name="uipath:..." content="...">` tag.
+ * Well-known SDK keys use the predefined suffix from UIPATH_META_TAGS; all other keys
+ * are converted from camelCase to kebab-case automatically.
  */
 export function generateMetaTagsHtml(config: UiPathConfig): string {
   const lines: string[] = []
 
   for (const [key, value] of Object.entries(config)) {
-    const metaName = getMetaTagName(key)
-    if (metaName && value) {
-      lines.push(`<meta name="${metaName}" content="${value}">`)
-    }
+    if (!value) continue
+    lines.push(`<meta name="${getMetaTagName(key)}" content="${value}">`)
   }
 
   return lines.join('\n  ')
 }
 
+/**
+ * Map a config key to its meta tag name.
+ * Known SDK keys use the predefined mapping (e.g. clientId → uipath:client-id).
+ * Unknown keys are converted from camelCase to kebab-case (e.g. folderKey → uipath:folder-key).
+ */
 function getMetaTagName(configKey: string): string {
-  if (!isValidKey(configKey)) return ''
-  const suffix = UIPATH_META_TAGS[configKey]
-  return suffix ? `${META_TAG_PREFIX}:${suffix}` : ''
+  if (isValidKey(configKey)) {
+    return `${META_TAG_PREFIX}:${UIPATH_META_TAGS[configKey]}`
+  }
+  return `${META_TAG_PREFIX}:${camelToKebab(configKey)}`
 }

--- a/packages/plugins/coded-apps/src/core/meta-tag-generator.ts
+++ b/packages/plugins/coded-apps/src/core/meta-tag-generator.ts
@@ -5,20 +5,22 @@ import type { UiPathConfig, ViteMetaTag } from '../types'
 /**
  * Generate meta tags in Vite format (for Vite's transformIndexHtml hook).
  *
- * Every key in the config is injected as a `<meta name="uipath:..." content="...">` tag.
- * Well-known SDK keys use the predefined suffix from UIPATH_META_TAGS; all other keys
+ * Intended for UiPath SDK configuration keys only (see UIPATH_META_TAGS in constants.ts
+ * for the well-known set, plus deployment-time keys like folderKey).
+ * Well-known SDK keys use the predefined suffix from UIPATH_META_TAGS; additional keys
  * are converted from camelCase to kebab-case automatically.
  */
 export function generateMetaTagsForVite(config: UiPathConfig): ViteMetaTag[] {
   const tags: ViteMetaTag[] = []
 
   for (const [key, value] of Object.entries(config)) {
-    if (!value) continue
-    tags.push({
-      tag: 'meta',
-      attrs: { name: getMetaTagName(key), content: String(value) },
-      injectTo: 'head',
-    })
+    if (value) {
+      tags.push({
+        tag: 'meta',
+        attrs: { name: getMetaTagName(key), content: String(value) },
+        injectTo: 'head',
+      })
+    }
   }
 
   return tags
@@ -27,16 +29,18 @@ export function generateMetaTagsForVite(config: UiPathConfig): ViteMetaTag[] {
 /**
  * Generate meta tags as HTML string (for Webpack, Rollup, esbuild).
  *
- * Every key in the config is injected as a `<meta name="uipath:..." content="...">` tag.
- * Well-known SDK keys use the predefined suffix from UIPATH_META_TAGS; all other keys
+ * Intended for UiPath SDK configuration keys only (see UIPATH_META_TAGS in constants.ts
+ * for the well-known set, plus deployment-time keys like folderKey).
+ * Well-known SDK keys use the predefined suffix from UIPATH_META_TAGS; additional keys
  * are converted from camelCase to kebab-case automatically.
  */
 export function generateMetaTagsHtml(config: UiPathConfig): string {
   const lines: string[] = []
 
   for (const [key, value] of Object.entries(config)) {
-    if (!value) continue
-    lines.push(`<meta name="${getMetaTagName(key)}" content="${value}">`)
+    if (value) {
+      lines.push(`<meta name="${getMetaTagName(key)}" content="${value}">`)
+    }
   }
 
   return lines.join('\n  ')
@@ -48,8 +52,6 @@ export function generateMetaTagsHtml(config: UiPathConfig): string {
  * Unknown keys are converted from camelCase to kebab-case (e.g. folderKey → uipath:folder-key).
  */
 function getMetaTagName(configKey: string): string {
-  if (isValidKey(configKey)) {
-    return `${META_TAG_PREFIX}:${UIPATH_META_TAGS[configKey]}`
-  }
-  return `${META_TAG_PREFIX}:${camelToKebab(configKey)}`
+  const suffix = isValidKey(configKey) ? UIPATH_META_TAGS[configKey] : camelToKebab(configKey)
+  return `${META_TAG_PREFIX}:${suffix}`
 }

--- a/packages/plugins/coded-apps/src/core/utils.ts
+++ b/packages/plugins/coded-apps/src/core/utils.ts
@@ -64,13 +64,12 @@ export function isValidKey(key: string): key is ValidConfigKey {
 
 // ===== String Conversion Utilities =====
 
+const CAMEL_TO_KEBAB_RE = /([a-z0-9])([A-Z])/g
+
 /**
  * Convert a camelCase string to kebab-case.
  * e.g. 'folderKey' → 'folder-key', 'cdnBase' → 'cdn-base'
  */
-export function camelToKebab(str: string): string {
-const CAMEL_TO_KEBAB_RE = /([a-z0-9])([A-Z])/g
-
 export function camelToKebab(str: string): string {
   return str.replace(CAMEL_TO_KEBAB_RE, '$1-$2').toLowerCase()
 }

--- a/packages/plugins/coded-apps/src/core/utils.ts
+++ b/packages/plugins/coded-apps/src/core/utils.ts
@@ -62,6 +62,16 @@ export function isValidKey(key: string): key is ValidConfigKey {
   return validKeys.includes(key as ValidConfigKey)
 }
 
+// ===== String Conversion Utilities =====
+
+/**
+ * Convert a camelCase string to kebab-case.
+ * e.g. 'folderKey' → 'folder-key', 'cdnBase' → 'cdn-base'
+ */
+export function camelToKebab(str: string): string {
+  return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+}
+
 // ===== Error Utilities =====
 
 export function createPluginError(message: string): Error {

--- a/packages/plugins/coded-apps/src/core/utils.ts
+++ b/packages/plugins/coded-apps/src/core/utils.ts
@@ -69,7 +69,10 @@ export function isValidKey(key: string): key is ValidConfigKey {
  * e.g. 'folderKey' → 'folder-key', 'cdnBase' → 'cdn-base'
  */
 export function camelToKebab(str: string): string {
-  return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+const CAMEL_TO_KEBAB_RE = /([a-z0-9])([A-Z])/g
+
+export function camelToKebab(str: string): string {
+  return str.replace(CAMEL_TO_KEBAB_RE, '$1-$2').toLowerCase()
 }
 
 // ===== Error Utilities =====

--- a/packages/plugins/coded-apps/src/types.ts
+++ b/packages/plugins/coded-apps/src/types.ts
@@ -10,7 +10,18 @@ export interface Options {
 }
 
 /**
- * UiPath SDK configuration
+ * Well-known SDK configuration keys recognized by the UiPath SDK at runtime.
+ * Used for validation and format suggestions (e.g. snake_case → camelCase).
+ */
+export type ValidConfigKey = 'clientId' | 'scope' | 'orgName' | 'tenantName' | 'baseUrl' | 'redirectUri'
+
+/**
+ * UiPath configuration from uipath.json.
+ *
+ * Includes well-known SDK keys (clientId, scope, etc.) plus any additional
+ * keys the developer adds. All keys are injected as `<meta name="uipath:<kebab-case-key>">` tags
+ * into the local dev index.html, so adding a new key here (e.g. folderKey) automatically
+ * produces `<meta name="uipath:folder-key" content="...">` — no plugin changes needed.
  */
 export interface UiPathConfig {
   clientId?: string
@@ -19,12 +30,8 @@ export interface UiPathConfig {
   tenantName?: string
   baseUrl?: string
   redirectUri?: string
+  [key: string]: string | undefined
 }
-
-/**
- * Valid configuration key
- */
-export type ValidConfigKey = keyof UiPathConfig
 
 
 /**

--- a/packages/plugins/coded-apps/tests/config-reader.test.ts
+++ b/packages/plugins/coded-apps/tests/config-reader.test.ts
@@ -66,10 +66,12 @@ describe('validateConfig', () => {
       expect(result.errors.some(e => e.includes('base-url') && e.includes('baseUrl'))).toBe(true)
     })
 
-    it('warns on unknown keys', () => {
-      const config = { ...fullConfig, unknownKey: 'value' }
+    it('accepts unknown keys without warnings (they are injected as meta tags)', () => {
+      const config = { ...fullConfig, folderKey: 'abc-123', customField: 'value' }
       const result = validateConfig(config, false)
-      expect(result.warnings.some(w => w.includes('unknownKey'))).toBe(true)
+      expect(result.isValid).toBe(true)
+      expect(result.warnings).toEqual([])
+      expect(result.errors).toEqual([])
     })
   })
 })

--- a/packages/plugins/coded-apps/tests/meta-tag-generator.test.ts
+++ b/packages/plugins/coded-apps/tests/meta-tag-generator.test.ts
@@ -12,7 +12,7 @@ const fullConfig: UiPathConfig = {
 }
 
 describe('generateMetaTagsForVite', () => {
-  it('generates correct Vite meta tags for all keys', () => {
+  it('generates correct Vite meta tags for all known SDK keys', () => {
     const tags = generateMetaTagsForVite(fullConfig)
     expect(tags).toHaveLength(6)
 
@@ -35,7 +35,7 @@ describe('generateMetaTagsForVite', () => {
     expect(tags[0].attrs.name).toBe('uipath:scope')
   })
 
-  it('maps all config keys to correct meta tag names', () => {
+  it('maps all known SDK keys to correct meta tag names', () => {
     const tags = generateMetaTagsForVite(fullConfig)
     const names = tags.map(t => t.attrs.name).sort()
     expect(names).toEqual([
@@ -47,22 +47,47 @@ describe('generateMetaTagsForVite', () => {
       'uipath:tenant-name',
     ])
   })
+
+  it('injects arbitrary keys from uipath.json as kebab-case meta tags', () => {
+    const config: UiPathConfig = {
+      ...fullConfig,
+      folderKey: 'my-folder-key-123',
+      cdnBase: 'https://cdn.example.com',
+    }
+    const tags = generateMetaTagsForVite(config)
+    expect(tags).toHaveLength(8)
+
+    const folderTag = tags.find(t => t.attrs.name === 'uipath:folder-key')
+    expect(folderTag).toBeDefined()
+    expect(folderTag!.attrs.content).toBe('my-folder-key-123')
+
+    const cdnTag = tags.find(t => t.attrs.name === 'uipath:cdn-base')
+    expect(cdnTag).toBeDefined()
+    expect(cdnTag!.attrs.content).toBe('https://cdn.example.com')
+  })
 })
 
 describe('generateMetaTagsHtml', () => {
   it('generates HTML meta tags string', () => {
-    const html = generateMetaTagsHtml({ scope: 'OR.Execution', clientId: 'my-client' } as UiPathConfig)
+    const html = generateMetaTagsHtml({ scope: 'OR.Execution', clientId: 'my-client' })
     expect(html).toContain('<meta name="uipath:scope" content="OR.Execution">')
     expect(html).toContain('<meta name="uipath:client-id" content="my-client">')
   })
 
   it('returns empty string for empty config', () => {
-    expect(generateMetaTagsHtml({} as UiPathConfig)).toBe('')
+    expect(generateMetaTagsHtml({})).toBe('')
   })
 
   it('preserves values exactly as provided in config', () => {
-    const config = { scope: 'OR.Administration OR.Administration.Read' } as UiPathConfig
+    const config: UiPathConfig = { scope: 'OR.Administration OR.Administration.Read' }
     const html = generateMetaTagsHtml(config)
     expect(html).toContain('content="OR.Administration OR.Administration.Read"')
+  })
+
+  it('injects arbitrary keys as kebab-case meta tags in HTML format', () => {
+    const config: UiPathConfig = { folderKey: 'abc-123', appBase: '/my-app' }
+    const html = generateMetaTagsHtml(config)
+    expect(html).toContain('<meta name="uipath:folder-key" content="abc-123">')
+    expect(html).toContain('<meta name="uipath:app-base" content="/my-app">')
   })
 })

--- a/packages/plugins/coded-apps/tests/utils.test.ts
+++ b/packages/plugins/coded-apps/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeKey, findMatchingKey, isValidKey, ValidationCollector, createPluginError, formatList } from '../src/core/utils'
+import { normalizeKey, findMatchingKey, isValidKey, camelToKebab, ValidationCollector, createPluginError, formatList } from '../src/core/utils'
 
 describe('normalizeKey', () => {
   it('normalizes camelCase to lowercase', () => {
@@ -75,6 +75,28 @@ describe('isValidKey', () => {
     expect(isValidKey('client_id')).toBe(false)
     expect(isValidKey('BASEURL')).toBe(false)
     expect(isValidKey('unknown')).toBe(false)
+  })
+})
+
+describe('camelToKebab', () => {
+  it('converts camelCase to kebab-case', () => {
+    expect(camelToKebab('folderKey')).toBe('folder-key')
+    expect(camelToKebab('cdnBase')).toBe('cdn-base')
+    expect(camelToKebab('appBase')).toBe('app-base')
+  })
+
+  it('converts multi-word camelCase', () => {
+    expect(camelToKebab('myCustomField')).toBe('my-custom-field')
+    expect(camelToKebab('someLongPropertyName')).toBe('some-long-property-name')
+  })
+
+  it('preserves already lowercase single words', () => {
+    expect(camelToKebab('scope')).toBe('scope')
+    expect(camelToKebab('name')).toBe('name')
+  })
+
+  it('handles strings with numbers', () => {
+    expect(camelToKebab('field2Value')).toBe('field2-value')
   })
 })
 


### PR DESCRIPTION
- Makes the coded-apps plugin **generic**: any key in `uipath.json` is now injected as a `<meta name="uipath:<kebab-case>">` tag into the local dev `index.html`
- No plugin changes needed when new config keys are added (e.g. `folderKey` → `uipath:folder-key`)
- Well-known SDK keys (`clientId`, `scope`, `orgName`, `tenantName`, `baseUrl`, `redirectUri`) still use their predefined suffix mapping
- Unknown keys are converted from camelCase to kebab-case automatically via a new `camelToKebab` utility

deployment though will only inject `clientId`, `scope`, `orgName`, `tenantName`, `baseUrl`, `redirectUri`, `folderkey` , behaviour documented for plugin code.
