### PR TITLE
feat(tasks): add createQuickForm for QuickForm HITL tasks[ACTN-11300]

### DIFF
--- a/src/models/action-center/tasks.internal-types.ts
+++ b/src/models/action-center/tasks.internal-types.ts
@@ -9,6 +9,7 @@ export const TASK_TYPE_ENDPOINTS: Record<TaskType, string> = {
   [TaskType.DocumentClassification]: TASK_ENDPOINTS.GET_GENERIC_TASK_BY_ID,
   [TaskType.External]: TASK_ENDPOINTS.GET_GENERIC_TASK_BY_ID,
   [TaskType.DataLabeling]: TASK_ENDPOINTS.GET_GENERIC_TASK_BY_ID,
+  [TaskType.QuickForm]: TASK_ENDPOINTS.GET_GENERIC_TASK_BY_ID,
 };
 
 export enum ActionCenterEventNames {

--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -1,6 +1,6 @@
-import type { 
+import type {
   RawTaskCreateResponse,
-  RawTaskGetResponse, 
+  RawTaskGetResponse,
   TaskAssignmentOptions,
   TaskAssignmentResponse,
   TaskCompletionOptions,
@@ -108,19 +108,40 @@ export interface TaskServiceModel {
   getById(id: number, options?: TaskGetByIdOptions, folderId?: number): Promise<TaskGetResponse>;
 
   /**
-   * Creates a new task
-   * 
-   * @param options - The task to be created
+   * Creates a new task. Pass `type: TaskType.QuickForm` (with `taskSchemaKey`
+   * and `schema`) for a schema-first HITL task rendered by FormLib in Action
+   * Center; otherwise the default `TaskType.External` shape is used.
+   *
+   * For QuickForm, both `taskSchemaKey` AND `schema` are sent on every call:
+   * Orchestrator upserts the schema in its TaskSchemas table keyed by
+   * `taskSchemaKey`, then creates the task in the same call.
+   *
+   * @param options - Task options. The `type` field discriminates the shape.
    * @param folderId - Required folder ID
    * @returns Promise resolving to the created task
    * {@link TaskCreateResponse}
    * @example
    * ```typescript
-   * import { TaskPriority } from '@uipath/uipath-typescript';
-   * const task = await tasks.create({
+   * import { TaskPriority, TaskType } from '@uipath/uipath-typescript';
+   *
+   * // External task (default)
+   * await tasks.create({
    *   title: "My Task",
    *   priority: TaskPriority.Medium
-   * }, <folderId>); // folderId is required
+   * }, <folderId>);
+   *
+   * // QuickForm task
+   * await tasks.create({
+   *   type: TaskType.QuickForm,
+   *   title: "Approve invoice",
+   *   taskSchemaKey: "8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91",
+   *   schema: {
+   *     id: "8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91",
+   *     fields: [{ id: "invoice", type: "text", label: "Invoice", direction: "input" }],
+   *     outcomes: [{ id: "approve", name: "Approve", type: "string", isPrimary: true }],
+   *   },
+   *   data: { invoice: "INV-1234" },
+   * }, <folderId>);
    * ```
    */
   create(options: TaskCreateOptions, folderId: number): Promise<TaskCreateResponse>;

--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -114,22 +114,42 @@ export interface TaskServiceModel {
   getById(id: number, options?: TaskGetByIdOptions, folderId?: number): Promise<TaskGetResponse>;
 
   /**
-   * Creates a new task
-   * 
-   * @param options - The task to be created
+   * Creates a new task. Pass `type: TaskType.QuickForm` (with `taskSchemaKey`
+   * and `schema`) for a schema-first HITL task rendered in Action Center;
+   * otherwise the default `TaskType.External` shape is used.
+   *
+   * For QuickForm, `schema` is registered under `taskSchemaKey` on first use and
+   * reused (not updated) on subsequent calls with the same key, then the task is
+   * created in the same call. Schema keys are unique per tenant.
+   *
+   * @param task - The task to create. Set `type` to select the task shape.
    * @param folderId - Required folder ID
-   * @returns Promise resolving to the created task
-   * {@link TaskCreateResponse}
+   * @returns Promise resolving to the created {@link TaskCreateResponse}.
    * @example
    * ```typescript
-   * import { TaskPriority } from '@uipath/uipath-typescript';
-   * const task = await tasks.create({
+   * import { TaskPriority, TaskType } from '@uipath/uipath-typescript';
+   *
+   * // External task (default)
+   * await tasks.create({
    *   title: "My Task",
    *   priority: TaskPriority.Medium
-   * }, <folderId>); // folderId is required
+   * }, <folderId>);
+   *
+   * // QuickForm task
+   * await tasks.create({
+   *   type: TaskType.QuickForm,
+   *   title: "Approve invoice",
+   *   taskSchemaKey: "8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91",
+   *   schema: {
+   *     id: "8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91",
+   *     fields: [{ id: "invoice", type: "text", label: "Invoice", direction: "input" }],
+   *     outcomes: [{ id: "approve", name: "Approve", type: "string", isPrimary: true }],
+   *   },
+   *   data: { invoice: "INV-1234" },
+   * }, <folderId>);
    * ```
    */
-  create(options: TaskCreateOptions, folderId: number): Promise<TaskCreateResponse>;
+  create(task: TaskCreateOptions, folderId: number): Promise<TaskCreateResponse>;
 
   /**
    * Assigns tasks to users

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -43,7 +43,9 @@ export enum TaskType {
   /** A document classification task for categorizing documents */
   DocumentClassification = 'DocumentClassificationTask',
   /** A data labeling task for annotating training data */
-  DataLabeling = 'DataLabelingTask'
+  DataLabeling = 'DataLabelingTask',
+  /** A schema-first HITL task rendered by FormLib in Action Center via a registered TaskSchema */
+  QuickForm = 'QuickFormTask'
 }
 
 export enum TaskPriority {
@@ -162,11 +164,49 @@ export interface TaskBaseResponse {
   lastModifiedTime: string | null;
 }
 
-export interface TaskCreateOptions {
+/**
+ * Options for creating an External task. `type` is the discriminator for the
+ * `TaskCreateOptions` union; omit it (or set it to `TaskType.External`) for
+ * the default external-task shape.
+ */
+export interface TaskCreateExternalOptions {
+  type?: TaskType.External;
   title: string;
   data?: Record<string, unknown>;
   priority?: TaskPriority;
 }
+
+/**
+ * Options for creating a QuickForm task — a schema-first HITL task rendered by
+ * FormLib in Action Center.
+ *
+ * Both `taskSchemaKey` and `schema` are sent on every call: Orchestrator upserts
+ * the schema by `taskSchemaKey`, then creates the task in the same call.
+ */
+export interface TaskCreateQuickFormOptions {
+  type: TaskType.QuickForm;
+  title: string;
+  /** UUID key under which Orchestrator registers/looks up the schema in TaskSchemas */
+  taskSchemaKey: string;
+  /** Inline schema body. Sent on every call so Orchestrator can upsert it */
+  schema: Record<string, unknown>;
+  data?: Record<string, unknown>;
+  priority?: TaskPriority;
+  /** Converted to wire-shape `tags` on submit */
+  labels?: string[];
+  isActionableMessageEnabled?: boolean;
+  /** When null on QuickForm, Orchestrator derives it from the referenced TaskSchema */
+  actionableMessageMetaData?: Record<string, unknown>;
+  /** Identifies the job that triggered the schema creation (paired with `schema`) */
+  creatorJobKey?: string;
+}
+
+/**
+ * Discriminated union over `type`. `tasks.create` accepts either shape — the
+ * `type` field on `TaskCreateQuickFormOptions` narrows it; omitting `type`
+ * defaults to the external-task shape.
+ */
+export type TaskCreateOptions = TaskCreateExternalOptions | TaskCreateQuickFormOptions;
 
 export interface RawTaskCreateResponse extends TaskBaseResponse {
   waitJobState: JobState | null;
@@ -243,6 +283,7 @@ export type TaskCompleteOptions =
   | { type: TaskType.DataLabeling; data?: any; action?: string }
   | { type: TaskType.Form; data: any; action: string }
   | { type: TaskType.App; data: any; action: string }
+  | { type: TaskType.QuickForm; data: any; action: string }
 
 /**
  * Options for completing a task when called from the service

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -43,7 +43,9 @@ export enum TaskType {
   /** A document classification task for categorizing documents */
   DocumentClassification = 'DocumentClassificationTask',
   /** A data labeling task for annotating training data */
-  DataLabeling = 'DataLabelingTask'
+  DataLabeling = 'DataLabelingTask',
+  /** A schema-first HITL task rendered in Action Center via a registered TaskSchema */
+  QuickForm = 'QuickFormTask'
 }
 
 export enum TaskPriority {
@@ -162,10 +164,44 @@ export interface TaskBaseResponse {
   lastModifiedTime: string | null;
 }
 
-export interface TaskCreateOptions {
+/**
+ * Fields common to every task-creation shape.
+ */
+export interface TaskCreateBaseOptions {
   title: string;
   data?: Record<string, unknown>;
   priority?: TaskPriority;
+  /**
+   * Free-form labels shown on the task. Supported for all task types.
+   */
+  labels?: string[];
+}
+
+/**
+ * Options for creating a task.
+ *
+ * `type` defaults to {@link TaskType.External} when omitted. For a schema-first
+ * HITL task, set `type: TaskType.QuickForm` and provide `taskSchemaKey` and
+ * `schema`: the schema is registered under `taskSchemaKey` on first use and
+ * reused (not updated) on later calls with the same key (keys are unique per
+ * tenant).
+ */
+export interface TaskCreateOptions extends TaskCreateBaseOptions {
+  /** Task type. Defaults to {@link TaskType.External} when omitted. */
+  type?: TaskType;
+  /**
+   * Schema key for a QuickForm task. Required when `type` is
+   * {@link TaskType.QuickForm}; ignored for other task types.
+   */
+  taskSchemaKey?: string;
+  /** Inline schema body for a QuickForm task, registered under `taskSchemaKey` on first use. */
+  schema?: Record<string, unknown>;
+  /** Enables actionable (e.g. Outlook) notifications for a QuickForm task. */
+  isActionableMessageEnabled?: boolean;
+  /** When omitted on a QuickForm task, the backend derives it from the referenced schema. */
+  actionableMessageMetaData?: Record<string, unknown>;
+  /** Identifies the job that triggered the schema creation (paired with `schema`). */
+  creatorJobKey?: string;
 }
 
 export interface RawTaskCreateResponse extends TaskBaseResponse {
@@ -272,6 +308,7 @@ export type TaskCompleteOptions =
   | { type: TaskType.DataLabeling; data?: any; action?: string }
   | { type: TaskType.Form; data: any; action: string }
   | { type: TaskType.App; data: any; action: string }
+  | { type: TaskType.QuickForm; data: any; action: string }
 
 /**
  * Options for completing a task when called from the service

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -37,35 +37,65 @@ import { BaseService } from '../base';
  */
 export class TaskService extends BaseService implements TaskServiceModel {
   /**
-   * Creates a new task
-   * @param task - The task to be created
+   * Creates a new task. Pass `type: TaskType.QuickForm` (with `taskSchemaKey`
+   * and `schema`) for a schema-first HITL task rendered by FormLib in Action
+   * Center; otherwise the default `TaskType.External` shape is used.
+   *
+   * @param options - Task options. The `type` field discriminates the shape.
    * @param folderId - Required folder ID
    * @returns Promise resolving to the created task
-   * 
+   *
    * @example
    * ```typescript
    * import { Tasks } from '@uipath/uipath-typescript/tasks';
+   * import { TaskPriority, TaskType } from '@uipath/uipath-typescript';
    *
    * const tasks = new Tasks(sdk);
-   * const task = await tasks.create({
+   *
+   * // External task (default)
+   * await tasks.create({
    *   title: "My Task",
    *   priority: TaskPriority.Medium,
    *   data: { key: "value" }
-   * }, 123); // folderId is required
+   * }, 123);
+   *
+   * // QuickForm task — both taskSchemaKey AND schema are sent on every call:
+   * // Orchestrator upserts the schema by taskSchemaKey, then creates the task.
+   * await tasks.create({
+   *   type: TaskType.QuickForm,
+   *   title: "Approve invoice INV-1234",
+   *   taskSchemaKey: "8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91",
+   *   schema: {
+   *     id: "8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91",
+   *     fields: [
+   *       { id: "invoice", type: "text", label: "Invoice", direction: "input" },
+   *     ],
+   *     outcomes: [
+   *       { id: "approve", name: "Approve", type: "string", isPrimary: true },
+   *     ],
+   *   },
+   *   data: { invoice: "INV-1234" },
+   * }, 123);
    * ```
    */
   @track('Tasks.Create')
-  async create(task: TaskCreateOptions, folderId: number): Promise<TaskCreateResponse> {
+  async create(options: TaskCreateOptions, folderId: number): Promise<TaskCreateResponse> {
     const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
-    const externalTask = {
-      ...task,
-      type: TaskType.External //currently only external task is supported
-    };
-    
+
+    let payload: Record<string, unknown>;
+    if (options.type === TaskType.QuickForm) {
+      const { labels, ...rest } = options;
+      payload = labels === undefined ? rest : {
+        ...rest,
+        tags: labels.map(label => ({ name: label, displayName: label, value: label, displayValue: label })),
+      };
+    } else {
+      payload = { ...options, type: TaskType.External };
+    }
+
     const response = await this.post<TaskCreateResponse>(
       TASK_ENDPOINTS.CREATE_GENERIC_TASK,
-      externalTask,
+      payload,
       { headers }
     );
     // Transform time fields for consistency

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -45,16 +45,21 @@ import { FolderScopedService } from '../folder-scoped';
 export class TaskService extends FolderScopedService implements TaskServiceModel {
   @track('Tasks.Create')
   async create(task: TaskCreateOptions, folderId: number): Promise<TaskCreateResponse> {
+    if (task.type === TaskType.QuickForm && !task.taskSchemaKey) {
+      throw new ValidationError({ message: 'taskSchemaKey is required when creating a QuickForm task.' });
+    }
+
     const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
-    const externalTask = {
-      ...task,
-      type: TaskType.External //currently only external task is supported
-    };
-    
+
+    const { labels, type, ...rest } = task;
+    const payload: Record<string, unknown> = { ...rest, type: type ?? TaskType.External };
+    if (labels?.length) {
+      payload.tags = labels.map((label): Tag => ({ name: label, displayName: label, displayValue: label }));
+    }
+
     const response = await this.post<TaskCreateResponse>(
       TASK_ENDPOINTS.CREATE_GENERIC_TASK,
-      externalTask,
+      payload,
       { headers }
     );
     // Transform time fields for consistency

--- a/tests/integration/shared/action-center/tasks.integration.test.ts
+++ b/tests/integration/shared/action-center/tasks.integration.test.ts
@@ -99,6 +99,46 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe('create (QuickForm)', () => {
+    it('should create a QuickForm task with inline schema', async () => {
+      const { tasks } = getServices();
+      const config = getTestConfig();
+
+      // Use a fresh schema key per run so we don't collide with prior tests.
+      const taskSchemaKey = crypto.randomUUID();
+      const quickFormTitle = generateTestResourceName(`QuickForm_${mode}`);
+
+      const schema = {
+        id: taskSchemaKey,
+        fields: [
+          { id: 'note', label: 'Reviewer Note', type: 'text', direction: 'input' },
+        ],
+        outcomes: [
+          { id: 'approve', name: 'Approve', type: 'string', isPrimary: true },
+          { id: 'reject', name: 'Reject', type: 'string', isPrimary: false },
+        ],
+      };
+
+      const folderId = config.folderId ? Number(config.folderId) : undefined;
+
+      const result = await tasks.create({
+        type: TaskType.QuickForm,
+        title: quickFormTitle,
+        taskSchemaKey,
+        schema,
+        data: { note: 'Sample input for QuickForm integration test' },
+        priority: TaskPriority.Medium,
+      }, folderId!);
+
+      expect(result).toBeDefined();
+      expect(result.title).toBe(quickFormTitle);
+      expect(result.id).toBeDefined();
+      expect(typeof result.id).toBe('number');
+
+      registerResource('tasks', { id: result.id, folderId });
+    });
+  });
+
   describe('getById', () => {
     it('should retrieve the created task by ID', async () => {
       if (!createdTaskId) {
@@ -345,4 +385,4 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
       await cleanupTestTask(createdTaskId);
     }
   });
-}, 120000);
+});

--- a/tests/integration/shared/action-center/tasks.integration.test.ts
+++ b/tests/integration/shared/action-center/tasks.integration.test.ts
@@ -99,6 +99,49 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
     });
   });
 
+  describe('create (QuickForm)', () => {
+    it('should create a QuickForm task with inline schema', async () => {
+      const { tasks } = getServices();
+      const config = getTestConfig();
+
+      // Use a fresh schema key per run so we don't collide with prior tests.
+      const taskSchemaKey = crypto.randomUUID();
+      const quickFormTitle = generateTestResourceName(`QuickForm_${mode}`);
+
+      const schema = {
+        id: taskSchemaKey,
+        fields: [
+          { id: 'note', label: 'Reviewer Note', type: 'text', direction: 'input' },
+        ],
+        outcomes: [
+          { id: 'approve', name: 'Approve', type: 'string', isPrimary: true },
+          { id: 'reject', name: 'Reject', type: 'string', isPrimary: false },
+        ],
+      };
+
+      if (!config.folderId) {
+        throw new Error('QuickForm integration test requires folderId — set FOLDER_ID in the test environment');
+      }
+      const folderId = Number(config.folderId);
+
+      const result = await tasks.create({
+        type: TaskType.QuickForm,
+        title: quickFormTitle,
+        taskSchemaKey,
+        schema,
+        data: { note: 'Sample input for QuickForm integration test' },
+        priority: TaskPriority.Medium,
+      }, folderId);
+
+      expect(result).toBeDefined();
+      expect(result.title).toBe(quickFormTitle);
+      expect(result.id).toBeDefined();
+      expect(typeof result.id).toBe('number');
+
+      registerResource('tasks', { id: result.id, folderId });
+    });
+  });
+
   describe('getById', () => {
     it('should retrieve the created task by ID', async () => {
       if (!createdTaskId) {

--- a/tests/unit/services/action-center/tasks.test.ts
+++ b/tests/unit/services/action-center/tasks.test.ts
@@ -1,12 +1,13 @@
 // ===== IMPORTS =====
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TaskService } from '../../../../src/services/action-center/tasks';
-import { 
-  TaskType, 
-  TaskPriority, 
+import {
+  TaskType,
+  TaskPriority,
   TaskAssignmentOptions,
   TaskCompletionOptions,
   TaskCreateOptions,
+  TaskCreateQuickFormOptions,
   TaskGetAllOptions,
   TaskGetUsersOptions
 } from '../../../../src/models/action-center/tasks.types';
@@ -137,6 +138,102 @@ describe('TaskService Unit Tests', () => {
       mockApiClient.post.mockRejectedValue(error);
 
       await expect(taskService.create(taskInput, TEST_CONSTANTS.FOLDER_ID)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('create (QuickForm)', () => {
+    const QF_SCHEMA_KEY = '8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91';
+    const QF_SCHEMA: Record<string, unknown> = {
+      id: QF_SCHEMA_KEY,
+      fields: [
+        { id: 'invoice', type: 'text', label: 'Invoice', direction: 'input' },
+      ],
+      outcomes: [
+        { id: 'approve', name: 'Approve', type: 'string', isPrimary: true },
+      ],
+    };
+
+    const baseInput = (): TaskCreateQuickFormOptions => ({
+      type: TaskType.QuickForm,
+      title: TASK_TEST_CONSTANTS.TASK_TITLE,
+      taskSchemaKey: QF_SCHEMA_KEY,
+      schema: QF_SCHEMA,
+    });
+
+    const postBody = () => mockApiClient.post.mock.calls[0][1];
+
+    beforeEach(() => {
+      mockApiClient.post.mockResolvedValue(createMockTaskResponse({
+        title: TASK_TEST_CONSTANTS.TASK_TITLE,
+      }));
+    });
+
+    it('posts to the GenericTasks/CreateTask endpoint with type=QuickFormTask, schema, and taskSchemaKey', async () => {
+      await taskService.create(baseInput(), TEST_CONSTANTS.FOLDER_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        TASK_ENDPOINTS.CREATE_GENERIC_TASK,
+        expect.objectContaining({
+          type: TaskType.QuickForm,
+          taskSchemaKey: QF_SCHEMA_KEY,
+          schema: QF_SCHEMA,
+          title: TASK_TEST_CONSTANTS.TASK_TITLE,
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+          }),
+        })
+      );
+    });
+
+    it('passes optional fields through verbatim and converts labels into tags', async () => {
+      await taskService.create({
+        ...baseInput(),
+        data: { invoice: 'INV-1234' },
+        priority: TaskPriority.High,
+        labels: ['finance', 'agent-escalation'],
+        isActionableMessageEnabled: true,
+        actionableMessageMetaData: { fieldSet: {}, actionSet: {} },
+        creatorJobKey: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      }, TEST_CONSTANTS.FOLDER_ID);
+
+      const body = postBody();
+      expect(body.data).toEqual({ invoice: 'INV-1234' });
+      expect(body.priority).toBe(TaskPriority.High);
+      expect(body.isActionableMessageEnabled).toBe(true);
+      expect(body.actionableMessageMetaData).toEqual({ fieldSet: {}, actionSet: {} });
+      expect(body.creatorJobKey).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+      expect(body.tags).toEqual([
+        { name: 'finance', displayName: 'finance', value: 'finance', displayValue: 'finance' },
+        { name: 'agent-escalation', displayName: 'agent-escalation', value: 'agent-escalation', displayValue: 'agent-escalation' },
+      ]);
+      // labels is the SDK input field; tags is the wire field — labels should NOT leak through
+      expect('labels' in body).toBe(false);
+    });
+
+    it('omits optional fields from the payload when not provided', async () => {
+      await taskService.create(baseInput(), TEST_CONSTANTS.FOLDER_ID);
+
+      const body = postBody();
+      for (const omitted of [
+        'priority',
+        'tags',
+        'isActionableMessageEnabled',
+        'actionableMessageMetaData',
+        'creatorJobKey',
+        'labels',
+      ]) {
+        expect(omitted in body).toBe(false);
+      }
+    });
+
+    it('propagates API errors', async () => {
+      mockApiClient.post.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(
+        taskService.create(baseInput(), TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 

--- a/tests/unit/services/action-center/tasks.test.ts
+++ b/tests/unit/services/action-center/tasks.test.ts
@@ -130,6 +130,23 @@ describe('TaskService Unit Tests', () => {
       );
     });
 
+    it('converts labels into tags for external tasks (labels is a common field)', async () => {
+      mockApiClient.post.mockResolvedValue(createMockTaskResponse({ title: TASK_TEST_CONSTANTS.TASK_TITLE }));
+
+      await taskService.create({
+        title: TASK_TEST_CONSTANTS.TASK_TITLE,
+        labels: ['finance'],
+      } as TaskCreateOptions, TEST_CONSTANTS.FOLDER_ID);
+
+      const body = mockApiClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.type).toBe(TaskType.External);
+      expect(body.tags).toEqual([
+        { name: 'finance', displayName: 'finance', displayValue: 'finance' },
+      ]);
+      // `labels` is the SDK input field; only `tags` goes on the wire.
+      expect('labels' in body).toBe(false);
+    });
+
     it('should handle API errors', async () => {
       const taskInput = {
         title: TASK_TEST_CONSTANTS.TASK_TITLE,
@@ -140,6 +157,111 @@ describe('TaskService Unit Tests', () => {
       mockApiClient.post.mockRejectedValue(error);
 
       await expect(taskService.create(taskInput, TEST_CONSTANTS.FOLDER_ID)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('create (QuickForm)', () => {
+    const QF_SCHEMA_KEY = '8e4f2a91-3c7e-4d2b-9b5c-1a6f8d3e2c91';
+    const QF_SCHEMA: Record<string, unknown> = {
+      id: QF_SCHEMA_KEY,
+      fields: [
+        { id: 'invoice', type: 'text', label: 'Invoice', direction: 'input' },
+      ],
+      outcomes: [
+        { id: 'approve', name: 'Approve', type: 'string', isPrimary: true },
+      ],
+    };
+
+    const baseInput = (): TaskCreateOptions => ({
+      type: TaskType.QuickForm,
+      title: TASK_TEST_CONSTANTS.TASK_TITLE,
+      taskSchemaKey: QF_SCHEMA_KEY,
+      schema: QF_SCHEMA,
+    });
+
+    const postBody = (): Record<string, unknown> => mockApiClient.post.mock.calls[0][1] as Record<string, unknown>;
+
+    beforeEach(() => {
+      mockApiClient.post.mockResolvedValue(createMockTaskResponse({
+        title: TASK_TEST_CONSTANTS.TASK_TITLE,
+      }));
+    });
+
+    it('posts to the GenericTasks/CreateTask endpoint with type=QuickFormTask, schema, and taskSchemaKey', async () => {
+      await taskService.create(baseInput(), TEST_CONSTANTS.FOLDER_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        TASK_ENDPOINTS.CREATE_GENERIC_TASK,
+        expect.objectContaining({
+          type: TaskType.QuickForm,
+          taskSchemaKey: QF_SCHEMA_KEY,
+          schema: QF_SCHEMA,
+          title: TASK_TEST_CONSTANTS.TASK_TITLE,
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString(),
+          }),
+        })
+      );
+    });
+
+    it('passes optional fields through verbatim and converts labels into tags', async () => {
+      await taskService.create({
+        ...baseInput(),
+        data: { invoice: 'INV-1234' },
+        priority: TaskPriority.High,
+        labels: ['finance', 'agent-escalation'],
+        isActionableMessageEnabled: true,
+        actionableMessageMetaData: { fieldSet: {}, actionSet: {} },
+        creatorJobKey: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      }, TEST_CONSTANTS.FOLDER_ID);
+
+      const body = postBody();
+      expect(body.data).toEqual({ invoice: 'INV-1234' });
+      expect(body.priority).toBe(TaskPriority.High);
+      expect(body.isActionableMessageEnabled).toBe(true);
+      expect(body.actionableMessageMetaData).toEqual({ fieldSet: {}, actionSet: {} });
+      expect(body.creatorJobKey).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+      expect(body.tags).toEqual([
+        { name: 'finance', displayName: 'finance', displayValue: 'finance' },
+        { name: 'agent-escalation', displayName: 'agent-escalation', displayValue: 'agent-escalation' },
+      ]);
+      // labels is the SDK input field; tags is the wire field — labels should NOT leak through
+      expect('labels' in body).toBe(false);
+    });
+
+    it('omits optional fields from the payload when not provided', async () => {
+      await taskService.create(baseInput(), TEST_CONSTANTS.FOLDER_ID);
+
+      const body = postBody();
+      for (const omitted of [
+        'priority',
+        'tags',
+        'isActionableMessageEnabled',
+        'actionableMessageMetaData',
+        'creatorJobKey',
+        'labels',
+      ]) {
+        expect(omitted in body).toBe(false);
+      }
+    });
+
+    it('propagates API errors', async () => {
+      mockApiClient.post.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(
+        taskService.create(baseInput(), TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it('throws before calling the API when a QuickForm task has no taskSchemaKey', async () => {
+      const { taskSchemaKey: _omitted, ...withoutKey } = baseInput();
+
+      await expect(
+        taskService.create(withoutKey as TaskCreateOptions, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(/taskSchemaKey is required/);
+      expect(mockApiClient.post).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Adds QuickForm HITL task support to `tasks.create`. Existing callers keep working — `tasks.create({ title, data, priority }, folderId)` still posts a `TaskType.External` task.

`TaskCreateOptions` is a **single flat interface** (extends `TaskCreateBaseOptions`: title, data, priority, labels → converted to tags, common to every type). QuickForm fields — `type`, `taskSchemaKey`, `schema`, `isActionableMessageEnabled`, `actionableMessageMetaData`, `creatorJobKey` — are optional at the type level; **`taskSchemaKey` is required only for QuickForm**, enforced by a runtime `ValidationError` guard in `create()` (mirrors the backend's 400). For a QuickForm task pass `type: TaskType.QuickForm` with `taskSchemaKey` + inline `schema`. Both paths POST to `/orchestrator_/tasks/GenericTasks/CreateTask` and return a Task.

**Schema semantics:** the backend keys off the top-level `taskSchemaKey` (the `id` inside the schema body is ignored). On first use the `schema` is registered under `taskSchemaKey`; on later calls with the same key it is **reused, not updated** (keys are unique per tenant). The SDK sends `taskSchemaKey` + inline `schema` in a single call (the backend's create-on-first-use path).

**Errors** from the backend (e.g. invalid/oversized schema, assignment/folder failures) propagate unchanged as SDK errors.

Modeled as a flat interface rather than a discriminated union so callers can construct the options object before calling `create()` and consumers can extend the type; the QuickForm `taskSchemaKey` requirement is enforced at runtime.
