### PR TITLE
feat(agents): add AgentMemory service (memory timeline, calls timeline, top spaces)

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -187,7 +187,7 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getCategories()` | `Traces.Api` |
 | `deleteCategory()` | `Traces.Api` |
 
-### Memory
+### Agent Memory
 
 | Method | OAuth Scope |
 |--------|-------------|

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -187,6 +187,12 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getCategories()` | `Traces.Api` |
 | `deleteCategory()` | `Traces.Api` |
 
+### Memory
+
+| Method | OAuth Scope |
+|--------|-------------|
+| `getMemoryTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+
 ## Traces
 
 | Method | OAuth Scope |

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -192,6 +192,7 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | Method | OAuth Scope |
 |--------|-------------|
 | `getMemoryTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getMemoryCallsTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Traces
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -191,9 +191,9 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 
 | Method | OAuth Scope |
 |--------|-------------|
-| `getMemoryTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getMemoryCallsTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getTopMemorySpaces()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getCallsTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopSpaces()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Traces
 

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -193,6 +193,7 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 |--------|-------------|
 | `getMemoryTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getMemoryCallsTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopMemorySpaces()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Traces
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,7 +190,7 @@ nav:
               - User Settings: api/interfaces/UserSettingsServiceModel.md
             - Feedback: api/interfaces/FeedbackServiceModel.md
             - Agents: api/interfaces/AgentServiceModel.md
-            - Memory: api/interfaces/MemoryServiceModel.md
+            - Agent Memory: api/interfaces/AgentMemoryServiceModel.md
           - Attachments:
             - api/interfaces/attachments/index.md
           - Assets: api/interfaces/AssetServiceModel.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,7 @@ nav:
               - User Settings: api/interfaces/UserSettingsServiceModel.md
             - Feedback: api/interfaces/FeedbackServiceModel.md
             - Agents: api/interfaces/AgentServiceModel.md
+            - Memory: api/interfaces/MemoryServiceModel.md
           - Attachments:
             - api/interfaces/attachments/index.md
           - Assets: api/interfaces/AssetServiceModel.md

--- a/package.json
+++ b/package.json
@@ -156,14 +156,14 @@
                 "default": "./dist/feedback/index.cjs"
             }
         },
-        "./memory": {
+        "./agent-memory": {
             "import": {
-                "types": "./dist/memory/index.d.ts",
-                "default": "./dist/memory/index.mjs"
+                "types": "./dist/agent-memory/index.d.ts",
+                "default": "./dist/agent-memory/index.mjs"
             },
             "require": {
-                "types": "./dist/memory/index.d.ts",
-                "default": "./dist/memory/index.cjs"
+                "types": "./dist/agent-memory/index.d.ts",
+                "default": "./dist/agent-memory/index.cjs"
             }
         },
         "./traces": {

--- a/package.json
+++ b/package.json
@@ -156,6 +156,16 @@
                 "default": "./dist/feedback/index.cjs"
             }
         },
+        "./memory": {
+            "import": {
+                "types": "./dist/memory/index.d.ts",
+                "default": "./dist/memory/index.mjs"
+            },
+            "require": {
+                "types": "./dist/memory/index.d.ts",
+                "default": "./dist/memory/index.cjs"
+            }
+        },
         "./traces": {
             "import": {
                 "types": "./dist/traces/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -200,9 +200,9 @@ const serviceEntries = [
     output: 'feedback/index'
   },
   {
-    name: 'memory',
+    name: 'agent-memory',
     input: 'src/services/agents/memory/index.ts',
-    output: 'memory/index'
+    output: 'agent-memory/index'
   },
   {
     name: 'traces',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -200,6 +200,11 @@ const serviceEntries = [
     output: 'feedback/index'
   },
   {
+    name: 'memory',
+    input: 'src/services/agents/memory/index.ts',
+    output: 'memory/index'
+  },
+  {
     name: 'traces',
     input: 'src/services/observability/traces/index.ts',
     output: 'traces/index'

--- a/src/models/agents/index.ts
+++ b/src/models/agents/index.ts
@@ -7,3 +7,4 @@
 export * from './feedback';
 export * from './agents.types';
 export * from './agents.models';
+export * from './memory';

--- a/src/models/agents/memory/index.ts
+++ b/src/models/agents/memory/index.ts
@@ -1,0 +1,2 @@
+export * from './memory.types';
+export * from './memory.models';

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -1,41 +1,41 @@
 import {
-  MemoryGetTimelineOptions,
-  MemoryGetTimelineResponse,
-  MemoryGetCallsTimelineOptions,
-  MemoryGetCallsTimelineResponse,
-  MemoryGetTopSpacesOptions,
-  MemoryGetTopSpacesResponse,
+  AgentMemoryGetTimelineOptions,
+  AgentMemoryGetTimelineResponse,
+  AgentMemoryGetCallsTimelineOptions,
+  AgentMemoryGetCallsTimelineResponse,
+  AgentMemoryGetTopSpacesOptions,
+  AgentMemoryGetTopSpacesResponse,
 } from './memory.types';
 
 /**
  * Service for managing UiPath Agent Memory.
  *
- * Agent Memory is a shared store of human-in-the-loop interactions that
- * improves agent runtime reliability.
+ * Agent Memory is a persistent store of information an agent 
+ * retains across runs to improve runtime reliability.
  *
  * @example
  * ```typescript
  * import { UiPath } from '@uipath/uipath-typescript/core';
- * import { Memory } from '@uipath/uipath-typescript/memory';
+ * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
  *
  * const sdk = new UiPath(config);
  * await sdk.initialize();
  *
- * const memory = new Memory(sdk);
+ * const memory = new AgentMemory(sdk);
  * const timeline = await memory.getTimeline();
  * ```
  */
-export interface MemoryServiceModel {
+export interface AgentMemoryServiceModel {
   /**
    * Gets agent memory state over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryGetTimelineResponse}, one per time bucket.
+   * @returns Promise resolving to an array of {@link AgentMemoryGetTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
    *
-   * const memory = new Memory(sdk);
+   * const memory = new AgentMemory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getTimeline();
@@ -43,7 +43,7 @@ export interface MemoryServiceModel {
    * ```
    * @example
    * ```typescript
-   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemoryExecutionType } from '@uipath/uipath-typescript/agent-memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getTimeline({
@@ -51,22 +51,22 @@ export interface MemoryServiceModel {
    *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   agentId: '<agentId>',
    *   folderKeys: ['<folderKey>'],
-   *   executionType: ExecutionType.Runtime,
+   *   executionType: AgentMemoryExecutionType.Runtime,
    * });
    * ```
    */
-  getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse[]>;
+  getTimeline(options?: AgentMemoryGetTimelineOptions): Promise<AgentMemoryGetTimelineResponse[]>;
 
   /**
-   * Gets agent memory-access counts over time, with optional filters.
+   * Gets the number of agent memory calls (accesses to the memory store) over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryGetCallsTimelineResponse}, one per time bucket.
+   * @returns Promise resolving to an array of {@link AgentMemoryGetCallsTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
    *
-   * const memory = new Memory(sdk);
+   * const memory = new AgentMemory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getCallsTimeline();
@@ -74,7 +74,7 @@ export interface MemoryServiceModel {
    * ```
    * @example
    * ```typescript
-   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemoryExecutionType } from '@uipath/uipath-typescript/agent-memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getCallsTimeline({
@@ -82,22 +82,22 @@ export interface MemoryServiceModel {
    *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   agentId: '<agentId>', 
    *   folderKeys: ['<folderKey>'],
-   *   executionType: ExecutionType.Runtime,
+   *   executionType: AgentMemoryExecutionType.Runtime,
    * });
    * ```
    */
-  getCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryGetCallsTimelineResponse[]>;
+  getCallsTimeline(options?: AgentMemoryGetCallsTimelineOptions): Promise<AgentMemoryGetCallsTimelineResponse[]>;
 
   /**
    * Gets the top memory spaces by memory count, with optional filters
    *
    * @param options - Optional limit, time window, and scope filters
-   * @returns Promise resolving to an array of {@link MemoryGetTopSpacesResponse}, ranked by memory count.
+   * @returns Promise resolving to an array of {@link AgentMemoryGetTopSpacesResponse}, ranked by memory count.
    * @example
    * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
    *
-   * const memory = new Memory(sdk);
+   * const memory = new AgentMemory(sdk);
    *
    * // Top 5 memory spaces (default limit and window)
    * const top = await memory.getTopSpaces();
@@ -105,17 +105,17 @@ export interface MemoryServiceModel {
    * ```
    * @example
    * ```typescript
-   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemoryExecutionType } from '@uipath/uipath-typescript/agent-memory';
    *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
    * const topScoped = await memory.getTopSpaces({
    *   startTime: new Date('2026-05-01T00:00:00Z'),
    *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   folderKeys: ['<folderKey>'],
-   *   executionType: ExecutionType.Runtime,
+   *   executionType: AgentMemoryExecutionType.Runtime,
    *   limit: 10,
    * });
    * ```
    */
-  getTopSpaces(options?: MemoryGetTopSpacesOptions): Promise<MemoryGetTopSpacesResponse[]>;
+  getTopSpaces(options?: AgentMemoryGetTopSpacesOptions): Promise<AgentMemoryGetTopSpacesResponse[]>;
 }

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -1,0 +1,66 @@
+import {
+  MemoryTimelineGetOptions,
+  MemoryTimelineResponse,
+} from './memory.types';
+
+/**
+ * Service for querying UiPath Agent Memory analytics.
+ *
+ * Agent Memory is a shared store of human-in-the-loop interactions that
+ * improves agent runtime reliability. These read-only analytics power the
+ * Agents app's "Memory spaces" dashboards.
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { Memory } from '@uipath/uipath-typescript/memory';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * const memory = new Memory(sdk);
+ * const timeline = await memory.getMemoryTimeline();
+ * ```
+ */
+export interface MemoryServiceModel {
+  /**
+   * Retrieves a time-series of agent-memory state counts bucketed across the
+   * requested window.
+   *
+   * Each point reports how many memory entries were in-memory vs not-in-memory
+   * and enabled vs disabled for that time bucket. Bucket size is chosen
+   * server-side based on the window length. When no time window is provided,
+   * the server defaults to the last 24 hours (with the upper bound defaulting
+   * to now). Optionally filter by agent, agent version, folder, or execution
+   * type.
+   *
+   * @param options - Optional time window and scope filters {@link MemoryTimelineGetOptions}
+   * @returns Promise resolving to {@link MemoryTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @example
+   * ```typescript
+   * import { Memory } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Last 24 hours (server-default window)
+   * const timeline = await memory.getMemoryTimeline();
+   * console.log(timeline.data?.[0]?.inMemoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Scoped to one agent in one folder, runtime executions only
+   * const timeline = await memory.getMemoryTimeline({
+   *   startTime: '2026-05-01T00:00:00Z',
+   *   endTime: '2026-06-01T00:00:00Z',
+   *   agentId: '<agentId>',
+   *   folderKeys: ['<folderKey>'],
+   *   executionType: ExecutionType.Runtime,
+   * });
+   * ```
+   */
+  getMemoryTimeline(options?: MemoryTimelineGetOptions): Promise<MemoryTimelineResponse>;
+}

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -1,10 +1,10 @@
 import {
-  MemoryTimelineGetOptions,
-  MemoryTimelineResponse,
-  MemoryCallsTimelineGetOptions,
-  MemoryCallsTimelineResponse,
-  TopMemorySpacesGetOptions,
-  TopMemorySpacesResponse,
+  MemoryGetTimelineOptions,
+  MemoryGetTimelineResponse,
+  MemoryGetCallsTimelineOptions,
+  MemoryGetCallsTimelineResponse,
+  MemoryGetTopSpacesOptions,
+  MemoryGetTopSpacesResponse,
 } from './memory.types';
 
 /**
@@ -38,8 +38,8 @@ export interface MemoryServiceModel {
    * to now). Optionally filter by agent, agent version, folder, or execution
    * type.
    *
-   * @param options - Optional time window and scope filters {@link MemoryTimelineGetOptions}
-   * @returns Promise resolving to {@link MemoryTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @param options - Optional time window and scope filters {@link MemoryGetTimelineOptions}
+   * @returns Promise resolving to {@link MemoryGetTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
    * @example
    * ```typescript
    * import { Memory } from '@uipath/uipath-typescript/memory';
@@ -66,7 +66,7 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getMemoryTimeline(options?: MemoryTimelineGetOptions): Promise<MemoryTimelineResponse>;
+  getMemoryTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse>;
 
   /**
    * Retrieves a time-series of memory-call counts bucketed across the requested
@@ -78,8 +78,8 @@ export interface MemoryServiceModel {
    * upper bound defaulting to now). Optionally filter by agent, agent version,
    * folder, or execution type.
    *
-   * @param options - Optional time window and scope filters {@link MemoryCallsTimelineGetOptions}
-   * @returns Promise resolving to {@link MemoryCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @param options - Optional time window and scope filters {@link MemoryGetCallsTimelineOptions}
+   * @returns Promise resolving to {@link MemoryGetCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
    * @example
    * ```typescript
    * import { Memory } from '@uipath/uipath-typescript/memory';
@@ -106,7 +106,7 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getMemoryCallsTimeline(options?: MemoryCallsTimelineGetOptions): Promise<MemoryCallsTimelineResponse>;
+  getMemoryCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryGetCallsTimelineResponse>;
 
   /**
    * Retrieves the top memory spaces ranked by memory count over the requested
@@ -118,8 +118,8 @@ export interface MemoryServiceModel {
    * server defaults to the last 24 hours (with the upper bound defaulting to
    * now). Optionally filter by agent, agent version, folder, or execution type.
    *
-   * @param options - Optional limit, time window, and scope filters {@link TopMemorySpacesGetOptions}
-   * @returns Promise resolving to {@link TopMemorySpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
+   * @param options - Optional limit, time window, and scope filters {@link MemoryGetTopSpacesOptions}
+   * @returns Promise resolving to {@link MemoryGetTopSpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
    * @example
    * ```typescript
    * import { Memory } from '@uipath/uipath-typescript/memory';
@@ -146,5 +146,5 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getTopMemorySpaces(options?: TopMemorySpacesGetOptions): Promise<TopMemorySpacesResponse>;
+  getTopMemorySpaces(options?: MemoryGetTopSpacesOptions): Promise<MemoryGetTopSpacesResponse>;
 }

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -1,6 +1,8 @@
 import {
   MemoryTimelineGetOptions,
   MemoryTimelineResponse,
+  MemoryCallsTimelineGetOptions,
+  MemoryCallsTimelineResponse,
 } from './memory.types';
 
 /**
@@ -63,4 +65,44 @@ export interface MemoryServiceModel {
    * ```
    */
   getMemoryTimeline(options?: MemoryTimelineGetOptions): Promise<MemoryTimelineResponse>;
+
+  /**
+   * Retrieves a time-series of memory-call counts bucketed across the requested
+   * window.
+   *
+   * Each point reports how many memory calls occurred in that time bucket.
+   * Bucket size is chosen server-side based on the window length. When no time
+   * window is provided, the server defaults to the last 24 hours (with the
+   * upper bound defaulting to now). Optionally filter by agent, agent version,
+   * folder, or execution type.
+   *
+   * @param options - Optional time window and scope filters {@link MemoryCallsTimelineGetOptions}
+   * @returns Promise resolving to {@link MemoryCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @example
+   * ```typescript
+   * import { Memory } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Last 24 hours (server-default window)
+   * const timeline = await memory.getMemoryCallsTimeline();
+   * console.log(timeline.data?.[0]?.memoryCallsCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Scoped to one agent in one folder, runtime executions only
+   * const timeline = await memory.getMemoryCallsTimeline({
+   *   startTime: '2026-05-01T00:00:00Z',
+   *   endTime: '2026-06-01T00:00:00Z',
+   *   agentId: '<agentId>',
+   *   folderKeys: ['<folderKey>'],
+   *   executionType: ExecutionType.Runtime,
+   * });
+   * ```
+   */
+  getMemoryCallsTimeline(options?: MemoryCallsTimelineGetOptions): Promise<MemoryCallsTimelineResponse>;
 }

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -1,10 +1,10 @@
 import {
   MemoryGetTimelineOptions,
-  MemoryTimelinePoint,
+  MemoryGetTimelineResponse,
   MemoryGetCallsTimelineOptions,
-  MemoryCallsTimelinePoint,
+  MemoryGetCallsTimelineResponse,
   MemoryGetTopSpacesOptions,
-  MemorySpace,
+  MemoryGetTopSpacesResponse,
 } from './memory.types';
 
 /**
@@ -27,86 +27,95 @@ import {
  */
 export interface MemoryServiceModel {
   /**
-   * Retrieves a time-series of agent-memory state counts bucketed across the
-   * requested window.
+   * Gets agent memory state over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryTimelinePoint}, one per time bucket. Empty when no data matches.
+   * @returns Promise resolving to an array of {@link MemoryGetTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { Memory } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getTimeline();
    * console.log(timeline[0]?.inMemoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getTimeline({
-   *   startTime: '2026-05-01T00:00:00Z',
-   *   endTime: '2026-06-01T00:00:00Z',
+   *   startTime: new Date('2026-05-01T00:00:00Z'),
+   *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   agentId: '<agentId>',
    *   folderKeys: ['<folderKey>'],
    *   executionType: ExecutionType.Runtime,
    * });
    * ```
    */
-  getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryTimelinePoint[]>;
+  getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse[]>;
 
   /**
-   * Retrieves a time-series of memory-call counts bucketed across the requested
-   * window.
+   * Gets agent memory-access counts over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryCallsTimelinePoint}, one per time bucket. Empty when no data matches.
+   * @returns Promise resolving to an array of {@link MemoryGetCallsTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { Memory } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getCallsTimeline();
    * console.log(timeline[0]?.memoryCallsCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getCallsTimeline({
-   *   startTime: '2026-05-01T00:00:00Z',
-   *   endTime: '2026-06-01T00:00:00Z',
-   *   agentId: '<agentId>',
+   *   startTime: new Date('2026-05-01T00:00:00Z'),
+   *   endTime: new Date('2026-06-01T00:00:00Z'),
+   *   agentId: '<agentId>', 
    *   folderKeys: ['<folderKey>'],
    *   executionType: ExecutionType.Runtime,
    * });
    * ```
    */
-  getCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryCallsTimelinePoint[]>;
+  getCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryGetCallsTimelineResponse[]>;
 
   /**
-   * Retrieves the top memory spaces ranked by memory count over the requested
-   * window.
+   * Gets the top memory spaces by memory count, with optional filters
    *
    * @param options - Optional limit, time window, and scope filters
-   * @returns Promise resolving to an array of {@link MemorySpace}, ranked by memory count. Empty when no data matches.
+   * @returns Promise resolving to an array of {@link MemoryGetTopSpacesResponse}, ranked by memory count.
    * @example
    * ```typescript
-   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { Memory } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
    * // Top 5 memory spaces (default limit and window)
    * const top = await memory.getTopSpaces();
    * console.log(top[0]?.memorySpaceName, top[0]?.memoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
    * const topScoped = await memory.getTopSpaces({
-   *   startTime: '2026-05-01T00:00:00Z',
-   *   endTime: '2026-06-01T00:00:00Z',
+   *   startTime: new Date('2026-05-01T00:00:00Z'),
+   *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   folderKeys: ['<folderKey>'],
    *   executionType: ExecutionType.Runtime,
    *   limit: 10,
    * });
    * ```
    */
-  getTopSpaces(options?: MemoryGetTopSpacesOptions): Promise<MemorySpace[]>;
+  getTopSpaces(options?: MemoryGetTopSpacesOptions): Promise<MemoryGetTopSpacesResponse[]>;
 }

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -1,18 +1,17 @@
 import {
   MemoryGetTimelineOptions,
-  MemoryGetTimelineResponse,
+  MemoryTimelinePoint,
   MemoryGetCallsTimelineOptions,
-  MemoryGetCallsTimelineResponse,
+  MemoryCallsTimelinePoint,
   MemoryGetTopSpacesOptions,
-  MemoryGetTopSpacesResponse,
+  MemorySpace,
 } from './memory.types';
 
 /**
- * Service for querying UiPath Agent Memory analytics.
+ * Service for managing UiPath Agent Memory.
  *
  * Agent Memory is a shared store of human-in-the-loop interactions that
- * improves agent runtime reliability. These read-only analytics power the
- * Agents app's "Memory spaces" dashboards.
+ * improves agent runtime reliability.
  *
  * @example
  * ```typescript
@@ -31,26 +30,20 @@ export interface MemoryServiceModel {
    * Retrieves a time-series of agent-memory state counts bucketed across the
    * requested window.
    *
-   * @param options - Optional time window and scope filters {@link MemoryGetTimelineOptions}
-   * @returns Promise resolving to {@link MemoryGetTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @param options - Optional time window and scope filters
+   * @returns Promise resolving to an array of {@link MemoryTimelinePoint}, one per time bucket. Empty when no data matches.
    * @example
    * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
+   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getTimeline();
-   * console.log(timeline.data?.[0]?.inMemoryCount);
-   * ```
-   * @example
-   * ```typescript
-   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
-   *
-   * const memory = new Memory(sdk);
+   * console.log(timeline[0]?.inMemoryCount);
    *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getTimeline({
+   * const scoped = await memory.getTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -59,32 +52,26 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse>;
+  getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryTimelinePoint[]>;
 
   /**
    * Retrieves a time-series of memory-call counts bucketed across the requested
    * window.
    *
-   * @param options - Optional time window and scope filters {@link MemoryGetCallsTimelineOptions}
-   * @returns Promise resolving to {@link MemoryGetCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
-   * @example
-   * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
-   *
-   * const memory = new Memory(sdk);
-   *
-   * // Last 24 hours (default window)
-   * const timeline = await memory.getCallsTimeline();
-   * console.log(timeline.data?.[0]?.memoryCallsCount);
-   * ```
+   * @param options - Optional time window and scope filters
+   * @returns Promise resolving to an array of {@link MemoryCallsTimelinePoint}, one per time bucket. Empty when no data matches.
    * @example
    * ```typescript
    * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
+   * // Last 24 hours (default window)
+   * const timeline = await memory.getCallsTimeline();
+   * console.log(timeline[0]?.memoryCallsCount);
+   *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getCallsTimeline({
+   * const scoped = await memory.getCallsTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -93,32 +80,26 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryGetCallsTimelineResponse>;
+  getCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryCallsTimelinePoint[]>;
 
   /**
    * Retrieves the top memory spaces ranked by memory count over the requested
    * window.
    *
-   * @param options - Optional limit, time window, and scope filters {@link MemoryGetTopSpacesOptions}
-   * @returns Promise resolving to {@link MemoryGetTopSpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
-   * @example
-   * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
-   *
-   * const memory = new Memory(sdk);
-   *
-   * // Top 5 memory spaces (default limit and window)
-   * const top = await memory.getTopSpaces();
-   * console.log(top.data?.[0]?.memorySpaceName, top.data?.[0]?.memoryCount);
-   * ```
+   * @param options - Optional limit, time window, and scope filters
+   * @returns Promise resolving to an array of {@link MemorySpace}, ranked by memory count. Empty when no data matches.
    * @example
    * ```typescript
    * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
+   * // Top 5 memory spaces (default limit and window)
+   * const top = await memory.getTopSpaces();
+   * console.log(top[0]?.memorySpaceName, top[0]?.memoryCount);
+   *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
-   * const top = await memory.getTopSpaces({
+   * const topScoped = await memory.getTopSpaces({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   folderKeys: ['<folderKey>'],
@@ -127,5 +108,5 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getTopSpaces(options?: MemoryGetTopSpacesOptions): Promise<MemoryGetTopSpacesResponse>;
+  getTopSpaces(options?: MemoryGetTopSpacesOptions): Promise<MemorySpace[]>;
 }

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -23,20 +23,13 @@ import {
  * await sdk.initialize();
  *
  * const memory = new Memory(sdk);
- * const timeline = await memory.getMemoryTimeline();
+ * const timeline = await memory.getTimeline();
  * ```
  */
 export interface MemoryServiceModel {
   /**
    * Retrieves a time-series of agent-memory state counts bucketed across the
    * requested window.
-   *
-   * Each point reports how many memory entries were in-memory vs not-in-memory
-   * and enabled vs disabled for that time bucket. Bucket size is chosen
-   * server-side based on the window length. When no time window is provided,
-   * the server defaults to the last 24 hours (with the upper bound defaulting
-   * to now). Optionally filter by agent, agent version, folder, or execution
-   * type.
    *
    * @param options - Optional time window and scope filters {@link MemoryGetTimelineOptions}
    * @returns Promise resolving to {@link MemoryGetTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
@@ -46,8 +39,8 @@ export interface MemoryServiceModel {
    *
    * const memory = new Memory(sdk);
    *
-   * // Last 24 hours (server-default window)
-   * const timeline = await memory.getMemoryTimeline();
+   * // Last 24 hours (default window)
+   * const timeline = await memory.getTimeline();
    * console.log(timeline.data?.[0]?.inMemoryCount);
    * ```
    * @example
@@ -57,7 +50,7 @@ export interface MemoryServiceModel {
    * const memory = new Memory(sdk);
    *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getMemoryTimeline({
+   * const timeline = await memory.getTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -66,17 +59,11 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getMemoryTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse>;
+  getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse>;
 
   /**
    * Retrieves a time-series of memory-call counts bucketed across the requested
    * window.
-   *
-   * Each point reports how many memory calls occurred in that time bucket.
-   * Bucket size is chosen server-side based on the window length. When no time
-   * window is provided, the server defaults to the last 24 hours (with the
-   * upper bound defaulting to now). Optionally filter by agent, agent version,
-   * folder, or execution type.
    *
    * @param options - Optional time window and scope filters {@link MemoryGetCallsTimelineOptions}
    * @returns Promise resolving to {@link MemoryGetCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
@@ -86,8 +73,8 @@ export interface MemoryServiceModel {
    *
    * const memory = new Memory(sdk);
    *
-   * // Last 24 hours (server-default window)
-   * const timeline = await memory.getMemoryCallsTimeline();
+   * // Last 24 hours (default window)
+   * const timeline = await memory.getCallsTimeline();
    * console.log(timeline.data?.[0]?.memoryCallsCount);
    * ```
    * @example
@@ -97,7 +84,7 @@ export interface MemoryServiceModel {
    * const memory = new Memory(sdk);
    *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getMemoryCallsTimeline({
+   * const timeline = await memory.getCallsTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -106,17 +93,11 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getMemoryCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryGetCallsTimelineResponse>;
+  getCallsTimeline(options?: MemoryGetCallsTimelineOptions): Promise<MemoryGetCallsTimelineResponse>;
 
   /**
    * Retrieves the top memory spaces ranked by memory count over the requested
    * window.
-   *
-   * Each entry is a memory space with its total memory count and an
-   * enabled/disabled breakdown. Use `limit` to cap how many spaces are
-   * returned (defaults to 5 server-side). When no time window is provided, the
-   * server defaults to the last 24 hours (with the upper bound defaulting to
-   * now). Optionally filter by agent, agent version, folder, or execution type.
    *
    * @param options - Optional limit, time window, and scope filters {@link MemoryGetTopSpacesOptions}
    * @returns Promise resolving to {@link MemoryGetTopSpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
@@ -126,8 +107,8 @@ export interface MemoryServiceModel {
    *
    * const memory = new Memory(sdk);
    *
-   * // Top 5 memory spaces (server-default limit and window)
-   * const top = await memory.getTopMemorySpaces();
+   * // Top 5 memory spaces (default limit and window)
+   * const top = await memory.getTopSpaces();
    * console.log(top.data?.[0]?.memorySpaceName, top.data?.[0]?.memoryCount);
    * ```
    * @example
@@ -137,7 +118,7 @@ export interface MemoryServiceModel {
    * const memory = new Memory(sdk);
    *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
-   * const top = await memory.getTopMemorySpaces({
+   * const top = await memory.getTopSpaces({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   folderKeys: ['<folderKey>'],
@@ -146,5 +127,5 @@ export interface MemoryServiceModel {
    * });
    * ```
    */
-  getTopMemorySpaces(options?: MemoryGetTopSpacesOptions): Promise<MemoryGetTopSpacesResponse>;
+  getTopSpaces(options?: MemoryGetTopSpacesOptions): Promise<MemoryGetTopSpacesResponse>;
 }

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -3,6 +3,8 @@ import {
   MemoryTimelineResponse,
   MemoryCallsTimelineGetOptions,
   MemoryCallsTimelineResponse,
+  TopMemorySpacesGetOptions,
+  TopMemorySpacesResponse,
 } from './memory.types';
 
 /**
@@ -105,4 +107,44 @@ export interface MemoryServiceModel {
    * ```
    */
   getMemoryCallsTimeline(options?: MemoryCallsTimelineGetOptions): Promise<MemoryCallsTimelineResponse>;
+
+  /**
+   * Retrieves the top memory spaces ranked by memory count over the requested
+   * window.
+   *
+   * Each entry is a memory space with its total memory count and an
+   * enabled/disabled breakdown. Use `limit` to cap how many spaces are
+   * returned (defaults to 5 server-side). When no time window is provided, the
+   * server defaults to the last 24 hours (with the upper bound defaulting to
+   * now). Optionally filter by agent, agent version, folder, or execution type.
+   *
+   * @param options - Optional limit, time window, and scope filters {@link TopMemorySpacesGetOptions}
+   * @returns Promise resolving to {@link TopMemorySpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
+   * @example
+   * ```typescript
+   * import { Memory } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Top 5 memory spaces (server-default limit and window)
+   * const top = await memory.getTopMemorySpaces();
+   * console.log(top.data?.[0]?.memorySpaceName, top.data?.[0]?.memoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Top 10 spaces for one folder over an explicit window, runtime executions only
+   * const top = await memory.getTopMemorySpaces({
+   *   startTime: '2026-05-01T00:00:00Z',
+   *   endTime: '2026-06-01T00:00:00Z',
+   *   folderKeys: ['<folderKey>'],
+   *   executionType: ExecutionType.Runtime,
+   *   limit: 10,
+   * });
+   * ```
+   */
+  getTopMemorySpaces(options?: TopMemorySpacesGetOptions): Promise<TopMemorySpacesResponse>;
 }

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -41,6 +41,11 @@ export interface MemoryFilterOptions {
 export interface MemoryTimelineGetOptions extends MemoryFilterOptions {}
 
 /**
+ * Options for {@link MemoryServiceModel.getMemoryCallsTimeline}.
+ */
+export interface MemoryCallsTimelineGetOptions extends MemoryFilterOptions {}
+
+/**
  * One point on the agent-memory state timeline — memory-state counts for a
  * single time bucket.
  */
@@ -65,4 +70,23 @@ export interface MemoryTimelinePoint {
 export interface MemoryTimelineResponse {
   /** Time-series points, one per bucket. May be absent when no data matches. */
   data?: MemoryTimelinePoint[];
+}
+
+/**
+ * One point on the memory-calls timeline — the count of memory calls for a
+ * single time bucket.
+ */
+export interface MemoryCallsTimelinePoint {
+  /** Bucket timestamp (ISO 8601, UTC). */
+  timeSlice: string;
+  /** Number of memory calls in this bucket. */
+  memoryCallsCount: number;
+}
+
+/**
+ * Response from {@link MemoryServiceModel.getMemoryCallsTimeline}.
+ */
+export interface MemoryCallsTimelineResponse {
+  /** Time-series points, one per bucket. May be absent when no data matches. */
+  data?: MemoryCallsTimelinePoint[];
 }

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -21,10 +21,10 @@ export enum ExecutionType {
  */
 export interface MemoryFilterOptions {
   /** Inclusive lower bound for the query window. Defaults to 24 hours before `endTime` when omitted. */
-  startTime?: string;
+  startTime?: Date;
   /** Exclusive upper bound for the query window. Defaults to now when omitted. */
-  endTime?: string;
-  /** Filter to a single agent by ID. */
+  endTime?: Date;
+  /** Filter to a single agent by ID. Obtain an `agentId` from the Agents service. */
   agentId?: string;
   /** Filter to a specific agent version. */
   agentVersion?: string;
@@ -56,7 +56,7 @@ export interface MemoryGetTopSpacesOptions extends MemoryFilterOptions {
  * One point on the agent-memory state timeline — memory-state counts for a
  * single time bucket.
  */
-export interface MemoryTimelinePoint {
+export interface MemoryGetTimelineResponse {
   /** Bucket timestamp. */
   timeSlice: string;
   /** Count of memory entries that were in-memory in this bucket. */
@@ -75,7 +75,7 @@ export interface MemoryTimelinePoint {
  * One point on the memory-calls timeline — the count of memory calls for a
  * single time bucket.
  */
-export interface MemoryCallsTimelinePoint {
+export interface MemoryGetCallsTimelineResponse {
   /** Bucket timestamp. */
   timeSlice: string;
   /** Number of memory calls in this bucket. */
@@ -85,7 +85,7 @@ export interface MemoryCallsTimelinePoint {
 /**
  * A single memory space with its enabled/disabled memory-entry breakdown.
  */
-export interface MemorySpace {
+export interface MemoryGetTopSpacesResponse {
   /** Memory space identifier. */
   memorySpaceId: string;
   /** Memory space display name. */

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -1,0 +1,68 @@
+/**
+ * Types for the Agent Memory (Traceview) analytics service.
+ */
+
+/**
+ * Execution kind to filter Agent Memory queries by. Omit to include both
+ * Debug and Runtime executions.
+ */
+export enum ExecutionType {
+  /** Executions produced during agent debugging sessions. */
+  Debug = 'Debug',
+  /** Executions produced during production runtime. */
+  Runtime = 'Runtime',
+}
+
+/**
+ * Common time-window and scope filters shared by Agent Memory queries.
+ *
+ * All fields are optional. When `startTime`/`endTime` are omitted, the server
+ * applies default bounds (typically the last 24 hours, with `endTime`
+ * defaulting to now).
+ */
+export interface MemoryFilterOptions {
+  /** Inclusive lower bound for the query window (ISO 8601, UTC). Defaults server-side when omitted. */
+  startTime?: string;
+  /** Exclusive upper bound for the query window (ISO 8601, UTC). Defaults to now server-side when omitted. */
+  endTime?: string;
+  /** Filter to a single agent by ID. */
+  agentId?: string;
+  /** Filter to a specific agent version. */
+  agentVersion?: string;
+  /** Folder keys (GUIDs) to scope the query. Intersected with the caller's accessible folders. */
+  folderKeys?: string[];
+  /** Filter to a specific execution kind. Omit to include both Debug and Runtime. */
+  executionType?: ExecutionType;
+}
+
+/**
+ * Options for {@link MemoryServiceModel.getMemoryTimeline}.
+ */
+export interface MemoryTimelineGetOptions extends MemoryFilterOptions {}
+
+/**
+ * One point on the agent-memory state timeline — memory-state counts for a
+ * single time bucket.
+ */
+export interface MemoryTimelinePoint {
+  /** Bucket timestamp (ISO 8601, UTC). */
+  timeSlice: string;
+  /** Count of memory entries that were in-memory in this bucket. */
+  inMemoryCount: number;
+  /** Count of memory entries that were not in-memory in this bucket. */
+  notInMemoryCount: number;
+  /** Total memory entries in this bucket. */
+  totalCount: number;
+  /** Count of enabled memory entries in this bucket. */
+  enabledMemoryCount: number;
+  /** Count of disabled memory entries in this bucket. */
+  disabledMemoryCount: number;
+}
+
+/**
+ * Response from {@link MemoryServiceModel.getMemoryTimeline}.
+ */
+export interface MemoryTimelineResponse {
+  /** Time-series points, one per bucket. May be absent when no data matches. */
+  data?: MemoryTimelinePoint[];
+}

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -38,17 +38,17 @@ export interface MemoryFilterOptions {
 /**
  * Options for {@link MemoryServiceModel.getMemoryTimeline}.
  */
-export interface MemoryTimelineGetOptions extends MemoryFilterOptions {}
+export interface MemoryGetTimelineOptions extends MemoryFilterOptions {}
 
 /**
  * Options for {@link MemoryServiceModel.getMemoryCallsTimeline}.
  */
-export interface MemoryCallsTimelineGetOptions extends MemoryFilterOptions {}
+export interface MemoryGetCallsTimelineOptions extends MemoryFilterOptions {}
 
 /**
  * Options for {@link MemoryServiceModel.getTopMemorySpaces}.
  */
-export interface TopMemorySpacesGetOptions extends MemoryFilterOptions {
+export interface MemoryGetTopSpacesOptions extends MemoryFilterOptions {
   /** Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 server-side. */
   limit?: number;
 }
@@ -75,7 +75,7 @@ export interface MemoryTimelinePoint {
 /**
  * Response from {@link MemoryServiceModel.getMemoryTimeline}.
  */
-export interface MemoryTimelineResponse {
+export interface MemoryGetTimelineResponse {
   /** Time-series points, one per bucket. May be absent when no data matches. */
   data?: MemoryTimelinePoint[];
 }
@@ -94,7 +94,7 @@ export interface MemoryCallsTimelinePoint {
 /**
  * Response from {@link MemoryServiceModel.getMemoryCallsTimeline}.
  */
-export interface MemoryCallsTimelineResponse {
+export interface MemoryGetCallsTimelineResponse {
   /** Time-series points, one per bucket. May be absent when no data matches. */
   data?: MemoryCallsTimelinePoint[];
 }
@@ -119,7 +119,7 @@ export interface MemorySpace {
 /**
  * Response from {@link MemoryServiceModel.getTopMemorySpaces}.
  */
-export interface TopMemorySpacesResponse {
+export interface MemoryGetTopSpacesResponse {
   /** Memory spaces ranked by memory count. May be absent when no data matches. */
   data?: MemorySpace[];
 }

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -46,6 +46,14 @@ export interface MemoryTimelineGetOptions extends MemoryFilterOptions {}
 export interface MemoryCallsTimelineGetOptions extends MemoryFilterOptions {}
 
 /**
+ * Options for {@link MemoryServiceModel.getTopMemorySpaces}.
+ */
+export interface TopMemorySpacesGetOptions extends MemoryFilterOptions {
+  /** Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 server-side. */
+  limit?: number;
+}
+
+/**
  * One point on the agent-memory state timeline — memory-state counts for a
  * single time bucket.
  */
@@ -89,4 +97,29 @@ export interface MemoryCallsTimelinePoint {
 export interface MemoryCallsTimelineResponse {
   /** Time-series points, one per bucket. May be absent when no data matches. */
   data?: MemoryCallsTimelinePoint[];
+}
+
+/**
+ * A single memory space with its enabled/disabled memory-entry breakdown,
+ * as returned by {@link MemoryServiceModel.getTopMemorySpaces}.
+ */
+export interface MemorySpace {
+  /** Memory space identifier. */
+  memorySpaceId: string;
+  /** Memory space display name. */
+  memorySpaceName: string;
+  /** Total memory entries in this space over the requested window. */
+  memoryCount: number;
+  /** Count of enabled memory entries in this space. */
+  enabledMemoryCount: number;
+  /** Count of disabled memory entries in this space. */
+  disabledMemoryCount: number;
+}
+
+/**
+ * Response from {@link MemoryServiceModel.getTopMemorySpaces}.
+ */
+export interface TopMemorySpacesResponse {
+  /** Memory spaces ranked by memory count. May be absent when no data matches. */
+  data?: MemorySpace[];
 }

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -1,5 +1,5 @@
 /**
- * Types for the Agent Memory (Traceview) analytics service.
+ * Types for the Agent Memory analytics service.
  */
 
 /**
@@ -16,40 +16,39 @@ export enum ExecutionType {
 /**
  * Common time-window and scope filters shared by Agent Memory queries.
  *
- * All fields are optional. When `startTime`/`endTime` are omitted, the server
- * applies default bounds (typically the last 24 hours, with `endTime`
- * defaulting to now).
+ * All fields are optional. When `startTime`/`endTime` are omitted, the query
+ * defaults to the last 24 hours, with `endTime` defaulting to now.
  */
 export interface MemoryFilterOptions {
-  /** Inclusive lower bound for the query window (ISO 8601, UTC). Defaults server-side when omitted. */
+  /** Inclusive lower bound for the query window (ISO 8601, UTC). Defaults to 24 hours before `endTime` when omitted. */
   startTime?: string;
-  /** Exclusive upper bound for the query window (ISO 8601, UTC). Defaults to now server-side when omitted. */
+  /** Exclusive upper bound for the query window (ISO 8601, UTC). Defaults to now when omitted. */
   endTime?: string;
   /** Filter to a single agent by ID. */
   agentId?: string;
   /** Filter to a specific agent version. */
   agentVersion?: string;
-  /** Folder keys (GUIDs) to scope the query. Intersected with the caller's accessible folders. */
+  /** Folder keys (GUIDs) to scope the query. Results are limited to folders you can access. */
   folderKeys?: string[];
   /** Filter to a specific execution kind. Omit to include both Debug and Runtime. */
   executionType?: ExecutionType;
 }
 
 /**
- * Options for {@link MemoryServiceModel.getMemoryTimeline}.
+ * Options for {@link MemoryServiceModel.getTimeline}.
  */
 export interface MemoryGetTimelineOptions extends MemoryFilterOptions {}
 
 /**
- * Options for {@link MemoryServiceModel.getMemoryCallsTimeline}.
+ * Options for {@link MemoryServiceModel.getCallsTimeline}.
  */
 export interface MemoryGetCallsTimelineOptions extends MemoryFilterOptions {}
 
 /**
- * Options for {@link MemoryServiceModel.getTopMemorySpaces}.
+ * Options for {@link MemoryServiceModel.getTopSpaces}.
  */
 export interface MemoryGetTopSpacesOptions extends MemoryFilterOptions {
-  /** Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 server-side. */
+  /** Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 when omitted. */
   limit?: number;
 }
 
@@ -73,7 +72,7 @@ export interface MemoryTimelinePoint {
 }
 
 /**
- * Response from {@link MemoryServiceModel.getMemoryTimeline}.
+ * Response from {@link MemoryServiceModel.getTimeline}.
  */
 export interface MemoryGetTimelineResponse {
   /** Time-series points, one per bucket. May be absent when no data matches. */
@@ -92,7 +91,7 @@ export interface MemoryCallsTimelinePoint {
 }
 
 /**
- * Response from {@link MemoryServiceModel.getMemoryCallsTimeline}.
+ * Response from {@link MemoryServiceModel.getCallsTimeline}.
  */
 export interface MemoryGetCallsTimelineResponse {
   /** Time-series points, one per bucket. May be absent when no data matches. */
@@ -101,7 +100,7 @@ export interface MemoryGetCallsTimelineResponse {
 
 /**
  * A single memory space with its enabled/disabled memory-entry breakdown,
- * as returned by {@link MemoryServiceModel.getTopMemorySpaces}.
+ * as returned by {@link MemoryServiceModel.getTopSpaces}.
  */
 export interface MemorySpace {
   /** Memory space identifier. */
@@ -117,7 +116,7 @@ export interface MemorySpace {
 }
 
 /**
- * Response from {@link MemoryServiceModel.getTopMemorySpaces}.
+ * Response from {@link MemoryServiceModel.getTopSpaces}.
  */
 export interface MemoryGetTopSpacesResponse {
   /** Memory spaces ranked by memory count. May be absent when no data matches. */

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -6,7 +6,7 @@
  * Execution kind to filter Agent Memory queries by. Omit to include both
  * Debug and Runtime executions.
  */
-export enum ExecutionType {
+export enum AgentMemoryExecutionType {
   /** Executions produced during agent debugging sessions. */
   Debug = 'Debug',
   /** Executions produced during production runtime. */
@@ -19,7 +19,7 @@ export enum ExecutionType {
  * All fields are optional. When `startTime`/`endTime` are omitted, the query
  * defaults to the last 24 hours, with `endTime` defaulting to now.
  */
-export interface MemoryFilterOptions {
+export interface AgentMemoryFilterOptions {
   /** Inclusive lower bound for the query window. Defaults to 24 hours before `endTime` when omitted. */
   startTime?: Date;
   /** Exclusive upper bound for the query window. Defaults to now when omitted. */
@@ -31,23 +31,23 @@ export interface MemoryFilterOptions {
   /** Folder keys to scope the query. Results are limited to folders you can access. */
   folderKeys?: string[];
   /** Filter to a specific execution kind. Omit to include both Debug and Runtime. */
-  executionType?: ExecutionType;
+  executionType?: AgentMemoryExecutionType;
 }
 
 /**
  * Options for retrieving the agent-memory state timeline.
  */
-export interface MemoryGetTimelineOptions extends MemoryFilterOptions {}
+export interface AgentMemoryGetTimelineOptions extends AgentMemoryFilterOptions {}
 
 /**
  * Options for retrieving the memory-calls timeline.
  */
-export interface MemoryGetCallsTimelineOptions extends MemoryFilterOptions {}
+export interface AgentMemoryGetCallsTimelineOptions extends AgentMemoryFilterOptions {}
 
 /**
  * Options for retrieving the top memory spaces.
  */
-export interface MemoryGetTopSpacesOptions extends MemoryFilterOptions {
+export interface AgentMemoryGetTopSpacesOptions extends AgentMemoryFilterOptions {
   /** Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 when omitted. */
   limit?: number;
 }
@@ -56,7 +56,7 @@ export interface MemoryGetTopSpacesOptions extends MemoryFilterOptions {
  * One point on the agent-memory state timeline — memory-state counts for a
  * single time bucket.
  */
-export interface MemoryGetTimelineResponse {
+export interface AgentMemoryGetTimelineResponse {
   /** Bucket timestamp. */
   timeSlice: string;
   /** Count of memory entries that were in-memory in this bucket. */
@@ -75,7 +75,7 @@ export interface MemoryGetTimelineResponse {
  * One point on the memory-calls timeline — the count of memory calls for a
  * single time bucket.
  */
-export interface MemoryGetCallsTimelineResponse {
+export interface AgentMemoryGetCallsTimelineResponse {
   /** Bucket timestamp. */
   timeSlice: string;
   /** Number of memory calls in this bucket. */
@@ -85,7 +85,7 @@ export interface MemoryGetCallsTimelineResponse {
 /**
  * A single memory space with its enabled/disabled memory-entry breakdown.
  */
-export interface MemoryGetTopSpacesResponse {
+export interface AgentMemoryGetTopSpacesResponse {
   /** Memory space identifier. */
   memorySpaceId: string;
   /** Memory space display name. */

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -1,5 +1,5 @@
 /**
- * Types for the Agent Memory analytics service.
+ * Types for the Agent Memory metrics service.
  */
 
 /**
@@ -20,32 +20,32 @@ export enum ExecutionType {
  * defaults to the last 24 hours, with `endTime` defaulting to now.
  */
 export interface MemoryFilterOptions {
-  /** Inclusive lower bound for the query window (ISO 8601, UTC). Defaults to 24 hours before `endTime` when omitted. */
+  /** Inclusive lower bound for the query window. Defaults to 24 hours before `endTime` when omitted. */
   startTime?: string;
-  /** Exclusive upper bound for the query window (ISO 8601, UTC). Defaults to now when omitted. */
+  /** Exclusive upper bound for the query window. Defaults to now when omitted. */
   endTime?: string;
   /** Filter to a single agent by ID. */
   agentId?: string;
   /** Filter to a specific agent version. */
   agentVersion?: string;
-  /** Folder keys (GUIDs) to scope the query. Results are limited to folders you can access. */
+  /** Folder keys to scope the query. Results are limited to folders you can access. */
   folderKeys?: string[];
   /** Filter to a specific execution kind. Omit to include both Debug and Runtime. */
   executionType?: ExecutionType;
 }
 
 /**
- * Options for {@link MemoryServiceModel.getTimeline}.
+ * Options for retrieving the agent-memory state timeline.
  */
 export interface MemoryGetTimelineOptions extends MemoryFilterOptions {}
 
 /**
- * Options for {@link MemoryServiceModel.getCallsTimeline}.
+ * Options for retrieving the memory-calls timeline.
  */
 export interface MemoryGetCallsTimelineOptions extends MemoryFilterOptions {}
 
 /**
- * Options for {@link MemoryServiceModel.getTopSpaces}.
+ * Options for retrieving the top memory spaces.
  */
 export interface MemoryGetTopSpacesOptions extends MemoryFilterOptions {
   /** Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 when omitted. */
@@ -57,7 +57,7 @@ export interface MemoryGetTopSpacesOptions extends MemoryFilterOptions {
  * single time bucket.
  */
 export interface MemoryTimelinePoint {
-  /** Bucket timestamp (ISO 8601, UTC). */
+  /** Bucket timestamp. */
   timeSlice: string;
   /** Count of memory entries that were in-memory in this bucket. */
   inMemoryCount: number;
@@ -72,35 +72,18 @@ export interface MemoryTimelinePoint {
 }
 
 /**
- * Response from {@link MemoryServiceModel.getTimeline}.
- */
-export interface MemoryGetTimelineResponse {
-  /** Time-series points, one per bucket. May be absent when no data matches. */
-  data?: MemoryTimelinePoint[];
-}
-
-/**
  * One point on the memory-calls timeline — the count of memory calls for a
  * single time bucket.
  */
 export interface MemoryCallsTimelinePoint {
-  /** Bucket timestamp (ISO 8601, UTC). */
+  /** Bucket timestamp. */
   timeSlice: string;
   /** Number of memory calls in this bucket. */
   memoryCallsCount: number;
 }
 
 /**
- * Response from {@link MemoryServiceModel.getCallsTimeline}.
- */
-export interface MemoryGetCallsTimelineResponse {
-  /** Time-series points, one per bucket. May be absent when no data matches. */
-  data?: MemoryCallsTimelinePoint[];
-}
-
-/**
- * A single memory space with its enabled/disabled memory-entry breakdown,
- * as returned by {@link MemoryServiceModel.getTopSpaces}.
+ * A single memory space with its enabled/disabled memory-entry breakdown.
  */
 export interface MemorySpace {
   /** Memory space identifier. */
@@ -113,12 +96,4 @@ export interface MemorySpace {
   enabledMemoryCount: number;
   /** Count of disabled memory entries in this space. */
   disabledMemoryCount: number;
-}
-
-/**
- * Response from {@link MemoryServiceModel.getTopSpaces}.
- */
-export interface MemoryGetTopSpacesResponse {
-  /** Memory spaces ranked by memory count. May be absent when no data matches. */
-  data?: MemorySpace[];
 }

--- a/src/services/agents/memory/index.ts
+++ b/src/services/agents/memory/index.ts
@@ -1,7 +1,7 @@
 /**
  * Memory Module
  *
- * Provides access to UiPath Agent Memory analytics (Traceview).
+ * Provides access to UiPath Agent Memory analytics.
  *
  * @example
  * ```typescript
@@ -12,7 +12,7 @@
  * await sdk.initialize();
  *
  * const memory = new Memory(sdk);
- * const timeline = await memory.getMemoryTimeline();
+ * const timeline = await memory.getTimeline();
  * ```
  *
  * @module

--- a/src/services/agents/memory/index.ts
+++ b/src/services/agents/memory/index.ts
@@ -1,23 +1,23 @@
 /**
- * Memory Module
+ * Agent Memory Module
  *
  * Provides access to UiPath Agent Memory analytics.
  *
  * @example
  * ```typescript
  * import { UiPath } from '@uipath/uipath-typescript/core';
- * import { Memory } from '@uipath/uipath-typescript/memory';
+ * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
  *
  * const sdk = new UiPath(config);
  * await sdk.initialize();
  *
- * const memory = new Memory(sdk);
+ * const memory = new AgentMemory(sdk);
  * const timeline = await memory.getTimeline();
  * ```
  *
  * @module
  */
 
-export { MemoryService as Memory } from './memory';
+export { MemoryService as AgentMemory } from './memory';
 
 export * from '../../../models/agents/memory';

--- a/src/services/agents/memory/index.ts
+++ b/src/services/agents/memory/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Memory Module
+ *
+ * Provides access to UiPath Agent Memory analytics (Traceview).
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { Memory } from '@uipath/uipath-typescript/memory';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * const memory = new Memory(sdk);
+ * const timeline = await memory.getMemoryTimeline();
+ * ```
+ *
+ * @module
+ */
+
+export { MemoryService as Memory } from './memory';
+
+export * from '../../../models/agents/memory';

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -13,19 +13,12 @@ import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { track } from '../../../core/telemetry';
 
 /**
- * Service for interacting with UiPath Agent Memory analytics (Traceview).
+ * Service for interacting with UiPath Agent Memory metrics.
  */
 export class MemoryService extends BaseService implements MemoryServiceModel {
   /**
    * Retrieves a time-series of agent-memory state counts bucketed across the
    * requested window.
-   *
-   * Each point reports how many memory entries were in-memory vs not-in-memory
-   * and enabled vs disabled for that time bucket. Bucket size is chosen
-   * server-side based on the window length. When no time window is provided,
-   * the server defaults to the last 24 hours (with the upper bound defaulting
-   * to now). Optionally filter by agent, agent version, folder, or execution
-   * type.
    *
    * @param options - Optional time window and scope filters {@link MemoryGetTimelineOptions}
    * @returns Promise resolving to {@link MemoryGetTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
@@ -35,8 +28,8 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    *
    * const memory = new Memory(sdk);
    *
-   * // Last 24 hours (server-default window)
-   * const timeline = await memory.getMemoryTimeline();
+   * // Last 24 hours (default window)
+   * const timeline = await memory.getTimeline();
    * console.log(timeline.data?.[0]?.inMemoryCount);
    * ```
    * @example
@@ -46,7 +39,7 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * const memory = new Memory(sdk);
    *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getMemoryTimeline({
+   * const timeline = await memory.getTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -55,12 +48,12 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * });
    * ```
    */
-  @track('Memory.GetMemoryTimeline')
-  async getMemoryTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse> {
+  @track('Memory.GetTimeline')
+  async getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse> {
     const body = this.buildMemoryFilterBody(options);
 
     const response = await this.post<MemoryGetTimelineResponse>(
-      MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
+      MEMORY_ENDPOINTS.GET_TIMELINE,
       body,
     );
 
@@ -71,11 +64,6 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * Retrieves a time-series of memory-call counts bucketed across the requested
    * window.
    *
-   * Each point reports how many memory calls occurred in that time bucket.
-   * Bucket size is chosen server-side based on the window length. When no time
-   * window is provided, the server defaults to the last 24 hours (with the
-   * upper bound defaulting to now). Optionally filter by agent, agent version,
-   * folder, or execution type.
    *
    * @param options - Optional time window and scope filters {@link MemoryGetCallsTimelineOptions}
    * @returns Promise resolving to {@link MemoryGetCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
@@ -85,8 +73,8 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    *
    * const memory = new Memory(sdk);
    *
-   * // Last 24 hours (server-default window)
-   * const timeline = await memory.getMemoryCallsTimeline();
+   * // Last 24 hours (default window)
+   * const timeline = await memory.getCallsTimeline();
    * console.log(timeline.data?.[0]?.memoryCallsCount);
    * ```
    * @example
@@ -96,7 +84,7 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * const memory = new Memory(sdk);
    *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getMemoryCallsTimeline({
+   * const timeline = await memory.getCallsTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -105,14 +93,14 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * });
    * ```
    */
-  @track('Memory.GetMemoryCallsTimeline')
-  async getMemoryCallsTimeline(
+  @track('Memory.GetCallsTimeline')
+  async getCallsTimeline(
     options?: MemoryGetCallsTimelineOptions,
   ): Promise<MemoryGetCallsTimelineResponse> {
     const body = this.buildMemoryFilterBody(options);
 
     const response = await this.post<MemoryGetCallsTimelineResponse>(
-      MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
+      MEMORY_ENDPOINTS.GET_CALLS_TIMELINE,
       body,
     );
 
@@ -123,12 +111,6 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * Retrieves the top memory spaces ranked by memory count over the requested
    * window.
    *
-   * Each entry is a memory space with its total memory count and an
-   * enabled/disabled breakdown. Use `limit` to cap how many spaces are
-   * returned (defaults to 5 server-side). When no time window is provided, the
-   * server defaults to the last 24 hours (with the upper bound defaulting to
-   * now). Optionally filter by agent, agent version, folder, or execution type.
-   *
    * @param options - Optional limit, time window, and scope filters {@link MemoryGetTopSpacesOptions}
    * @returns Promise resolving to {@link MemoryGetTopSpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
    * @example
@@ -137,8 +119,8 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    *
    * const memory = new Memory(sdk);
    *
-   * // Top 5 memory spaces (server-default limit and window)
-   * const top = await memory.getTopMemorySpaces();
+   * // Top 5 memory spaces (default limit and window)
+   * const top = await memory.getTopSpaces();
    * console.log(top.data?.[0]?.memorySpaceName, top.data?.[0]?.memoryCount);
    * ```
    * @example
@@ -148,7 +130,7 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * const memory = new Memory(sdk);
    *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
-   * const top = await memory.getTopMemorySpaces({
+   * const top = await memory.getTopSpaces({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   folderKeys: ['<folderKey>'],
@@ -157,15 +139,15 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * });
    * ```
    */
-  @track('Memory.GetTopMemorySpaces')
-  async getTopMemorySpaces(
+  @track('Memory.GetTopSpaces')
+  async getTopSpaces(
     options?: MemoryGetTopSpacesOptions,
   ): Promise<MemoryGetTopSpacesResponse> {
     const body = this.buildMemoryFilterBody(options);
     if (options?.limit !== undefined) body.limit = options.limit;
 
     const response = await this.post<MemoryGetTopSpacesResponse>(
-      MEMORY_ENDPOINTS.GET_TOP_MEMORY_SPACES,
+      MEMORY_ENDPOINTS.GET_TOP_SPACES,
       body,
     );
 

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -2,11 +2,11 @@ import { BaseService } from '../../base';
 import {
   MemoryFilterOptions,
   MemoryGetTimelineOptions,
-  MemoryTimelinePoint,
+  MemoryGetTimelineResponse,
   MemoryGetCallsTimelineOptions,
-  MemoryCallsTimelinePoint,
+  MemoryGetCallsTimelineResponse,
   MemoryGetTopSpacesOptions,
-  MemorySpace,
+  MemoryGetTopSpacesResponse,
 } from '../../../models/agents/memory/memory.types';
 import { MemoryServiceModel } from '../../../models/agents/memory/memory.models';
 import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -17,25 +17,28 @@ import { track } from '../../../core/telemetry';
  */
 export class MemoryService extends BaseService implements MemoryServiceModel {
   /**
-   * Retrieves a time-series of agent-memory state counts bucketed across the
-   * requested window.
+   * Gets agent memory state over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryTimelinePoint}, one per time bucket. Empty when no data matches.
+   * @returns Promise resolving to an array of {@link MemoryGetTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { Memory } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getTimeline();
    * console.log(timeline[0]?.inMemoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getTimeline({
-   *   startTime: '2026-05-01T00:00:00Z',
-   *   endTime: '2026-06-01T00:00:00Z',
+   *   startTime: new Date('2026-05-01T00:00:00Z'),
+   *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   agentId: '<agentId>',
    *   folderKeys: ['<folderKey>'],
    *   executionType: ExecutionType.Runtime,
@@ -43,10 +46,10 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * ```
    */
   @track('Memory.GetTimeline')
-  async getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryTimelinePoint[]> {
+  async getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse[]> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<{ data?: MemoryTimelinePoint[] }>(
+    const response = await this.post<{ data?: MemoryGetTimelineResponse[] }>(
       MEMORY_ENDPOINTS.GET_TIMELINE,
       body,
     );
@@ -55,25 +58,28 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
   }
 
   /**
-   * Retrieves a time-series of memory-call counts bucketed across the requested
-   * window.
+   * Gets agent memory-access counts over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryCallsTimelinePoint}, one per time bucket. Empty when no data matches.
+   * @returns Promise resolving to an array of {@link MemoryGetCallsTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { Memory } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getCallsTimeline();
    * console.log(timeline[0]?.memoryCallsCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getCallsTimeline({
-   *   startTime: '2026-05-01T00:00:00Z',
-   *   endTime: '2026-06-01T00:00:00Z',
+   *   startTime: new Date('2026-05-01T00:00:00Z'),
+   *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   agentId: '<agentId>',
    *   folderKeys: ['<folderKey>'],
    *   executionType: ExecutionType.Runtime,
@@ -83,10 +89,10 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
   @track('Memory.GetCallsTimeline')
   async getCallsTimeline(
     options?: MemoryGetCallsTimelineOptions,
-  ): Promise<MemoryCallsTimelinePoint[]> {
+  ): Promise<MemoryGetCallsTimelineResponse[]> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<{ data?: MemoryCallsTimelinePoint[] }>(
+    const response = await this.post<{ data?: MemoryGetCallsTimelineResponse[] }>(
       MEMORY_ENDPOINTS.GET_CALLS_TIMELINE,
       body,
     );
@@ -95,25 +101,28 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
   }
 
   /**
-   * Retrieves the top memory spaces ranked by memory count over the requested
-   * window.
+   * Gets the top memory spaces by memory count, with optional filters
    *
    * @param options - Optional limit, time window, and scope filters
-   * @returns Promise resolving to an array of {@link MemorySpace}, ranked by memory count. Empty when no data matches.
+   * @returns Promise resolving to an array of {@link MemoryGetTopSpacesResponse}, ranked by memory count.
    * @example
    * ```typescript
-   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { Memory } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
    * // Top 5 memory spaces (default limit and window)
    * const top = await memory.getTopSpaces();
    * console.log(top[0]?.memorySpaceName, top[0]?.memoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
    * const topScoped = await memory.getTopSpaces({
-   *   startTime: '2026-05-01T00:00:00Z',
-   *   endTime: '2026-06-01T00:00:00Z',
+   *   startTime: new Date('2026-05-01T00:00:00Z'),
+   *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   folderKeys: ['<folderKey>'],
    *   executionType: ExecutionType.Runtime,
    *   limit: 10,
@@ -123,11 +132,11 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
   @track('Memory.GetTopSpaces')
   async getTopSpaces(
     options?: MemoryGetTopSpacesOptions,
-  ): Promise<MemorySpace[]> {
+  ): Promise<MemoryGetTopSpacesResponse[]> {
     const body = this.buildMemoryFilterBody(options);
     if (options?.limit !== undefined) body.limit = options.limit;
 
-    const response = await this.post<{ data?: MemorySpace[] }>(
+    const response = await this.post<{ data?: MemoryGetTopSpacesResponse[] }>(
       MEMORY_ENDPOINTS.GET_TOP_SPACES,
       body,
     );
@@ -137,8 +146,8 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
 
   private buildMemoryFilterBody(options?: MemoryFilterOptions): Record<string, unknown> {
     const body: Record<string, unknown> = {};
-    if (options?.startTime !== undefined) body.startTime = options.startTime;
-    if (options?.endTime !== undefined) body.endTime = options.endTime;
+    if (options?.startTime !== undefined) body.startTime = options.startTime.toISOString();
+    if (options?.endTime !== undefined) body.endTime = options.endTime.toISOString();
     if (options?.agentId !== undefined) body.agentId = options.agentId;
     if (options?.agentVersion !== undefined) body.agentVersion = options.agentVersion;
     if (options?.folderKeys !== undefined) body.folderKeys = options.folderKeys;

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -1,0 +1,76 @@
+import { BaseService } from '../../base';
+import {
+  MemoryFilterOptions,
+  MemoryTimelineGetOptions,
+  MemoryTimelineResponse,
+} from '../../../models/agents/memory/memory.types';
+import { MemoryServiceModel } from '../../../models/agents/memory/memory.models';
+import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { track } from '../../../core/telemetry';
+
+/**
+ * Service for interacting with UiPath Agent Memory analytics (Traceview).
+ */
+export class MemoryService extends BaseService implements MemoryServiceModel {
+  /**
+   * Retrieves a time-series of agent-memory state counts bucketed across the
+   * requested window.
+   *
+   * Each point reports how many memory entries were in-memory vs not-in-memory
+   * and enabled vs disabled for that time bucket. Bucket size is chosen
+   * server-side based on the window length. When no time window is provided,
+   * the server defaults to the last 24 hours (with the upper bound defaulting
+   * to now). Optionally filter by agent, agent version, folder, or execution
+   * type.
+   *
+   * @param options - Optional time window and scope filters {@link MemoryTimelineGetOptions}
+   * @returns Promise resolving to {@link MemoryTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @example
+   * ```typescript
+   * import { Memory } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Last 24 hours (server-default window)
+   * const timeline = await memory.getMemoryTimeline();
+   * console.log(timeline.data?.[0]?.inMemoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Scoped to one agent in one folder, runtime executions only
+   * const timeline = await memory.getMemoryTimeline({
+   *   startTime: '2026-05-01T00:00:00Z',
+   *   endTime: '2026-06-01T00:00:00Z',
+   *   agentId: '<agentId>',
+   *   folderKeys: ['<folderKey>'],
+   *   executionType: ExecutionType.Runtime,
+   * });
+   * ```
+   */
+  @track('Memory.GetMemoryTimeline')
+  async getMemoryTimeline(options?: MemoryTimelineGetOptions): Promise<MemoryTimelineResponse> {
+    const body = this.buildMemoryFilterBody(options);
+
+    const response = await this.post<MemoryTimelineResponse>(
+      MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
+      body,
+    );
+
+    return response.data;
+  }
+
+  private buildMemoryFilterBody(options?: MemoryFilterOptions): Record<string, unknown> {
+    const body: Record<string, unknown> = {};
+    if (options?.startTime !== undefined) body.startTime = options.startTime;
+    if (options?.endTime !== undefined) body.endTime = options.endTime;
+    if (options?.agentId !== undefined) body.agentId = options.agentId;
+    if (options?.agentVersion !== undefined) body.agentVersion = options.agentVersion;
+    if (options?.folderKeys !== undefined) body.folderKeys = options.folderKeys;
+    if (options?.executionType !== undefined) body.executionType = options.executionType;
+    return body;
+  }
+}

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -1,31 +1,31 @@
 import { BaseService } from '../../base';
 import {
-  MemoryFilterOptions,
-  MemoryGetTimelineOptions,
-  MemoryGetTimelineResponse,
-  MemoryGetCallsTimelineOptions,
-  MemoryGetCallsTimelineResponse,
-  MemoryGetTopSpacesOptions,
-  MemoryGetTopSpacesResponse,
+  AgentMemoryFilterOptions,
+  AgentMemoryGetTimelineOptions,
+  AgentMemoryGetTimelineResponse,
+  AgentMemoryGetCallsTimelineOptions,
+  AgentMemoryGetCallsTimelineResponse,
+  AgentMemoryGetTopSpacesOptions,
+  AgentMemoryGetTopSpacesResponse,
 } from '../../../models/agents/memory/memory.types';
-import { MemoryServiceModel } from '../../../models/agents/memory/memory.models';
+import { AgentMemoryServiceModel } from '../../../models/agents/memory/memory.models';
 import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { track } from '../../../core/telemetry';
 
 /**
  * Service for managing UiPath Agent Memory.
  */
-export class MemoryService extends BaseService implements MemoryServiceModel {
+export class MemoryService extends BaseService implements AgentMemoryServiceModel {
   /**
    * Gets agent memory state over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryGetTimelineResponse}, one per time bucket.
+   * @returns Promise resolving to an array of {@link AgentMemoryGetTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
    *
-   * const memory = new Memory(sdk);
+   * const memory = new AgentMemory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getTimeline();
@@ -33,7 +33,7 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * ```
    * @example
    * ```typescript
-   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemoryExecutionType } from '@uipath/uipath-typescript/agent-memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getTimeline({
@@ -41,32 +41,32 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   agentId: '<agentId>',
    *   folderKeys: ['<folderKey>'],
-   *   executionType: ExecutionType.Runtime,
+   *   executionType: AgentMemoryExecutionType.Runtime,
    * });
    * ```
    */
-  @track('Memory.GetTimeline')
-  async getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse[]> {
+  @track('AgentMemory.GetTimeline')
+  async getTimeline(options?: AgentMemoryGetTimelineOptions): Promise<AgentMemoryGetTimelineResponse[]> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<{ data?: MemoryGetTimelineResponse[] }>(
+    const response = await this.post<{ data: AgentMemoryGetTimelineResponse[] }>(
       MEMORY_ENDPOINTS.GET_TIMELINE,
       body,
     );
 
-    return response.data.data ?? [];
+    return response.data.data;
   }
 
   /**
    * Gets agent memory-access counts over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
-   * @returns Promise resolving to an array of {@link MemoryGetCallsTimelineResponse}, one per time bucket.
+   * @returns Promise resolving to an array of {@link AgentMemoryGetCallsTimelineResponse}, one per time bucket.
    * @example
    * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
    *
-   * const memory = new Memory(sdk);
+   * const memory = new AgentMemory(sdk);
    *
    * // Last 24 hours (default window)
    * const timeline = await memory.getCallsTimeline();
@@ -74,7 +74,7 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * ```
    * @example
    * ```typescript
-   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemoryExecutionType } from '@uipath/uipath-typescript/agent-memory';
    *
    * // Scoped to one agent in one folder, runtime executions only
    * const scoped = await memory.getCallsTimeline({
@@ -82,34 +82,34 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   agentId: '<agentId>',
    *   folderKeys: ['<folderKey>'],
-   *   executionType: ExecutionType.Runtime,
+   *   executionType: AgentMemoryExecutionType.Runtime,
    * });
    * ```
    */
-  @track('Memory.GetCallsTimeline')
+  @track('AgentMemory.GetCallsTimeline')
   async getCallsTimeline(
-    options?: MemoryGetCallsTimelineOptions,
-  ): Promise<MemoryGetCallsTimelineResponse[]> {
+    options?: AgentMemoryGetCallsTimelineOptions,
+  ): Promise<AgentMemoryGetCallsTimelineResponse[]> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<{ data?: MemoryGetCallsTimelineResponse[] }>(
+    const response = await this.post<{ data: AgentMemoryGetCallsTimelineResponse[] }>(
       MEMORY_ENDPOINTS.GET_CALLS_TIMELINE,
       body,
     );
 
-    return response.data.data ?? [];
+    return response.data.data;
   }
 
   /**
    * Gets the top memory spaces by memory count, with optional filters
    *
    * @param options - Optional limit, time window, and scope filters
-   * @returns Promise resolving to an array of {@link MemoryGetTopSpacesResponse}, ranked by memory count.
+   * @returns Promise resolving to an array of {@link AgentMemoryGetTopSpacesResponse}, ranked by memory count.
    * @example
    * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemory } from '@uipath/uipath-typescript/agent-memory';
    *
-   * const memory = new Memory(sdk);
+   * const memory = new AgentMemory(sdk);
    *
    * // Top 5 memory spaces (default limit and window)
    * const top = await memory.getTopSpaces();
@@ -117,34 +117,34 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * ```
    * @example
    * ```typescript
-   * import { ExecutionType } from '@uipath/uipath-typescript/memory';
+   * import { AgentMemoryExecutionType } from '@uipath/uipath-typescript/agent-memory';
    *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
    * const topScoped = await memory.getTopSpaces({
    *   startTime: new Date('2026-05-01T00:00:00Z'),
    *   endTime: new Date('2026-06-01T00:00:00Z'),
    *   folderKeys: ['<folderKey>'],
-   *   executionType: ExecutionType.Runtime,
+   *   executionType: AgentMemoryExecutionType.Runtime,
    *   limit: 10,
    * });
    * ```
    */
-  @track('Memory.GetTopSpaces')
+  @track('AgentMemory.GetTopSpaces')
   async getTopSpaces(
-    options?: MemoryGetTopSpacesOptions,
-  ): Promise<MemoryGetTopSpacesResponse[]> {
+    options?: AgentMemoryGetTopSpacesOptions,
+  ): Promise<AgentMemoryGetTopSpacesResponse[]> {
     const body = this.buildMemoryFilterBody(options);
     if (options?.limit !== undefined) body.limit = options.limit;
 
-    const response = await this.post<{ data?: MemoryGetTopSpacesResponse[] }>(
+    const response = await this.post<{ data: AgentMemoryGetTopSpacesResponse[] }>(
       MEMORY_ENDPOINTS.GET_TOP_SPACES,
       body,
     );
 
-    return response.data.data ?? [];
+    return response.data.data;
   }
 
-  private buildMemoryFilterBody(options?: MemoryFilterOptions): Record<string, unknown> {
+  private buildMemoryFilterBody(options?: AgentMemoryFilterOptions): Record<string, unknown> {
     const body: Record<string, unknown> = {};
     if (options?.startTime !== undefined) body.startTime = options.startTime.toISOString();
     if (options?.endTime !== undefined) body.endTime = options.endTime.toISOString();

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -1,12 +1,12 @@
 import { BaseService } from '../../base';
 import {
   MemoryFilterOptions,
-  MemoryTimelineGetOptions,
-  MemoryTimelineResponse,
-  MemoryCallsTimelineGetOptions,
-  MemoryCallsTimelineResponse,
-  TopMemorySpacesGetOptions,
-  TopMemorySpacesResponse,
+  MemoryGetTimelineOptions,
+  MemoryGetTimelineResponse,
+  MemoryGetCallsTimelineOptions,
+  MemoryGetCallsTimelineResponse,
+  MemoryGetTopSpacesOptions,
+  MemoryGetTopSpacesResponse,
 } from '../../../models/agents/memory/memory.types';
 import { MemoryServiceModel } from '../../../models/agents/memory/memory.models';
 import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -27,8 +27,8 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * to now). Optionally filter by agent, agent version, folder, or execution
    * type.
    *
-   * @param options - Optional time window and scope filters {@link MemoryTimelineGetOptions}
-   * @returns Promise resolving to {@link MemoryTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @param options - Optional time window and scope filters {@link MemoryGetTimelineOptions}
+   * @returns Promise resolving to {@link MemoryGetTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
    * @example
    * ```typescript
    * import { Memory } from '@uipath/uipath-typescript/memory';
@@ -56,10 +56,10 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * ```
    */
   @track('Memory.GetMemoryTimeline')
-  async getMemoryTimeline(options?: MemoryTimelineGetOptions): Promise<MemoryTimelineResponse> {
+  async getMemoryTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<MemoryTimelineResponse>(
+    const response = await this.post<MemoryGetTimelineResponse>(
       MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
       body,
     );
@@ -77,8 +77,8 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * upper bound defaulting to now). Optionally filter by agent, agent version,
    * folder, or execution type.
    *
-   * @param options - Optional time window and scope filters {@link MemoryCallsTimelineGetOptions}
-   * @returns Promise resolving to {@link MemoryCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @param options - Optional time window and scope filters {@link MemoryGetCallsTimelineOptions}
+   * @returns Promise resolving to {@link MemoryGetCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
    * @example
    * ```typescript
    * import { Memory } from '@uipath/uipath-typescript/memory';
@@ -107,11 +107,11 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    */
   @track('Memory.GetMemoryCallsTimeline')
   async getMemoryCallsTimeline(
-    options?: MemoryCallsTimelineGetOptions,
-  ): Promise<MemoryCallsTimelineResponse> {
+    options?: MemoryGetCallsTimelineOptions,
+  ): Promise<MemoryGetCallsTimelineResponse> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<MemoryCallsTimelineResponse>(
+    const response = await this.post<MemoryGetCallsTimelineResponse>(
       MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
       body,
     );
@@ -129,8 +129,8 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * server defaults to the last 24 hours (with the upper bound defaulting to
    * now). Optionally filter by agent, agent version, folder, or execution type.
    *
-   * @param options - Optional limit, time window, and scope filters {@link TopMemorySpacesGetOptions}
-   * @returns Promise resolving to {@link TopMemorySpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
+   * @param options - Optional limit, time window, and scope filters {@link MemoryGetTopSpacesOptions}
+   * @returns Promise resolving to {@link MemoryGetTopSpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
    * @example
    * ```typescript
    * import { Memory } from '@uipath/uipath-typescript/memory';
@@ -159,12 +159,12 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    */
   @track('Memory.GetTopMemorySpaces')
   async getTopMemorySpaces(
-    options?: TopMemorySpacesGetOptions,
-  ): Promise<TopMemorySpacesResponse> {
+    options?: MemoryGetTopSpacesOptions,
+  ): Promise<MemoryGetTopSpacesResponse> {
     const body = this.buildMemoryFilterBody(options);
     if (options?.limit !== undefined) body.limit = options.limit;
 
-    const response = await this.post<TopMemorySpacesResponse>(
+    const response = await this.post<MemoryGetTopSpacesResponse>(
       MEMORY_ENDPOINTS.GET_TOP_MEMORY_SPACES,
       body,
     );

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -3,6 +3,8 @@ import {
   MemoryFilterOptions,
   MemoryTimelineGetOptions,
   MemoryTimelineResponse,
+  MemoryCallsTimelineGetOptions,
+  MemoryCallsTimelineResponse,
 } from '../../../models/agents/memory/memory.types';
 import { MemoryServiceModel } from '../../../models/agents/memory/memory.models';
 import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -57,6 +59,58 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
 
     const response = await this.post<MemoryTimelineResponse>(
       MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
+      body,
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Retrieves a time-series of memory-call counts bucketed across the requested
+   * window.
+   *
+   * Each point reports how many memory calls occurred in that time bucket.
+   * Bucket size is chosen server-side based on the window length. When no time
+   * window is provided, the server defaults to the last 24 hours (with the
+   * upper bound defaulting to now). Optionally filter by agent, agent version,
+   * folder, or execution type.
+   *
+   * @param options - Optional time window and scope filters {@link MemoryCallsTimelineGetOptions}
+   * @returns Promise resolving to {@link MemoryCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
+   * @example
+   * ```typescript
+   * import { Memory } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Last 24 hours (server-default window)
+   * const timeline = await memory.getMemoryCallsTimeline();
+   * console.log(timeline.data?.[0]?.memoryCallsCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Scoped to one agent in one folder, runtime executions only
+   * const timeline = await memory.getMemoryCallsTimeline({
+   *   startTime: '2026-05-01T00:00:00Z',
+   *   endTime: '2026-06-01T00:00:00Z',
+   *   agentId: '<agentId>',
+   *   folderKeys: ['<folderKey>'],
+   *   executionType: ExecutionType.Runtime,
+   * });
+   * ```
+   */
+  @track('Memory.GetMemoryCallsTimeline')
+  async getMemoryCallsTimeline(
+    options?: MemoryCallsTimelineGetOptions,
+  ): Promise<MemoryCallsTimelineResponse> {
+    const body = this.buildMemoryFilterBody(options);
+
+    const response = await this.post<MemoryCallsTimelineResponse>(
+      MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
       body,
     );
 

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -2,44 +2,38 @@ import { BaseService } from '../../base';
 import {
   MemoryFilterOptions,
   MemoryGetTimelineOptions,
-  MemoryGetTimelineResponse,
+  MemoryTimelinePoint,
   MemoryGetCallsTimelineOptions,
-  MemoryGetCallsTimelineResponse,
+  MemoryCallsTimelinePoint,
   MemoryGetTopSpacesOptions,
-  MemoryGetTopSpacesResponse,
+  MemorySpace,
 } from '../../../models/agents/memory/memory.types';
 import { MemoryServiceModel } from '../../../models/agents/memory/memory.models';
 import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { track } from '../../../core/telemetry';
 
 /**
- * Service for interacting with UiPath Agent Memory metrics.
+ * Service for managing UiPath Agent Memory.
  */
 export class MemoryService extends BaseService implements MemoryServiceModel {
   /**
    * Retrieves a time-series of agent-memory state counts bucketed across the
    * requested window.
    *
-   * @param options - Optional time window and scope filters {@link MemoryGetTimelineOptions}
-   * @returns Promise resolving to {@link MemoryGetTimelineResponse} — a `data` array of {@link MemoryTimelinePoint}, one per time bucket. The array may be absent when no data matches.
-   * @example
-   * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
-   *
-   * const memory = new Memory(sdk);
-   *
-   * // Last 24 hours (default window)
-   * const timeline = await memory.getTimeline();
-   * console.log(timeline.data?.[0]?.inMemoryCount);
-   * ```
+   * @param options - Optional time window and scope filters
+   * @returns Promise resolving to an array of {@link MemoryTimelinePoint}, one per time bucket. Empty when no data matches.
    * @example
    * ```typescript
    * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
+   * // Last 24 hours (default window)
+   * const timeline = await memory.getTimeline();
+   * console.log(timeline[0]?.inMemoryCount);
+   *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getTimeline({
+   * const scoped = await memory.getTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -49,42 +43,35 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
    * ```
    */
   @track('Memory.GetTimeline')
-  async getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryGetTimelineResponse> {
+  async getTimeline(options?: MemoryGetTimelineOptions): Promise<MemoryTimelinePoint[]> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<MemoryGetTimelineResponse>(
+    const response = await this.post<{ data?: MemoryTimelinePoint[] }>(
       MEMORY_ENDPOINTS.GET_TIMELINE,
       body,
     );
 
-    return response.data;
+    return response.data.data ?? [];
   }
 
   /**
    * Retrieves a time-series of memory-call counts bucketed across the requested
    * window.
    *
-   *
-   * @param options - Optional time window and scope filters {@link MemoryGetCallsTimelineOptions}
-   * @returns Promise resolving to {@link MemoryGetCallsTimelineResponse} — a `data` array of {@link MemoryCallsTimelinePoint}, one per time bucket. The array may be absent when no data matches.
-   * @example
-   * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
-   *
-   * const memory = new Memory(sdk);
-   *
-   * // Last 24 hours (default window)
-   * const timeline = await memory.getCallsTimeline();
-   * console.log(timeline.data?.[0]?.memoryCallsCount);
-   * ```
+   * @param options - Optional time window and scope filters
+   * @returns Promise resolving to an array of {@link MemoryCallsTimelinePoint}, one per time bucket. Empty when no data matches.
    * @example
    * ```typescript
    * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
+   * // Last 24 hours (default window)
+   * const timeline = await memory.getCallsTimeline();
+   * console.log(timeline[0]?.memoryCallsCount);
+   *
    * // Scoped to one agent in one folder, runtime executions only
-   * const timeline = await memory.getCallsTimeline({
+   * const scoped = await memory.getCallsTimeline({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   agentId: '<agentId>',
@@ -96,41 +83,35 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
   @track('Memory.GetCallsTimeline')
   async getCallsTimeline(
     options?: MemoryGetCallsTimelineOptions,
-  ): Promise<MemoryGetCallsTimelineResponse> {
+  ): Promise<MemoryCallsTimelinePoint[]> {
     const body = this.buildMemoryFilterBody(options);
 
-    const response = await this.post<MemoryGetCallsTimelineResponse>(
+    const response = await this.post<{ data?: MemoryCallsTimelinePoint[] }>(
       MEMORY_ENDPOINTS.GET_CALLS_TIMELINE,
       body,
     );
 
-    return response.data;
+    return response.data.data ?? [];
   }
 
   /**
    * Retrieves the top memory spaces ranked by memory count over the requested
    * window.
    *
-   * @param options - Optional limit, time window, and scope filters {@link MemoryGetTopSpacesOptions}
-   * @returns Promise resolving to {@link MemoryGetTopSpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
-   * @example
-   * ```typescript
-   * import { Memory } from '@uipath/uipath-typescript/memory';
-   *
-   * const memory = new Memory(sdk);
-   *
-   * // Top 5 memory spaces (default limit and window)
-   * const top = await memory.getTopSpaces();
-   * console.log(top.data?.[0]?.memorySpaceName, top.data?.[0]?.memoryCount);
-   * ```
+   * @param options - Optional limit, time window, and scope filters
+   * @returns Promise resolving to an array of {@link MemorySpace}, ranked by memory count. Empty when no data matches.
    * @example
    * ```typescript
    * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
    *
    * const memory = new Memory(sdk);
    *
+   * // Top 5 memory spaces (default limit and window)
+   * const top = await memory.getTopSpaces();
+   * console.log(top[0]?.memorySpaceName, top[0]?.memoryCount);
+   *
    * // Top 10 spaces for one folder over an explicit window, runtime executions only
-   * const top = await memory.getTopSpaces({
+   * const topScoped = await memory.getTopSpaces({
    *   startTime: '2026-05-01T00:00:00Z',
    *   endTime: '2026-06-01T00:00:00Z',
    *   folderKeys: ['<folderKey>'],
@@ -142,16 +123,16 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
   @track('Memory.GetTopSpaces')
   async getTopSpaces(
     options?: MemoryGetTopSpacesOptions,
-  ): Promise<MemoryGetTopSpacesResponse> {
+  ): Promise<MemorySpace[]> {
     const body = this.buildMemoryFilterBody(options);
     if (options?.limit !== undefined) body.limit = options.limit;
 
-    const response = await this.post<MemoryGetTopSpacesResponse>(
+    const response = await this.post<{ data?: MemorySpace[] }>(
       MEMORY_ENDPOINTS.GET_TOP_SPACES,
       body,
     );
 
-    return response.data;
+    return response.data.data ?? [];
   }
 
   private buildMemoryFilterBody(options?: MemoryFilterOptions): Record<string, unknown> {

--- a/src/services/agents/memory/memory.ts
+++ b/src/services/agents/memory/memory.ts
@@ -5,6 +5,8 @@ import {
   MemoryTimelineResponse,
   MemoryCallsTimelineGetOptions,
   MemoryCallsTimelineResponse,
+  TopMemorySpacesGetOptions,
+  TopMemorySpacesResponse,
 } from '../../../models/agents/memory/memory.types';
 import { MemoryServiceModel } from '../../../models/agents/memory/memory.models';
 import { MEMORY_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -111,6 +113,59 @@ export class MemoryService extends BaseService implements MemoryServiceModel {
 
     const response = await this.post<MemoryCallsTimelineResponse>(
       MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
+      body,
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Retrieves the top memory spaces ranked by memory count over the requested
+   * window.
+   *
+   * Each entry is a memory space with its total memory count and an
+   * enabled/disabled breakdown. Use `limit` to cap how many spaces are
+   * returned (defaults to 5 server-side). When no time window is provided, the
+   * server defaults to the last 24 hours (with the upper bound defaulting to
+   * now). Optionally filter by agent, agent version, folder, or execution type.
+   *
+   * @param options - Optional limit, time window, and scope filters {@link TopMemorySpacesGetOptions}
+   * @returns Promise resolving to {@link TopMemorySpacesResponse} — a `data` array of {@link MemorySpace}, ranked by memory count. The array may be absent when no data matches.
+   * @example
+   * ```typescript
+   * import { Memory } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Top 5 memory spaces (server-default limit and window)
+   * const top = await memory.getTopMemorySpaces();
+   * console.log(top.data?.[0]?.memorySpaceName, top.data?.[0]?.memoryCount);
+   * ```
+   * @example
+   * ```typescript
+   * import { Memory, ExecutionType } from '@uipath/uipath-typescript/memory';
+   *
+   * const memory = new Memory(sdk);
+   *
+   * // Top 10 spaces for one folder over an explicit window, runtime executions only
+   * const top = await memory.getTopMemorySpaces({
+   *   startTime: '2026-05-01T00:00:00Z',
+   *   endTime: '2026-06-01T00:00:00Z',
+   *   folderKeys: ['<folderKey>'],
+   *   executionType: ExecutionType.Runtime,
+   *   limit: 10,
+   * });
+   * ```
+   */
+  @track('Memory.GetTopMemorySpaces')
+  async getTopMemorySpaces(
+    options?: TopMemorySpacesGetOptions,
+  ): Promise<TopMemorySpacesResponse> {
+    const body = this.buildMemoryFilterBody(options);
+    if (options?.limit !== undefined) body.limit = options.limit;
+
+    const response = await this.post<TopMemorySpacesResponse>(
+      MEMORY_ENDPOINTS.GET_TOP_MEMORY_SPACES,
       body,
     );
 

--- a/src/utils/constants/endpoints/index.ts
+++ b/src/utils/constants/endpoints/index.ts
@@ -24,6 +24,9 @@ export * from './conversational-agent';
 // Agent Feedback endpoints
 export * from './feedback';
 
+// Agent Memory endpoints
+export * from './memory';
+
 // Traces endpoints
 export * from './traces';
 

--- a/src/utils/constants/endpoints/memory.ts
+++ b/src/utils/constants/endpoints/memory.ts
@@ -1,13 +1,13 @@
 import { INSIGHTS_RTM_BASE } from './base';
 
 /**
- * Agent Memory (Traceview) Service Endpoints
+ * Agent Memory Service Endpoints
  */
 export const MEMORY_ENDPOINTS = {
   /** Time-series of agent-memory state counts bucketed across the requested window. */
-  GET_MEMORY_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryTimeline`,
+  GET_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryTimeline`,
   /** Time-series of memory-call counts bucketed across the requested window. */
-  GET_MEMORY_CALLS_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryCallsTimeline`,
+  GET_CALLS_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryCallsTimeline`,
   /** Top-N memory spaces ranked by memory count over the requested window. */
-  GET_TOP_MEMORY_SPACES: `${INSIGHTS_RTM_BASE}/Traceview/topMemorySpaces`,
+  GET_TOP_SPACES: `${INSIGHTS_RTM_BASE}/Traceview/topMemorySpaces`,
 } as const;

--- a/src/utils/constants/endpoints/memory.ts
+++ b/src/utils/constants/endpoints/memory.ts
@@ -1,0 +1,9 @@
+import { INSIGHTS_RTM_BASE } from './base';
+
+/**
+ * Agent Memory (Traceview) Service Endpoints
+ */
+export const MEMORY_ENDPOINTS = {
+  /** Time-series of agent-memory state counts bucketed across the requested window. */
+  GET_MEMORY_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryTimeline`,
+} as const;

--- a/src/utils/constants/endpoints/memory.ts
+++ b/src/utils/constants/endpoints/memory.ts
@@ -6,4 +6,6 @@ import { INSIGHTS_RTM_BASE } from './base';
 export const MEMORY_ENDPOINTS = {
   /** Time-series of agent-memory state counts bucketed across the requested window. */
   GET_MEMORY_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryTimeline`,
+  /** Time-series of memory-call counts bucketed across the requested window. */
+  GET_MEMORY_CALLS_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryCallsTimeline`,
 } as const;

--- a/src/utils/constants/endpoints/memory.ts
+++ b/src/utils/constants/endpoints/memory.ts
@@ -8,4 +8,6 @@ export const MEMORY_ENDPOINTS = {
   GET_MEMORY_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryTimeline`,
   /** Time-series of memory-call counts bucketed across the requested window. */
   GET_MEMORY_CALLS_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/memoryCallsTimeline`,
+  /** Top-N memory spaces ranked by memory count over the requested window. */
+  GET_TOP_MEMORY_SPACES: `${INSIGHTS_RTM_BASE}/Traceview/topMemorySpaces`,
 } as const;

--- a/tests/integration/config/unified-setup.ts
+++ b/tests/integration/config/unified-setup.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../src/services/maestro';
 import { Feedback } from '../../../src/services/agents/feedback';
 import { Agents } from '../../../src/services/agents';
+import { Memory } from '../../../src/services/agents/memory';
 import { Traces } from '../../../src/services/observability/traces';
 import { Governance } from '../../../src/services/governance';
 import { loadIntegrationConfig, IntegrationConfig } from './test-config';
@@ -49,6 +50,7 @@ export interface TestServices {
   cases: CasesService;
   caseInstances: CaseInstancesService;
   feedback?: Feedback;
+  memory?: Memory;
   traces?: Traces;
   agents?: Agents;
   governance?: Governance;
@@ -132,6 +134,7 @@ function createV1Services(config: IntegrationConfig): TestServices {
     cases: new CasesService(sdk),
     caseInstances: new CaseInstancesService(sdk),
     feedback: new Feedback(sdk),
+    memory: new Memory(sdk),
     traces: new Traces(sdk),
     agents: new Agents(sdk),
     governance: new Governance(sdk),

--- a/tests/integration/config/unified-setup.ts
+++ b/tests/integration/config/unified-setup.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../src/services/maestro';
 import { Feedback } from '../../../src/services/agents/feedback';
 import { Agents } from '../../../src/services/agents';
-import { Memory } from '../../../src/services/agents/memory';
+import { AgentMemory } from '../../../src/services/agents/memory';
 import { Traces } from '../../../src/services/observability/traces';
 import { Governance } from '../../../src/services/governance';
 import { loadIntegrationConfig, IntegrationConfig } from './test-config';
@@ -50,7 +50,7 @@ export interface TestServices {
   cases: CasesService;
   caseInstances: CaseInstancesService;
   feedback?: Feedback;
-  memory?: Memory;
+  memory?: AgentMemory;
   traces?: Traces;
   agents?: Agents;
   governance?: Governance;
@@ -134,7 +134,7 @@ function createV1Services(config: IntegrationConfig): TestServices {
     cases: new CasesService(sdk),
     caseInstances: new CaseInstancesService(sdk),
     feedback: new Feedback(sdk),
-    memory: new Memory(sdk),
+    memory: new AgentMemory(sdk),
     traces: new Traces(sdk),
     agents: new Agents(sdk),
     governance: new Governance(sdk),

--- a/tests/integration/shared/agents/memory.integration.test.ts
+++ b/tests/integration/shared/agents/memory.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
-import { Memory } from '../../../../src/services/agents/memory';
-import { ExecutionType } from '../../../../src/models/agents/memory/memory.types';
+import { AgentMemory } from '../../../../src/services/agents/memory';
+import { AgentMemoryExecutionType } from '../../../../src/models/agents/memory/memory.types';
 import { MEMORY_TEST_CONSTANTS } from '../../../utils/constants';
 
 const modes: InitMode[] = ['v1'];
@@ -21,7 +21,7 @@ const WINDOW = {
 describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
   setupUnifiedTests(mode);
 
-  let memory!: Memory;
+  let memory!: AgentMemory;
 
   beforeAll(() => {
     const service = getServices().memory;
@@ -51,7 +51,7 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
         ...WINDOW,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-        executionType: ExecutionType.Runtime,
+        executionType: AgentMemoryExecutionType.Runtime,
       });
 
       expect(result).toBeDefined();
@@ -95,7 +95,7 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
         ...WINDOW,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-        executionType: ExecutionType.Runtime,
+        executionType: AgentMemoryExecutionType.Runtime,
       });
 
       expect(result).toBeDefined();
@@ -136,7 +136,7 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
         ...WINDOW,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-        executionType: ExecutionType.Runtime,
+        executionType: AgentMemoryExecutionType.Runtime,
       });
 
       expect(result).toBeDefined();

--- a/tests/integration/shared/agents/memory.integration.test.ts
+++ b/tests/integration/shared/agents/memory.integration.test.ts
@@ -7,8 +7,8 @@ import { MEMORY_TEST_CONSTANTS } from '../../../utils/constants';
 const modes: InitMode[] = ['v1'];
 
 const WINDOW = {
-  startTime: MEMORY_TEST_CONSTANTS.START_TIME,
-  endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+  startTime: new Date(MEMORY_TEST_CONSTANTS.START_TIME),
+  endTime: new Date(MEMORY_TEST_CONSTANTS.END_TIME),
 };
 
 // The filter tests pass arbitrary well-formed identifiers (AGENT_ID / FOLDER_KEY)

--- a/tests/integration/shared/agents/memory.integration.test.ts
+++ b/tests/integration/shared/agents/memory.integration.test.ts
@@ -2,19 +2,18 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { Memory } from '../../../../src/services/agents/memory';
 import { ExecutionType } from '../../../../src/models/agents/memory/memory.types';
+import { MEMORY_TEST_CONSTANTS } from '../../../utils/constants';
 
 const modes: InitMode[] = ['v1'];
 
 const WINDOW = {
-  startTime: '2026-05-01T00:00:00Z',
-  endTime: '2026-06-01T00:00:00Z',
+  startTime: MEMORY_TEST_CONSTANTS.START_TIME,
+  endTime: MEMORY_TEST_CONSTANTS.END_TIME,
 };
 
-// Arbitrary well-formed identifiers used only to exercise the filter
-// body-building path against the live API. Filters narrow results, so
-// unmatched values simply yield empty/zero buckets (still HTTP 200).
-const FILTER_AGENT_ID = '6f0f123e-88db-4f2a-a632-5f315f631534';
-const FILTER_FOLDER_KEY = '8709b9b7-5779-4952-b519-016db272da0a';
+// The filter tests pass arbitrary well-formed identifiers (AGENT_ID / FOLDER_KEY)
+// only to exercise the filter body-building path against the live API. Filters
+// narrow results, so unmatched values simply yield empty/zero buckets (still HTTP 200).
 
 // skip: insightsrtm_ endpoints do not support PAT auth — they reject PAT tokens
 // with 401 regardless of scopes and require OAuth. Test bodies are kept intact
@@ -32,26 +31,26 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
     memory = service;
   });
 
-  describe('getMemoryTimeline', () => {
+  describe('getTimeline', () => {
     it('should retrieve the memory timeline for the default window', async () => {
-      const result = await memory.getMemoryTimeline();
+      const result = await memory.getTimeline();
 
       expect(result).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
     });
 
     it('should retrieve the memory timeline for an explicit window', async () => {
-      const result = await memory.getMemoryTimeline(WINDOW);
+      const result = await memory.getTimeline(WINDOW);
 
       expect(result).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
     });
 
     it('should accept agent, folder, and execution-type filters', async () => {
-      const result = await memory.getMemoryTimeline({
+      const result = await memory.getTimeline({
         ...WINDOW,
-        agentId: FILTER_AGENT_ID,
-        folderKeys: [FILTER_FOLDER_KEY],
+        agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+        folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
         executionType: ExecutionType.Runtime,
       });
 
@@ -60,7 +59,7 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
     });
 
     it('should return points with the expected numeric shape', async () => {
-      const result = await memory.getMemoryTimeline(WINDOW);
+      const result = await memory.getTimeline(WINDOW);
 
       if (!result.data || result.data.length === 0) {
         throw new Error('No memory timeline points returned for the requested window');
@@ -76,26 +75,26 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getMemoryCallsTimeline', () => {
+  describe('getCallsTimeline', () => {
     it('should retrieve the memory calls timeline for the default window', async () => {
-      const result = await memory.getMemoryCallsTimeline();
+      const result = await memory.getCallsTimeline();
 
       expect(result).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
     });
 
     it('should retrieve the memory calls timeline for an explicit window', async () => {
-      const result = await memory.getMemoryCallsTimeline(WINDOW);
+      const result = await memory.getCallsTimeline(WINDOW);
 
       expect(result).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
     });
 
     it('should accept agent, folder, and execution-type filters', async () => {
-      const result = await memory.getMemoryCallsTimeline({
+      const result = await memory.getCallsTimeline({
         ...WINDOW,
-        agentId: FILTER_AGENT_ID,
-        folderKeys: [FILTER_FOLDER_KEY],
+        agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+        folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
         executionType: ExecutionType.Runtime,
       });
 
@@ -104,7 +103,7 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
     });
 
     it('should return points with the expected numeric shape', async () => {
-      const result = await memory.getMemoryCallsTimeline(WINDOW);
+      const result = await memory.getCallsTimeline(WINDOW);
 
       if (!result.data || result.data.length === 0) {
         throw new Error('No memory calls timeline points returned for the requested window');
@@ -116,16 +115,16 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopMemorySpaces', () => {
+  describe('getTopSpaces', () => {
     it('should retrieve the top memory spaces for the default window', async () => {
-      const result = await memory.getTopMemorySpaces();
+      const result = await memory.getTopSpaces();
 
       expect(result).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
     });
 
     it('should respect the limit option', async () => {
-      const result = await memory.getTopMemorySpaces({ ...WINDOW, limit: 3 });
+      const result = await memory.getTopSpaces({ ...WINDOW, limit: 3 });
 
       expect(result).toBeDefined();
       expect(Array.isArray(result.data)).toBe(true);
@@ -133,10 +132,10 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
     });
 
     it('should accept agent, folder, and execution-type filters', async () => {
-      const result = await memory.getTopMemorySpaces({
+      const result = await memory.getTopSpaces({
         ...WINDOW,
-        agentId: FILTER_AGENT_ID,
-        folderKeys: [FILTER_FOLDER_KEY],
+        agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+        folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
         executionType: ExecutionType.Runtime,
       });
 
@@ -145,7 +144,7 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
     });
 
     it('should return spaces with the expected shape', async () => {
-      const result = await memory.getTopMemorySpaces(WINDOW);
+      const result = await memory.getTopSpaces(WINDOW);
 
       if (!result.data || result.data.length === 0) {
         throw new Error('No memory spaces returned for the requested window');

--- a/tests/integration/shared/agents/memory.integration.test.ts
+++ b/tests/integration/shared/agents/memory.integration.test.ts
@@ -36,14 +36,14 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       const result = await memory.getTimeline();
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should retrieve the memory timeline for an explicit window', async () => {
       const result = await memory.getTimeline(WINDOW);
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should accept agent, folder, and execution-type filters', async () => {
@@ -55,17 +55,17 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       });
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should return points with the expected numeric shape', async () => {
       const result = await memory.getTimeline(WINDOW);
 
-      if (!result.data || result.data.length === 0) {
+      if (result.length === 0) {
         throw new Error('No memory timeline points returned for the requested window');
       }
 
-      const point = result.data[0];
+      const point = result[0];
       expect(typeof point.timeSlice).toBe('string');
       expect(typeof point.inMemoryCount).toBe('number');
       expect(typeof point.notInMemoryCount).toBe('number');
@@ -80,14 +80,14 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       const result = await memory.getCallsTimeline();
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should retrieve the memory calls timeline for an explicit window', async () => {
       const result = await memory.getCallsTimeline(WINDOW);
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should accept agent, folder, and execution-type filters', async () => {
@@ -99,17 +99,17 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       });
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should return points with the expected numeric shape', async () => {
       const result = await memory.getCallsTimeline(WINDOW);
 
-      if (!result.data || result.data.length === 0) {
+      if (result.length === 0) {
         throw new Error('No memory calls timeline points returned for the requested window');
       }
 
-      const point = result.data[0];
+      const point = result[0];
       expect(typeof point.timeSlice).toBe('string');
       expect(typeof point.memoryCallsCount).toBe('number');
     });
@@ -120,15 +120,15 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       const result = await memory.getTopSpaces();
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should respect the limit option', async () => {
       const result = await memory.getTopSpaces({ ...WINDOW, limit: 3 });
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
-      expect(result.data?.length ?? 0).toBeLessThanOrEqual(3);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeLessThanOrEqual(3);
     });
 
     it('should accept agent, folder, and execution-type filters', async () => {
@@ -140,17 +140,17 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       });
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result.data)).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('should return spaces with the expected shape', async () => {
       const result = await memory.getTopSpaces(WINDOW);
 
-      if (!result.data || result.data.length === 0) {
+      if (result.length === 0) {
         throw new Error('No memory spaces returned for the requested window');
       }
 
-      const space = result.data[0];
+      const space = result[0];
       expect(typeof space.memorySpaceId).toBe('string');
       expect(typeof space.memorySpaceName).toBe('string');
       expect(typeof space.memoryCount).toBe('number');

--- a/tests/integration/shared/agents/memory.integration.test.ts
+++ b/tests/integration/shared/agents/memory.integration.test.ts
@@ -16,7 +16,10 @@ const WINDOW = {
 const FILTER_AGENT_ID = '6f0f123e-88db-4f2a-a632-5f315f631534';
 const FILTER_FOLDER_KEY = '8709b9b7-5779-4952-b519-016db272da0a';
 
-describe.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
+// skip: insightsrtm_ endpoints do not support PAT auth — they reject PAT tokens
+// with 401 regardless of scopes and require OAuth. Test bodies are kept intact
+// so they run once the integration harness supports OAuth for this service.
+describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
   setupUnifiedTests(mode);
 
   let memory!: Memory;
@@ -70,6 +73,46 @@ describe.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       expect(typeof point.totalCount).toBe('number');
       expect(typeof point.enabledMemoryCount).toBe('number');
       expect(typeof point.disabledMemoryCount).toBe('number');
+    });
+  });
+
+  describe('getMemoryCallsTimeline', () => {
+    it('should retrieve the memory calls timeline for the default window', async () => {
+      const result = await memory.getMemoryCallsTimeline();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should retrieve the memory calls timeline for an explicit window', async () => {
+      const result = await memory.getMemoryCallsTimeline(WINDOW);
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should accept agent, folder, and execution-type filters', async () => {
+      const result = await memory.getMemoryCallsTimeline({
+        ...WINDOW,
+        agentId: FILTER_AGENT_ID,
+        folderKeys: [FILTER_FOLDER_KEY],
+        executionType: ExecutionType.Runtime,
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should return points with the expected numeric shape', async () => {
+      const result = await memory.getMemoryCallsTimeline(WINDOW);
+
+      if (!result.data || result.data.length === 0) {
+        throw new Error('No memory calls timeline points returned for the requested window');
+      }
+
+      const point = result.data[0];
+      expect(typeof point.timeSlice).toBe('string');
+      expect(typeof point.memoryCallsCount).toBe('number');
     });
   });
 });

--- a/tests/integration/shared/agents/memory.integration.test.ts
+++ b/tests/integration/shared/agents/memory.integration.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { Memory } from '../../../../src/services/agents/memory';
+import { ExecutionType } from '../../../../src/models/agents/memory/memory.types';
+
+const modes: InitMode[] = ['v1'];
+
+const WINDOW = {
+  startTime: '2026-05-01T00:00:00Z',
+  endTime: '2026-06-01T00:00:00Z',
+};
+
+// Arbitrary well-formed identifiers used only to exercise the filter
+// body-building path against the live API. Filters narrow results, so
+// unmatched values simply yield empty/zero buckets (still HTTP 200).
+const FILTER_AGENT_ID = '6f0f123e-88db-4f2a-a632-5f315f631534';
+const FILTER_FOLDER_KEY = '8709b9b7-5779-4952-b519-016db272da0a';
+
+describe.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
+  setupUnifiedTests(mode);
+
+  let memory!: Memory;
+
+  beforeAll(() => {
+    const service = getServices().memory;
+    if (!service) {
+      throw new Error('Memory service is not registered for this init mode');
+    }
+    memory = service;
+  });
+
+  describe('getMemoryTimeline', () => {
+    it('should retrieve the memory timeline for the default window', async () => {
+      const result = await memory.getMemoryTimeline();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should retrieve the memory timeline for an explicit window', async () => {
+      const result = await memory.getMemoryTimeline(WINDOW);
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should accept agent, folder, and execution-type filters', async () => {
+      const result = await memory.getMemoryTimeline({
+        ...WINDOW,
+        agentId: FILTER_AGENT_ID,
+        folderKeys: [FILTER_FOLDER_KEY],
+        executionType: ExecutionType.Runtime,
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should return points with the expected numeric shape', async () => {
+      const result = await memory.getMemoryTimeline(WINDOW);
+
+      if (!result.data || result.data.length === 0) {
+        throw new Error('No memory timeline points returned for the requested window');
+      }
+
+      const point = result.data[0];
+      expect(typeof point.timeSlice).toBe('string');
+      expect(typeof point.inMemoryCount).toBe('number');
+      expect(typeof point.notInMemoryCount).toBe('number');
+      expect(typeof point.totalCount).toBe('number');
+      expect(typeof point.enabledMemoryCount).toBe('number');
+      expect(typeof point.disabledMemoryCount).toBe('number');
+    });
+  });
+});

--- a/tests/integration/shared/agents/memory.integration.test.ts
+++ b/tests/integration/shared/agents/memory.integration.test.ts
@@ -115,4 +115,48 @@ describe.skip.each(modes)('Agent Memory - Integration Tests [%s]', (mode) => {
       expect(typeof point.memoryCallsCount).toBe('number');
     });
   });
+
+  describe('getTopMemorySpaces', () => {
+    it('should retrieve the top memory spaces for the default window', async () => {
+      const result = await memory.getTopMemorySpaces();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should respect the limit option', async () => {
+      const result = await memory.getTopMemorySpaces({ ...WINDOW, limit: 3 });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+      expect(result.data?.length ?? 0).toBeLessThanOrEqual(3);
+    });
+
+    it('should accept agent, folder, and execution-type filters', async () => {
+      const result = await memory.getTopMemorySpaces({
+        ...WINDOW,
+        agentId: FILTER_AGENT_ID,
+        folderKeys: [FILTER_FOLDER_KEY],
+        executionType: ExecutionType.Runtime,
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should return spaces with the expected shape', async () => {
+      const result = await memory.getTopMemorySpaces(WINDOW);
+
+      if (!result.data || result.data.length === 0) {
+        throw new Error('No memory spaces returned for the requested window');
+      }
+
+      const space = result.data[0];
+      expect(typeof space.memorySpaceId).toBe('string');
+      expect(typeof space.memorySpaceName).toBe('string');
+      expect(typeof space.memoryCount).toBe('number');
+      expect(typeof space.enabledMemoryCount).toBe('number');
+      expect(typeof space.disabledMemoryCount).toBe('number');
+    });
+  });
 });

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -36,12 +36,12 @@ describe('MemoryService Unit Tests', () => {
     vi.clearAllMocks();
   });
 
-  describe('getMemoryTimeline', () => {
+  describe('getTimeline', () => {
     it('should retrieve the memory timeline successfully', async () => {
       const mockResponse = createMockMemoryGetTimelineResponse();
       mockApiClient.post.mockResolvedValue(mockResponse);
 
-      const result = await memoryService.getMemoryTimeline();
+      const result = await memoryService.getTimeline();
 
       expect(result.data).toHaveLength(2);
       expect(result.data?.[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
@@ -52,10 +52,10 @@ describe('MemoryService Unit Tests', () => {
     it('should call the endpoint with an empty body when no options are provided', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTimelineResponse());
 
-      await memoryService.getMemoryTimeline();
+      await memoryService.getTimeline();
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
+        MEMORY_ENDPOINTS.GET_TIMELINE,
         {},
         expect.anything(),
       );
@@ -73,10 +73,10 @@ describe('MemoryService Unit Tests', () => {
         executionType: ExecutionType.Runtime,
       };
 
-      await memoryService.getMemoryTimeline(options);
+      await memoryService.getTimeline(options);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
+        MEMORY_ENDPOINTS.GET_TIMELINE,
         {
           startTime: MEMORY_TEST_CONSTANTS.START_TIME,
           endTime: MEMORY_TEST_CONSTANTS.END_TIME,
@@ -92,7 +92,7 @@ describe('MemoryService Unit Tests', () => {
     it('should omit undefined filters from the request body', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTimelineResponse());
 
-      await memoryService.getMemoryTimeline({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      await memoryService.getTimeline({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
 
       const sentBody = mockApiClient.post.mock.calls[0][1];
       expect(sentBody).toEqual({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
@@ -103,18 +103,18 @@ describe('MemoryService Unit Tests', () => {
     it('should propagate API errors', async () => {
       mockApiClient.post.mockRejectedValue(new Error(MEMORY_TEST_CONSTANTS.ERROR_MESSAGE));
 
-      await expect(memoryService.getMemoryTimeline()).rejects.toThrow(
+      await expect(memoryService.getTimeline()).rejects.toThrow(
         MEMORY_TEST_CONSTANTS.ERROR_MESSAGE,
       );
     });
   });
 
-  describe('getMemoryCallsTimeline', () => {
+  describe('getCallsTimeline', () => {
     it('should retrieve the memory calls timeline successfully', async () => {
       const mockResponse = createMockMemoryGetCallsTimelineResponse();
       mockApiClient.post.mockResolvedValue(mockResponse);
 
-      const result = await memoryService.getMemoryCallsTimeline();
+      const result = await memoryService.getCallsTimeline();
 
       expect(result.data).toHaveLength(2);
       expect(result.data?.[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
@@ -125,10 +125,10 @@ describe('MemoryService Unit Tests', () => {
     it('should call the endpoint with an empty body when no options are provided', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetCallsTimelineResponse());
 
-      await memoryService.getMemoryCallsTimeline();
+      await memoryService.getCallsTimeline();
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
+        MEMORY_ENDPOINTS.GET_CALLS_TIMELINE,
         {},
         expect.anything(),
       );
@@ -146,10 +146,10 @@ describe('MemoryService Unit Tests', () => {
         executionType: ExecutionType.Runtime,
       };
 
-      await memoryService.getMemoryCallsTimeline(options);
+      await memoryService.getCallsTimeline(options);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
+        MEMORY_ENDPOINTS.GET_CALLS_TIMELINE,
         {
           startTime: MEMORY_TEST_CONSTANTS.START_TIME,
           endTime: MEMORY_TEST_CONSTANTS.END_TIME,
@@ -165,7 +165,7 @@ describe('MemoryService Unit Tests', () => {
     it('should omit undefined filters from the request body', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetCallsTimelineResponse());
 
-      await memoryService.getMemoryCallsTimeline({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
+      await memoryService.getCallsTimeline({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
 
       const sentBody = mockApiClient.post.mock.calls[0][1];
       expect(sentBody).toEqual({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
@@ -176,18 +176,18 @@ describe('MemoryService Unit Tests', () => {
     it('should propagate API errors', async () => {
       mockApiClient.post.mockRejectedValue(new Error(MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_CALLS));
 
-      await expect(memoryService.getMemoryCallsTimeline()).rejects.toThrow(
+      await expect(memoryService.getCallsTimeline()).rejects.toThrow(
         MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_CALLS,
       );
     });
   });
 
-  describe('getTopMemorySpaces', () => {
+  describe('getTopSpaces', () => {
     it('should retrieve the top memory spaces successfully', async () => {
       const mockResponse = createMockMemoryGetTopSpacesResponse();
       mockApiClient.post.mockResolvedValue(mockResponse);
 
-      const result = await memoryService.getTopMemorySpaces();
+      const result = await memoryService.getTopSpaces();
 
       expect(result.data).toHaveLength(2);
       expect(result.data?.[0].memorySpaceId).toBe(MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID);
@@ -200,10 +200,10 @@ describe('MemoryService Unit Tests', () => {
     it('should call the endpoint with an empty body when no options are provided', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTopSpacesResponse());
 
-      await memoryService.getTopMemorySpaces();
+      await memoryService.getTopSpaces();
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        MEMORY_ENDPOINTS.GET_TOP_MEMORY_SPACES,
+        MEMORY_ENDPOINTS.GET_TOP_SPACES,
         {},
         expect.anything(),
       );
@@ -222,10 +222,10 @@ describe('MemoryService Unit Tests', () => {
         limit: MEMORY_TEST_CONSTANTS.LIMIT,
       };
 
-      await memoryService.getTopMemorySpaces(options);
+      await memoryService.getTopSpaces(options);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        MEMORY_ENDPOINTS.GET_TOP_MEMORY_SPACES,
+        MEMORY_ENDPOINTS.GET_TOP_SPACES,
         {
           startTime: MEMORY_TEST_CONSTANTS.START_TIME,
           endTime: MEMORY_TEST_CONSTANTS.END_TIME,
@@ -242,7 +242,7 @@ describe('MemoryService Unit Tests', () => {
     it('should omit limit from the request body when not provided', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTopSpacesResponse());
 
-      await memoryService.getTopMemorySpaces({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      await memoryService.getTopSpaces({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
 
       const sentBody = mockApiClient.post.mock.calls[0][1];
       expect(sentBody).toEqual({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
@@ -252,7 +252,7 @@ describe('MemoryService Unit Tests', () => {
     it('should propagate API errors', async () => {
       mockApiClient.post.mockRejectedValue(new Error(MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_SPACES));
 
-      await expect(memoryService.getTopMemorySpaces()).rejects.toThrow(
+      await expect(memoryService.getTopSpaces()).rejects.toThrow(
         MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_SPACES,
       );
     });

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -64,9 +64,11 @@ describe('MemoryService Unit Tests', () => {
     it('should pass all provided filters into the request body', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTimelineResponse());
 
+      const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
+      const endTime = new Date(MEMORY_TEST_CONSTANTS.END_TIME);
       const options: MemoryGetTimelineOptions = {
-        startTime: MEMORY_TEST_CONSTANTS.START_TIME,
-        endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+        startTime,
+        endTime,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
@@ -78,8 +80,8 @@ describe('MemoryService Unit Tests', () => {
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MEMORY_ENDPOINTS.GET_TIMELINE,
         {
-          startTime: MEMORY_TEST_CONSTANTS.START_TIME,
-          endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+          startTime: startTime.toISOString(),
+          endTime: endTime.toISOString(),
           agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
           agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
           folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
@@ -92,10 +94,11 @@ describe('MemoryService Unit Tests', () => {
     it('should omit undefined filters from the request body', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTimelineResponse());
 
-      await memoryService.getTimeline({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
+      await memoryService.getTimeline({ startTime });
 
       const sentBody = mockApiClient.post.mock.calls[0][1];
-      expect(sentBody).toEqual({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      expect(sentBody).toEqual({ startTime: startTime.toISOString() });
       expect(sentBody).not.toHaveProperty('agentId');
       expect(sentBody).not.toHaveProperty('executionType');
     });
@@ -137,9 +140,11 @@ describe('MemoryService Unit Tests', () => {
     it('should pass all provided filters into the request body', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetCallsTimelineResponse());
 
+      const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
+      const endTime = new Date(MEMORY_TEST_CONSTANTS.END_TIME);
       const options: MemoryGetCallsTimelineOptions = {
-        startTime: MEMORY_TEST_CONSTANTS.START_TIME,
-        endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+        startTime,
+        endTime,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
@@ -151,8 +156,8 @@ describe('MemoryService Unit Tests', () => {
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MEMORY_ENDPOINTS.GET_CALLS_TIMELINE,
         {
-          startTime: MEMORY_TEST_CONSTANTS.START_TIME,
-          endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+          startTime: startTime.toISOString(),
+          endTime: endTime.toISOString(),
           agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
           agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
           folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
@@ -165,10 +170,11 @@ describe('MemoryService Unit Tests', () => {
     it('should omit undefined filters from the request body', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetCallsTimelineResponse());
 
-      await memoryService.getCallsTimeline({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
+      const endTime = new Date(MEMORY_TEST_CONSTANTS.END_TIME);
+      await memoryService.getCallsTimeline({ endTime });
 
       const sentBody = mockApiClient.post.mock.calls[0][1];
-      expect(sentBody).toEqual({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
+      expect(sentBody).toEqual({ endTime: endTime.toISOString() });
       expect(sentBody).not.toHaveProperty('startTime');
       expect(sentBody).not.toHaveProperty('folderKeys');
     });
@@ -212,9 +218,11 @@ describe('MemoryService Unit Tests', () => {
     it('should pass all provided filters including limit into the request body', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTopSpacesResponse());
 
+      const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
+      const endTime = new Date(MEMORY_TEST_CONSTANTS.END_TIME);
       const options: MemoryGetTopSpacesOptions = {
-        startTime: MEMORY_TEST_CONSTANTS.START_TIME,
-        endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+        startTime,
+        endTime,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
@@ -227,8 +235,8 @@ describe('MemoryService Unit Tests', () => {
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MEMORY_ENDPOINTS.GET_TOP_SPACES,
         {
-          startTime: MEMORY_TEST_CONSTANTS.START_TIME,
-          endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+          startTime: startTime.toISOString(),
+          endTime: endTime.toISOString(),
           agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
           agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
           folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
@@ -242,10 +250,11 @@ describe('MemoryService Unit Tests', () => {
     it('should omit limit from the request body when not provided', async () => {
       mockApiClient.post.mockResolvedValue(createMockMemoryGetTopSpacesResponse());
 
-      await memoryService.getTopSpaces({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
+      await memoryService.getTopSpaces({ startTime });
 
       const sentBody = mockApiClient.post.mock.calls[0][1];
-      expect(sentBody).toEqual({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      expect(sentBody).toEqual({ startTime: startTime.toISOString() });
       expect(sentBody).not.toHaveProperty('limit');
     });
 

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -1,0 +1,102 @@
+// ===== IMPORTS =====
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MemoryService } from '../../../../../src/services/agents/memory/memory';
+import { ApiClient } from '../../../../../src/core/http/api-client';
+import { createServiceTestDependencies, createMockApiClient } from '../../../../utils/setup';
+import { MEMORY_ENDPOINTS } from '../../../../../src/utils/constants/endpoints';
+import { MEMORY_TEST_CONSTANTS } from '../../../../utils/constants';
+import { createMockMemoryTimelineResponse } from '../../../../utils/mocks/memory';
+import { ExecutionType, MemoryTimelineGetOptions } from '../../../../../src/models/agents/memory/memory.types';
+
+// ===== MOCKING =====
+vi.mock('../../../../../src/core/http/api-client');
+
+// ===== TEST SUITE =====
+describe('MemoryService Unit Tests', () => {
+  let memoryService: MemoryService;
+  let mockApiClient: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    const { instance } = createServiceTestDependencies();
+    mockApiClient = createMockApiClient();
+    vi.mocked(ApiClient).mockImplementation(() => mockApiClient as never);
+    memoryService = new MemoryService(instance);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getMemoryTimeline', () => {
+    it('should retrieve the memory timeline successfully', async () => {
+      const mockResponse = createMockMemoryTimelineResponse();
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const result = await memoryService.getMemoryTimeline();
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data?.[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
+      expect(result.data?.[0].inMemoryCount).toBe(3);
+      expect(result.data?.[0].totalCount).toBe(4);
+    });
+
+    it('should call the endpoint with an empty body when no options are provided', async () => {
+      mockApiClient.post.mockResolvedValue(createMockMemoryTimelineResponse());
+
+      await memoryService.getMemoryTimeline();
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
+        {},
+        expect.anything(),
+      );
+    });
+
+    it('should pass all provided filters into the request body', async () => {
+      mockApiClient.post.mockResolvedValue(createMockMemoryTimelineResponse());
+
+      const options: MemoryTimelineGetOptions = {
+        startTime: MEMORY_TEST_CONSTANTS.START_TIME,
+        endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+        agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+        agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
+        folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
+        executionType: ExecutionType.Runtime,
+      };
+
+      await memoryService.getMemoryTimeline(options);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MEMORY_ENDPOINTS.GET_MEMORY_TIMELINE,
+        {
+          startTime: MEMORY_TEST_CONSTANTS.START_TIME,
+          endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+          agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+          agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
+          folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
+          executionType: ExecutionType.Runtime,
+        },
+        expect.anything(),
+      );
+    });
+
+    it('should omit undefined filters from the request body', async () => {
+      mockApiClient.post.mockResolvedValue(createMockMemoryTimelineResponse());
+
+      await memoryService.getMemoryTimeline({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+
+      const sentBody = mockApiClient.post.mock.calls[0][1];
+      expect(sentBody).toEqual({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      expect(sentBody).not.toHaveProperty('agentId');
+      expect(sentBody).not.toHaveProperty('executionType');
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(MEMORY_TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(memoryService.getMemoryTimeline()).rejects.toThrow(
+        MEMORY_TEST_CONSTANTS.ERROR_MESSAGE,
+      );
+    });
+  });
+});

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -8,11 +8,13 @@ import { MEMORY_TEST_CONSTANTS } from '../../../../utils/constants';
 import {
   createMockMemoryTimelineResponse,
   createMockMemoryCallsTimelineResponse,
+  createMockTopMemorySpacesResponse,
 } from '../../../../utils/mocks/memory';
 import {
   ExecutionType,
   MemoryTimelineGetOptions,
   MemoryCallsTimelineGetOptions,
+  TopMemorySpacesGetOptions,
 } from '../../../../../src/models/agents/memory/memory.types';
 
 // ===== MOCKING =====
@@ -176,6 +178,82 @@ describe('MemoryService Unit Tests', () => {
 
       await expect(memoryService.getMemoryCallsTimeline()).rejects.toThrow(
         MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_CALLS,
+      );
+    });
+  });
+
+  describe('getTopMemorySpaces', () => {
+    it('should retrieve the top memory spaces successfully', async () => {
+      const mockResponse = createMockTopMemorySpacesResponse();
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const result = await memoryService.getTopMemorySpaces();
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data?.[0].memorySpaceId).toBe(MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID);
+      expect(result.data?.[0].memorySpaceName).toBe(MEMORY_TEST_CONSTANTS.MEMORY_SPACE_NAME);
+      expect(result.data?.[0].memoryCount).toBe(9);
+      expect(result.data?.[0].enabledMemoryCount).toBe(6);
+      expect(result.data?.[0].disabledMemoryCount).toBe(3);
+    });
+
+    it('should call the endpoint with an empty body when no options are provided', async () => {
+      mockApiClient.post.mockResolvedValue(createMockTopMemorySpacesResponse());
+
+      await memoryService.getTopMemorySpaces();
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MEMORY_ENDPOINTS.GET_TOP_MEMORY_SPACES,
+        {},
+        expect.anything(),
+      );
+    });
+
+    it('should pass all provided filters including limit into the request body', async () => {
+      mockApiClient.post.mockResolvedValue(createMockTopMemorySpacesResponse());
+
+      const options: TopMemorySpacesGetOptions = {
+        startTime: MEMORY_TEST_CONSTANTS.START_TIME,
+        endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+        agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+        agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
+        folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
+        executionType: ExecutionType.Runtime,
+        limit: MEMORY_TEST_CONSTANTS.LIMIT,
+      };
+
+      await memoryService.getTopMemorySpaces(options);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MEMORY_ENDPOINTS.GET_TOP_MEMORY_SPACES,
+        {
+          startTime: MEMORY_TEST_CONSTANTS.START_TIME,
+          endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+          agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+          agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
+          folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
+          executionType: ExecutionType.Runtime,
+          limit: MEMORY_TEST_CONSTANTS.LIMIT,
+        },
+        expect.anything(),
+      );
+    });
+
+    it('should omit limit from the request body when not provided', async () => {
+      mockApiClient.post.mockResolvedValue(createMockTopMemorySpacesResponse());
+
+      await memoryService.getTopMemorySpaces({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+
+      const sentBody = mockApiClient.post.mock.calls[0][1];
+      expect(sentBody).toEqual({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
+      expect(sentBody).not.toHaveProperty('limit');
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_SPACES));
+
+      await expect(memoryService.getTopMemorySpaces()).rejects.toThrow(
+        MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_SPACES,
       );
     });
   });

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -43,10 +43,10 @@ describe('MemoryService Unit Tests', () => {
 
       const result = await memoryService.getTimeline();
 
-      expect(result.data).toHaveLength(2);
-      expect(result.data?.[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
-      expect(result.data?.[0].inMemoryCount).toBe(3);
-      expect(result.data?.[0].totalCount).toBe(4);
+      expect(result).toHaveLength(2);
+      expect(result[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
+      expect(result[0].inMemoryCount).toBe(3);
+      expect(result[0].totalCount).toBe(4);
     });
 
     it('should call the endpoint with an empty body when no options are provided', async () => {
@@ -116,10 +116,10 @@ describe('MemoryService Unit Tests', () => {
 
       const result = await memoryService.getCallsTimeline();
 
-      expect(result.data).toHaveLength(2);
-      expect(result.data?.[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
-      expect(result.data?.[0].memoryCallsCount).toBe(7);
-      expect(result.data?.[1].memoryCallsCount).toBe(12);
+      expect(result).toHaveLength(2);
+      expect(result[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
+      expect(result[0].memoryCallsCount).toBe(7);
+      expect(result[1].memoryCallsCount).toBe(12);
     });
 
     it('should call the endpoint with an empty body when no options are provided', async () => {
@@ -189,12 +189,12 @@ describe('MemoryService Unit Tests', () => {
 
       const result = await memoryService.getTopSpaces();
 
-      expect(result.data).toHaveLength(2);
-      expect(result.data?.[0].memorySpaceId).toBe(MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID);
-      expect(result.data?.[0].memorySpaceName).toBe(MEMORY_TEST_CONSTANTS.MEMORY_SPACE_NAME);
-      expect(result.data?.[0].memoryCount).toBe(9);
-      expect(result.data?.[0].enabledMemoryCount).toBe(6);
-      expect(result.data?.[0].disabledMemoryCount).toBe(3);
+      expect(result).toHaveLength(2);
+      expect(result[0].memorySpaceId).toBe(MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID);
+      expect(result[0].memorySpaceName).toBe(MEMORY_TEST_CONSTANTS.MEMORY_SPACE_NAME);
+      expect(result[0].memoryCount).toBe(9);
+      expect(result[0].enabledMemoryCount).toBe(6);
+      expect(result[0].disabledMemoryCount).toBe(3);
     });
 
     it('should call the endpoint with an empty body when no options are provided', async () => {

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -6,15 +6,15 @@ import { createServiceTestDependencies, createMockApiClient } from '../../../../
 import { MEMORY_ENDPOINTS } from '../../../../../src/utils/constants/endpoints';
 import { MEMORY_TEST_CONSTANTS } from '../../../../utils/constants';
 import {
-  createMockMemoryTimelineResponse,
-  createMockMemoryCallsTimelineResponse,
-  createMockTopMemorySpacesResponse,
+  createMockMemoryGetTimelineResponse,
+  createMockMemoryGetCallsTimelineResponse,
+  createMockMemoryGetTopSpacesResponse,
 } from '../../../../utils/mocks/memory';
 import {
   ExecutionType,
-  MemoryTimelineGetOptions,
-  MemoryCallsTimelineGetOptions,
-  TopMemorySpacesGetOptions,
+  MemoryGetTimelineOptions,
+  MemoryGetCallsTimelineOptions,
+  MemoryGetTopSpacesOptions,
 } from '../../../../../src/models/agents/memory/memory.types';
 
 // ===== MOCKING =====
@@ -38,7 +38,7 @@ describe('MemoryService Unit Tests', () => {
 
   describe('getMemoryTimeline', () => {
     it('should retrieve the memory timeline successfully', async () => {
-      const mockResponse = createMockMemoryTimelineResponse();
+      const mockResponse = createMockMemoryGetTimelineResponse();
       mockApiClient.post.mockResolvedValue(mockResponse);
 
       const result = await memoryService.getMemoryTimeline();
@@ -50,7 +50,7 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should call the endpoint with an empty body when no options are provided', async () => {
-      mockApiClient.post.mockResolvedValue(createMockMemoryTimelineResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetTimelineResponse());
 
       await memoryService.getMemoryTimeline();
 
@@ -62,9 +62,9 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should pass all provided filters into the request body', async () => {
-      mockApiClient.post.mockResolvedValue(createMockMemoryTimelineResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetTimelineResponse());
 
-      const options: MemoryTimelineGetOptions = {
+      const options: MemoryGetTimelineOptions = {
         startTime: MEMORY_TEST_CONSTANTS.START_TIME,
         endTime: MEMORY_TEST_CONSTANTS.END_TIME,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
@@ -90,7 +90,7 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should omit undefined filters from the request body', async () => {
-      mockApiClient.post.mockResolvedValue(createMockMemoryTimelineResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetTimelineResponse());
 
       await memoryService.getMemoryTimeline({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
 
@@ -111,7 +111,7 @@ describe('MemoryService Unit Tests', () => {
 
   describe('getMemoryCallsTimeline', () => {
     it('should retrieve the memory calls timeline successfully', async () => {
-      const mockResponse = createMockMemoryCallsTimelineResponse();
+      const mockResponse = createMockMemoryGetCallsTimelineResponse();
       mockApiClient.post.mockResolvedValue(mockResponse);
 
       const result = await memoryService.getMemoryCallsTimeline();
@@ -123,7 +123,7 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should call the endpoint with an empty body when no options are provided', async () => {
-      mockApiClient.post.mockResolvedValue(createMockMemoryCallsTimelineResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetCallsTimelineResponse());
 
       await memoryService.getMemoryCallsTimeline();
 
@@ -135,9 +135,9 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should pass all provided filters into the request body', async () => {
-      mockApiClient.post.mockResolvedValue(createMockMemoryCallsTimelineResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetCallsTimelineResponse());
 
-      const options: MemoryCallsTimelineGetOptions = {
+      const options: MemoryGetCallsTimelineOptions = {
         startTime: MEMORY_TEST_CONSTANTS.START_TIME,
         endTime: MEMORY_TEST_CONSTANTS.END_TIME,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
@@ -163,7 +163,7 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should omit undefined filters from the request body', async () => {
-      mockApiClient.post.mockResolvedValue(createMockMemoryCallsTimelineResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetCallsTimelineResponse());
 
       await memoryService.getMemoryCallsTimeline({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
 
@@ -184,7 +184,7 @@ describe('MemoryService Unit Tests', () => {
 
   describe('getTopMemorySpaces', () => {
     it('should retrieve the top memory spaces successfully', async () => {
-      const mockResponse = createMockTopMemorySpacesResponse();
+      const mockResponse = createMockMemoryGetTopSpacesResponse();
       mockApiClient.post.mockResolvedValue(mockResponse);
 
       const result = await memoryService.getTopMemorySpaces();
@@ -198,7 +198,7 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should call the endpoint with an empty body when no options are provided', async () => {
-      mockApiClient.post.mockResolvedValue(createMockTopMemorySpacesResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetTopSpacesResponse());
 
       await memoryService.getTopMemorySpaces();
 
@@ -210,9 +210,9 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should pass all provided filters including limit into the request body', async () => {
-      mockApiClient.post.mockResolvedValue(createMockTopMemorySpacesResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetTopSpacesResponse());
 
-      const options: TopMemorySpacesGetOptions = {
+      const options: MemoryGetTopSpacesOptions = {
         startTime: MEMORY_TEST_CONSTANTS.START_TIME,
         endTime: MEMORY_TEST_CONSTANTS.END_TIME,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
@@ -240,7 +240,7 @@ describe('MemoryService Unit Tests', () => {
     });
 
     it('should omit limit from the request body when not provided', async () => {
-      mockApiClient.post.mockResolvedValue(createMockTopMemorySpacesResponse());
+      mockApiClient.post.mockResolvedValue(createMockMemoryGetTopSpacesResponse());
 
       await memoryService.getTopMemorySpaces({ startTime: MEMORY_TEST_CONSTANTS.START_TIME });
 

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -11,10 +11,10 @@ import {
   createMockMemoryGetTopSpacesResponse,
 } from '../../../../utils/mocks/memory';
 import {
-  ExecutionType,
-  MemoryGetTimelineOptions,
-  MemoryGetCallsTimelineOptions,
-  MemoryGetTopSpacesOptions,
+  AgentMemoryExecutionType,
+  AgentMemoryGetTimelineOptions,
+  AgentMemoryGetCallsTimelineOptions,
+  AgentMemoryGetTopSpacesOptions,
 } from '../../../../../src/models/agents/memory/memory.types';
 
 // ===== MOCKING =====
@@ -66,13 +66,13 @@ describe('MemoryService Unit Tests', () => {
 
       const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
       const endTime = new Date(MEMORY_TEST_CONSTANTS.END_TIME);
-      const options: MemoryGetTimelineOptions = {
+      const options: AgentMemoryGetTimelineOptions = {
         startTime,
         endTime,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-        executionType: ExecutionType.Runtime,
+        executionType: AgentMemoryExecutionType.Runtime,
       };
 
       await memoryService.getTimeline(options);
@@ -85,7 +85,7 @@ describe('MemoryService Unit Tests', () => {
           agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
           agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
           folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-          executionType: ExecutionType.Runtime,
+          executionType: AgentMemoryExecutionType.Runtime,
         },
         expect.anything(),
       );
@@ -142,13 +142,13 @@ describe('MemoryService Unit Tests', () => {
 
       const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
       const endTime = new Date(MEMORY_TEST_CONSTANTS.END_TIME);
-      const options: MemoryGetCallsTimelineOptions = {
+      const options: AgentMemoryGetCallsTimelineOptions = {
         startTime,
         endTime,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-        executionType: ExecutionType.Runtime,
+        executionType: AgentMemoryExecutionType.Runtime,
       };
 
       await memoryService.getCallsTimeline(options);
@@ -161,7 +161,7 @@ describe('MemoryService Unit Tests', () => {
           agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
           agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
           folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-          executionType: ExecutionType.Runtime,
+          executionType: AgentMemoryExecutionType.Runtime,
         },
         expect.anything(),
       );
@@ -220,13 +220,13 @@ describe('MemoryService Unit Tests', () => {
 
       const startTime = new Date(MEMORY_TEST_CONSTANTS.START_TIME);
       const endTime = new Date(MEMORY_TEST_CONSTANTS.END_TIME);
-      const options: MemoryGetTopSpacesOptions = {
+      const options: AgentMemoryGetTopSpacesOptions = {
         startTime,
         endTime,
         agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
         agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
         folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-        executionType: ExecutionType.Runtime,
+        executionType: AgentMemoryExecutionType.Runtime,
         limit: MEMORY_TEST_CONSTANTS.LIMIT,
       };
 
@@ -240,7 +240,7 @@ describe('MemoryService Unit Tests', () => {
           agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
           agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
           folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
-          executionType: ExecutionType.Runtime,
+          executionType: AgentMemoryExecutionType.Runtime,
           limit: MEMORY_TEST_CONSTANTS.LIMIT,
         },
         expect.anything(),

--- a/tests/unit/services/agents/memory/memory.test.ts
+++ b/tests/unit/services/agents/memory/memory.test.ts
@@ -5,8 +5,15 @@ import { ApiClient } from '../../../../../src/core/http/api-client';
 import { createServiceTestDependencies, createMockApiClient } from '../../../../utils/setup';
 import { MEMORY_ENDPOINTS } from '../../../../../src/utils/constants/endpoints';
 import { MEMORY_TEST_CONSTANTS } from '../../../../utils/constants';
-import { createMockMemoryTimelineResponse } from '../../../../utils/mocks/memory';
-import { ExecutionType, MemoryTimelineGetOptions } from '../../../../../src/models/agents/memory/memory.types';
+import {
+  createMockMemoryTimelineResponse,
+  createMockMemoryCallsTimelineResponse,
+} from '../../../../utils/mocks/memory';
+import {
+  ExecutionType,
+  MemoryTimelineGetOptions,
+  MemoryCallsTimelineGetOptions,
+} from '../../../../../src/models/agents/memory/memory.types';
 
 // ===== MOCKING =====
 vi.mock('../../../../../src/core/http/api-client');
@@ -96,6 +103,79 @@ describe('MemoryService Unit Tests', () => {
 
       await expect(memoryService.getMemoryTimeline()).rejects.toThrow(
         MEMORY_TEST_CONSTANTS.ERROR_MESSAGE,
+      );
+    });
+  });
+
+  describe('getMemoryCallsTimeline', () => {
+    it('should retrieve the memory calls timeline successfully', async () => {
+      const mockResponse = createMockMemoryCallsTimelineResponse();
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const result = await memoryService.getMemoryCallsTimeline();
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data?.[0].timeSlice).toBe(MEMORY_TEST_CONSTANTS.TIME_SLICE_1);
+      expect(result.data?.[0].memoryCallsCount).toBe(7);
+      expect(result.data?.[1].memoryCallsCount).toBe(12);
+    });
+
+    it('should call the endpoint with an empty body when no options are provided', async () => {
+      mockApiClient.post.mockResolvedValue(createMockMemoryCallsTimelineResponse());
+
+      await memoryService.getMemoryCallsTimeline();
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
+        {},
+        expect.anything(),
+      );
+    });
+
+    it('should pass all provided filters into the request body', async () => {
+      mockApiClient.post.mockResolvedValue(createMockMemoryCallsTimelineResponse());
+
+      const options: MemoryCallsTimelineGetOptions = {
+        startTime: MEMORY_TEST_CONSTANTS.START_TIME,
+        endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+        agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+        agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
+        folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
+        executionType: ExecutionType.Runtime,
+      };
+
+      await memoryService.getMemoryCallsTimeline(options);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MEMORY_ENDPOINTS.GET_MEMORY_CALLS_TIMELINE,
+        {
+          startTime: MEMORY_TEST_CONSTANTS.START_TIME,
+          endTime: MEMORY_TEST_CONSTANTS.END_TIME,
+          agentId: MEMORY_TEST_CONSTANTS.AGENT_ID,
+          agentVersion: MEMORY_TEST_CONSTANTS.AGENT_VERSION,
+          folderKeys: [MEMORY_TEST_CONSTANTS.FOLDER_KEY],
+          executionType: ExecutionType.Runtime,
+        },
+        expect.anything(),
+      );
+    });
+
+    it('should omit undefined filters from the request body', async () => {
+      mockApiClient.post.mockResolvedValue(createMockMemoryCallsTimelineResponse());
+
+      await memoryService.getMemoryCallsTimeline({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
+
+      const sentBody = mockApiClient.post.mock.calls[0][1];
+      expect(sentBody).toEqual({ endTime: MEMORY_TEST_CONSTANTS.END_TIME });
+      expect(sentBody).not.toHaveProperty('startTime');
+      expect(sentBody).not.toHaveProperty('folderKeys');
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_CALLS));
+
+      await expect(memoryService.getMemoryCallsTimeline()).rejects.toThrow(
+        MEMORY_TEST_CONSTANTS.ERROR_MESSAGE_CALLS,
       );
     });
   });

--- a/tests/utils/constants/index.ts
+++ b/tests/utils/constants/index.ts
@@ -15,6 +15,7 @@ export * from './pagination';
 export * from './conversational-agent';
 export * from './attachments';
 export * from './feedback';
+export * from './memory';
 export * from './traces';
 export * from './agents';
 export * from './governance';

--- a/tests/utils/constants/memory.ts
+++ b/tests/utils/constants/memory.ts
@@ -1,5 +1,5 @@
 /**
- * Memory (Agent Memory / Traceview) test constants used across memory service tests
+ * Agent Memory test constants used across memory service tests
  */
 
 export const MEMORY_TEST_CONSTANTS = {

--- a/tests/utils/constants/memory.ts
+++ b/tests/utils/constants/memory.ts
@@ -12,6 +12,13 @@ export const MEMORY_TEST_CONSTANTS = {
   AGENT_VERSION: '1.0.0',
   FOLDER_KEY: '8709b9b7-5779-4952-b519-016db272da0a',
 
+  MEMORY_SPACE_ID: '8645d674-92d8-4281-9aef-43f3e3608ded',
+  MEMORY_SPACE_NAME: 'Shared memory space',
+  MEMORY_SPACE_ID_2: '00000000-0000-0000-0000-000000000002',
+  MEMORY_SPACE_NAME_2: 'Second memory space',
+  LIMIT: 10,
+
   ERROR_MESSAGE: 'Failed to retrieve memory timeline',
   ERROR_MESSAGE_CALLS: 'Failed to retrieve memory calls timeline',
+  ERROR_MESSAGE_SPACES: 'Failed to retrieve top memory spaces',
 } as const;

--- a/tests/utils/constants/memory.ts
+++ b/tests/utils/constants/memory.ts
@@ -13,4 +13,5 @@ export const MEMORY_TEST_CONSTANTS = {
   FOLDER_KEY: '8709b9b7-5779-4952-b519-016db272da0a',
 
   ERROR_MESSAGE: 'Failed to retrieve memory timeline',
+  ERROR_MESSAGE_CALLS: 'Failed to retrieve memory calls timeline',
 } as const;

--- a/tests/utils/constants/memory.ts
+++ b/tests/utils/constants/memory.ts
@@ -1,0 +1,16 @@
+/**
+ * Memory (Agent Memory / Traceview) test constants used across memory service tests
+ */
+
+export const MEMORY_TEST_CONSTANTS = {
+  START_TIME: '2026-05-01T00:00:00Z',
+  END_TIME: '2026-06-01T00:00:00Z',
+  TIME_SLICE_1: '2026-05-07T00:00:00Z',
+  TIME_SLICE_2: '2026-05-14T00:00:00Z',
+
+  AGENT_ID: '6f0f123e-88db-4f2a-a632-5f315f631534',
+  AGENT_VERSION: '1.0.0',
+  FOLDER_KEY: '8709b9b7-5779-4952-b519-016db272da0a',
+
+  ERROR_MESSAGE: 'Failed to retrieve memory timeline',
+} as const;

--- a/tests/utils/mocks/index.ts
+++ b/tests/utils/mocks/index.ts
@@ -19,6 +19,7 @@ export * from './pagination';
 export * from './conversational-agent';
 export * from './feedback';
 export * from './attachments';
+export * from './memory';
 export * from './traces';
 export * from './governance';
 

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -4,11 +4,11 @@
 
 import {
   MemoryTimelinePoint,
-  MemoryTimelineResponse,
+  MemoryGetTimelineResponse,
   MemoryCallsTimelinePoint,
-  MemoryCallsTimelineResponse,
+  MemoryGetCallsTimelineResponse,
   MemorySpace,
-  TopMemorySpacesResponse,
+  MemoryGetTopSpacesResponse,
 } from '../../../src/models/agents/memory/memory.types';
 import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
 
@@ -32,9 +32,9 @@ export function createMockMemoryTimelinePoint(
 /**
  * Creates a memory timeline response envelope with two points by default.
  */
-export function createMockMemoryTimelineResponse(
+export function createMockMemoryGetTimelineResponse(
   points?: MemoryTimelinePoint[],
-): MemoryTimelineResponse {
+): MemoryGetTimelineResponse {
   return {
     data: points ?? [
       createMockMemoryTimelinePoint(),
@@ -66,9 +66,9 @@ export function createMockMemoryCallsTimelinePoint(
 /**
  * Creates a memory-calls timeline response envelope with two points by default.
  */
-export function createMockMemoryCallsTimelineResponse(
+export function createMockMemoryGetCallsTimelineResponse(
   points?: MemoryCallsTimelinePoint[],
-): MemoryCallsTimelineResponse {
+): MemoryGetCallsTimelineResponse {
   return {
     data: points ?? [
       createMockMemoryCallsTimelinePoint(),
@@ -99,9 +99,9 @@ export function createMockMemorySpace(
 /**
  * Creates a top-memory-spaces response envelope with two spaces by default.
  */
-export function createMockTopMemorySpacesResponse(
+export function createMockMemoryGetTopSpacesResponse(
   spaces?: MemorySpace[],
-): TopMemorySpacesResponse {
+): MemoryGetTopSpacesResponse {
   return {
     data: spaces ?? [
       createMockMemorySpace(),

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -1,5 +1,5 @@
 /**
- * Mock factories for Agent Memory (Traceview) service tests.
+ * Mock factories for Agent Memory service tests.
  */
 
 import {

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -1,0 +1,47 @@
+/**
+ * Mock factories for Agent Memory (Traceview) service tests.
+ */
+
+import {
+  MemoryTimelinePoint,
+  MemoryTimelineResponse,
+} from '../../../src/models/agents/memory/memory.types';
+import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
+
+/**
+ * Creates a single memory timeline point with overridable fields.
+ */
+export function createMockMemoryTimelinePoint(
+  overrides: Partial<MemoryTimelinePoint> = {},
+): MemoryTimelinePoint {
+  return {
+    timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_1,
+    inMemoryCount: 3,
+    notInMemoryCount: 1,
+    totalCount: 4,
+    enabledMemoryCount: 2,
+    disabledMemoryCount: 2,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a memory timeline response envelope with two points by default.
+ */
+export function createMockMemoryTimelineResponse(
+  points?: MemoryTimelinePoint[],
+): MemoryTimelineResponse {
+  return {
+    data: points ?? [
+      createMockMemoryTimelinePoint(),
+      createMockMemoryTimelinePoint({
+        timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_2,
+        inMemoryCount: 5,
+        notInMemoryCount: 0,
+        totalCount: 5,
+        enabledMemoryCount: 5,
+        disabledMemoryCount: 0,
+      }),
+    ],
+  };
+}

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -3,9 +3,9 @@
  */
 
 import {
-  MemoryGetTimelineResponse,
-  MemoryGetCallsTimelineResponse,
-  MemoryGetTopSpacesResponse,
+  AgentMemoryGetTimelineResponse,
+  AgentMemoryGetCallsTimelineResponse,
+  AgentMemoryGetTopSpacesResponse,
 } from '../../../src/models/agents/memory/memory.types';
 import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
 
@@ -13,8 +13,8 @@ import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
  * Creates a single memory timeline point with overridable fields.
  */
 export function createMockMemoryTimelinePoint(
-  overrides: Partial<MemoryGetTimelineResponse> = {},
-): MemoryGetTimelineResponse {
+  overrides: Partial<AgentMemoryGetTimelineResponse> = {},
+): AgentMemoryGetTimelineResponse {
   return {
     timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_1,
     inMemoryCount: 3,
@@ -30,8 +30,8 @@ export function createMockMemoryTimelinePoint(
  * Creates a raw memory timeline API body (`{ data }` envelope) with two points by default.
  */
 export function createMockMemoryGetTimelineResponse(
-  points?: MemoryGetTimelineResponse[],
-): { data: MemoryGetTimelineResponse[] } {
+  points?: AgentMemoryGetTimelineResponse[],
+): { data: AgentMemoryGetTimelineResponse[] } {
   return {
     data: points ?? [
       createMockMemoryTimelinePoint(),
@@ -51,8 +51,8 @@ export function createMockMemoryGetTimelineResponse(
  * Creates a single memory-calls timeline point with overridable fields.
  */
 export function createMockMemoryCallsTimelinePoint(
-  overrides: Partial<MemoryGetCallsTimelineResponse> = {},
-): MemoryGetCallsTimelineResponse {
+  overrides: Partial<AgentMemoryGetCallsTimelineResponse> = {},
+): AgentMemoryGetCallsTimelineResponse {
   return {
     timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_1,
     memoryCallsCount: 7,
@@ -64,8 +64,8 @@ export function createMockMemoryCallsTimelinePoint(
  * Creates a raw memory-calls timeline API body (`{ data }` envelope) with two points by default.
  */
 export function createMockMemoryGetCallsTimelineResponse(
-  points?: MemoryGetCallsTimelineResponse[],
-): { data: MemoryGetCallsTimelineResponse[] } {
+  points?: AgentMemoryGetCallsTimelineResponse[],
+): { data: AgentMemoryGetCallsTimelineResponse[] } {
   return {
     data: points ?? [
       createMockMemoryCallsTimelinePoint(),
@@ -81,8 +81,8 @@ export function createMockMemoryGetCallsTimelineResponse(
  * Creates a single memory space with overridable fields.
  */
 export function createMockMemorySpace(
-  overrides: Partial<MemoryGetTopSpacesResponse> = {},
-): MemoryGetTopSpacesResponse {
+  overrides: Partial<AgentMemoryGetTopSpacesResponse> = {},
+): AgentMemoryGetTopSpacesResponse {
   return {
     memorySpaceId: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID,
     memorySpaceName: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_NAME,
@@ -97,8 +97,8 @@ export function createMockMemorySpace(
  * Creates a raw top-memory-spaces API body (`{ data }` envelope) with two spaces by default.
  */
 export function createMockMemoryGetTopSpacesResponse(
-  spaces?: MemoryGetTopSpacesResponse[],
-): { data: MemoryGetTopSpacesResponse[] } {
+  spaces?: AgentMemoryGetTopSpacesResponse[],
+): { data: AgentMemoryGetTopSpacesResponse[] } {
   return {
     data: spaces ?? [
       createMockMemorySpace(),

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -7,6 +7,8 @@ import {
   MemoryTimelineResponse,
   MemoryCallsTimelinePoint,
   MemoryCallsTimelineResponse,
+  MemorySpace,
+  TopMemorySpacesResponse,
 } from '../../../src/models/agents/memory/memory.types';
 import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
 
@@ -73,6 +75,42 @@ export function createMockMemoryCallsTimelineResponse(
       createMockMemoryCallsTimelinePoint({
         timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_2,
         memoryCallsCount: 12,
+      }),
+    ],
+  };
+}
+
+/**
+ * Creates a single memory space with overridable fields.
+ */
+export function createMockMemorySpace(
+  overrides: Partial<MemorySpace> = {},
+): MemorySpace {
+  return {
+    memorySpaceId: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID,
+    memorySpaceName: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_NAME,
+    memoryCount: 9,
+    enabledMemoryCount: 6,
+    disabledMemoryCount: 3,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a top-memory-spaces response envelope with two spaces by default.
+ */
+export function createMockTopMemorySpacesResponse(
+  spaces?: MemorySpace[],
+): TopMemorySpacesResponse {
+  return {
+    data: spaces ?? [
+      createMockMemorySpace(),
+      createMockMemorySpace({
+        memorySpaceId: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID_2,
+        memorySpaceName: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_NAME_2,
+        memoryCount: 4,
+        enabledMemoryCount: 4,
+        disabledMemoryCount: 0,
       }),
     ],
   };

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -3,9 +3,9 @@
  */
 
 import {
-  MemoryTimelinePoint,
-  MemoryCallsTimelinePoint,
-  MemorySpace,
+  MemoryGetTimelineResponse,
+  MemoryGetCallsTimelineResponse,
+  MemoryGetTopSpacesResponse,
 } from '../../../src/models/agents/memory/memory.types';
 import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
 
@@ -13,8 +13,8 @@ import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
  * Creates a single memory timeline point with overridable fields.
  */
 export function createMockMemoryTimelinePoint(
-  overrides: Partial<MemoryTimelinePoint> = {},
-): MemoryTimelinePoint {
+  overrides: Partial<MemoryGetTimelineResponse> = {},
+): MemoryGetTimelineResponse {
   return {
     timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_1,
     inMemoryCount: 3,
@@ -30,8 +30,8 @@ export function createMockMemoryTimelinePoint(
  * Creates a raw memory timeline API body (`{ data }` envelope) with two points by default.
  */
 export function createMockMemoryGetTimelineResponse(
-  points?: MemoryTimelinePoint[],
-): { data: MemoryTimelinePoint[] } {
+  points?: MemoryGetTimelineResponse[],
+): { data: MemoryGetTimelineResponse[] } {
   return {
     data: points ?? [
       createMockMemoryTimelinePoint(),
@@ -51,8 +51,8 @@ export function createMockMemoryGetTimelineResponse(
  * Creates a single memory-calls timeline point with overridable fields.
  */
 export function createMockMemoryCallsTimelinePoint(
-  overrides: Partial<MemoryCallsTimelinePoint> = {},
-): MemoryCallsTimelinePoint {
+  overrides: Partial<MemoryGetCallsTimelineResponse> = {},
+): MemoryGetCallsTimelineResponse {
   return {
     timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_1,
     memoryCallsCount: 7,
@@ -64,8 +64,8 @@ export function createMockMemoryCallsTimelinePoint(
  * Creates a raw memory-calls timeline API body (`{ data }` envelope) with two points by default.
  */
 export function createMockMemoryGetCallsTimelineResponse(
-  points?: MemoryCallsTimelinePoint[],
-): { data: MemoryCallsTimelinePoint[] } {
+  points?: MemoryGetCallsTimelineResponse[],
+): { data: MemoryGetCallsTimelineResponse[] } {
   return {
     data: points ?? [
       createMockMemoryCallsTimelinePoint(),
@@ -81,8 +81,8 @@ export function createMockMemoryGetCallsTimelineResponse(
  * Creates a single memory space with overridable fields.
  */
 export function createMockMemorySpace(
-  overrides: Partial<MemorySpace> = {},
-): MemorySpace {
+  overrides: Partial<MemoryGetTopSpacesResponse> = {},
+): MemoryGetTopSpacesResponse {
   return {
     memorySpaceId: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_ID,
     memorySpaceName: MEMORY_TEST_CONSTANTS.MEMORY_SPACE_NAME,
@@ -97,8 +97,8 @@ export function createMockMemorySpace(
  * Creates a raw top-memory-spaces API body (`{ data }` envelope) with two spaces by default.
  */
 export function createMockMemoryGetTopSpacesResponse(
-  spaces?: MemorySpace[],
-): { data: MemorySpace[] } {
+  spaces?: MemoryGetTopSpacesResponse[],
+): { data: MemoryGetTopSpacesResponse[] } {
   return {
     data: spaces ?? [
       createMockMemorySpace(),

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -4,11 +4,8 @@
 
 import {
   MemoryTimelinePoint,
-  MemoryGetTimelineResponse,
   MemoryCallsTimelinePoint,
-  MemoryGetCallsTimelineResponse,
   MemorySpace,
-  MemoryGetTopSpacesResponse,
 } from '../../../src/models/agents/memory/memory.types';
 import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
 
@@ -30,11 +27,11 @@ export function createMockMemoryTimelinePoint(
 }
 
 /**
- * Creates a memory timeline response envelope with two points by default.
+ * Creates a raw memory timeline API body (`{ data }` envelope) with two points by default.
  */
 export function createMockMemoryGetTimelineResponse(
   points?: MemoryTimelinePoint[],
-): MemoryGetTimelineResponse {
+): { data: MemoryTimelinePoint[] } {
   return {
     data: points ?? [
       createMockMemoryTimelinePoint(),
@@ -64,11 +61,11 @@ export function createMockMemoryCallsTimelinePoint(
 }
 
 /**
- * Creates a memory-calls timeline response envelope with two points by default.
+ * Creates a raw memory-calls timeline API body (`{ data }` envelope) with two points by default.
  */
 export function createMockMemoryGetCallsTimelineResponse(
   points?: MemoryCallsTimelinePoint[],
-): MemoryGetCallsTimelineResponse {
+): { data: MemoryCallsTimelinePoint[] } {
   return {
     data: points ?? [
       createMockMemoryCallsTimelinePoint(),
@@ -97,11 +94,11 @@ export function createMockMemorySpace(
 }
 
 /**
- * Creates a top-memory-spaces response envelope with two spaces by default.
+ * Creates a raw top-memory-spaces API body (`{ data }` envelope) with two spaces by default.
  */
 export function createMockMemoryGetTopSpacesResponse(
   spaces?: MemorySpace[],
-): MemoryGetTopSpacesResponse {
+): { data: MemorySpace[] } {
   return {
     data: spaces ?? [
       createMockMemorySpace(),

--- a/tests/utils/mocks/memory.ts
+++ b/tests/utils/mocks/memory.ts
@@ -5,6 +5,8 @@
 import {
   MemoryTimelinePoint,
   MemoryTimelineResponse,
+  MemoryCallsTimelinePoint,
+  MemoryCallsTimelineResponse,
 } from '../../../src/models/agents/memory/memory.types';
 import { MEMORY_TEST_CONSTANTS } from '../constants/memory';
 
@@ -41,6 +43,36 @@ export function createMockMemoryTimelineResponse(
         totalCount: 5,
         enabledMemoryCount: 5,
         disabledMemoryCount: 0,
+      }),
+    ],
+  };
+}
+
+/**
+ * Creates a single memory-calls timeline point with overridable fields.
+ */
+export function createMockMemoryCallsTimelinePoint(
+  overrides: Partial<MemoryCallsTimelinePoint> = {},
+): MemoryCallsTimelinePoint {
+  return {
+    timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_1,
+    memoryCallsCount: 7,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a memory-calls timeline response envelope with two points by default.
+ */
+export function createMockMemoryCallsTimelineResponse(
+  points?: MemoryCallsTimelinePoint[],
+): MemoryCallsTimelineResponse {
+  return {
+    data: points ?? [
+      createMockMemoryCallsTimelinePoint(),
+      createMockMemoryCallsTimelinePoint({
+        timeSlice: MEMORY_TEST_CONSTANTS.TIME_SLICE_2,
+        memoryCallsCount: 12,
       }),
     ],
   };


### PR DESCRIPTION
## Methods Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `agentMemory.getTimeline()` | `getTimeline(options?: AgentMemoryGetTimelineOptions): Promise<AgentMemoryGetTimelineResponse[]>` |
| Service | `agentMemory.getCallsTimeline()` | `getCallsTimeline(options?: AgentMemoryGetCallsTimelineOptions): Promise<AgentMemoryGetCallsTimelineResponse[]>` |
| Service | `agentMemory.getTopSpaces()` | `getTopSpaces(options?: AgentMemoryGetTopSpacesOptions): Promise<AgentMemoryGetTopSpacesResponse[]>` |

## Endpoints Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `getTimeline()` | POST | `insightsrtm_/Traceview/memoryTimeline` | `Insights.RealTimeData Insights OR.Folders.Read` |
| `getCallsTimeline()` | POST | `insightsrtm_/Traceview/memoryCallsTimeline` | `Insights.RealTimeData Insights OR.Folders.Read` |
| `getTopSpaces()` | POST | `insightsrtm_/Traceview/topMemorySpaces` | `Insights.RealTimeData Insights OR.Folders.Read` |

- New modular-only service, exported via the `@uipath/uipath-typescript/agent-memory` subpath as `AgentMemory`.
- Read-only analytics over Agent Memory — no bound methods, no pagination.
- All methods accept a shared `AgentMemoryFilterOptions` (time window + agent/folder/execution-type scope); `getTopSpaces` adds `limit`. `startTime`/`endTime` are `Date` objects (serialized to ISO-8601 internally); when omitted, the window defaults to the last 24 hours.
- Each method unwraps the API's `{ data: [...] }` envelope and returns a bare array. The envelope field is typed **required** — the backend always returns a populated list — so a malformed/empty response fails loud rather than silently returning `[]`.

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { AgentMemory, AgentMemoryExecutionType } from '@uipath/uipath-typescript/agent-memory';

const sdk = new UiPath(config);
await sdk.initialize();
const memory = new AgentMemory(sdk);

// Basic usage — last 24 hours (default window)
const timeline = await memory.getTimeline();
console.log(timeline[0]?.inMemoryCount);

// With options — scoped to one agent in one folder, runtime executions only
const scoped = await memory.getTimeline({
  startTime: new Date('2026-05-01T00:00:00Z'),
  endTime: new Date('2026-06-01T00:00:00Z'),
  agentId: '<agentId>',
  folderKeys: ['<folderKey>'],
  executionType: AgentMemoryExecutionType.Runtime,
});

// Top memory spaces ranked by memory count
const top = await memory.getTopSpaces({ limit: 10, executionType: AgentMemoryExecutionType.Runtime });
```

## API Response vs SDK Response

### Transform pipeline
`response.data.data` — unwrap the required `{ data: [...] }` envelope to a bare array.

No case conversion or field renaming is applied: the Insights RTM API already returns camelCase keys (`timeSlice`, `inMemoryCount`, `memoryCallsCount`, `memorySpaceName`, …), so item fields pass through unchanged. The only SDK-side transformation is dropping the single-field envelope wrapper. The envelope `data` field is typed required (backend initializes it to an empty list), so there is no `?? []` fallback — an unexpected shape surfaces as an error instead of a silent empty result.

### Field mapping
| API Response | SDK Response | Change | Reason |
|--------------|--------------|--------|--------|
| `{ data: AgentMemoryGetTimelineResponse[] }` | `AgentMemoryGetTimelineResponse[]` | Unwrap envelope | Single-field `{ data }` wrapper adds no value; return the array directly (matches Maestro analytics/timeline methods) |
| item fields (camelCase) | item fields (camelCase) | None | API returns camelCase natively — no transform needed |

## Sample SDK Response

<details>
<summary><code>getTimeline()</code></summary>

```json
[
  {
    "timeSlice": "2025-05-12T00:00:00Z",
    "inMemoryCount": 0,
    "notInMemoryCount": 0,
    "totalCount": 0,
    "enabledMemoryCount": 0,
    "disabledMemoryCount": 0
  },
  {
    "timeSlice": "2025-06-11T00:00:00Z",
    "inMemoryCount": 0,
    "notInMemoryCount": 0,
    "totalCount": 0,
    "enabledMemoryCount": 0,
    "disabledMemoryCount": 0
  }
]
```

*Truncated to 2 items — full response returned 14 time buckets.*

</details>

<details>
<summary><code>getCallsTimeline()</code></summary>

```json
[
  { "timeSlice": "2026-02-06T00:00:00Z", "memoryCallsCount": 0 },
  { "timeSlice": "2026-03-08T00:00:00Z", "memoryCallsCount": 0 }
]
```

*Truncated to 2 items — full response returned 14 time buckets.*

</details>

<details>
<summary><code>getTopSpaces({ limit: 5, executionType: Runtime })</code></summary>

```json
[]
```

*Empty array — no memory spaces matched the requested window.*

</details>

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/memory.ts`, `src/utils/constants/endpoints/index.ts` |
| Types | `src/models/agents/memory/memory.types.ts` |
| Models | `src/models/agents/memory/memory.models.ts` |
| Service | `src/services/agents/memory/memory.ts` |
| Build | `package.json`, `rollup.config.js` |
| Barrel exports | `src/models/agents/index.ts`, `src/models/agents/memory/index.ts`, `src/services/agents/memory/index.ts` |
| Unit tests | `tests/unit/services/agents/memory/memory.test.ts` (15 tests) |
| Integration tests | `tests/integration/shared/agents/memory.integration.test.ts` (12 tests, `describe.skip` — `insightsrtm_` endpoints require OAuth, reject PAT) |
| Test utils | `tests/utils/mocks/memory.ts`, `tests/utils/mocks/index.ts`, `tests/utils/constants/memory.ts`, `tests/utils/constants/index.ts`, `tests/integration/config/unified-setup.ts` |
| Docs | `docs/oauth-scopes.md`, `mkdocs.yml` |

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*
