### PR TITLE
feat(data-fabric): add folder support to entity schema and attachment ops

### DIFF
--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -425,6 +425,7 @@ export interface EntityServiceModel {
    *
    * @param id - UUID of the entity
    * @param file - CSV file to import as a Blob or File or Uint8Array
+   * @param options - Optional {@link EntityImportRecordsByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to {@link EntityImportRecordsResponse} with record counts
    * @example
    * ```typescript
@@ -432,6 +433,9 @@ export interface EntityServiceModel {
    * const fileInput = document.getElementById('csv-input') as HTMLInputElement;
    * const result = await entities.importRecordsById(<id>, fileInput.files[0]);
    * console.log(`Inserted ${result.insertedRecords} of ${result.totalRecords} records`);
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.importRecordsById(<id>, fileInput.files[0], { folderKey: "<folderKey>" });
    * ```
    * @internal
    */
@@ -857,6 +861,7 @@ export interface EntityMethods {
    * Imports records from a CSV file into this entity
    *
    * @param file - CSV file to import as a Blob, File, or Uint8Array
+   * @param options - Optional {@link EntityImportRecordsByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to {@link EntityImportRecordsResponse} with record counts
    * @example
    * ```typescript
@@ -864,6 +869,9 @@ export interface EntityMethods {
    * const fileInput = document.getElementById('csv-input') as HTMLInputElement;
    * const result = await entity.importRecords(fileInput.files[0]);
    * console.log(`Inserted ${result.insertedRecords} of ${result.totalRecords} records`);
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entity.importRecords(fileInput.files[0], { folderKey: "<folderKey>" });
    * ```
    */
   importRecords(file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>;

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -14,6 +14,8 @@ import {
   EntityFileType,
   EntityUploadAttachmentOptions,
   EntityUploadAttachmentResponse,
+  EntityDownloadAttachmentOptions,
+  EntityDeleteAttachmentOptions,
   EntityDeleteAttachmentResponse,
   EntityInsertRecordsOptions,
   EntityUpdateRecordsOptions,
@@ -22,8 +24,12 @@ import {
   EntityInsertRecordOptions,
   EntityQueryRecordsOptions,
   EntityImportRecordsResponse,
+  EntityImportRecordsByIdOptions,
   EntityCreateOptions,
   EntityCreateFieldOptions,
+  EntityGetByIdOptions,
+  EntityDeleteByIdOptions,
+  EntityDeleteRecordByIdOptions,
   EntityUpdateByIdOptions,
 } from './entities.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination/types';
@@ -86,6 +92,7 @@ export interface EntityServiceModel {
    * Gets entity metadata by entity ID with attached operation methods
    *
    * @param id - UUID of the entity
+   * @param options - Optional {@link EntityGetByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to entity metadata with operation methods
    * {@link EntityGetResponse}
    * @example
@@ -97,6 +104,9 @@ export interface EntityServiceModel {
    *
    * // Get entity metadata with methods
    * const entity = await entities.getById("<entityId>");
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * const folderEntity = await entities.getById("<entityId>", { folderKey: "<folderKey>" });
    *
    * // Call operations directly on the entity
    * const records = await entity.getAllRecords();
@@ -117,7 +127,7 @@ export interface EntityServiceModel {
    * ]);
    * ```
    */
-  getById(id: string): Promise<EntityGetResponse>;
+  getById(id: string, options?: EntityGetByIdOptions): Promise<EntityGetResponse>;
 
   /**
    * Gets entity records by entity ID
@@ -341,6 +351,7 @@ export interface EntityServiceModel {
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to delete
+   * @param options - Optional {@link EntityDeleteRecordByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to void on success
    * @example
    * ```typescript
@@ -349,9 +360,12 @@ export interface EntityServiceModel {
    * const entities = new Entities(sdk);
    *
    * await entities.deleteRecordById("<entityId>", "<recordId>");
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * await entities.deleteRecordById("<entityId>", "<recordId>", { folderKey: "<folderKey>" });
    * ```
    */
-  deleteRecordById(entityId: string, recordId: string): Promise<void>;
+  deleteRecordById(entityId: string, recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void>;
 
   /**
    * Queries entity records with filters, sorting, aggregates, and SDK-managed pagination
@@ -421,7 +435,7 @@ export interface EntityServiceModel {
    * ```
    * @internal
    */
-  importRecordsById(id: string, file: EntityFileType): Promise<EntityImportRecordsResponse>;
+  importRecordsById(id: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>;
 
   /**
    * Downloads an attachment stored in a File-type field of an entity record.
@@ -429,6 +443,7 @@ export interface EntityServiceModel {
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
+   * @param options - Optional {@link EntityDownloadAttachmentOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to Blob containing the file content
    * @example
    * ```typescript
@@ -475,7 +490,7 @@ export interface EntityServiceModel {
    * fs.writeFileSync('attachment.pdf', buffer);
    * ```
    */
-  downloadAttachment(entityId: string, recordId: string, fieldName: string): Promise<Blob>;
+  downloadAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob>;
 
   /**
    * Uploads an attachment to a File-type field of an entity record.
@@ -486,7 +501,7 @@ export interface EntityServiceModel {
    * @param recordId - UUID of the record to upload the attachment to
    * @param fieldName - Name of the File-type field
    * @param file - File to upload (Blob, File, or Uint8Array)
-   * @param options - Optional {@link EntityUploadAttachmentOptions} (e.g. expansionLevel)
+   * @param options - Optional {@link EntityUploadAttachmentOptions} (e.g. `expansionLevel`, `folderKey` for folder-scoped entities)
    * @returns Promise resolving to {@link EntityUploadAttachmentResponse}
    * @example
    * ```typescript
@@ -507,6 +522,9 @@ export interface EntityServiceModel {
    * const file = fileInput.files[0];
    * const response = await entities.uploadAttachment(entityId, recordId, 'Documents', file);
    *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.uploadAttachment(entityId, recordId, 'Documents', file, { folderKey: "<folderKey>" });
+   *
    * // Node.js: Upload a file from disk
    * const fileBuffer = fs.readFileSync('document.pdf');
    * const blob = new Blob([fileBuffer], { type: 'application/pdf' });
@@ -521,6 +539,7 @@ export interface EntityServiceModel {
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
+   * @param options - Optional {@link EntityDeleteAttachmentOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to {@link EntityDeleteAttachmentResponse}
    * @example
    * ```typescript
@@ -544,7 +563,7 @@ export interface EntityServiceModel {
    * await entity.deleteAttachment(recordId, 'Documents');
    * ```
    */
-  deleteAttachment(entityId: string, recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse>;
+  deleteAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse>;
 
   /**
    * Creates a new Data Fabric entity with the given schema
@@ -580,14 +599,18 @@ export interface EntityServiceModel {
    * Deletes a Data Fabric entity and all its records
    *
    * @param id - UUID of the entity to delete
+   * @param options - Optional {@link EntityDeleteByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving when the entity is deleted
    * @example
    * ```typescript
    * await entities.deleteById(<id>);
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * await entities.deleteById(<id>, { folderKey: "<folderKey>" });
    * ```
    * @internal
    */
-  deleteById(id: string): Promise<void>;
+  deleteById(id: string, options?: EntityDeleteByIdOptions): Promise<void>;
 
   /**
    * Updates an existing Data Fabric entity — schema and/or metadata.
@@ -597,7 +620,6 @@ export interface EntityServiceModel {
    * only when the corresponding fields are provided.
    *
    * @param id - UUID of the entity to update
-   * @param name - name of the entity (required by the API)
    * @param options - Changes to apply ({@link EntityUpdateByIdOptions})
    * @returns Promise resolving when the update is complete
    *
@@ -630,6 +652,12 @@ export interface EntityServiceModel {
    *   updateFields: [
    *     { id: <fieldId>, lengthLimit: 1000 },
    *   ],
+   * });
+   *
+   * // Folder-scoped entity: add a field to an entity that lives in a non-tenant folder
+   * await entities.updateById(<id>, {
+   *   folderKey: "<folderKey>",
+   *   addFields: [{ fieldName: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
    * });
    * ```
    * @internal
@@ -710,9 +738,10 @@ export interface EntityMethods {
    * Use this method if you need trigger events to fire for the deleted record.
    *
    * @param recordId - UUID of the record to delete
+   * @param options - Optional {@link EntityDeleteRecordByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to void on success
    */
-  deleteRecord(recordId: string): Promise<void>;
+  deleteRecord(recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void>;
 
   /**
    * Get all records from this entity
@@ -740,9 +769,10 @@ export interface EntityMethods {
    *
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
+   * @param options - Optional {@link EntityDownloadAttachmentOptions} (e.g. folderKey)
    * @returns Promise resolving to Blob containing the file content
    */
-  downloadAttachment(recordId: string, fieldName: string): Promise<Blob>;
+  downloadAttachment(recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob>;
 
   /**
    * Uploads an attachment to a File-type field of an entity record
@@ -750,7 +780,7 @@ export interface EntityMethods {
    * @param recordId - UUID of the record to upload the attachment to
    * @param fieldName - Name of the File-type field
    * @param file - File to upload (Blob, File, or Uint8Array)
-   * @param options - Optional {@link EntityUploadAttachmentOptions} (e.g. expansionLevel)
+   * @param options - Optional {@link EntityUploadAttachmentOptions} (e.g. expansionLevel, folderKey)
    * @returns Promise resolving to {@link EntityUploadAttachmentResponse}
    */
   uploadAttachment(recordId: string, fieldName: string, file: EntityFileType, options?: EntityUploadAttachmentOptions): Promise<EntityUploadAttachmentResponse>;
@@ -760,9 +790,10 @@ export interface EntityMethods {
    *
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
+   * @param options - Optional {@link EntityDeleteAttachmentOptions} (e.g. folderKey)
    * @returns Promise resolving to {@link EntityDeleteAttachmentResponse}
    */
-  deleteAttachment(recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse>;
+  deleteAttachment(recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse>;
 
   /**
    * @deprecated Use {@link insertRecord} instead.
@@ -835,7 +866,7 @@ export interface EntityMethods {
    * console.log(`Inserted ${result.insertedRecords} of ${result.totalRecords} records`);
    * ```
    */
-  importRecords(file: EntityFileType): Promise<EntityImportRecordsResponse>;
+  importRecords(file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>;
 
   /**
    * @deprecated Use {@link getAllRecords} instead.
@@ -850,15 +881,19 @@ export interface EntityMethods {
   /**
    * Deletes this entity and all its records
    *
+   * @param options - Optional {@link EntityDeleteByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving when the entity is deleted
    * @example
    * ```typescript
    * const entity = await entities.getById(<id>);
    * await entity.delete();
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entity.delete({ folderKey: "<folderKey>" });
    * ```
    * @internal
    */
-  delete(): Promise<void>;
+  delete(options?: EntityDeleteByIdOptions): Promise<void>;
 
   /**
    * Updates this entity — schema and/or metadata.
@@ -927,10 +962,10 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
       return service.deleteRecordsById(entityData.id, recordIds, options);
     },
 
-    async deleteRecord(recordId: string): Promise<void> {
+    async deleteRecord(recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
       if (!recordId) throw new Error('Record ID is undefined');
-      return service.deleteRecordById(entityData.id, recordId);
+      return service.deleteRecordById(entityData.id, recordId, options);
     },
 
     async getAllRecords<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(options?: T): Promise<
@@ -948,9 +983,9 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
       return service.getRecordById(entityData.id, recordId, options);
     },
 
-    async downloadAttachment(recordId: string, fieldName: string): Promise<Blob> {
+    async downloadAttachment(recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.downloadAttachment(entityData.id, recordId, fieldName);
+      return service.downloadAttachment(entityData.id, recordId, fieldName, options);
     },
 
     async uploadAttachment(recordId: string, fieldName: string, file: EntityFileType, options?: EntityUploadAttachmentOptions): Promise<EntityUploadAttachmentResponse> {
@@ -958,9 +993,9 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
       return service.uploadAttachment(entityData.id, recordId, fieldName, file, options);
     },
 
-    async deleteAttachment(recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse> {
+    async deleteAttachment(recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.deleteAttachment(entityData.id, recordId, fieldName);
+      return service.deleteAttachment(entityData.id, recordId, fieldName, options);
     },
 
     async queryRecords<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(options?: T): Promise<
@@ -972,9 +1007,9 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
       return service.queryRecordsById(entityData.id, options);
     },
 
-    async importRecords(file: EntityFileType): Promise<EntityImportRecordsResponse> {
+    async importRecords(file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.importRecordsById(entityData.id, file);
+      return service.importRecordsById(entityData.id, file, options);
     },
 
     async insert(data: Record<string, any>, options?: EntityInsertOptions): Promise<EntityInsertResponse> {
@@ -994,9 +1029,9 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
       return this.getAllRecords(options);
     },
 
-    async delete(): Promise<void> {
+    async delete(options?: EntityDeleteByIdOptions): Promise<void> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.deleteById(entityData.id);
+      return service.deleteById(entityData.id, options);
     },
 
     async update(options: EntityUpdateByIdOptions): Promise<void> {

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -45,7 +45,7 @@ export interface EntityRecord {
 export type EntityGetRecordsByIdOptions = {
   /** Level of entity expansion (default: 0) */
   expansionLevel?: number;
-} & PaginationOptions;
+} & PaginationOptions & EntityFolderScopedOptions;
 
 /**
  * Options for getting all records of an entity
@@ -55,7 +55,7 @@ export type EntityGetAllRecordsOptions = EntityGetRecordsByIdOptions;
 /**
  * Options for getting a single entity record by entity ID and record ID
  */
-export interface EntityGetRecordByIdOptions {
+export interface EntityGetRecordByIdOptions extends EntityFolderScopedOptions {
   /** Level of entity expansion (default: 0) */
   expansionLevel?: number;
 }
@@ -63,7 +63,7 @@ export interface EntityGetRecordByIdOptions {
 /**
  * Common options for entity operations that modify multiple records
  */
-export interface EntityOperationOptions {
+export interface EntityOperationOptions extends EntityFolderScopedOptions {
   /** Level of entity expansion (default: 0) */
   expansionLevel?: number;
   /** Whether to fail on first error (default: false) */
@@ -74,7 +74,7 @@ export interface EntityOperationOptions {
  * Options for inserting a single record into an entity
  * @deprecated Use {@link EntityInsertRecordOptions} instead for better clarity on inserting a single record into an entity. This type will be removed in future versions.
  */
-export interface EntityInsertOptions {
+export interface EntityInsertOptions extends EntityFolderScopedOptions {
   /** Level of entity expansion (default: 0) */
   expansionLevel?: number;
 }
@@ -115,7 +115,7 @@ export interface EntityUpdateRecordsOptions extends EntityOperationOptions {}
  * Options for deleting data from an entity
  * @deprecated Use {@link EntityDeleteRecordsOptions} instead for better clarity on deleting records from an entity. This type will be removed in future versions.
  */
-export interface EntityDeleteOptions {
+export interface EntityDeleteOptions extends EntityFolderScopedOptions {
   /** Whether to fail on first error (default: false) */
   failOnFirst?: boolean;
 }
@@ -124,6 +124,16 @@ export interface EntityDeleteOptions {
  * Options for deleting records in an entity
  */
 export interface EntityDeleteRecordsOptions extends EntityDeleteOptions {}
+
+/**
+ * Options for {@link EntityServiceModel.deleteRecordById}
+ */
+export interface EntityDeleteRecordByIdOptions extends EntityFolderScopedOptions {}
+
+/**
+ * Options for {@link EntityServiceModel.importRecordsById}
+ */
+export interface EntityImportRecordsByIdOptions extends EntityFolderScopedOptions {}
 
 
 /**
@@ -241,7 +251,7 @@ export type EntityQueryRecordsOptions = {
   aggregates?: EntityAggregate[];
   /** Field names to group aggregate results by. */
   groupBy?: string[];
-} & PaginationOptions;
+} & PaginationOptions & EntityFolderScopedOptions;
 
 /**
  * Response from querying entity records
@@ -304,15 +314,32 @@ export interface EntityCreateFieldOptions extends EntityFieldBase {
 
 
 /**
+ * Common shape for every folder-scoped Data Fabric entity operation.
+ * Forwarded on the wire as the `X-UIPATH-FolderKey` header.
+ */
+export interface EntityFolderScopedOptions {
+  /** Key identifying the folder the entity belongs to. Omit for tenant-level entities. */
+  folderKey?: string;
+}
+
+/**
+ * Options for {@link EntityServiceModel.getById}
+ */
+export interface EntityGetByIdOptions extends EntityFolderScopedOptions {}
+
+/**
+ * Options for {@link EntityServiceModel.deleteById}
+ */
+export interface EntityDeleteByIdOptions extends EntityFolderScopedOptions {}
+
+/**
  * Options for creating a new Data Fabric entity
  */
-export interface EntityCreateOptions {
+export interface EntityCreateOptions extends EntityFolderScopedOptions {
   /** Human-readable display name shown in the UI (defaults to `name` if omitted) */
   displayName?: string;
   /** Optional entity description */
   description?: string;
-  /** UUID of the folder to place the entity in (defaults to the tenant-level folder) */
-  folderKey?: string;
   /** Whether role-based access control is enabled for this entity (default: false) */
   isRbacEnabled?: boolean;
   /** Whether Analytics integration is enabled for this entity (default: false) */
@@ -344,7 +371,7 @@ export interface EntityRemoveFieldOptions {
  * (`displayName`, `description`, `isRbacEnabled`) can be combined; each is applied
  * only when the corresponding fields are provided.
  */
-export interface EntityUpdateByIdOptions {
+export interface EntityUpdateByIdOptions extends EntityFolderScopedOptions {
   /** New fields to add */
   addFields?: EntityCreateFieldOptions[];
   /** Fields to remove, each identified by field name */
@@ -379,10 +406,20 @@ export type EntityFileType = Blob | File | Uint8Array;
 /**
  * Optional options for uploading an attachment to an entity record
  */
-export interface EntityUploadAttachmentOptions {
+export interface EntityUploadAttachmentOptions extends EntityFolderScopedOptions {
   /** Optional expansion level (default: 0) */
   expansionLevel?: number;
 }
+
+/**
+ * Optional options for downloading an attachment from an entity record
+ */
+export interface EntityDownloadAttachmentOptions extends EntityFolderScopedOptions {}
+
+/**
+ * Optional options for deleting an attachment from an entity record
+ */
+export interface EntityDeleteAttachmentOptions extends EntityFolderScopedOptions {}
 
 /**
  * Response from uploading an attachment to an entity record

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -588,6 +588,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * @param id - UUID of the entity
    * @param file - CSV file to import (Blob, File, or Uint8Array)
+   * @param options - Optional {@link EntityImportRecordsByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to import result with record counts
    *
    * @example
@@ -608,6 +609,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * if (result.errorFileLink) {
    *   console.log(`Error file link: ${result.errorFileLink}`);
    * }
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.importRecordsById("<entityId>", fileInput.files[0], { folderKey: "<folderKey>" });
    * ```
    * @internal
    */

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -23,12 +23,18 @@ import {
   EntityFileType,
   EntityUploadAttachmentOptions,
   EntityUploadAttachmentResponse,
+  EntityDownloadAttachmentOptions,
+  EntityDeleteAttachmentOptions,
   EntityDeleteAttachmentResponse,
   EntityQueryRecordsOptions,
   EntityImportRecordsResponse,
+  EntityImportRecordsByIdOptions,
   EntityCreateOptions,
   EntityCreateFieldOptions,
   EntityFieldDataType,
+  EntityGetByIdOptions,
+  EntityDeleteByIdOptions,
+  EntityDeleteRecordByIdOptions,
   EntityUpdateByIdOptions,
   SqlType,
   FieldDisplayType,
@@ -39,7 +45,8 @@ import { PaginationType } from '../../utils/pagination/internal-types';
 import { PaginationHelpers } from '../../utils/pagination/helpers';
 import { ENTITY_PAGINATION, ENTITY_OFFSET_PARAMS, HTTP_METHODS } from '../../utils/constants/common';
 import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../utils/constants/endpoints/data-fabric';
-import { RESPONSE_TYPES } from '../../utils/constants/headers';
+import { FOLDER_KEY, RESPONSE_TYPES } from '../../utils/constants/headers';
+import { createHeaders } from '../../utils/http/headers';
 import { createParams } from '../../utils/http/params';
 import { transformData } from '../../utils/transform';
 import {
@@ -61,6 +68,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * Gets entity metadata by entity ID with attached operation methods
    *
    * @param id - UUID of the entity
+   * @param options - Optional {@link EntityGetByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to entity metadata with schema information and operation methods
    *
    * @example
@@ -69,6 +77,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * const entities = new Entities(sdk);
    * const entity = await entities.getById("<entityId>");
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * const folderEntity = await entities.getById("<entityId>", { folderKey: "<folderKey>" });
    *
    * // Call operations directly on the entity
    * const records = await entity.getAllRecords();
@@ -84,18 +95,19 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * ```
    */
   @track('Entities.GetById')
-  async getById(id: string): Promise<EntityGetResponse> {
+  async getById(id: string, options?: EntityGetByIdOptions): Promise<EntityGetResponse> {
     // Get entity metadata
     const response = await this.get<RawEntityGetResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(id)
+      DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(id),
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
     );
-    
+
     // Apply EntityMap transformations
     const metadata = transformData(response.data as RawEntityGetResponse, EntityMap)
-    
+
     // Transform metadata with field mappers
     this.applyFieldMappings(metadata);
-    
+
     // Return the entity metadata with methods attached
     return createEntityWithMethods(metadata, this);
   }
@@ -143,21 +155,26 @@ export class EntityService extends BaseService implements EntityServiceModel {
       ? PaginatedResponse<EntityRecord>
       : NonPaginatedResponse<EntityRecord>
   > {
+    // folderKey is header-only — destructure it out so PaginationHelpers doesn't serialise it
+    // into the query string as $folderKey.
+    const { folderKey, ...rest } = options ?? {} as T;
+    const downstreamOptions = options === undefined ? undefined : (rest as T);
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => DATA_FABRIC_ENDPOINTS.ENTITY.GET_ENTITY_RECORDS(entityId),
+      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
       pagination: {
         paginationType: PaginationType.OFFSET,
         itemsField: ENTITY_PAGINATION.ITEMS_FIELD,
         totalCountField: ENTITY_PAGINATION.TOTAL_COUNT_FIELD,
         paginationParams: {
-          pageSizeParam: ENTITY_OFFSET_PARAMS.PAGE_SIZE_PARAM,    
-          offsetParam: ENTITY_OFFSET_PARAMS.OFFSET_PARAM,         
-          countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM            
+          pageSizeParam: ENTITY_OFFSET_PARAMS.PAGE_SIZE_PARAM,
+          offsetParam: ENTITY_OFFSET_PARAMS.OFFSET_PARAM,
+          countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
         }
       },
       excludeFromPrefix: ['expansionLevel'] // Don't add ODATA prefix to expansionLevel
-    }, options);
+    }, downstreamOptions);
   }
 
   /**
@@ -191,7 +208,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
 
     const response = await this.get<EntityRecord>(
       DATA_FABRIC_ENDPOINTS.ENTITY.GET_RECORD_BY_ID(entityId, recordId),
-      { params }
+      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
     );
 
     return response.data;
@@ -231,7 +248,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
       data,
       {
         params,
-        ...options
+        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
       }
     );
 
@@ -280,7 +297,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
       data,
       {
         params,
-        ...options
+        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
       }
     );
 
@@ -322,7 +339,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
       data,
       {
         params,
-        ...options
+        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
       }
     );
 
@@ -372,7 +389,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
       data,
       {
         params,
-        ...options
+        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
       }
     );
 
@@ -412,7 +429,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
       recordIds,
       {
         params,
-        ...options
+        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
       }
     );
 
@@ -427,6 +444,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to delete
+   * @param options - Optional {@link EntityDeleteRecordByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to void on success
    * @example
    * ```typescript
@@ -435,12 +453,16 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * const entities = new Entities(sdk);
    *
    * await entities.deleteRecordById("<entityId>", "<recordId>");
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * await entities.deleteRecordById("<entityId>", "<recordId>", { folderKey: "<folderKey>" });
    * ```
    */
   @track('Entities.DeleteRecordById')
-  async deleteRecordById(entityId: string, recordId: string): Promise<void> {
+  async deleteRecordById(entityId: string, recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void> {
     await this.delete(
-      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId, recordId)
+      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId, recordId),
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
     );
   }
 
@@ -538,10 +560,15 @@ export class EntityService extends BaseService implements EntityServiceModel {
     id: string,
     options?: T
   ): Promise<T extends HasPaginationOptions<T> ? PaginatedResponse<EntityRecord> : NonPaginatedResponse<EntityRecord>> {
+    // folderKey is header-only — destructure it out so PaginationHelpers doesn't include
+    // it in the POST body alongside the query filters.
+    const { folderKey, ...rest } = options ?? {} as T;
+    const downstreamOptions = options === undefined ? undefined : (rest as T);
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_ID(id),
       method: HTTP_METHODS.POST,
+      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
       pagination: {
         paginationType: PaginationType.OFFSET,
         itemsField: ENTITY_PAGINATION.ITEMS_FIELD,
@@ -553,7 +580,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
         }
       },
       excludeFromPrefix: ['expansionLevel', 'filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy']
-    }, options);
+    }, downstreamOptions);
   }
 
   /**
@@ -585,7 +612,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * @internal
    */
   @track('Entities.ImportRecordsById')
-  async importRecordsById(id: string, file: EntityFileType): Promise<EntityImportRecordsResponse> {
+  async importRecordsById(id: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse> {
     const formData = new FormData();
     if (file instanceof Uint8Array) {
       formData.append('file', new Blob([file.buffer as ArrayBuffer]));
@@ -595,7 +622,8 @@ export class EntityService extends BaseService implements EntityServiceModel {
 
     const response = await this.post<EntityImportRecordsResponse>(
       DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_ID(id),
-      formData
+      formData,
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
     );
 
     return response.data;
@@ -607,6 +635,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
+   * @param options - Optional {@link EntityDownloadAttachmentOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to Blob containing the file content
    *
    * @example
@@ -625,14 +654,18 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * // Download attachment for a specific record and field
    * const blob = await entities.downloadAttachment(entityId, recordId, 'Documents');
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * const blob = await entities.downloadAttachment(entityId, recordId, 'Documents', { folderKey: "<folderKey>" });
    * ```
    */
   @track('Entities.DownloadAttachment')
-  async downloadAttachment(entityId: string, recordId: string, fieldName: string): Promise<Blob> {
+  async downloadAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob> {
     const response = await this.get<Blob>(
       DATA_FABRIC_ENDPOINTS.ENTITY.DOWNLOAD_ATTACHMENT(entityId, recordId, fieldName),
       {
-        responseType: RESPONSE_TYPES.BLOB
+        responseType: RESPONSE_TYPES.BLOB,
+        headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }),
       }
     );
 
@@ -646,7 +679,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * @param recordId - UUID of the record to upload the attachment to
    * @param fieldName - Name of the File-type field
    * @param file - File to upload (Blob, File, or Uint8Array)
-   * @param options - Optional {@link EntityUploadAttachmentOptions} (e.g. expansionLevel)
+   * @param options - Optional {@link EntityUploadAttachmentOptions} (e.g. `expansionLevel`, `folderKey` for folder-scoped entities)
    * @returns Promise resolving to {@link EntityUploadAttachmentResponse}
    *
    * @example
@@ -665,6 +698,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * // Upload a file attachment
    * const response = await entities.uploadAttachment(entityId, recordId, 'Documents', file);
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.uploadAttachment(entityId, recordId, 'Documents', file, { folderKey: "<folderKey>" });
    * ```
    */
   @track('Entities.UploadAttachment')
@@ -681,7 +717,10 @@ export class EntityService extends BaseService implements EntityServiceModel {
     const response = await this.post<EntityUploadAttachmentResponse>(
       DATA_FABRIC_ENDPOINTS.ENTITY.UPLOAD_ATTACHMENT(entityId, recordId, fieldName),
       formData,
-      { params }
+      {
+        params,
+        headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }),
+      }
     );
 
     return response.data;
@@ -693,6 +732,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
+   * @param options - Optional {@link EntityDeleteAttachmentOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving to {@link EntityDeleteAttachmentResponse}
    *
    * @example
@@ -711,12 +751,16 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *
    * // Delete attachment for a specific record and field
    * await entities.deleteAttachment(entityId, recordId, 'Documents');
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * await entities.deleteAttachment(entityId, recordId, 'Documents', { folderKey: "<folderKey>" });
    * ```
    */
   @track('Entities.DeleteAttachment')
-  async deleteAttachment(entityId: string, recordId: string, fieldName: string): Promise<EntityDeleteAttachmentResponse> {
+  async deleteAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse> {
     const response = await this.delete<EntityDeleteAttachmentResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_ATTACHMENT(entityId, recordId, fieldName)
+      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_ATTACHMENT(entityId, recordId, fieldName),
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
     );
 
     return response.data;
@@ -793,7 +837,11 @@ export class EntityService extends BaseService implements EntityServiceModel {
         externalFields: opts.externalFields ?? [],
       },
     };
-    const response = await this.post<string>(DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT, payload);
+    const response = await this.post<string>(
+      DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
+      payload,
+      { headers: createHeaders({ [FOLDER_KEY]: opts.folderKey }) },
+    );
     return response.data;
   }
 
@@ -801,17 +849,24 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * Deletes a Data Fabric entity and all its records
    *
    * @param id - UUID of the entity to delete
+   * @param options - Optional {@link EntityDeleteByIdOptions} (e.g. `folderKey` for folder-scoped entities)
    * @returns Promise resolving when the entity is deleted
    *
    * @example
    * ```typescript
    * await entities.deleteById("<entityId>");
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * await entities.deleteById("<entityId>", { folderKey: "<folderKey>" });
    * ```
    * @internal
    */
   @track('Entities.DeleteById')
-  async deleteById(id: string): Promise<void> {
-    await this.delete(DATA_FABRIC_ENDPOINTS.ENTITY.DELETE(id));
+  async deleteById(id: string, options?: EntityDeleteByIdOptions): Promise<void> {
+    await this.delete(
+      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE(id),
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
+    );
   }
 
   /**
@@ -859,6 +914,12 @@ export class EntityService extends BaseService implements EntityServiceModel {
    *     { id: "<fieldId>", lengthLimit: 1000 },
    *   ],
    * });
+   *
+   * // Folder-scoped entity: add a field to an entity that lives in a non-tenant folder
+   * await entities.updateById("<entityId>", {
+   *   folderKey: "<folderKey>",
+   *   addFields: [{ fieldName: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
+   * });
    * ```
    * @internal
    */
@@ -872,11 +933,15 @@ export class EntityService extends BaseService implements EntityServiceModel {
       await this.applySchemaUpdate(id, opts);
     }
     if (hasMetadataChanges) {
-      await this.patch(DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(id), {
-        ...(opts.displayName !== undefined && { displayName: opts.displayName }),
-        ...(opts.description !== undefined && { description: opts.description }),
-        ...(opts.isRbacEnabled !== undefined && { isRbacEnabled: opts.isRbacEnabled }),
-      });
+      await this.patch(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(id),
+        {
+          ...(opts.displayName !== undefined && { displayName: opts.displayName }),
+          ...(opts.description !== undefined && { description: opts.description }),
+          ...(opts.isRbacEnabled !== undefined && { isRbacEnabled: opts.isRbacEnabled }),
+        },
+        { headers: createHeaders({ [FOLDER_KEY]: opts.folderKey }) },
+      );
     }
   }
 
@@ -887,9 +952,11 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * @param options - Field changes to apply
    * @private
    */
-  private async applySchemaUpdate(entityId: string, options: Pick<EntityUpdateByIdOptions, 'addFields' | 'removeFields' | 'updateFields'>): Promise<void> {
+  private async applySchemaUpdate(entityId: string, options: Pick<EntityUpdateByIdOptions, 'addFields' | 'removeFields' | 'updateFields' | 'folderKey'>): Promise<void> {
+    const folderHeaders = createHeaders({ [FOLDER_KEY]: options.folderKey });
     const entityResponse = await this.get<RawEntityGetResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(entityId)
+      DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(entityId),
+      { headers: folderHeaders },
     );
     const raw = entityResponse.data;
 
@@ -945,19 +1012,23 @@ export class EntityService extends BaseService implements EntityServiceModel {
       newFields.push(...options.addFields.map(f => this.buildSchemaFieldPayload(f)));
     }
 
-    await this.post(DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT, {
-      displayName: raw.displayName,
-      description: raw.description,
-      entityDefinition: {
-        id: entityId,
-        name: raw.name,
-        fields: [...fields, ...newFields],
-        folderId: raw.folderId ?? DATA_FABRIC_TENANT_FOLDER_ID,
-        isRbacEnabled: raw.isRbacEnabled ?? false,
-        isInsightsEnabled: raw.isInsightsEnabled ?? false,
-        externalFields: raw.externalFields ?? [],
+    await this.post(
+      DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
+      {
+        displayName: raw.displayName,
+        description: raw.description,
+        entityDefinition: {
+          id: entityId,
+          name: raw.name,
+          fields: [...fields, ...newFields],
+          folderId: raw.folderId ?? DATA_FABRIC_TENANT_FOLDER_ID,
+          isRbacEnabled: raw.isRbacEnabled ?? false,
+          isInsightsEnabled: raw.isInsightsEnabled ?? false,
+          externalFields: raw.externalFields ?? [],
+        },
       },
-    });
+      { headers: folderHeaders },
+    );
   }
 
   /**

--- a/tests/.env.integration.example
+++ b/tests/.env.integration.example
@@ -54,6 +54,9 @@ ORCHESTRATOR_TEST_PROCESS_KEY=
 
 # Data Fabric test entity ID
 DATA_FABRIC_TEST_ENTITY_ID=
+# Pre-existing folder-scoped Data Fabric entity ID — used by the folder-scoped
+# record CRUD tests. Must live in the folder identified by INTEGRATION_TEST_FOLDER_KEY.
+DATA_FABRIC_TEST_FOLDER_ENTITY_ID=
 DATA_FABRIC_TEST_CHOICESET_ID=
 DATA_FABRIC_TEST_ATTACHMENT_FIELD=
 

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -17,6 +17,7 @@ export interface IntegrationConfig {
   maestroTestProcessKey?: string;
   orchestratorTestProcessKey?: string;
   dataFabricTestEntityId?: string;
+  dataFabricTestFolderEntityId?: string;
   dataFabricTestChoiceSetId?: string;
   dataFabricTestAttachmentField?: string;
   orchestratorAttachmentId?: string;
@@ -69,6 +70,7 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     maestroTestProcessKey: typeof rawConfig.maestroTestProcessKey === 'string' ? rawConfig.maestroTestProcessKey : undefined,
     orchestratorTestProcessKey: typeof rawConfig.orchestratorTestProcessKey === 'string' ? rawConfig.orchestratorTestProcessKey : undefined,
     dataFabricTestEntityId: typeof rawConfig.dataFabricTestEntityId === 'string' ? rawConfig.dataFabricTestEntityId : undefined,
+    dataFabricTestFolderEntityId: typeof rawConfig.dataFabricTestFolderEntityId === 'string' ? rawConfig.dataFabricTestFolderEntityId : undefined,
     dataFabricTestChoiceSetId: typeof rawConfig.dataFabricTestChoiceSetId === 'string' ? rawConfig.dataFabricTestChoiceSetId : undefined,
     dataFabricTestAttachmentField: typeof rawConfig.dataFabricTestAttachmentField === 'string' ? rawConfig.dataFabricTestAttachmentField : undefined,
     orchestratorAttachmentId: typeof rawConfig.orchestratorAttachmentId === 'string' ? rawConfig.orchestratorAttachmentId : undefined,
@@ -105,6 +107,7 @@ export function loadIntegrationConfig(): IntegrationConfig {
     maestroTestProcessKey: process.env.MAESTRO_TEST_PROCESS_KEY || undefined,
     orchestratorTestProcessKey: process.env.ORCHESTRATOR_TEST_PROCESS_KEY || undefined,
     dataFabricTestEntityId: process.env.DATA_FABRIC_TEST_ENTITY_ID || undefined,
+    dataFabricTestFolderEntityId: process.env.DATA_FABRIC_TEST_FOLDER_ENTITY_ID || undefined,
     dataFabricTestChoiceSetId: process.env.DATA_FABRIC_TEST_CHOICESET_ID || undefined,
     dataFabricTestAttachmentField: process.env.DATA_FABRIC_TEST_ATTACHMENT_FIELD || undefined,
     orchestratorAttachmentId: process.env.ORCHESTRATOR_ATTACHMENT_ID || undefined,

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -1340,7 +1340,11 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
   // so the suite runs with the standard integration-test PAT — entity schema
   // create/delete are NOT exercised here (they live in the skipped schema-write
   // describes above).
-  describe('Folder-scoped record CRUD', () => {
+  //
+  // Skipped when DATA_FABRIC_TEST_FOLDER_ENTITY_ID is not configured — CI does
+  // not yet provision a persistent folder-scoped test entity. Run locally by
+  // setting both INTEGRATION_TEST_FOLDER_KEY and DATA_FABRIC_TEST_FOLDER_ENTITY_ID.
+  describe.skipIf(!process.env.DATA_FABRIC_TEST_FOLDER_ENTITY_ID || !process.env.INTEGRATION_TEST_FOLDER_KEY)('Folder-scoped record CRUD', () => {
     let folderEntityId!: string;
     let folderKey!: string;
     let folderEntityMetadata!: RawEntityGetResponse;
@@ -1348,18 +1352,8 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
     beforeAll(async () => {
       const config = getTestConfig();
-      if (!config.folderKey) {
-        throw new Error(
-          'INTEGRATION_TEST_FOLDER_KEY is not set — folder-scoped record CRUD tests need the target folder key',
-        );
-      }
-      if (!config.dataFabricTestFolderEntityId) {
-        throw new Error(
-          'DATA_FABRIC_TEST_FOLDER_ENTITY_ID is not set — point this at an existing entity in the configured folder',
-        );
-      }
-      folderKey = config.folderKey;
-      folderEntityId = config.dataFabricTestFolderEntityId;
+      folderKey = config.folderKey!;
+      folderEntityId = config.dataFabricTestFolderEntityId!;
 
       // Fetch schema once so per-test record bodies match the entity's shape.
       const { entities } = getServices();

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -1336,45 +1336,40 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
   // Verifies that every record-CRUD method correctly forwards the
   // X-UIPATH-FolderKey header for an entity that lives in a non-tenant folder.
   //
-  // Skipped: beforeAll provisions a fresh folder-scoped entity via entities.create,
-  // which requires the DataFabric.Schema.Write OAuth scope — not granted to the
-  // standard integration-test PAT. Mirrors the existing skip on `create`,
-  // `updateById`, `deleteById`, and `entity schema methods (bound)` above.
-  describe.skip('Folder-scoped record CRUD', () => {
+  // Uses a pre-existing folder-scoped entity (DATA_FABRIC_TEST_FOLDER_ENTITY_ID)
+  // so the suite runs with the standard integration-test PAT — entity schema
+  // create/delete are NOT exercised here (they live in the skipped schema-write
+  // describes above).
+  describe('Folder-scoped record CRUD', () => {
     let folderEntityId!: string;
     let folderKey!: string;
+    let folderEntityMetadata!: RawEntityGetResponse;
     const folderRecordIds: string[] = [];
 
     beforeAll(async () => {
       const config = getTestConfig();
       if (!config.folderKey) {
         throw new Error(
-          'INTEGRATION_TEST_FOLDER_KEY is not set — folder-scoped record CRUD tests need a folder the test PAT can write to',
+          'INTEGRATION_TEST_FOLDER_KEY is not set — folder-scoped record CRUD tests need the target folder key',
+        );
+      }
+      if (!config.dataFabricTestFolderEntityId) {
+        throw new Error(
+          'DATA_FABRIC_TEST_FOLDER_ENTITY_ID is not set — point this at an existing entity in the configured folder',
         );
       }
       folderKey = config.folderKey;
+      folderEntityId = config.dataFabricTestFolderEntityId;
 
+      // Fetch schema once so per-test record bodies match the entity's shape.
       const { entities } = getServices();
-      const entityName = `sdk_fld_${mode}_${generateRandomString(8).toLowerCase()}`;
-      folderEntityId = await entities.create(
-        entityName,
-        [
-          { fieldName: 'name', type: EntityFieldDataType.STRING },
-          { fieldName: 'age', type: EntityFieldDataType.INTEGER },
-          { fieldName: 'isActive', type: EntityFieldDataType.BOOLEAN },
-        ],
-        { folderKey, displayName: entityName },
-      );
-      createdEntityIds.push(folderEntityId);
+      folderEntityMetadata = await entities.getById(folderEntityId, { folderKey });
     });
 
     it('should insert a single record with folderKey via insertRecordById', async () => {
       const { entities } = getServices();
-      const result = await entities.insertRecordById(
-        folderEntityId,
-        { name: `Alice_${generateRandomString(6)}`, age: 30, isActive: true },
-        { folderKey },
-      );
+      const data = await buildDummyRecord(folderEntityMetadata);
+      const result = await entities.insertRecordById(folderEntityId, data, { folderKey });
 
       expect(result).toBeDefined();
       expect(result.Id).toBeDefined();
@@ -1383,17 +1378,15 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
     it('should batch-insert records with folderKey via insertRecordsById', async () => {
       const { entities } = getServices();
-      const result = await entities.insertRecordsById(
-        folderEntityId,
-        [
-          { name: `Bob_${generateRandomString(6)}`, age: 25, isActive: false },
-          { name: `Charlie_${generateRandomString(6)}`, age: 40, isActive: true },
-        ],
-        { folderKey },
-      );
+      const batch = await Promise.all([
+        buildDummyRecord(folderEntityMetadata),
+        buildDummyRecord(folderEntityMetadata),
+      ]);
+
+      const result = await entities.insertRecordsById(folderEntityId, batch, { folderKey });
 
       expect(result.successRecords).toBeDefined();
-      expect(result.successRecords.length).toBe(2);
+      expect(result.successRecords.length).toBe(batch.length);
 
       const ids = result.successRecords.map((r) => r.Id).filter(Boolean) as string[];
       folderRecordIds.push(...ids);
@@ -1401,65 +1394,58 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
     it('should get a single record with folderKey via getRecordById', async () => {
       const { entities } = getServices();
-      const record = await entities.getRecordById(
-        folderEntityId,
-        folderRecordIds[0],
-        { folderKey },
-      );
+      const record = await entities.getRecordById(folderEntityId, folderRecordIds[0], { folderKey });
 
       expect(record).toBeDefined();
       expect(record.Id).toBe(folderRecordIds[0]);
-      expect(record.age).toBe(30);
     });
 
     it('should list paginated records with folderKey via getAllRecords', async () => {
       const { entities } = getServices();
-      const result = await entities.getAllRecords(folderEntityId, {
-        folderKey,
-        pageSize: 10,
-      });
+      const result = await entities.getAllRecords(folderEntityId, { folderKey, pageSize: 10 });
 
       expect(result.items).toBeDefined();
       expect(Array.isArray(result.items)).toBe(true);
-      expect(result.items.length).toBeGreaterThanOrEqual(folderRecordIds.length);
       expect(hasValidPagination(result)).toBe(true);
     });
 
-    it('should filter records with folderKey via queryRecordsById', async () => {
+    it('should query records with folderKey via queryRecordsById', async () => {
       const { entities } = getServices();
       const result = await entities.queryRecordsById(folderEntityId, {
         folderKey,
         filterGroup: {
           queryFilters: [
-            { fieldName: 'isActive', operator: QueryFilterOperator.Equals, value: 'true' },
+            { fieldName: 'Id', operator: QueryFilterOperator.Equals, value: folderRecordIds[0] },
           ],
         },
       });
 
       expect(Array.isArray(result.items)).toBe(true);
-      // We inserted 2 active records (Alice + Charlie); no others exist in this fresh entity.
-      expect(result.items.length).toBeGreaterThanOrEqual(2);
+      // The folder header must reach the server for the row to be retrievable; the
+      // filter narrows to the record we just inserted in this run.
+      expect(result.items.some((r) => r.Id === folderRecordIds[0])).toBe(true);
     });
 
     it('should update a record with folderKey via updateRecordById', async () => {
       const { entities } = getServices();
-      const result = await entities.updateRecordById(
-        folderEntityId,
-        folderRecordIds[0],
-        { age: 31 },
-        { folderKey },
-      );
+      const patch = await buildDummyRecord(folderEntityMetadata);
+      const result = await entities.updateRecordById(folderEntityId, folderRecordIds[0], patch, { folderKey });
 
       expect(result).toBeDefined();
-      expect(result.age).toBe(31);
+      expect(result.Id).toBe(folderRecordIds[0]);
     });
 
     it('should batch-update records with folderKey via updateRecordsById', async () => {
       const { entities } = getServices();
-      const updates: EntityRecord[] = folderRecordIds.slice(1).map((id) => ({
-        Id: id,
-        isActive: true,
-      } as EntityRecord));
+      const updates: EntityRecord[] = await Promise.all(
+        folderRecordIds.slice(1).map(async (id) => {
+          const patch = await buildDummyRecord(folderEntityMetadata);
+          return { Id: id, ...patch } as EntityRecord;
+        }),
+      );
+      if (updates.length === 0) {
+        throw new Error('No batch-inserted records to update — prior insert test must have failed');
+      }
 
       const result = await entities.updateRecordsById(folderEntityId, updates, { folderKey });
 
@@ -1473,10 +1459,16 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       await entities.deleteRecordById(folderEntityId, idToDelete, { folderKey });
 
-      // Verify gone via getAllRecords — the deleted Id should not appear in the list.
-      const page = await entities.getAllRecords(folderEntityId, { folderKey, pageSize: 50 });
-      const ids = page.items.map((r) => r.Id);
-      expect(ids).not.toContain(idToDelete);
+      // Verify gone via queryRecordsById — the deleted Id should not appear.
+      const result = await entities.queryRecordsById(folderEntityId, {
+        folderKey,
+        filterGroup: {
+          queryFilters: [
+            { fieldName: 'Id', operator: QueryFilterOperator.Equals, value: idToDelete },
+          ],
+        },
+      });
+      expect(result.items.some((r) => r.Id === idToDelete)).toBe(false);
     });
 
     it('should batch-delete records with folderKey via deleteRecordsById', async () => {
@@ -1500,15 +1492,11 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       if (config.skipCleanup) return;
       const { entities } = getServices();
 
+      // Records only — the test entity is owned by the tenant, not created here.
       if (folderRecordIds.length > 0) {
         await entities
           .deleteRecordsById(folderEntityId, folderRecordIds, { folderKey })
           .catch(() => undefined);
-      }
-      if (folderEntityId) {
-        await entities.deleteById(folderEntityId, { folderKey }).catch(() => undefined);
-        const idx = createdEntityIds.indexOf(folderEntityId);
-        if (idx !== -1) createdEntityIds.splice(idx, 1);
       }
     });
   });

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import {
   getServices,
   getTestConfig,
@@ -14,6 +14,7 @@ import {
   EntityRecord,
   FieldDisplayType,
   FieldMetaData,
+  QueryFilterOperator,
   RawEntityGetResponse,
 } from '../../../../src/models/data-fabric/entities.types';
 
@@ -1328,6 +1329,187 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       const idx = createdRecordIds.indexOf(inserted.Id);
       if (idx !== -1) createdRecordIds.splice(idx, 1);
+    });
+  });
+
+  // ─── Folder-scoped record CRUD ────────────────────────────────────────────
+  // Verifies that every record-CRUD method correctly forwards the
+  // X-UIPATH-FolderKey header for an entity that lives in a non-tenant folder.
+  //
+  // Skipped: beforeAll provisions a fresh folder-scoped entity via entities.create,
+  // which requires the DataFabric.Schema.Write OAuth scope — not granted to the
+  // standard integration-test PAT. Mirrors the existing skip on `create`,
+  // `updateById`, `deleteById`, and `entity schema methods (bound)` above.
+  describe.skip('Folder-scoped record CRUD', () => {
+    let folderEntityId!: string;
+    let folderKey!: string;
+    const folderRecordIds: string[] = [];
+
+    beforeAll(async () => {
+      const config = getTestConfig();
+      if (!config.folderKey) {
+        throw new Error(
+          'INTEGRATION_TEST_FOLDER_KEY is not set — folder-scoped record CRUD tests need a folder the test PAT can write to',
+        );
+      }
+      folderKey = config.folderKey;
+
+      const { entities } = getServices();
+      const entityName = `sdk_fld_${mode}_${generateRandomString(8).toLowerCase()}`;
+      folderEntityId = await entities.create(
+        entityName,
+        [
+          { fieldName: 'name', type: EntityFieldDataType.STRING },
+          { fieldName: 'age', type: EntityFieldDataType.INTEGER },
+          { fieldName: 'isActive', type: EntityFieldDataType.BOOLEAN },
+        ],
+        { folderKey, displayName: entityName },
+      );
+      createdEntityIds.push(folderEntityId);
+    });
+
+    it('should insert a single record with folderKey via insertRecordById', async () => {
+      const { entities } = getServices();
+      const result = await entities.insertRecordById(
+        folderEntityId,
+        { name: `Alice_${generateRandomString(6)}`, age: 30, isActive: true },
+        { folderKey },
+      );
+
+      expect(result).toBeDefined();
+      expect(result.Id).toBeDefined();
+      folderRecordIds.push(result.Id);
+    });
+
+    it('should batch-insert records with folderKey via insertRecordsById', async () => {
+      const { entities } = getServices();
+      const result = await entities.insertRecordsById(
+        folderEntityId,
+        [
+          { name: `Bob_${generateRandomString(6)}`, age: 25, isActive: false },
+          { name: `Charlie_${generateRandomString(6)}`, age: 40, isActive: true },
+        ],
+        { folderKey },
+      );
+
+      expect(result.successRecords).toBeDefined();
+      expect(result.successRecords.length).toBe(2);
+
+      const ids = result.successRecords.map((r) => r.Id).filter(Boolean) as string[];
+      folderRecordIds.push(...ids);
+    });
+
+    it('should get a single record with folderKey via getRecordById', async () => {
+      const { entities } = getServices();
+      const record = await entities.getRecordById(
+        folderEntityId,
+        folderRecordIds[0],
+        { folderKey },
+      );
+
+      expect(record).toBeDefined();
+      expect(record.Id).toBe(folderRecordIds[0]);
+      expect(record.age).toBe(30);
+    });
+
+    it('should list paginated records with folderKey via getAllRecords', async () => {
+      const { entities } = getServices();
+      const result = await entities.getAllRecords(folderEntityId, {
+        folderKey,
+        pageSize: 10,
+      });
+
+      expect(result.items).toBeDefined();
+      expect(Array.isArray(result.items)).toBe(true);
+      expect(result.items.length).toBeGreaterThanOrEqual(folderRecordIds.length);
+      expect(hasValidPagination(result)).toBe(true);
+    });
+
+    it('should filter records with folderKey via queryRecordsById', async () => {
+      const { entities } = getServices();
+      const result = await entities.queryRecordsById(folderEntityId, {
+        folderKey,
+        filterGroup: {
+          queryFilters: [
+            { fieldName: 'isActive', operator: QueryFilterOperator.Equals, value: 'true' },
+          ],
+        },
+      });
+
+      expect(Array.isArray(result.items)).toBe(true);
+      // We inserted 2 active records (Alice + Charlie); no others exist in this fresh entity.
+      expect(result.items.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should update a record with folderKey via updateRecordById', async () => {
+      const { entities } = getServices();
+      const result = await entities.updateRecordById(
+        folderEntityId,
+        folderRecordIds[0],
+        { age: 31 },
+        { folderKey },
+      );
+
+      expect(result).toBeDefined();
+      expect(result.age).toBe(31);
+    });
+
+    it('should batch-update records with folderKey via updateRecordsById', async () => {
+      const { entities } = getServices();
+      const updates: EntityRecord[] = folderRecordIds.slice(1).map((id) => ({
+        Id: id,
+        isActive: true,
+      } as EntityRecord));
+
+      const result = await entities.updateRecordsById(folderEntityId, updates, { folderKey });
+
+      expect(result.successRecords).toBeDefined();
+      expect(result.successRecords.length).toBe(updates.length);
+    });
+
+    it('should delete a single record with folderKey via deleteRecordById', async () => {
+      const { entities } = getServices();
+      const idToDelete = folderRecordIds.pop()!;
+
+      await entities.deleteRecordById(folderEntityId, idToDelete, { folderKey });
+
+      // Verify gone via getAllRecords — the deleted Id should not appear in the list.
+      const page = await entities.getAllRecords(folderEntityId, { folderKey, pageSize: 50 });
+      const ids = page.items.map((r) => r.Id);
+      expect(ids).not.toContain(idToDelete);
+    });
+
+    it('should batch-delete records with folderKey via deleteRecordsById', async () => {
+      const { entities } = getServices();
+      if (folderRecordIds.length === 0) {
+        throw new Error('No folder records to batch-delete — prior insert tests may have failed to track IDs');
+      }
+
+      const result = await entities.deleteRecordsById(
+        folderEntityId,
+        [...folderRecordIds],
+        { folderKey },
+      );
+
+      expect(result.successRecords).toBeDefined();
+      folderRecordIds.length = 0;
+    });
+
+    afterAll(async () => {
+      const config = getTestConfig();
+      if (config.skipCleanup) return;
+      const { entities } = getServices();
+
+      if (folderRecordIds.length > 0) {
+        await entities
+          .deleteRecordsById(folderEntityId, folderRecordIds, { folderKey })
+          .catch(() => undefined);
+      }
+      if (folderEntityId) {
+        await entities.deleteById(folderEntityId, { folderKey }).catch(() => undefined);
+        const idx = createdEntityIds.indexOf(folderEntityId);
+        if (idx !== -1) createdEntityIds.splice(idx, 1);
+      }
     });
   });
 

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -501,7 +501,8 @@ describe("Entity Models", () => {
 
         expect(mockService.deleteRecordById).toHaveBeenCalledWith(
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
-          ENTITY_TEST_CONSTANTS.RECORD_ID
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          undefined,
         );
       });
 
@@ -712,6 +713,7 @@ describe("Entity Models", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+          undefined,
         );
         expect(result).toBe(mockBlob);
       });
@@ -806,6 +808,7 @@ describe("Entity Models", () => {
         ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        undefined,
       );
       expect(result).toEqual(mockResponse);
     });
@@ -871,6 +874,20 @@ describe("Entity Models", () => {
 
       expect(mockService.deleteById).toHaveBeenCalledWith(
         ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        undefined,
+      );
+    });
+
+    it("entity.delete() should forward folderKey to service.deleteById", async () => {
+      const entityData = createBasicEntity();
+      const entity = createEntityWithMethods(entityData, mockService);
+      mockService.deleteById = vi.fn().mockResolvedValue(undefined);
+
+      await entity.delete({ folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID });
+
+      expect(mockService.deleteById).toHaveBeenCalledWith(
+        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
       );
     });
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -39,6 +39,7 @@ import {
   ExternalField,
   FieldDisplayType,
   QueryFilterOperator,
+  RawEntityGetResponse,
 } from "../../../../src/models/data-fabric/entities.types";
 import {
   EntityFieldTypeMap,
@@ -112,7 +113,7 @@ describe("EntityService Unit Tests", () => {
       // Verify the API call has correct endpoint
       expect(mockApiClient.get).toHaveBeenCalledWith(
         DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
-        {},
+        { headers: {} },
       );
 
       // Verify entity has methods attached
@@ -123,6 +124,20 @@ describe("EntityService Unit Tests", () => {
       expect(typeof result.deleteRecords).toBe("function");
       expect(typeof result.deleteRecord).toBe("function");
       expect(typeof result.getAllRecords).toBe("function");
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      const mockResponse = createMockEntityResponse();
+      mockApiClient.get.mockResolvedValue(mockResponse);
+
+      await entityService.getById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
+      );
     });
 
     it("should get entity with external fields successfully and transform field metadata", async () => {
@@ -470,6 +485,23 @@ describe("EntityService Unit Tests", () => {
       expect(result.hasNextPage).toBe(true);
     });
 
+    it("should forward folderKey as X-UIPATH-FolderKey header but NOT pass it to PaginationHelpers (avoids $folderKey query param)", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.getAllRecords(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+        pageSize: TEST_CONSTANTS.PAGE_SIZE,
+      });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID },
+        }),
+        // folderKey must be stripped — only pageSize survives
+        { pageSize: TEST_CONSTANTS.PAGE_SIZE },
+      );
+    });
+
     it("should handle expansion level option", async () => {
       // With expansionLevel, reference fields should be expanded to objects
       const mockRecords = createMockEntityRecords(3, {
@@ -541,7 +573,7 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
           ENTITY_TEST_CONSTANTS.RECORD_ID,
         ),
-        { params: {} },
+        { params: {}, headers: {} },
       );
     });
 
@@ -575,6 +607,7 @@ describe("EntityService Unit Tests", () => {
           params: expect.objectContaining({
             expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
           }),
+          headers: {},
         },
       );
     });
@@ -1147,7 +1180,25 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
           ENTITY_TEST_CONSTANTS.RECORD_ID
         ),
-        {}
+        { headers: {} }
+      );
+    });
+
+    it('should pass folderKey via X-UIPATH-FolderKey header when provided', async () => {
+      mockApiClient.delete.mockResolvedValue(true);
+
+      await entityService.deleteRecordById(
+        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID
+        ),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } }
       );
     });
 
@@ -1185,7 +1236,28 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         ),
-        { responseType: "blob" },
+        { responseType: "blob", headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      const mockBlob = new Blob(["test content"], { type: "application/pdf" });
+      mockApiClient.get.mockResolvedValue(mockBlob);
+
+      await entityService.downloadAttachment(
+        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DOWNLOAD_ATTACHMENT(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { responseType: "blob", headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
@@ -1235,7 +1307,7 @@ describe("EntityService Unit Tests", () => {
             ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
           ),
           expect.any(FormData),
-          { params: {} },
+          { params: {}, headers: {} },
         );
       },
     );
@@ -1261,7 +1333,31 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         ),
         expect.any(FormData),
-        { params: { expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL } },
+        { params: { expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL }, headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      mockApiClient.post.mockResolvedValue({ id: ENTITY_TEST_CONSTANTS.RECORD_ID });
+
+      const file = new Blob(["test"]);
+
+      await entityService.uploadAttachment(
+        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        file,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPLOAD_ATTACHMENT(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        expect.any(FormData),
+        { params: {}, headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
@@ -1298,7 +1394,27 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         ),
-        {},
+        { headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await entityService.deleteAttachment(
+        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_ATTACHMENT(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
@@ -1345,6 +1461,28 @@ describe("EntityService Unit Tests", () => {
       );
       expect(result.items).toHaveLength(2);
       expect(result.totalCount).toBe(2);
+    });
+
+    it("should forward folderKey as X-UIPATH-FolderKey header but NOT include it in the POST body", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      const options = {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+        filterGroup: {
+          logicalOperator: 0 as const,
+          queryFilters: [{ fieldName: "isActive", operator: QueryFilterOperator.Equals, value: "true" }],
+        },
+      };
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, options);
+
+      const [config, downstreamOptions] = vi.mocked(PaginationHelpers.getAll).mock.calls[0];
+      expect((config as { headers: Record<string, string> }).headers).toEqual({
+        "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID,
+      });
+      // folderKey must be stripped from the options passed downstream — otherwise it lands in the POST body
+      expect(downstreamOptions).not.toHaveProperty("folderKey");
+      expect(downstreamOptions).toHaveProperty("filterGroup");
     });
 
     it("should pass filter and sort options through to PaginationHelpers.getAll", async () => {
@@ -1544,7 +1682,7 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ),
         expect.any(FormData),
-        {},
+        { headers: {} },
       );
     });
 
@@ -1567,7 +1705,7 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ),
         expect.any(FormData),
-        {},
+        { headers: {} },
       );
     });
 
@@ -1590,7 +1728,7 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ),
         expect.any(FormData),
-        {},
+        { headers: {} },
       );
     });
 
@@ -1651,7 +1789,7 @@ describe("EntityService Unit Tests", () => {
             isInsightsEnabled: false,
           }),
         }),
-        {},
+        { headers: {} },
       );
     });
 
@@ -1666,11 +1804,11 @@ describe("EntityService Unit Tests", () => {
           displayName: "my_new_entity",
           entityDefinition: expect.objectContaining({ name: "my_new_entity" }),
         }),
-        {},
+        { headers: {} },
       );
     });
 
-    it("should pass custom folderKey to the entity definition", async () => {
+    it("should pass custom folderKey to the entity definition and the X-UIPATH-FolderKey header", async () => {
       mockApiClient.post.mockResolvedValue(ENTITY_TEST_CONSTANTS.ENTITY_ID);
 
       await entityService.create("my_entity", [], {
@@ -1684,7 +1822,7 @@ describe("EntityService Unit Tests", () => {
             folderId: ENTITY_TEST_CONSTANTS.FIELD_ID,
           }),
         }),
-        {},
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
@@ -1702,7 +1840,7 @@ describe("EntityService Unit Tests", () => {
             isInsightsEnabled: true,
           }),
         }),
-        {},
+        { headers: {} },
       );
     });
 
@@ -1722,7 +1860,7 @@ describe("EntityService Unit Tests", () => {
             externalFields,
           }),
         }),
-        {},
+        { headers: {} },
       );
     });
 
@@ -2043,7 +2181,20 @@ describe("EntityService Unit Tests", () => {
 
       expect(mockApiClient.delete).toHaveBeenCalledWith(
         DATA_FABRIC_ENDPOINTS.ENTITY.DELETE(ENTITY_TEST_CONSTANTS.ENTITY_ID),
-        {},
+        { headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await entityService.deleteById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+      });
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
@@ -2091,7 +2242,7 @@ describe("EntityService Unit Tests", () => {
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
         DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
-        {},
+        { headers: {} },
       );
       expect(mockApiClient.post).toHaveBeenCalledWith(
         DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
@@ -2108,7 +2259,7 @@ describe("EntityService Unit Tests", () => {
             ]),
           }),
         }),
-        {},
+        { headers: {} },
       );
     });
 
@@ -2173,7 +2324,7 @@ describe("EntityService Unit Tests", () => {
           displayName: mockRawEntity.displayName,
           description: mockRawEntity.description,
         }),
-        {},
+        { headers: {} },
       );
     });
 
@@ -2785,7 +2936,7 @@ describe("EntityService Unit Tests", () => {
           description: ENTITY_TEST_CONSTANTS.ENTITY_DESCRIPTION,
           isRbacEnabled: true,
         },
-        {},
+        { headers: {} },
       );
       expect(mockApiClient.get).not.toHaveBeenCalled();
     });
@@ -2802,7 +2953,47 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ),
         { displayName: ENTITY_TEST_CONSTANTS.ENTITY_DISPLAY_NAME },
-        {},
+        { headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header on both schema GET/POST and metadata PATCH", async () => {
+      const mockRawEntity: RawEntityGetResponse = {
+        name: "my_entity",
+        displayName: "My Entity",
+        description: "",
+        isRbacEnabled: false,
+        fields: [],
+        id: ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        entityType: 0,
+        externalFields: [],
+        createdBy: "u",
+        createdTime: "t",
+      } as RawEntityGetResponse;
+      mockApiClient.get.mockResolvedValue(mockRawEntity);
+      mockApiClient.post.mockResolvedValue(undefined);
+      mockApiClient.patch.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+        addFields: [{ fieldName: "newcol", type: EntityFieldDataType.STRING }],
+        displayName: "renamed",
+      });
+
+      const folderHeaders = { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } };
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        folderHeaders,
+      );
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
+        expect.any(Object),
+        folderHeaders,
+      );
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        { displayName: "renamed" },
+        folderHeaders,
       );
     });
 
@@ -2818,7 +3009,7 @@ describe("EntityService Unit Tests", () => {
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ),
         { isRbacEnabled: false },
-        {},
+        { headers: {} },
       );
     });
 
@@ -2841,14 +3032,14 @@ describe("EntityService Unit Tests", () => {
             ]),
           }),
         }),
-        {},
+        { headers: {} },
       );
       expect(mockApiClient.patch).toHaveBeenCalledWith(
         DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(
           ENTITY_TEST_CONSTANTS.ENTITY_ID,
         ),
         { displayName: "New Display Name" },
-        {},
+        { headers: {} },
       );
     });
 


### PR DESCRIPTION
## Summary

Backend doc §7.4 requires the `X-UIPATH-FolderKey` header for folder-scoped entity operations. SDK previously only embedded `folderId` in the create body — every other entity-level method skipped the folder context entirely, which meant folder-scoped entities were unreachable from the SDK.

All entity schema operations and attachment operations now accept an optional `folderKey` and forward it as the `X-UIPATH-FolderKey` header.

## Methods updated

| Method | Before | After |
|---|---|---|
| `getById(id)` | (no options) | `getById(id, options?: EntityGetByIdOptions)` |
| `create(name, fields, options?)` | already had `folderKey` in options (body only) | now also sends the header |
| `updateById(id, options?)` | no `folderKey` | `folderKey` on the options + header on GET/POST/PATCH |
| `deleteById(id)` | (no options) | `deleteById(id, options?: EntityDeleteByIdOptions)` |
| `uploadAttachment(...)` | options without `folderKey` | `folderKey` on the options + header |
| `downloadAttachment(...)` | (no options) | `downloadAttachment(..., options?: EntityDownloadAttachmentOptions)` |
| `deleteAttachment(...)` | (no options) | `deleteAttachment(..., options?: EntityDeleteAttachmentOptions)` |

Bound entity methods (returned from `getById`) thread `folderKey` through.
Record CRUD

  ┌────────────────────────────────────┬──────────────────────────────────────────────┐
  │               Method               │                    Change                    │
  ├────────────────────────────────────┼──────────────────────────────────────────────┤
  │ insertRecordById /                 │ folderKey on options + header                │
  │ insertRecordsById                  │                                              │
  ├────────────────────────────────────┼──────────────────────────────────────────────┤
  │ updateRecordById /                 │ folderKey on options + header                │
  │ updateRecordsById                  │                                              │
  ├────────────────────────────────────┼──────────────────────────────────────────────┤
  │ deleteRecordById (new options      │ folderKey on options + header                │
  │ param) / deleteRecordsById         │                                              │
  ├────────────────────────────────────┼──────────────────────────────────────────────┤
  │ getRecordById / getAllRecords /    │ folderKey on options + header (threaded      │
  │ queryRecordsById                   │ through PaginationHelpers for list/query)    │
  ├────────────────────────────────────┼──────────────────────────────────────────────┤
  │ importRecordsById (new options     │ folderKey on options + header                │
  │ param)                             │                                              │
  └────────────────────────────────────┴──────────────────────────────────────────────┘

  Attachments

  ┌─────────────────────────────────────────────┬───────────────────────────────┐
  │                   Method                    │            Change             │
  ├─────────────────────────────────────────────┼───────────────────────────────┤
  │ uploadAttachment(...)                       │ folderKey on options + header │
  ├─────────────────────────────────────────────┼───────────────────────────────┤
  │ downloadAttachment(...) (new options param) │ folderKey on options + header │
  ├─────────────────────────────────────────────┼───────────────────────────────┤
  │ deleteAttachment(...) (new options param)   │ folderKey on options + header │
  └─────────────────────────────────────────────┴───────────────────────────────┘

## New types

- `EntityFolderScopedOptions` — base with one field, `folderKey?: string`
- `EntityGetByIdOptions`, `EntityDeleteByIdOptions`, `EntityDownloadAttachmentOptions`, `EntityDeleteAttachmentOptions` — each extends the base
- `EntityCreateOptions`, `EntityUpdateByIdOptions`, `EntityUploadAttachmentOptions` now extend the base (removes the previously hand-rolled `folderKey` on `EntityCreateOptions`)

## Pattern consistency with the rest of the SDK

Same `createHeaders({ [FOLDER_KEY]: folderKey })` + `X-UIPATH-FolderKey` header used by Maestro (processes, process-instances, case-instances) and Agents/Feedback. No service-specific deviation.
## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 warnings / 0 errors
- [x] `npm run test:unit` — 1683 / 1683 pass; added folderKey-header tests for `create` and `deleteById`; updated existing assertions to expect the new `{ headers: ... }` arg on `post`/`patch`/`delete`/`get`.
- [ ] Manual integration: create an entity in a non-tenant folder via `entities.create(name, fields, { folderKey })` and verify the request lands in that folder; then `getById` / `updateById` / `deleteById` from outside that folder context succeed only when `folderKey` is supplied.

## Depends on

This branch is rebased on top of #489. Merge that first; this PR's diff against `main` will then become the folder commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)