### PR TITLE
feat(telemetry): report CloudUserId on telemetry events from the auth token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.3.11",
             "license": "MIT",
             "dependencies": {
-                "@uipath/core-telemetry": "^1.0.0-beta.2",
+                "@uipath/core-telemetry": "^1.0.0-beta.3",
                 "socket.io-client": "^4.8.1"
             },
             "devDependencies": {
@@ -1546,9 +1546,9 @@
             "license": "MIT"
         },
         "node_modules/@uipath/core-telemetry": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@uipath/core-telemetry/-/core-telemetry-1.0.0-beta.2.tgz",
-            "integrity": "sha512-behZVGmVq7fn+6bvqdJvu4AbJzJV5ZHJqM4E6AaYle+nqSJoSYyLmAQO2+PSoI5h/Pd+1tU0n0MUpjw2OLXJSA==",
+            "version": "1.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@uipath/core-telemetry/-/core-telemetry-1.0.0-beta.3.tgz",
+            "integrity": "sha512-e/IHHJ77tygw/LvFRSEQ/bxFlmTivrk0ApeRIsPqTpwxXNEryGxLzSjWCRflAKs3EYj+jiwEYRWINpodMjmrqw==",
             "license": "MIT",
             "dependencies": {
                 "@opentelemetry/sdk-logs": "^0.204.0"

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
         "test:coverage": "vitest --coverage"
     },
     "dependencies": {
-        "@uipath/core-telemetry": "^1.0.0-beta.2",
+        "@uipath/core-telemetry": "^1.0.0-beta.3",
         "socket.io-client": "^4.8.1"
     },
     "peerDependencies": {

--- a/packages/coded-action-app/package-lock.json
+++ b/packages/coded-action-app/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@uipath/coded-action-app",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uipath/coded-action-app",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@uipath/core-telemetry": "^1.0.0-beta.2"
+        "@uipath/core-telemetry": "^1.0.0-beta.3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
@@ -1101,9 +1101,9 @@
       "license": "MIT"
     },
     "node_modules/@uipath/core-telemetry": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@uipath/core-telemetry/-/core-telemetry-1.0.0-beta.2.tgz",
-      "integrity": "sha512-behZVGmVq7fn+6bvqdJvu4AbJzJV5ZHJqM4E6AaYle+nqSJoSYyLmAQO2+PSoI5h/Pd+1tU0n0MUpjw2OLXJSA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@uipath/core-telemetry/-/core-telemetry-1.0.0-beta.3.tgz",
+      "integrity": "sha512-e/IHHJ77tygw/LvFRSEQ/bxFlmTivrk0ApeRIsPqTpwxXNEryGxLzSjWCRflAKs3EYj+jiwEYRWINpodMjmrqw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/sdk-logs": "^0.204.0"

--- a/packages/coded-action-app/package.json
+++ b/packages/coded-action-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/coded-action-app",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "UiPath package to be used for viewing coded action apps in Action Center",
   "license": "MIT",
   "type": "module",
@@ -32,7 +32,7 @@
     "lint": "oxlint"
   },
   "dependencies": {
-    "@uipath/core-telemetry": "^1.0.0-beta.2"
+    "@uipath/core-telemetry": "^1.0.0-beta.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.0",

--- a/packages/coded-action-app/src/coded-action-app-service.ts
+++ b/packages/coded-action-app/src/coded-action-app-service.ts
@@ -4,7 +4,11 @@ import {
   TaskCompleteResponse,
 } from './types';
 import { CodedActionAppServiceModel } from './coded-action-app.models';
-import { ActionCenterEventNames, ActionCenterEventResponsePayload } from './types.internal';
+import {
+  ActionCenterEventNames,
+  ActionCenterEventResponsePayload,
+  TaskWithCloudUserId,
+} from './types.internal';
 import { telemetryClient, track } from './telemetry';
 import { loadFromMetaTags } from './telemetry/runtime';
 
@@ -18,7 +22,12 @@ export class CodedActionAppService implements CodedActionAppServiceModel {
   private isCompletingTask = false;
 
   constructor() {
-    telemetryClient.initialize(loadFromMetaTags() ?? undefined);
+    const metaConfig = loadFromMetaTags();
+    telemetryClient.initialize(
+      metaConfig
+        ? { ...metaConfig, orgId: metaConfig.orgName, tenantId: metaConfig.tenantName }
+        : undefined,
+    );
   }
 
   /**
@@ -111,7 +120,10 @@ export class CodedActionAppService implements CodedActionAppServiceModel {
         clearTimeout(timer);
 
         this.cleanup(messageListener);
-        resolve(event.data?.content as Task);
+
+        const task = event.data?.content as TaskWithCloudUserId;
+        telemetryClient.setUserId(task?.cloudUserId ?? '');
+        resolve(task);
       };
 
       const timer = setTimeout(() => {

--- a/packages/coded-action-app/src/telemetry/constants.ts
+++ b/packages/coded-action-app/src/telemetry/constants.ts
@@ -11,3 +11,4 @@ export const SDK_SERVICE_NAME = 'UiPath.CodedActionApp.Sdk';
 export const CLOUD_ROLE_NAME = 'uipath-coded-action-app-sdk';
 export const SDK_LOGGER_NAME = 'uipath-coded-action-app-telemetry';
 export const SDK_RUN_EVENT = 'CodedActionApp.Sdk.Run';
+export const TS_SDK_CLOUD_ROLE_NAME = 'uipath-ts-sdk';

--- a/packages/coded-action-app/src/telemetry/index.ts
+++ b/packages/coded-action-app/src/telemetry/index.ts
@@ -20,6 +20,7 @@ import {
     SDK_RUN_EVENT,
     SDK_SERVICE_NAME,
     SDK_VERSION,
+    TS_SDK_CLOUD_ROLE_NAME,
 } from './constants';
 
 /** Keyed by `CLOUD_ROLE_NAME` so all CodedActionApp SDK module loads share a single `TelemetryClient`. Each SDK uses
@@ -40,5 +41,14 @@ export const telemetryClient = {
             defaultEventName: SDK_RUN_EVENT,
             context,
         });
+    },
+
+    /**
+     * Sets the authenticated user's id so completeTask event and all ts-sdk api calls
+     * carry it as `CloudUserId`.
+     */
+    setUserId(userId: string): void {
+        codedActionAppTelemetryClient.setUserId(userId);
+        getOrCreateClient(TS_SDK_CLOUD_ROLE_NAME).setUserId(userId);
     },
 };

--- a/packages/coded-action-app/src/types.internal.ts
+++ b/packages/coded-action-app/src/types.internal.ts
@@ -10,7 +10,14 @@ export enum ActionCenterEventNames {
   COMPLETERESPONSE = 'AC.completeResponse',
 }
 
+/**
+ * Task content as delivered by Action Center on the `LOADAPP` event. Carries
+ * the hidden `cloudUserId` that is reported as `CloudUserId` on telemetry
+ * events but is intentionally absent from the public {@link Task} contract.
+ */
+export type TaskWithCloudUserId = Task & { cloudUserId?: string };
+
 export type ActionCenterEventResponsePayload = {
   eventType: ActionCenterEventNames;
-  content: Task | TaskCompleteResponse;
+  content: TaskWithCloudUserId | TaskCompleteResponse;
 };

--- a/src/core/auth/token-manager.ts
+++ b/src/core/auth/token-manager.ts
@@ -8,6 +8,8 @@ import { AuthenticationError, HttpStatus } from '../errors';
 import { ActionCenterTokenManager } from './action-center-token-manager';
 import { EmbeddedTokenManager } from './embedded-token-manager';
 import { isValidHostOrigin } from './host-token-request';
+import { telemetryClient } from '../telemetry';
+import { extractUserIdFromToken } from '../../utils/encoding';
 
 /**
  * TokenManager is responsible for managing authentication tokens.
@@ -269,6 +271,7 @@ export class TokenManager {
    */
   private _updateExecutionContext(tokenInfo: TokenInfo): void {
     this.executionContext.set('tokenInfo', tokenInfo);
+    telemetryClient.setUserId(extractUserIdFromToken(tokenInfo.token));
   }
 
   /**

--- a/src/core/telemetry/index.ts
+++ b/src/core/telemetry/index.ts
@@ -42,4 +42,12 @@ export const telemetryClient = {
             context,
         });
     },
+
+    /**
+     * Sets the authenticated user's id so every subsequently emitted event
+     * carries it as `CloudUserId`.
+     */
+    setUserId(userId: string): void {
+        sdkClient.setUserId(userId);
+    },
 };

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -52,6 +52,13 @@ export class UiPath implements IUiPath {
   // deployments). Not accepted via the public constructor; lives here so the
   // SDK can flow it through to BaseService.config without polluting BaseConfig.
   #metaFolderKey?: string;
+  // Org/tenant ids captured from the meta tags before the constructor config
+  // is merged in. The `uipath:org-name`/`uipath:tenant-name` meta tags always
+  // carry org/tenant *ids* in coded-app deployments, whereas a
+  // constructor-supplied `orgName`/`tenantName` may be actual names — so the
+  // telemetry ids must be read from the meta tags.
+  #metaOrgId?: string;
+  #metaTenantId?: string;
 
   /** Read-only config for user convenience */
   public readonly config!: Readonly<BaseConfig>;
@@ -60,6 +67,8 @@ export class UiPath implements IUiPath {
     // Load configuration from meta tags
     const configFromMetaTags = loadFromMetaTags();
     this.#metaFolderKey = configFromMetaTags?.folderKey;
+    this.#metaOrgId = configFromMetaTags?.orgName;
+    this.#metaTenantId = configFromMetaTags?.tenantName;
 
     // Merge configuration: constructor config overrides meta tags
     const mergedConfig = config ? { ...configFromMetaTags, ...config } : configFromMetaTags;
@@ -113,9 +122,11 @@ export class UiPath implements IUiPath {
       tenantName: internalConfig.tenantName
     };
 
-    // Initialize telemetry with SDK configuration
+    // Initialize telemetry with SDK configuration.
     telemetryClient.initialize({
       baseUrl: config.baseUrl,
+      orgId: this.#metaOrgId,
+      tenantId: this.#metaTenantId,
       orgName: config.orgName,
       tenantName: config.tenantName,
       clientId: hasOAuthAuth ? config.clientId : undefined,
@@ -138,6 +149,8 @@ export class UiPath implements IUiPath {
     // Load from meta tags
     const metaConfig = loadFromMetaTags();
     this.#metaFolderKey = metaConfig?.folderKey;
+    this.#metaOrgId = metaConfig?.orgName;
+    this.#metaTenantId = metaConfig?.tenantName;
 
     // Merge with any partial config from constructor (constructor overrides meta tags)
     const merged = { ...metaConfig, ...this.#partialConfig };

--- a/src/utils/encoding/index.ts
+++ b/src/utils/encoding/index.ts
@@ -1,2 +1,3 @@
 export * from './base64';
 export * from './folder-path';
+export * from './jwt';

--- a/src/utils/encoding/jwt.ts
+++ b/src/utils/encoding/jwt.ts
@@ -1,0 +1,39 @@
+/**
+ * JWT decoding helpers — payload inspection only, no signature verification.
+ */
+import { decodeBase64 } from './base64';
+
+const BASE64URL_DASH_RE = /-/g;
+const BASE64URL_UNDERSCORE_RE = /_/g;
+
+/**
+ * Converts a base64url-encoded JWT segment to standard base64 with padding.
+ */
+function base64UrlToBase64(value: string): string {
+  const base64 = value
+    .replace(BASE64URL_DASH_RE, '+')
+    .replace(BASE64URL_UNDERSCORE_RE, '/');
+  return base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+}
+
+/**
+ * Extracts the user id (`sub` claim) from a JWT access token payload.
+ * Returns an empty string for opaque (non-JWT) tokens or malformed payloads.
+ *
+ * @param token - The access token to inspect
+ * @returns The user id, or an empty string if it cannot be extracted
+ */
+export function extractUserIdFromToken(token: string): string {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) {
+      return '';
+    }
+
+    const claims = JSON.parse(decodeBase64(base64UrlToBase64(payload))) as Record<string, unknown>;
+    const sub = claims['sub'];
+    return typeof sub === 'string' && sub ? sub : '';
+  } catch {
+    return '';
+  }
+}

--- a/tests/unit/core/auth/token-manager-telemetry.test.ts
+++ b/tests/unit/core/auth/token-manager-telemetry.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenManager } from '@/core/auth/token-manager';
+import { ExecutionContext } from '@/core/context/execution';
+import type { Config } from '@/core/config/config';
+import { telemetryClient } from '@/core/telemetry';
+import { TEST_CONSTANTS } from '@tests/utils/constants/common';
+import { TEST_USER_ID, createTestJwt } from '@tests/utils/jwt';
+
+// ---------------------------------------------------------------------------
+// Mock platform — plain (non-embedded, non-Action-Center) environment
+// ---------------------------------------------------------------------------
+vi.mock('@/utils/platform', () => ({
+  isBrowser: false,
+  isInActionCenter: false,
+  isHostEmbedded: false,
+  embeddingOrigin: null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeManager() {
+  const context = new ExecutionContext();
+  const config: Config = {
+    baseUrl: TEST_CONSTANTS.BASE_URL,
+    orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+    tenantName: TEST_CONSTANTS.TENANT_ID,
+    secret: TEST_CONSTANTS.CLIENT_SECRET,
+  };
+  return new TokenManager(context, config, false);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('TokenManager — telemetry user id wiring', () => {
+  let setUserIdSpy!: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setUserIdSpy = vi.spyOn(telemetryClient, 'setUserId').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setUserIdSpy.mockRestore();
+  });
+
+  it('feeds the user id extracted from a JWT token to telemetry on setToken', () => {
+    const manager = makeManager();
+
+    manager.setToken({
+      token: createTestJwt({ sub: TEST_USER_ID }),
+      type: 'oauth',
+    });
+
+    expect(setUserIdSpy).toHaveBeenCalledTimes(1);
+    expect(setUserIdSpy).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  it('feeds an empty user id to telemetry for an opaque (non-JWT) token', () => {
+    const manager = makeManager();
+
+    manager.setToken({
+      token: 'rt_opaque-personal-access-token',
+      type: 'secret',
+    });
+
+    expect(setUserIdSpy).toHaveBeenCalledWith('');
+  });
+});

--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -1,8 +1,10 @@
 // ===== IMPORTS =====
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { TelemetryContext } from '@uipath/core-telemetry';
 import { UiPath } from '../../../src/core/uipath';
 import { UiPathConfig } from '../../../src/core/config/config';
 import { ExecutionContext } from '../../../src/core/context/execution';
+import { telemetryClient } from '../../../src/core/telemetry';
 import { getConfig, getContext, getTokenManager, getPrivateSDK } from '../../utils/setup';
 import { TEST_CONSTANTS } from '../../utils/constants/common';
 
@@ -37,6 +39,13 @@ vi.mock('../../../src/core/auth/service', () => {
 });
 
 vi.mock('../../../src/core/http/api-client');
+
+// Mock meta-tag loading so the telemetry tests can drive the org/tenant ids
+// the deployment injects. Defaults to no meta tags (matching server-side use).
+const { mockLoadFromMetaTags } = vi.hoisted(() => ({ mockLoadFromMetaTags: vi.fn() }));
+vi.mock('../../../src/core/config/runtime', () => ({
+  loadFromMetaTags: mockLoadFromMetaTags,
+}));
 
 // ===== TEST SUITE =====
 describe('UiPath Core', () => {
@@ -418,6 +427,58 @@ describe('UiPath Core', () => {
       expect(getConfig(sdk1).orgName).toBe('org1');
       expect(getConfig(sdk2).orgName).toBe('org2');
       expect(getContext(sdk1)).not.toBe(getContext(sdk2));
+    });
+  });
+
+  describe('Telemetry', () => {
+    let initializeSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      initializeSpy = vi.spyOn(telemetryClient, 'initialize').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      initializeSpy.mockRestore();
+      mockLoadFromMetaTags.mockReset();
+    });
+
+    it('reports the meta-tag org/tenant values as orgId/tenantId and the merged config as orgName/tenantName', () => {
+      mockLoadFromMetaTags.mockReturnValue({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: 'meta-org-id',
+        tenantName: 'meta-tenant-id',
+      });
+
+      const sdk = new UiPath({ secret: TEST_CONSTANTS.CLIENT_SECRET });
+      expect(sdk).toBeInstanceOf(UiPath);
+
+      const context = initializeSpy.mock.calls[0][0] as TelemetryContext;
+      expect(context.orgId).toBe('meta-org-id');
+      expect(context.tenantId).toBe('meta-tenant-id');
+      // No constructor override, so the merged config values match the meta tags.
+      expect(context.orgName).toBe('meta-org-id');
+      expect(context.tenantName).toBe('meta-tenant-id');
+    });
+
+    it('uses the meta-tag ids for orgId/tenantId and the constructor override for orgName/tenantName', () => {
+      mockLoadFromMetaTags.mockReturnValue({
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgName: 'meta-org-id',
+        tenantName: 'meta-tenant-id',
+      });
+
+      const sdk = new UiPath({
+        orgName: 'constructor-org-name',
+        tenantName: 'constructor-tenant-name',
+        secret: TEST_CONSTANTS.CLIENT_SECRET,
+      });
+      expect(sdk).toBeInstanceOf(UiPath);
+
+      const context = initializeSpy.mock.calls[0][0] as TelemetryContext;
+      expect(context.orgId).toBe('meta-org-id');
+      expect(context.tenantId).toBe('meta-tenant-id');
+      expect(context.orgName).toBe('constructor-org-name');
+      expect(context.tenantName).toBe('constructor-tenant-name');
     });
   });
 });

--- a/tests/unit/utils/encoding/jwt.test.ts
+++ b/tests/unit/utils/encoding/jwt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { extractUserIdFromToken } from '@/utils/encoding';
+import { TEST_USER_ID, createTestJwt } from '@tests/utils/jwt';
+
+describe('extractUserIdFromToken', () => {
+  it('extracts the sub claim from a valid JWT', () => {
+    const token = createTestJwt({ sub: TEST_USER_ID, client_id: 'client-1' });
+
+    expect(extractUserIdFromToken(token)).toBe(TEST_USER_ID);
+  });
+
+  it('extracts the user id from a base64url payload containing - and _ characters', () => {
+    // `???>>>` encodes to base64 containing `/` and `+`, which become `_`
+    // and `-` in the JWT's base64url payload — exercising the
+    // base64url-to-base64 conversion and unpadded-length handling.
+    const token = createTestJwt({ sub: TEST_USER_ID, name: '???>>>', padding: 'x' });
+
+    expect(extractUserIdFromToken(token)).toBe(TEST_USER_ID);
+  });
+
+  it('returns an empty string for an opaque (non-JWT) token', () => {
+    expect(extractUserIdFromToken('rt_opaque-personal-access-token')).toBe('');
+  });
+
+  it('returns an empty string for an empty token', () => {
+    expect(extractUserIdFromToken('')).toBe('');
+  });
+
+  it('returns an empty string when the payload has no sub claim', () => {
+    const token = createTestJwt({ client_id: 'client-1' });
+
+    expect(extractUserIdFromToken(token)).toBe('');
+  });
+
+  it('returns an empty string when the sub claim is not a string', () => {
+    const token = createTestJwt({ sub: 12345 });
+
+    expect(extractUserIdFromToken(token)).toBe('');
+  });
+
+  it('returns an empty string when the payload is not valid JSON', () => {
+    expect(extractUserIdFromToken('header.%%%invalid%%%.signature')).toBe('');
+  });
+});

--- a/tests/utils/jwt.ts
+++ b/tests/utils/jwt.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared JWT test helpers — build unsigned JWTs for tests that exercise
+ * token-payload decoding.
+ */
+
+export const TEST_USER_ID = 'user-guid-1234';
+
+const BASE64_PLUS_RE = /\+/g;
+const BASE64_SLASH_RE = /\//g;
+const BASE64_PADDING_RE = /=+$/;
+
+/** Encodes a claims object as an unpadded base64url JWT segment. */
+export function encodeJwtSegment(value: Record<string, unknown>): string {
+  return btoa(JSON.stringify(value))
+    .replace(BASE64_PLUS_RE, '-')
+    .replace(BASE64_SLASH_RE, '_')
+    .replace(BASE64_PADDING_RE, '');
+}
+
+/** Builds an unsigned JWT whose payload carries the given claims. */
+export function createTestJwt(claims: Record<string, unknown>): string {
+  return `${encodeJwtSegment({ alg: 'none', typ: 'JWT' })}.${encodeJwtSegment(claims)}.signature`;
+}


### PR DESCRIPTION
## Summary

SDK-side consumption of the `CloudUserId` telemetry attribute introduced in `@uipath/core-telemetry@1.0.0-beta.3` (#494):

- **`src/utils/encoding/jwt.ts`** (new) — `extractUserIdFromToken()` decodes the JWT payload (`sub` claim) using the existing `atob`-based `decodeBase64` util (base64url → base64 conversion + padding, no new dependencies). Fail-soft: returns `""` for opaque tokens (PATs/secrets) or malformed payloads — telemetry enrichment never breaks the auth flow.
- **`src/core/auth/token-manager.ts`** — whenever a token is stored (`setToken`, `loadFromStorage`, OAuth refresh, Action Center / embedded callbacks, `updateToken`), the extracted user id is fed to the telemetry client, so all events emitted afterwards carry `CloudUserId`.
- **`src/core/telemetry/index.ts`** — SDK telemetry wrapper exposes `setUserId()` delegating to the shared client.
- Coded action app SDK also has the same changes for orgId and tenantId. Additionally for coded action apps, the sdk does not have any context of the user id until it receives the userId from getTask() method so that method always has null userId. Once getTask() event response is received, the user id is set in the telemetry client for ts-sdk as well.
- completeTask() has a userId linked to it and post getTask(), all ts-sdk api calls also have the userId in the telmetry event.

The telemetry init context keeps the existing `orgName`/`tenantName` keys — beta.3 carries both name and id context fields, so no call-site change is needed; `orgId`/`tenantId` can be fed later once a real id source exists.

<img width="2141" height="802" alt="Screenshot 2026-06-09 002358" src="https://github.com/user-attachments/assets/28a96b36-4701-40e3-a0d8-c941152b0baf" />
<img width="2257" height="808" alt="Screenshot 2026-06-09 002409" src="https://github.com/user-attachments/assets/8686e948-e15a-49a6-b51b-b2d5f34ae7f8" />


## Dependencies

⚠️ **Depends on #494**: requires `@uipath/core-telemetry@1.0.0-beta.3` to be published and the root lockfile refreshed — typecheck fails against the currently locked `beta.2` (no `setUserId`). Merge order: #494 → publish telemetry → refresh lockfile → this PR.

## Verification

- [x] `npm run typecheck` (against beta.3 dist)
- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — all pass
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)