### PR TITLE
fix: fix conversational paginated response and conversational delete output

### DIFF
--- a/src/models/conversational-agent/conversations/conversations.models.ts
+++ b/src/models/conversational-agent/conversations/conversations.models.ts
@@ -118,7 +118,7 @@ export interface ConversationServiceModel {
   /**
    * Gets conversations with pagination and optional sort/filter parameters
    *
-   * Returns a paginated response. When called without `pageSize`/`cursor`, a 
+   * Returns a paginated response. When called without `pageSize`/`cursor`, a
    * default page size is applied - inspect `hasNextPage`/`nextCursor`
    * to navigate further pages.
    *
@@ -142,32 +142,39 @@ export interface ConversationServiceModel {
    * }
    * ```
    *
-   * @example With explicit page size
+   * @example With explicit page size and sort order (by last-activity timestamp)
    * ```typescript
    * // First page
-   * const firstPage = await conversationalAgent.conversations.getAll({ pageSize: 10 });
+   * const firstPage = await conversationalAgent.conversations.getAll({
+   *   pageSize: 10,
+   *   sort: SortOrder.Descending
+   * });
    *
-   * // Navigate using cursor
+   * // Navigate using cursor and same parameters
    * if (firstPage.hasNextPage) {
    *   const nextPage = await conversationalAgent.conversations.getAll({
+   *     pageSize: 10,
+   *     sort: SortOrder.Descending,
    *     cursor: firstPage.nextCursor
    *   });
    * }
    * ```
    *
-   * @example Explicit sort order by the last activity timestamp
+   * @example With agent-filter and label-search
    * ```typescript
-   * const result = await conversationalAgent.conversations.getAll({
-   *   sort: SortOrder.Descending
-   * });
-   * ```
-   *
-   * @example Filter by agent and search by label
-   * ```typescript
-   * const filtered = await conversationalAgent.conversations.getAll({
+   * const firstPage = await conversationalAgent.conversations.getAll({
    *   agentId: <agentId>,
    *   label: 'budget'
    * });
+   *
+   * // Navigate using cursor and same parameters
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await conversationalAgent.conversations.getAll({
+   *     agentId: <agentId>,
+   *     label: 'budget',
+   *     cursor: firstPage.nextCursor
+   *   });
+   * }
    * ```
    */
   getAll(options?: ConversationGetAllOptions): Promise<PaginatedResponse<ConversationGetResponse>>;

--- a/src/models/conversational-agent/conversations/conversations.models.ts
+++ b/src/models/conversational-agent/conversations/conversations.models.ts
@@ -144,6 +144,8 @@ export interface ConversationServiceModel {
    *
    * @example With explicit page size and sort order (by last-activity timestamp)
    * ```typescript
+   * import { SortOrder } from '@uipath/uipath-typescript/conversational-agent';
+   *
    * // First page
    * const firstPage = await conversationalAgent.conversations.getAll({
    *   pageSize: 10,

--- a/src/models/conversational-agent/conversations/conversations.models.ts
+++ b/src/models/conversational-agent/conversations/conversations.models.ts
@@ -19,7 +19,7 @@ import type {
 } from './conversations.types';
 import type { ExchangeServiceModel, ConversationExchangeServiceModel } from './exchanges.models';
 import type { ExchangeGetByIdOptions, CreateFeedbackOptions } from './exchanges.types';
-import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '@/utils/pagination';
+import type { PaginatedResponse } from '@/utils/pagination';
 import type { ConnectionStatus, ConnectionStatusChangedHandler } from '@/core/websocket';
 import type { SessionStream } from './types/events/session.types';
 
@@ -116,25 +116,33 @@ export interface ConversationServiceModel {
   create(agentId: number, folderId: number, options?: ConversationCreateOptions): Promise<ConversationCreateResponse>;
 
   /**
-   * Gets all conversations with optional filtering and pagination
+   * Gets conversations with pagination and optional sort/filter parameters
    *
-   * The method returns either:
-   * - A NonPaginatedResponse with items array (when no pagination parameters are provided)
-   * - A PaginatedResponse with navigation cursors (when any pagination parameter is provided)
+   * Returns a paginated response. When called without `pageSize`/`cursor`, a 
+   * default page size is applied - inspect `hasNextPage`/`nextCursor`
+   * to navigate further pages.
    *
-   * @param options - Options for querying conversations including optional pagination parameters
-   * @returns Promise resolving to either an array of conversations {@link NonPaginatedResponse}<{@link ConversationGetResponse}> or a {@link PaginatedResponse}<{@link ConversationGetResponse}> when pagination options are used
+   * @param options - Options for querying conversations
+   * @returns Promise resolving to a {@link PaginatedResponse}<{@link ConversationGetResponse}>
    *
-   * @example Basic usage - get all conversations
+   * @example Basic usage - default sort, pagination, and without filtering
    * ```typescript
-   * const allConversations = await conversationalAgent.conversations.getAll();
+   * // First page
+   * const firstPage = await conversationalAgent.conversations.getAll();
    *
-   * for (const conversation of allConversations.items) {
+   * for (const conversation of firstPage.items) {
    *   console.log(`${conversation.label} - created: ${conversation.createdTime}`);
+   * }
+   *
+   * // Navigate using cursor
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await conversationalAgent.conversations.getAll({
+   *     cursor: firstPage.nextCursor
+   *   });
    * }
    * ```
    *
-   * @example With pagination
+   * @example With explicit page size
    * ```typescript
    * // First page
    * const firstPage = await conversationalAgent.conversations.getAll({ pageSize: 10 });
@@ -147,11 +155,10 @@ export interface ConversationServiceModel {
    * }
    * ```
    *
-   * @example Sorted with limit
+   * @example Explicit sort order by the last activity timestamp
    * ```typescript
    * const result = await conversationalAgent.conversations.getAll({
-   *   sort: SortOrder.Descending,
-   *   pageSize: 20
+   *   sort: SortOrder.Descending
    * });
    * ```
    *
@@ -163,13 +170,7 @@ export interface ConversationServiceModel {
    * });
    * ```
    */
-  getAll<T extends ConversationGetAllOptions = ConversationGetAllOptions>(
-    options?: T
-  ): Promise<
-    T extends HasPaginationOptions<T>
-      ? PaginatedResponse<ConversationGetResponse>
-      : NonPaginatedResponse<ConversationGetResponse>
-  >;
+  getAll(options?: ConversationGetAllOptions): Promise<PaginatedResponse<ConversationGetResponse>>;
 
   /**
    * Gets a conversation by ID

--- a/src/models/conversational-agent/conversations/conversations.types.ts
+++ b/src/models/conversational-agent/conversations/conversations.types.ts
@@ -76,7 +76,7 @@ export interface ConversationUpdateOptions {
 }
 
 export type ConversationGetAllOptions = PaginationOptions & {
-  /** Sort order for conversations */
+  /** Sort order for conversations (by the last activity timestamp) */
   sort?: SortOrder;
   /** GUID key of the agent to filter conversations by. */
   agentKey?: string;

--- a/src/models/conversational-agent/conversations/conversations.types.ts
+++ b/src/models/conversational-agent/conversations/conversations.types.ts
@@ -5,6 +5,7 @@
 import type { SortOrder, ConversationJobStartOverrides, RawConversationGetResponse } from './types/core.types';
 import type { AgentInput } from './types/common.types';
 import type { ConversationGetResponse } from './conversations.models';
+import type { SessionCapabilities } from './types/events/protocol.types';
 import type { PaginationOptions } from '@/utils/pagination/types';
 import type { LogLevel } from '@/core/websocket';
 
@@ -34,6 +35,12 @@ export interface ConversationSessionOptions {
    * ```
    */
   logLevel?: LogLevel;
+
+  /**
+   * Optional capabilities of this client to advertise to the service when starting the session.
+   * Generally not needed unless the client is accessing more advanced features.
+   */
+  capabilities?: SessionCapabilities;
 }
 
 // ==================== Conversation Response Types ====================

--- a/src/models/conversational-agent/conversations/exchanges.models.ts
+++ b/src/models/conversational-agent/conversations/exchanges.models.ts
@@ -133,7 +133,7 @@ export interface ConversationExchangeServiceModel {
    * 
    * // Navigate using cursor
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
    * }
    * ```
    * 
@@ -146,7 +146,7 @@ export interface ConversationExchangeServiceModel {
    * 
    * // Navigate using cursor
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
    * }
    * ```
    */

--- a/src/models/conversational-agent/conversations/exchanges.models.ts
+++ b/src/models/conversational-agent/conversations/exchanges.models.ts
@@ -32,7 +32,7 @@ import type { PaginatedResponse } from '@/utils/pagination';
  */
 export interface ExchangeServiceModel {
   /**
-   * Gets exchanges for a conversation with optional filtering and pagination
+   * Gets exchanges for a conversation with pagination and optional sort parameters
    *
    * Returns a paginated response. When called without `pageSize`/`cursor`, the
    * backend applies its default page size — inspect `hasNextPage`/`nextCursor`
@@ -41,18 +41,33 @@ export interface ExchangeServiceModel {
    * @param conversationId - The conversation ID to get exchanges for
    * @param options - Options for querying exchanges including optional pagination parameters
    * @returns Promise resolving to a {@link PaginatedResponse}<{@link ExchangeGetResponse}>
-   * @example
-   * ```typescript
-   * // First page (backend default page size)
-   * const firstPageOfExchanges = await exchanges.getAll(conversationId);
    *
-   * // First page with explicit page size
-   * const pagedExchanges = await exchanges.getAll(conversationId, { pageSize: 10 });
+   * @example Basic usage - default page size and sort order
+   * ```typescript
+   * // First page
+   * const firstPage = await exchanges.getAll(conversationId);
    *
    * // Navigate using cursor
-   * if (firstPageOfExchanges.hasNextPage) {
-   *   const nextPageOfExchanges = await exchanges.getAll(conversationId, {
-   *     cursor: firstPageOfExchanges.nextCursor
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await exchanges.getAll(conversationId, { cursor: firstPage.nextCursor });
+   * }
+   * ```
+   *
+   * @example With explicit page size and exchange/message sort orders
+   * ```typescript
+   * const firstPage = await exchanges.getAll(conversationId, {
+   *   pageSize: 10,
+   *   exchangeSort: SortOrder.Descending,
+   *   messageSort: SortOrder.Ascending
+   * });
+   *
+   * // Navigate using cursor and same parameters
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await exchanges.getAll(conversationId, {
+   *     pageSize: 10,
+   *     exchangeSort: SortOrder.Descending,
+   *     messageSort: SortOrder.Ascending,
+   *     cursor: firstPage.nextCursor
    *   });
    * }
    * ```
@@ -130,23 +145,32 @@ export interface ConversationExchangeServiceModel {
    *
    * // First page
    * const firstPage = await conversation.exchanges.getAll();
-   * 
+   *
    * // Navigate using cursor
    * if (firstPage.hasNextPage) {
    *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
    * }
    * ```
-   * 
+   *
    * @example With explicit page size and exchange/message sort orders
    * ```typescript
    * const conversation = await conversationalAgent.conversations.getById(conversationId);
-   * 
+   *
    * // First page
-   * const firstPage = await conversation.exchanges.getAll({ pageSize: 10, exchangeSort: SortOrder.Descending, messageSort: SortOrder.Ascending });
-   * 
-   * // Navigate using cursor
+   * const firstPage = await conversation.exchanges.getAll({
+   *   pageSize: 10,
+   *   exchangeSort: SortOrder.Descending,
+   *   messageSort: SortOrder.Ascending
+   * });
+   *
+   * // Navigate using cursor and same parameters
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
+   *   const nextPage = await conversation.exchanges.getAll({
+   *     pageSize: 10,
+   *     exchangeSort: SortOrder.Descending,
+   *     messageSort: SortOrder.Ascending,
+   *     cursor: firstPage.nextCursor
+   *   });
    * }
    * ```
    */

--- a/src/models/conversational-agent/conversations/exchanges.models.ts
+++ b/src/models/conversational-agent/conversations/exchanges.models.ts
@@ -55,6 +55,8 @@ export interface ExchangeServiceModel {
    *
    * @example With explicit page size and exchange/message sort orders
    * ```typescript
+   * import { SortOrder } from '@uipath/uipath-typescript/conversational-agent';
+   *
    * const firstPage = await exchanges.getAll(conversationId, {
    *   pageSize: 10,
    *   exchangeSort: SortOrder.Descending,
@@ -154,6 +156,8 @@ export interface ConversationExchangeServiceModel {
    *
    * @example With explicit page size and exchange/message sort orders
    * ```typescript
+   * import { SortOrder } from '@uipath/uipath-typescript/conversational-agent';
+   *
    * const conversation = await conversationalAgent.conversations.getById(conversationId);
    *
    * // First page

--- a/src/models/conversational-agent/conversations/exchanges.models.ts
+++ b/src/models/conversational-agent/conversations/exchanges.models.ts
@@ -9,7 +9,7 @@ import type {
   FeedbackCreateResponse,
   ExchangeGetResponse
 } from './exchanges.types';
-import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '@/utils/pagination';
+import type { PaginatedResponse } from '@/utils/pagination';
 
 /**
  * Service for retrieving exchanges and managing feedback within a {@link ConversationServiceModel | Conversation}
@@ -32,18 +32,22 @@ import type { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } fr
  */
 export interface ExchangeServiceModel {
   /**
-   * Gets all exchanges for a conversation with optional filtering and pagination
+   * Gets exchanges for a conversation with optional filtering and pagination
+   *
+   * Returns a paginated response. When called without `pageSize`/`cursor`, the
+   * backend applies its default page size — inspect `hasNextPage`/`nextCursor`
+   * to navigate further pages.
    *
    * @param conversationId - The conversation ID to get exchanges for
    * @param options - Options for querying exchanges including optional pagination parameters
-   * @returns Promise resolving to either an array of exchanges {@link NonPaginatedResponse}<{@link ExchangeGetResponse}> or a {@link PaginatedResponse}<{@link ExchangeGetResponse}> when pagination options are used
+   * @returns Promise resolving to a {@link PaginatedResponse}<{@link ExchangeGetResponse}>
    * @example
    * ```typescript
-   * // Get all exchanges (non-paginated)
-   * const conversationExchanges = await exchanges.getAll(conversationId);
+   * // First page (backend default page size)
+   * const firstPageOfExchanges = await exchanges.getAll(conversationId);
    *
-   * // First page with pagination
-   * const firstPageOfExchanges = await exchanges.getAll(conversationId, { pageSize: 10 });
+   * // First page with explicit page size
+   * const pagedExchanges = await exchanges.getAll(conversationId, { pageSize: 10 });
    *
    * // Navigate using cursor
    * if (firstPageOfExchanges.hasNextPage) {
@@ -53,14 +57,10 @@ export interface ExchangeServiceModel {
    * }
    * ```
    */
-  getAll<T extends ExchangeGetAllOptions = ExchangeGetAllOptions>(
+  getAll(
     conversationId: string,
-    options?: T
-  ): Promise<
-    T extends HasPaginationOptions<T>
-      ? PaginatedResponse<ExchangeGetResponse>
-      : NonPaginatedResponse<ExchangeGetResponse>
-  >;
+    options?: ExchangeGetAllOptions
+  ): Promise<PaginatedResponse<ExchangeGetResponse>>;
 
   /**
    * Gets an exchange by ID with its messages
@@ -115,32 +115,42 @@ export interface ExchangeServiceModel {
  */
 export interface ConversationExchangeServiceModel {
   /**
-   * Gets all exchanges for this conversation with optional filtering and pagination
+   * Gets exchanges for this conversation with pagination and optional sort parameters
+   *
+   * Returns a paginated response. When called without `pageSize`/`cursor`, the
+   * backend applies its default page size — inspect `hasNextPage`/`nextCursor`
+   * to navigate further pages.
    *
    * @param options - Options for querying exchanges including optional pagination parameters
-   * @returns Promise resolving to either an array of exchanges or a paginated response
+   * @returns Promise resolving to a {@link PaginatedResponse}<{@link ExchangeGetResponse}>
    *
-   * @example
+   * @example Basic usage - default page size and sort order
    * ```typescript
    * const conversation = await conversationalAgent.conversations.getById(conversationId);
    *
-   * // Get all exchanges
-   * const allExchanges = await conversation.exchanges.getAll();
-   *
-   * // With pagination
-   * const firstPage = await conversation.exchanges.getAll({ pageSize: 10 });
+   * // First page
+   * const firstPage = await conversation.exchanges.getAll();
+   * 
+   * // Navigate using cursor
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
+   * }
+   * ```
+   * 
+   * @example With explicit page size and exchange/message sort orders
+   * ```typescript
+   * const conversation = await conversationalAgent.conversations.getById(conversationId);
+   * 
+   * // First page
+   * const firstPage = await conversation.exchanges.getAll({ pageSize: 10, exchangeSort: SortOrder.Descending, messageSort: SortOrder.Ascending });
+   * 
+   * // Navigate using cursor
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
    * }
    * ```
    */
-  getAll<T extends ExchangeGetAllOptions = ExchangeGetAllOptions>(
-    options?: T
-  ): Promise<
-    T extends HasPaginationOptions<T>
-      ? PaginatedResponse<ExchangeGetResponse>
-      : NonPaginatedResponse<ExchangeGetResponse>
-  >;
+  getAll(options?: ExchangeGetAllOptions): Promise<PaginatedResponse<ExchangeGetResponse>>;
 
   /**
    * Gets an exchange by ID with its messages

--- a/src/models/conversational-agent/conversations/types/core.types.ts
+++ b/src/models/conversational-agent/conversations/types/core.types.ts
@@ -306,11 +306,12 @@ export interface Exchange {
 
 /**
  * Optional configuration options for when the service automatically starts agent job(s) to serve the conversation.
- * When not provided, service uses default configuration with RunAsMe set to false.
+ * When not provided, service uses recommended default configurations.
  */
 export interface ConversationJobStartOverrides {
   /**
-   * Whether the job(s) should run with the user's identity (RunAsMe). Defaults to false when not provided.
+   * Whether the job(s) should run with the user's identity (RunAsMe). When not provided, service 
+   * uses recommended default based on authentication-state and process-runtime.
    */
   runAsMe?: boolean;
 }

--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -36,30 +36,11 @@ export interface ContentPartInterrupted {}
  */
 export interface SessionCapabilities {
   /**
-   * Indicates the sender may produce a cross exchange input stream events if the receiver indicates they can be handled.
+   * Indicates that a client is prepared to handle events for exchanges initiated by service-role messages.
+   * When set to true, the client will receive events for the service-role message and any assistant-role messages 
+   * sent in response to it within the exchange.
    */
-  asyncInputStreamEmitter?: boolean;
-  /**
-   * Indicates the sender can handle cross exchange input stream events.
-   */
-  asyncInputStreamHandler?: boolean;
-  /**
-   * Indicates the sender may produce cross exchange tool calls if the receiver indicates they can be handled.
-   */
-  asyncToolCallEmitter?: boolean;
-  /**
-   * Indicates the sender can handle cross exchange tool calls.
-   */
-  asyncToolCallHandler?: boolean;
-  /**
-   * Indicates the mime types which the sender can send in input streams and as message content, provided the receiver
-   * indicates they can handle the mime type.
-   */
-  mimeTypesEmitted?: string[];
-  /**
-   * Indicates the mime types the sender can handle. Wildcards such as "*\/*" and "text/*" are allowed.
-   */
-  mimeTypesHandled?: string[];
+  serviceMessageClient?: boolean;
   /** Allow custom properties */
   [key: string]: unknown;
 }

--- a/src/services/conversational-agent/conversations/conversations.ts
+++ b/src/services/conversational-agent/conversations/conversations.ts
@@ -35,7 +35,7 @@ import { ConversationGetAllFilterMap, ConversationMap, createConversationWithMet
 // Utils
 import { CONVERSATIONAL_PAGINATION, CONVERSATIONAL_TOKEN_PARAMS } from '@/utils/constants/common';
 import { CONVERSATION_ENDPOINTS, ATTACHMENT_ENDPOINTS } from '@/utils/constants/endpoints';
-import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '@/utils/pagination';
+import { PaginatedResponse } from '@/utils/pagination';
 import { PaginationHelpers } from '@/utils/pagination/helpers';
 import { PaginationType } from '@/utils/pagination/internal-types';
 import { transformData, transformRequest, arrayDictionaryToRecord } from '@/utils/transform';
@@ -147,25 +147,33 @@ export class ConversationService extends BaseService implements ConversationServ
   }
 
   /**
-   * Gets all conversations with optional filtering and pagination
+   * Gets conversations with pagination and optional sort/filter parameters
    *
-   * The method returns either:
-   * - A NonPaginatedResponse with items array (when no pagination parameters are provided)
-   * - A PaginatedResponse with navigation cursors (when any pagination parameter is provided)
+   * Returns a paginated response. When called without `pageSize`/`cursor`, a 
+   * default page size is applied - inspect `hasNextPage`/`nextCursor`
+   * to navigate further pages.
    *
-   * @param options - Options for querying conversations including optional pagination parameters
-   * @returns Promise resolving to either an array of conversations {@link NonPaginatedResponse}<{@link ConversationGetResponse}> or a {@link PaginatedResponse}<{@link ConversationGetResponse}> when pagination options are used
+   * @param options - Options for querying conversations
+   * @returns Promise resolving to a {@link PaginatedResponse}<{@link ConversationGetResponse}>
    *
-   * @example Basic usage - get all conversations
+   * @example Basic usage - default sort, pagination, and without filtering
    * ```typescript
-   * const allConversations = await conversationalAgent.conversations.getAll();
+   * // First page
+   * const firstPage = await conversationalAgent.conversations.getAll();
    *
-   * for (const conversation of allConversations.items) {
+   * for (const conversation of firstPage.items) {
    *   console.log(`${conversation.label} - created: ${conversation.createdTime}`);
+   * }
+   *
+   * // Navigate using cursor
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await conversationalAgent.conversations.getAll({
+   *     cursor: firstPage.nextCursor
+   *   });
    * }
    * ```
    *
-   * @example With pagination
+   * @example With explicit page size
    * ```typescript
    * // First page
    * const firstPage = await conversationalAgent.conversations.getAll({ pageSize: 10 });
@@ -178,11 +186,10 @@ export class ConversationService extends BaseService implements ConversationServ
    * }
    * ```
    *
-   * @example Sorted with limit
+   * @example Explicit sort order by the last activity timestamp
    * ```typescript
    * const result = await conversationalAgent.conversations.getAll({
-   *   sort: SortOrder.Descending,
-   *   pageSize: 20
+   *   sort: SortOrder.Descending
    * });
    * ```
    *
@@ -195,29 +202,28 @@ export class ConversationService extends BaseService implements ConversationServ
    * ```
    */
   @track('ConversationalAgent.Conversations.GetAll')
-  async getAll<T extends ConversationGetAllOptions = ConversationGetAllOptions>(
-    options?: T
-  ): Promise<
-    T extends HasPaginationOptions<T>
-      ? PaginatedResponse<ConversationGetResponse>
-      : NonPaginatedResponse<ConversationGetResponse>
-  > {
-    // Transform function to convert API timestamps to SDK naming convention and add methods
+  async getAll(options?: ConversationGetAllOptions): Promise<PaginatedResponse<ConversationGetResponse>> {
     const transformFn = (conversation: RawConversationGetResponse) => {
       const transformedData = transformData(conversation, ConversationMap) as RawConversationGetResponse;
       return createConversationWithMethods(transformedData, this, this, this._exchangeService);
     };
 
+    const { pageSize, cursor, jumpToPage, ...filterOptions } = options ?? {};
     // Translate SDK filter names (agentKey/agentId/label) to backend names before forwarding
-    const apiOptions = options
-      ? transformRequest(options, ConversationGetAllFilterMap)
-      : undefined;
+    const additionalParams = transformRequest(filterOptions, ConversationGetAllFilterMap);
+    const paginationParams = cursor
+      ? { cursor, pageSize }
+      : jumpToPage
+        ? { jumpToPage, pageSize }
+        : { pageSize };
 
-    return PaginationHelpers.getAll({
+    return PaginationHelpers.getAllPaginated<RawConversationGetResponse, ConversationGetResponse>({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => CONVERSATION_ENDPOINTS.LIST,
+      paginationParams,
+      additionalParams,
       transformFn,
-      pagination: {
+      options: {
         paginationType: PaginationType.TOKEN,
         itemsField: CONVERSATIONAL_PAGINATION.ITEMS_FIELD,
         continuationTokenField: CONVERSATIONAL_PAGINATION.CONTINUATION_TOKEN_FIELD,
@@ -225,9 +231,8 @@ export class ConversationService extends BaseService implements ConversationServ
           pageSizeParam: CONVERSATIONAL_TOKEN_PARAMS.PAGE_SIZE_PARAM,
           tokenParam: CONVERSATIONAL_TOKEN_PARAMS.TOKEN_PARAM
         }
-      },
-      excludeFromPrefix: Object.keys(apiOptions || {}) // Conversational params are not OData
-    }, apiOptions as T | undefined) as any;
+      }
+    });
   }
 
   /**

--- a/src/services/conversational-agent/conversations/conversations.ts
+++ b/src/services/conversational-agent/conversations/conversations.ts
@@ -175,6 +175,8 @@ export class ConversationService extends BaseService implements ConversationServ
    *
    * @example With explicit page size and sort order (by last-activity timestamp)
    * ```typescript
+   * import { SortOrder } from '@uipath/uipath-typescript/conversational-agent';
+   *
    * // First page
    * const firstPage = await conversationalAgent.conversations.getAll({
    *   pageSize: 10,
@@ -218,11 +220,7 @@ export class ConversationService extends BaseService implements ConversationServ
     const { pageSize, cursor, jumpToPage, ...filterOptions } = options ?? {};
     // Translate SDK filter names (agentKey/agentId/label) to backend names before forwarding
     const additionalParams = transformRequest(filterOptions, ConversationGetAllFilterMap);
-    const paginationParams = cursor
-      ? { cursor, pageSize }
-      : jumpToPage
-        ? { jumpToPage, pageSize }
-        : { pageSize };
+    const paginationParams = cursor ? { cursor, pageSize } : jumpToPage ? { jumpToPage, pageSize } : { pageSize };
 
     return PaginationHelpers.getAllPaginated<RawConversationGetResponse, ConversationGetResponse>({
       serviceAccess: this.createPaginationServiceAccess(),

--- a/src/services/conversational-agent/conversations/conversations.ts
+++ b/src/services/conversational-agent/conversations/conversations.ts
@@ -149,7 +149,7 @@ export class ConversationService extends BaseService implements ConversationServ
   /**
    * Gets conversations with pagination and optional sort/filter parameters
    *
-   * Returns a paginated response. When called without `pageSize`/`cursor`, a 
+   * Returns a paginated response. When called without `pageSize`/`cursor`, a
    * default page size is applied - inspect `hasNextPage`/`nextCursor`
    * to navigate further pages.
    *
@@ -173,32 +173,39 @@ export class ConversationService extends BaseService implements ConversationServ
    * }
    * ```
    *
-   * @example With explicit page size
+   * @example With explicit page size and sort order (by last-activity timestamp)
    * ```typescript
    * // First page
-   * const firstPage = await conversationalAgent.conversations.getAll({ pageSize: 10 });
+   * const firstPage = await conversationalAgent.conversations.getAll({
+   *   pageSize: 10,
+   *   sort: SortOrder.Descending
+   * });
    *
-   * // Navigate using cursor
+   * // Navigate using cursor and same parameters
    * if (firstPage.hasNextPage) {
    *   const nextPage = await conversationalAgent.conversations.getAll({
+   *     pageSize: 10,
+   *     sort: SortOrder.Descending,
    *     cursor: firstPage.nextCursor
    *   });
    * }
    * ```
    *
-   * @example Explicit sort order by the last activity timestamp
+   * @example With agent-filter and label-search
    * ```typescript
-   * const result = await conversationalAgent.conversations.getAll({
-   *   sort: SortOrder.Descending
-   * });
-   * ```
-   *
-   * @example Filter by agent and search by label
-   * ```typescript
-   * const filtered = await conversationalAgent.conversations.getAll({
+   * const firstPage = await conversationalAgent.conversations.getAll({
    *   agentId: <agentId>,
    *   label: 'budget'
    * });
+   *
+   * // Navigate using cursor and same parameters
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await conversationalAgent.conversations.getAll({
+   *     agentId: <agentId>,
+   *     label: 'budget',
+   *     cursor: firstPage.nextCursor
+   *   });
+   * }
    * ```
    */
   @track('ConversationalAgent.Conversations.GetAll')

--- a/src/services/conversational-agent/conversations/conversations.ts
+++ b/src/services/conversational-agent/conversations/conversations.ts
@@ -270,10 +270,10 @@ export class ConversationService extends BaseService implements ConversationServ
    */
   @track('ConversationalAgent.Conversations.DeleteById')
   async deleteById(id: string): Promise<ConversationDeleteResponse> {
-    const response = await this.delete<ConversationDeleteResponse>(
+    const response = await this.delete<RawConversationGetResponse>(
       CONVERSATION_ENDPOINTS.DELETE(id)
     );
-    return response.data;
+    return transformData(response.data, ConversationMap) as ConversationDeleteResponse;
   }
 
   // ==================== Attachments ====================

--- a/src/services/conversational-agent/conversations/exchanges.ts
+++ b/src/services/conversational-agent/conversations/exchanges.ts
@@ -71,38 +71,43 @@ export class ExchangeService extends BaseService implements ExchangeServiceModel
   }
 
   /**
-   * Gets exchanges for this conversation with pagination and optional sort parameters
+   * Gets exchanges for a conversation with pagination and optional sort parameters
    *
    * Returns a paginated response. When called without `pageSize`/`cursor`, the
    * backend applies its default page size — inspect `hasNextPage`/`nextCursor`
    * to navigate further pages.
    *
+   * @param conversationId - The conversation ID to get exchanges for
    * @param options - Options for querying exchanges including optional pagination parameters
    * @returns Promise resolving to a {@link PaginatedResponse}<{@link ExchangeGetResponse}>
    *
    * @example Basic usage - default page size and sort order
    * ```typescript
-   * const conversation = await conversationalAgent.conversations.getById(conversationId);
-   *
    * // First page
-   * const firstPage = await conversation.exchanges.getAll();
-   * 
+   * const firstPage = await exchanges.getAll(conversationId);
+   *
    * // Navigate using cursor
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
+   *   const nextPage = await exchanges.getAll(conversationId, { cursor: firstPage.nextCursor });
    * }
    * ```
-   * 
+   *
    * @example With explicit page size and exchange/message sort orders
    * ```typescript
-   * const conversation = await conversationalAgent.conversations.getById(conversationId);
-   * 
-   * // First page
-   * const firstPage = await conversation.exchanges.getAll({ pageSize: 10, exchangeSort: SortOrder.Descending, messageSort: SortOrder.Ascending });
-   * 
-   * // Navigate using cursor
+   * const firstPage = await exchanges.getAll(conversationId, {
+   *   pageSize: 10,
+   *   exchangeSort: SortOrder.Descending,
+   *   messageSort: SortOrder.Ascending
+   * });
+   *
+   * // Navigate using cursor and same parameters
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
+   *   const nextPage = await exchanges.getAll(conversationId, {
+   *     pageSize: 10,
+   *     exchangeSort: SortOrder.Descending,
+   *     messageSort: SortOrder.Ascending,
+   *     cursor: firstPage.nextCursor
+   *   });
    * }
    * ```
    */

--- a/src/services/conversational-agent/conversations/exchanges.ts
+++ b/src/services/conversational-agent/conversations/exchanges.ts
@@ -94,6 +94,8 @@ export class ExchangeService extends BaseService implements ExchangeServiceModel
    *
    * @example With explicit page size and exchange/message sort orders
    * ```typescript
+   * import { SortOrder } from '@uipath/uipath-typescript/conversational-agent';
+   *
    * const firstPage = await exchanges.getAll(conversationId, {
    *   pageSize: 10,
    *   exchangeSort: SortOrder.Descending,
@@ -117,11 +119,7 @@ export class ExchangeService extends BaseService implements ExchangeServiceModel
     options?: ExchangeGetAllOptions
   ): Promise<PaginatedResponse<ExchangeGetResponse>> {
     const { pageSize, cursor, jumpToPage, ...additionalParams } = options ?? {};
-    const paginationParams = cursor
-      ? { cursor, pageSize }
-      : jumpToPage
-        ? { jumpToPage, pageSize }
-        : { pageSize };
+    const paginationParams = cursor ? { cursor, pageSize } : jumpToPage ? { jumpToPage, pageSize } : { pageSize };
 
     return PaginationHelpers.getAllPaginated<Exchange, ExchangeGetResponse>({
       serviceAccess: this.createPaginationServiceAccess(),

--- a/src/services/conversational-agent/conversations/exchanges.ts
+++ b/src/services/conversational-agent/conversations/exchanges.ts
@@ -89,7 +89,7 @@ export class ExchangeService extends BaseService implements ExchangeServiceModel
    * 
    * // Navigate using cursor
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
    * }
    * ```
    * 
@@ -102,7 +102,7 @@ export class ExchangeService extends BaseService implements ExchangeServiceModel
    * 
    * // Navigate using cursor
    * if (firstPage.hasNextPage) {
-   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: firstPage.nextCursor });
    * }
    * ```
    */

--- a/src/services/conversational-agent/conversations/exchanges.ts
+++ b/src/services/conversational-agent/conversations/exchanges.ts
@@ -26,7 +26,7 @@ import type {
 // Utils
 import { CONVERSATIONAL_PAGINATION, CONVERSATIONAL_TOKEN_PARAMS } from '@/utils/constants/common';
 import { EXCHANGE_ENDPOINTS } from '@/utils/constants/endpoints';
-import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '@/utils/pagination';
+import { PaginatedResponse } from '@/utils/pagination';
 import { PaginationHelpers } from '@/utils/pagination/helpers';
 import { PaginationType } from '@/utils/pagination/internal-types';
 
@@ -71,46 +71,60 @@ export class ExchangeService extends BaseService implements ExchangeServiceModel
   }
 
   /**
-   * Gets all exchanges for a conversation with optional filtering and pagination
+   * Gets exchanges for this conversation with pagination and optional sort parameters
    *
-   * The method returns either:
-   * - A NonPaginatedResponse with items array (when no pagination parameters are provided)
-   * - A PaginatedResponse with navigation cursors (when any pagination parameter is provided)
+   * Returns a paginated response. When called without `pageSize`/`cursor`, the
+   * backend applies its default page size — inspect `hasNextPage`/`nextCursor`
+   * to navigate further pages.
    *
-   * @param conversationId - The conversation ID to get exchanges for
    * @param options - Options for querying exchanges including optional pagination parameters
-   * @returns Promise resolving to either an array of exchanges {@link NonPaginatedResponse}<{@link ExchangeGetResponse}> or a {@link PaginatedResponse}<{@link ExchangeGetResponse}> when pagination options are used
+   * @returns Promise resolving to a {@link PaginatedResponse}<{@link ExchangeGetResponse}>
    *
-   * @example
+   * @example Basic usage - default page size and sort order
    * ```typescript
-   * // Get all exchanges (non-paginated)
-   * const conversationExchanges = await exchanges.getAll(conversationId);
+   * const conversation = await conversationalAgent.conversations.getById(conversationId);
    *
-   * // First page with pagination
-   * const firstPageOfExchanges = await exchanges.getAll(conversationId, { pageSize: 10 });
-   *
+   * // First page
+   * const firstPage = await conversation.exchanges.getAll();
+   * 
    * // Navigate using cursor
-   * if (firstPageOfExchanges.hasNextPage) {
-   *   const nextPageOfExchanges = await exchanges.getAll(conversationId, { cursor: firstPageOfExchanges.nextCursor });
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
+   * }
+   * ```
+   * 
+   * @example With explicit page size and exchange/message sort orders
+   * ```typescript
+   * const conversation = await conversationalAgent.conversations.getById(conversationId);
+   * 
+   * // First page
+   * const firstPage = await conversation.exchanges.getAll({ pageSize: 10, exchangeSort: SortOrder.Descending, messageSort: SortOrder.Ascending });
+   * 
+   * // Navigate using cursor
+   * if (firstPage.hasNextPage) {
+   *   const nextPage = await conversation.exchanges.getAll({ cursor: pagedExchanges.nextCursor });
    * }
    * ```
    */
   @track('ConversationalAgent.Exchanges.GetAll')
-  async getAll<T extends ExchangeGetAllOptions = ExchangeGetAllOptions>(
+  async getAll(
     conversationId: string,
-    options?: T
-  ): Promise<
-    T extends HasPaginationOptions<T>
-      ? PaginatedResponse<ExchangeGetResponse>
-      : NonPaginatedResponse<ExchangeGetResponse>
-  > {
-    const transformFn = transformExchange;
+    options?: ExchangeGetAllOptions
+  ): Promise<PaginatedResponse<ExchangeGetResponse>> {
+    const { pageSize, cursor, jumpToPage, ...additionalParams } = options ?? {};
+    const paginationParams = cursor
+      ? { cursor, pageSize }
+      : jumpToPage
+        ? { jumpToPage, pageSize }
+        : { pageSize };
 
-    return PaginationHelpers.getAll({
+    return PaginationHelpers.getAllPaginated<Exchange, ExchangeGetResponse>({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => EXCHANGE_ENDPOINTS.LIST(conversationId),
-      transformFn,
-      pagination: {
+      paginationParams,
+      additionalParams,
+      transformFn: transformExchange,
+      options: {
         paginationType: PaginationType.TOKEN,
         itemsField: CONVERSATIONAL_PAGINATION.ITEMS_FIELD,
         continuationTokenField: CONVERSATIONAL_PAGINATION.CONTINUATION_TOKEN_FIELD,
@@ -118,9 +132,8 @@ export class ExchangeService extends BaseService implements ExchangeServiceModel
           pageSizeParam: CONVERSATIONAL_TOKEN_PARAMS.PAGE_SIZE_PARAM,
           tokenParam: CONVERSATIONAL_TOKEN_PARAMS.TOKEN_PARAM
         }
-      },
-      excludeFromPrefix: Object.keys(options || {}) // Conversational params are not OData
-    }, options) as any;
+      }
+    });
   }
 
   /**

--- a/tests/unit/services/conversational-agent/conversations.test.ts
+++ b/tests/unit/services/conversational-agent/conversations.test.ts
@@ -472,6 +472,20 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
         CONVERSATION_ENDPOINTS.DELETE(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID),
         expect.any(Object)
       );
+
+      // Transformed SDK fields are present
+      expect(result.id).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID);
+      expect(result.createdTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CREATED_AT);
+      expect(result.updatedTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.UPDATED_AT);
+      expect(result.lastActivityTime).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.LAST_ACTIVITY_AT);
+      expect(result.agentId).toBe(CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_ID);
+
+      // Original API field names should not exist
+      expect((result as any).conversationId).toBeUndefined();
+      expect((result as any).createdAt).toBeUndefined();
+      expect((result as any).updatedAt).toBeUndefined();
+      expect((result as any).lastActivityAt).toBeUndefined();
+      expect((result as any).agentReleaseId).toBeUndefined();
     });
 
     it('should handle API errors', async () => {

--- a/tests/unit/services/conversational-agent/conversations.test.ts
+++ b/tests/unit/services/conversational-agent/conversations.test.ts
@@ -53,7 +53,7 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
     vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
 
     // Reset pagination helpers mock before each test
-    vi.mocked(PaginationHelpers.getAll).mockReset();
+    vi.mocked(PaginationHelpers.getAllPaginated).mockReset();
 
     conversationalAgent = new ConversationalAgentService(instance);
   });
@@ -274,21 +274,22 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
   });
 
   describe('getAll', () => {
-    it('should return all conversations without pagination options', async () => {
+    it('should return paginated conversations when called without options', async () => {
       const mockResponse = createMockTransformedConversationCollection();
 
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
 
       const result = await conversationalAgent.conversations.getAll();
 
-      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
         expect.objectContaining({
           serviceAccess: expect.any(Object),
           getEndpoint: expect.toSatisfy((fn: Function) => fn() === CONVERSATION_ENDPOINTS.LIST),
           transformFn: expect.any(Function),
-          pagination: expect.any(Object)
-        }),
-        undefined
+          paginationParams: { pageSize: undefined },
+          additionalParams: {},
+          options: expect.any(Object)
+        })
       );
 
       expect(result).toEqual(mockResponse);
@@ -301,14 +302,14 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
         nextCursor: TEST_CONSTANTS.NEXT_CURSOR,
       });
 
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
 
       const result = await conversationalAgent.conversations.getAll({ pageSize: TEST_CONSTANTS.PAGE_SIZE });
 
-      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
-        expect.any(Object),
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
         expect.objectContaining({
-          pageSize: TEST_CONSTANTS.PAGE_SIZE
+          paginationParams: { pageSize: TEST_CONSTANTS.PAGE_SIZE },
+          additionalParams: {}
         })
       );
 
@@ -317,24 +318,39 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
       expect(result.nextCursor).toBe(TEST_CONSTANTS.NEXT_CURSOR);
     });
 
+    it('should forward cursor in paginationParams', async () => {
+      const mockResponse = createMockTransformedConversationCollection();
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
+
+      const cursor = { value: TEST_CONSTANTS.NEXT_CURSOR };
+      await conversationalAgent.conversations.getAll({ cursor });
+
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paginationParams: { cursor, pageSize: undefined }
+        })
+      );
+    });
+
     it('should support sort option', async () => {
       const mockResponse = createMockTransformedConversationCollection();
 
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
 
       await conversationalAgent.conversations.getAll({ sort: 'descending' as any });
 
-      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
-        expect.any(Object),
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
         expect.objectContaining({
-          sort: 'descending'
+          additionalParams: expect.objectContaining({
+            sort: 'descending'
+          })
         })
       );
     });
 
     it('should translate agentKey/agentId/label filters to backend names before forwarding', async () => {
       const mockResponse = createMockTransformedConversationCollection();
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
 
       const options: ConversationGetAllOptions = {
         agentKey: CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_KEY,
@@ -343,23 +359,21 @@ describe('ConversationalAgent.conversations Unit Tests', () => {
       };
       await conversationalAgent.conversations.getAll(options);
 
-      const [ config, forwardedOptions ] = vi.mocked(PaginationHelpers.getAll).mock.calls[0];
+      const [ config ] = vi.mocked(PaginationHelpers.getAllPaginated).mock.calls[0];
       // SDK-facing names are mapped to backend names before forwarding to PaginationHelpers.
-      expect(forwardedOptions).toEqual(expect.objectContaining({
+      expect(config.additionalParams).toEqual(expect.objectContaining({
         agentReleaseKey: CONVERSATIONAL_AGENT_TEST_CONSTANTS.AGENT_KEY,
         agentReleaseId: CONVERSATIONAL_AGENT_TEST_CONSTANTS.FILTER_AGENT_ID,
         search: CONVERSATIONAL_AGENT_TEST_CONSTANTS.LABEL_QUERY
       }));
-      expect(forwardedOptions).not.toHaveProperty('agentKey');
-      expect(forwardedOptions).not.toHaveProperty('agentId');
-      expect(forwardedOptions).not.toHaveProperty('label');
-      // Conversational params must be excluded from the OData $-prefix.
-      expect(config.excludeFromPrefix).toEqual(expect.arrayContaining([ 'agentReleaseKey', 'agentReleaseId', 'search' ]));
+      expect(config.additionalParams).not.toHaveProperty('agentKey');
+      expect(config.additionalParams).not.toHaveProperty('agentId');
+      expect(config.additionalParams).not.toHaveProperty('label');
     });
 
     it('should handle API errors', async () => {
       const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
-      vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockRejectedValue(error);
 
       await expect(conversationalAgent.conversations.getAll()).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });

--- a/tests/unit/services/conversational-agent/exchanges.test.ts
+++ b/tests/unit/services/conversational-agent/exchanges.test.ts
@@ -37,7 +37,7 @@ describe('ExchangeService Unit Tests', () => {
     vi.mocked(ApiClient).mockImplementation(() => mockApiClient);
 
     // Reset pagination helpers mock before each test
-    vi.mocked(PaginationHelpers.getAll).mockReset();
+    vi.mocked(PaginationHelpers.getAllPaginated).mockReset();
 
     exchanges = new ExchangeService(instance);
   });
@@ -77,23 +77,24 @@ describe('ExchangeService Unit Tests', () => {
   });
 
   describe('getAll', () => {
-    it('should return all exchanges without pagination options', async () => {
+    it('should return paginated exchanges when called without options', async () => {
       const mockResponse = createMockTransformedExchangeCollection();
 
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
 
       const result = await exchanges.getAll(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID);
 
-      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
         expect.objectContaining({
           serviceAccess: expect.any(Object),
           getEndpoint: expect.toSatisfy((fn: Function) =>
             fn() === EXCHANGE_ENDPOINTS.LIST(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID)
           ),
           transformFn: expect.any(Function),
-          pagination: expect.any(Object)
-        }),
-        undefined
+          paginationParams: { pageSize: undefined },
+          additionalParams: {},
+          options: expect.any(Object)
+        })
       );
 
       expect(result).toEqual(mockResponse);
@@ -105,17 +106,17 @@ describe('ExchangeService Unit Tests', () => {
         nextCursor: TEST_CONSTANTS.NEXT_CURSOR,
       });
 
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
 
       const result = await exchanges.getAll(
         CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID,
         { pageSize: TEST_CONSTANTS.PAGE_SIZE }
       );
 
-      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
-        expect.any(Object),
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
         expect.objectContaining({
-          pageSize: TEST_CONSTANTS.PAGE_SIZE
+          paginationParams: { pageSize: TEST_CONSTANTS.PAGE_SIZE },
+          additionalParams: {}
         })
       );
 
@@ -124,28 +125,46 @@ describe('ExchangeService Unit Tests', () => {
       expect(result.nextCursor).toBe(TEST_CONSTANTS.NEXT_CURSOR);
     });
 
+    it('should forward cursor in paginationParams', async () => {
+      const mockResponse = createMockTransformedExchangeCollection();
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
+
+      const cursor = { value: TEST_CONSTANTS.NEXT_CURSOR };
+      await exchanges.getAll(
+        CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID,
+        { cursor }
+      );
+
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paginationParams: { cursor, pageSize: undefined }
+        })
+      );
+    });
+
     it('should support exchangeSort and messageSort options', async () => {
       const mockResponse = createMockTransformedExchangeCollection();
 
-      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockResolvedValue(mockResponse);
 
       await exchanges.getAll(
         CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID,
         { exchangeSort: 'descending' as any, messageSort: 'ascending' as any }
       );
 
-      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
-        expect.any(Object),
+      expect(PaginationHelpers.getAllPaginated).toHaveBeenCalledWith(
         expect.objectContaining({
-          exchangeSort: 'descending',
-          messageSort: 'ascending'
+          additionalParams: {
+            exchangeSort: 'descending',
+            messageSort: 'ascending'
+          }
         })
       );
     });
 
     it('should handle API errors', async () => {
       const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
-      vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
+      vi.mocked(PaginationHelpers.getAllPaginated).mockRejectedValue(error);
 
       await expect(
         exchanges.getAll(CONVERSATIONAL_AGENT_TEST_CONSTANTS.CONVERSATION_ID)

--- a/tests/utils/mocks/core.ts
+++ b/tests/utils/mocks/core.ts
@@ -29,6 +29,7 @@ export const mockTransformUtils = {
 export const mockPaginationHelpers = {
   PaginationHelpers: {
     getAll: vi.fn(),
+    getAllPaginated: vi.fn(),
     hasPaginationParameters: vi.fn((options = {}) => {
       const { cursor, pageSize, jumpToPage } = options;
       return cursor !== undefined || pageSize !== undefined || jumpToPage !== undefined;


### PR DESCRIPTION
Fixes two Conversational issues:

1. Exchange listing and Conversation listing from CAS API is always paginated, even when no page-size / cursor is passed-in. The backend defaults the page-size, see [CAS Swagger API](https://alpha.uipath.com/9568beba-50a8-49d1-801e-f2d1711089fd/77de6ae2-0968-4a9d-82a4-9ae4b67f4da3/autopilotforeveryone_/api/v1/ui). This PR changes return types and uses `getAllPaginated` directly within the SDK.

2. Conversations delete output was the raw response from Conversational Service:
e.g.
```
{"conversationId":"29deaf03-381c-4bf9-99aa-96b098d6678a","createdAt":"2026-06-03T04:17:52.072Z","updatedAt":"2026-06-03T04:17:52.072Z",
"lastActivityAt":"2026-06-03T04:17:52.063Z","label":"Test Label","autogenerateLabel":true,
"userId":"...","orgId":"...","tenantId":"...","folderId":712856,"folderKey":"...","agentReleaseId":115552,
"agentReleaseKey":"...","traceId":"...","spanId":"..."}
```
as opposed to ConversationDeleteResponse type (e.g. agentReleaseId should be mapped to agentId , createdAt should be mapped to createdTime, etc.
