### PR TITLE
feat(tasks): support assignment criteria for group task assignment

### DIFF
--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -162,8 +162,8 @@ export interface TaskServiceModel {
    * ```typescript
    * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
    *
-   * // Assign to a directory group by userId + criteria — the backend
-   * // distributes the task across the group's members
+   * // Assign to a directory group by userId + criteria — Action Center
+   * // distributes the task across the group's members based on the criteria
    * const result = await tasks.assign({
    *   taskId: <taskId>,
    *   userId: <groupId>, // a DirectoryGroup id from tasks.getUsers()
@@ -363,9 +363,10 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
     async assign(options: TaskAssignOptions): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
       if (!taskData.id) throw new Error('Task ID is undefined');
 
+      const criteria = options.assignmentCriteria !== undefined ? { assignmentCriteria: options.assignmentCriteria } : {};
       const assignmentOptions: TaskAssignmentOptions = 'userId' in options && options.userId !== undefined
-        ? { taskId: taskData.id, userId: options.userId, assignmentCriteria: options.assignmentCriteria }
-        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail!, assignmentCriteria: options.assignmentCriteria };
+        ? { taskId: taskData.id, userId: options.userId, ...criteria }
+        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail!, ...criteria };
 
       return service.assign(assignmentOptions);
     },
@@ -373,9 +374,10 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
     async reassign(options: TaskAssignOptions): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>> {
       if (!taskData.id) throw new Error('Task ID is undefined');
 
+      const criteria = options.assignmentCriteria !== undefined ? { assignmentCriteria: options.assignmentCriteria } : {};
       const assignmentOptions: TaskAssignmentOptions = 'userId' in options && options.userId !== undefined
-        ? { taskId: taskData.id, userId: options.userId, assignmentCriteria: options.assignmentCriteria }
-        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail!, assignmentCriteria: options.assignmentCriteria };
+        ? { taskId: taskData.id, userId: options.userId, ...criteria }
+        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail!, ...criteria };
 
       return service.reassign(assignmentOptions);
     },

--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -156,6 +156,15 @@ export interface TaskServiceModel {
    *   { taskId: <taskId1>, userId: <userId> },
    *   { taskId: <taskId2>, userNameOrEmail: "user@example.com" }
    * ]);
+   *
+   * // Assign to a directory group — set the assignment criteria so the
+   * // backend distributes the task across the group's members
+   * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   * const result = await tasks.assign({
+   *   taskId: <taskId>,
+   *   userId: <groupId>, // a DirectoryGroup id from tasks.getUsers()
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
    * ```
    */
   assign(options: TaskAssignmentOptions | TaskAssignmentOptions[]): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
@@ -191,6 +200,14 @@ export interface TaskServiceModel {
    *   { taskId: <taskId1>, userId: <userId> },
    *   { taskId: <taskId2>, userNameOrEmail: "user@example.com" }
    * ]);
+   *
+   * // Reassign to a directory group — set the assignment criteria
+   * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   * const result = await tasks.reassign({
+   *   taskId: <taskId>,
+   *   userId: <groupId>, // a DirectoryGroup id from tasks.getUsers()
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
    * ```
    */
   reassign(options: TaskAssignmentOptions | TaskAssignmentOptions[]): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
@@ -325,8 +342,8 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
       if (!taskData.id) throw new Error('Task ID is undefined');
 
       const assignmentOptions: TaskAssignmentOptions = 'userId' in options && options.userId !== undefined
-        ? { taskId: taskData.id, userId: options.userId }
-        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail! };
+        ? { taskId: taskData.id, userId: options.userId, assignmentCriteria: options.assignmentCriteria }
+        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail!, assignmentCriteria: options.assignmentCriteria };
 
       return service.assign(assignmentOptions);
     },
@@ -335,8 +352,8 @@ function createTaskMethods(taskData: RawTaskGetResponse | RawTaskCreateResponse,
       if (!taskData.id) throw new Error('Task ID is undefined');
 
       const assignmentOptions: TaskAssignmentOptions = 'userId' in options && options.userId !== undefined
-        ? { taskId: taskData.id, userId: options.userId }
-        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail! };
+        ? { taskId: taskData.id, userId: options.userId, assignmentCriteria: options.assignmentCriteria }
+        : { taskId: taskData.id, userNameOrEmail: options.userNameOrEmail!, assignmentCriteria: options.assignmentCriteria };
 
       return service.reassign(assignmentOptions);
     },

--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -156,10 +156,14 @@ export interface TaskServiceModel {
    *   { taskId: <taskId1>, userId: <userId> },
    *   { taskId: <taskId2>, userNameOrEmail: "user@example.com" }
    * ]);
+   * ```
    *
-   * // Assign to a directory group — set the assignment criteria so the
-   * // backend distributes the task across the group's members
+   * @example Group assignment
+   * ```typescript
    * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   *
+   * // Assign to a directory group by userId + criteria — the backend
+   * // distributes the task across the group's members
    * const result = await tasks.assign({
    *   taskId: <taskId>,
    *   userId: <groupId>, // a DirectoryGroup id from tasks.getUsers()
@@ -167,7 +171,7 @@ export interface TaskServiceModel {
    * });
    *
    * // ...or identify the group by name instead of id
-   * const result = await tasks.assign({
+   * const result2 = await tasks.assign({
    *   taskId: <taskId>,
    *   userNameOrEmail: "<groupName>",
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
@@ -207,9 +211,13 @@ export interface TaskServiceModel {
    *   { taskId: <taskId1>, userId: <userId> },
    *   { taskId: <taskId2>, userNameOrEmail: "user@example.com" }
    * ]);
+   * ```
    *
-   * // Reassign to a directory group — set the assignment criteria
+   * @example Group reassignment
+   * ```typescript
    * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   *
+   * // Reassign to a directory group by userId + criteria
    * const result = await tasks.reassign({
    *   taskId: <taskId>,
    *   userId: <groupId>, // a DirectoryGroup id from tasks.getUsers()
@@ -217,7 +225,7 @@ export interface TaskServiceModel {
    * });
    *
    * // ...or identify the group by name instead of id
-   * const result = await tasks.reassign({
+   * const result2 = await tasks.reassign({
    *   taskId: <taskId>,
    *   userNameOrEmail: "<groupName>",
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers

--- a/src/models/action-center/tasks.models.ts
+++ b/src/models/action-center/tasks.models.ts
@@ -165,6 +165,13 @@ export interface TaskServiceModel {
    *   userId: <groupId>, // a DirectoryGroup id from tasks.getUsers()
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
    * });
+   *
+   * // ...or identify the group by name instead of id
+   * const result = await tasks.assign({
+   *   taskId: <taskId>,
+   *   userNameOrEmail: "<groupName>",
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
    * ```
    */
   assign(options: TaskAssignmentOptions | TaskAssignmentOptions[]): Promise<OperationResponse<TaskAssignmentOptions[] | TaskAssignmentResponse[]>>;
@@ -206,6 +213,13 @@ export interface TaskServiceModel {
    * const result = await tasks.reassign({
    *   taskId: <taskId>,
    *   userId: <groupId>, // a DirectoryGroup id from tasks.getUsers()
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
+   *
+   * // ...or identify the group by name instead of id
+   * const result = await tasks.reassign({
+   *   taskId: <taskId>,
+   *   userNameOrEmail: "<groupName>",
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
    * });
    * ```

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -206,12 +206,43 @@ export interface RawTaskGetResponse extends TaskBaseResponse {
 }
 
 /**
- * Options for task assignment operations when called from a task instance
- * Requires either userId or userNameOrEmail, but not both
+ * Defines how a task assignment is distributed.
+ *
+ * Omit it (or use {@link TaskAssignmentCriteria.SingleUser}) for a direct
+ * single-user assignment. The group-based criteria are used when the assignee
+ * is a directory group, telling the backend how to distribute the task across
+ * the group's members.
  */
-export type TaskAssignOptions =
+export enum TaskAssignmentCriteria {
+  /** Assigned to a single user, like a direct assignment. */
+  SingleUser = 'SingleUser',
+  /** Assigned to the group member with the fewest pending tasks. */
+  Workload = 'Workload',
+  /** Assigned to all users in the group. */
+  AllUsers = 'AllUsers',
+  /** Assigned in a round-robin manner across the group's members. */
+  RoundRobin = 'RoundRobin',
+  /** Assigned hierarchically. */
+  Hierarchy = 'Hierarchy',
+}
+
+/**
+ * Options for task assignment operations when called from a task instance
+ * Requires either userId or userNameOrEmail, but not both. Optionally accepts
+ * an assignment criteria — required when assigning to a directory group (e.g.
+ * {@link TaskAssignmentCriteria.AllUsers}).
+ */
+export type TaskAssignOptions = (
   | { userId: number; userNameOrEmail?: never }
-  | { userId?: never; userNameOrEmail: string };
+  | { userId?: never; userNameOrEmail: string }
+) & {
+  /**
+   * How the assignment is distributed. Omit for a direct single-user
+   * assignment; set a group criteria (e.g. {@link TaskAssignmentCriteria.AllUsers})
+   * when the assignee is a directory group.
+   */
+  assignmentCriteria?: TaskAssignmentCriteria;
+};
 
 /**
  * Options for task assignment operations when called from the service

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -198,7 +198,7 @@ export interface RawTaskGetResponse extends TaskBaseResponse {
   actionLabel?: string | null;
   taskSlaDetails?: TaskSlaDetail[] | null;
   completedByUser?: UserLoginInfo | null;
-  taskAssignmentCriteria?: string;
+  taskAssignmentCriteria?: TaskAssignmentCriteria;
   taskAssignees?: UserLoginInfo[] | null;
   taskSource?: TaskSource | null;
   processingTime?: number | null;

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -208,10 +208,9 @@ export interface RawTaskGetResponse extends TaskBaseResponse {
 /**
  * Defines how a task assignment is distributed.
  *
- * Omit it (or use {@link TaskAssignmentCriteria.SingleUser}) for a direct
- * single-user assignment. The group-based criteria are used when the assignee
- * is a directory group, telling the backend how to distribute the task across
- * the group's members.
+ * Defaults to {@link TaskAssignmentCriteria.SingleUser} (a direct single-user
+ * assignment) when not specified. The group-based criteria tell the backend how
+ * to distribute the task across the members of a directory group.
  */
 export enum TaskAssignmentCriteria {
   /** Assigned to a single user, like a direct assignment. */
@@ -220,26 +219,23 @@ export enum TaskAssignmentCriteria {
   Workload = 'Workload',
   /** Assigned to all users in the group. */
   AllUsers = 'AllUsers',
-  /** Assigned in a round-robin manner across the group's members. */
-  RoundRobin = 'RoundRobin',
-  /** Assigned hierarchically. */
-  Hierarchy = 'Hierarchy',
 }
 
 /**
  * Options for task assignment operations when called from a task instance
  * Requires either userId or userNameOrEmail, but not both. Optionally accepts
- * an assignment criteria — required when assigning to a directory group (e.g.
- * {@link TaskAssignmentCriteria.AllUsers}).
+ * an assignment criteria; defaults to a single-user assignment, set a group
+ * criteria (e.g. {@link TaskAssignmentCriteria.AllUsers}) for a directory group.
  */
 export type TaskAssignOptions = (
   | { userId: number; userNameOrEmail?: never }
   | { userId?: never; userNameOrEmail: string }
 ) & {
   /**
-   * How the assignment is distributed. Omit for a direct single-user
-   * assignment; set a group criteria (e.g. {@link TaskAssignmentCriteria.AllUsers})
-   * when the assignee is a directory group.
+   * How the assignment is distributed. Optional — defaults to
+   * {@link TaskAssignmentCriteria.SingleUser} (a direct single-user assignment).
+   * Set a group criteria (e.g. {@link TaskAssignmentCriteria.AllUsers}) to
+   * distribute the task across a directory group's members.
    */
   assignmentCriteria?: TaskAssignmentCriteria;
 };

--- a/src/models/action-center/tasks.types.ts
+++ b/src/models/action-center/tasks.types.ts
@@ -209,8 +209,8 @@ export interface RawTaskGetResponse extends TaskBaseResponse {
  * Defines how a task assignment is distributed.
  *
  * Defaults to {@link TaskAssignmentCriteria.SingleUser} (a direct single-user
- * assignment) when not specified. The group-based criteria tell the backend how
- * to distribute the task across the members of a directory group.
+ * assignment) when not specified. The group-based criteria tell Action Center
+ * how to distribute the task across the members of a directory group.
  */
 export enum TaskAssignmentCriteria {
   /** Assigned to a single user, like a direct assignment. */
@@ -219,6 +219,8 @@ export enum TaskAssignmentCriteria {
   Workload = 'Workload',
   /** Assigned to all users in the group. */
   AllUsers = 'AllUsers',
+  /** Assigned in a round-robin manner across the group's members. */
+  RoundRobin = 'RoundRobin',
 }
 
 /**

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -333,10 +333,14 @@ export class TaskService extends BaseService implements TaskServiceModel {
    *     userNameOrEmail: "user@example.com"
    *   }
    * ]);
+   * ```
    *
-   * // Assign to a directory group — set the assignment criteria so the
-   * // backend distributes the task across the group's members
+   * @example Group assignment
+   * ```typescript
    * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   *
+   * // Assign to a directory group by userId + criteria — the backend
+   * // distributes the task across the group's members
    * const result = await tasks.assign({
    *   taskId: 123,
    *   userId: 456, // a DirectoryGroup id from tasks.getUsers()
@@ -344,7 +348,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * });
    *
    * // ...or identify the group by name instead of id
-   * const result = await tasks.assign({
+   * const result2 = await tasks.assign({
    *   taskId: 123,
    *   userNameOrEmail: "My Group",
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
@@ -410,9 +414,13 @@ export class TaskService extends BaseService implements TaskServiceModel {
    *     userNameOrEmail: "user@example.com"
    *   }
    * ]);
+   * ```
    *
-   * // Reassign to a directory group — set the assignment criteria
+   * @example Group reassignment
+   * ```typescript
    * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   *
+   * // Reassign to a directory group by userId + criteria
    * const result = await tasks.reassign({
    *   taskId: 123,
    *   userId: 456, // a DirectoryGroup id from tasks.getUsers()
@@ -420,7 +428,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * });
    *
    * // ...or identify the group by name instead of id
-   * const result = await tasks.reassign({
+   * const result2 = await tasks.reassign({
    *   taskId: 123,
    *   userNameOrEmail: "My Group",
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -333,6 +333,15 @@ export class TaskService extends BaseService implements TaskServiceModel {
    *     userNameOrEmail: "user@example.com"
    *   }
    * ]);
+   *
+   * // Assign to a directory group — set the assignment criteria so the
+   * // backend distributes the task across the group's members
+   * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   * const result = await tasks.assign({
+   *   taskId: 123,
+   *   userId: 456, // a DirectoryGroup id from tasks.getUsers()
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
    * ```
    */
   @track('Tasks.Assign')
@@ -394,6 +403,14 @@ export class TaskService extends BaseService implements TaskServiceModel {
    *     userNameOrEmail: "user@example.com"
    *   }
    * ]);
+   *
+   * // Reassign to a directory group — set the assignment criteria
+   * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
+   * const result = await tasks.reassign({
+   *   taskId: 123,
+   *   userId: 456, // a DirectoryGroup id from tasks.getUsers()
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
    * ```
    */
   @track('Tasks.Reassign')

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -339,8 +339,8 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * ```typescript
    * import { TaskAssignmentCriteria } from '@uipath/uipath-typescript/tasks';
    *
-   * // Assign to a directory group by userId + criteria — the backend
-   * // distributes the task across the group's members
+   * // Assign to a directory group by userId + criteria — Action Center
+   * // distributes the task across the group's members based on the criteria
    * const result = await tasks.assign({
    *   taskId: 123,
    *   userId: 456, // a DirectoryGroup id from tasks.getUsers()

--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -342,6 +342,13 @@ export class TaskService extends BaseService implements TaskServiceModel {
    *   userId: 456, // a DirectoryGroup id from tasks.getUsers()
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
    * });
+   *
+   * // ...or identify the group by name instead of id
+   * const result = await tasks.assign({
+   *   taskId: 123,
+   *   userNameOrEmail: "My Group",
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
    * ```
    */
   @track('Tasks.Assign')
@@ -409,6 +416,13 @@ export class TaskService extends BaseService implements TaskServiceModel {
    * const result = await tasks.reassign({
    *   taskId: 123,
    *   userId: 456, // a DirectoryGroup id from tasks.getUsers()
+   *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
+   * });
+   *
+   * // ...or identify the group by name instead of id
+   * const result = await tasks.reassign({
+   *   taskId: 123,
+   *   userNameOrEmail: "My Group",
    *   assignmentCriteria: TaskAssignmentCriteria.AllUsers
    * });
    * ```

--- a/tests/integration/shared/action-center/tasks.integration.test.ts
+++ b/tests/integration/shared/action-center/tasks.integration.test.ts
@@ -329,7 +329,17 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
         assignmentCriteria: TaskAssignmentCriteria.AllUsers,
       });
 
+      // Action Center responds 200 with an empty body on a successful assignment
+      // and with per-task failure details (errorCode/errorMessage) when an item
+      // fails. The SDK maps the empty body to success=true and echoes the request
+      // as `data`; a failure would instead surface error items here. Asserting the
+      // exact echoed payload proves the response carried no failure details.
       expect(result.success).toBe(true);
+      expect(result.data).toEqual([
+        { taskId: criteriaTaskId, userId: groupId, assignmentCriteria: TaskAssignmentCriteria.AllUsers },
+      ]);
+
+      await tasks.unassign(criteriaTaskId);
     });
   });
 

--- a/tests/integration/shared/action-center/tasks.integration.test.ts
+++ b/tests/integration/shared/action-center/tasks.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
   getServices,
   getTestConfig,
@@ -8,7 +8,7 @@ import {
 } from '../../config/unified-setup';
 import { registerResource } from '../../utils/cleanup';
 import { generateTestResourceName } from '../../utils/helpers';
-import { TaskPriority, TaskType, TaskUserType } from '../../../../src/models/action-center/tasks.types';
+import { TaskPriority, TaskType, TaskUserType, TaskAssignmentCriteria } from '../../../../src/models/action-center/tasks.types';
 
 const modes: InitMode[] = ['v0', 'v1'];
 
@@ -258,6 +258,78 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
       } catch (error: any) {
         throw new Error(`Task unassignment failed: ${error.message}`);
       }
+    });
+  });
+
+  describe('Assignment with criteria', () => {
+    // Resolved once for the whole block — Action Center assignment is
+    // folder-scoped, and the user/group must exist to exercise the paths.
+    // (Single-user assignment by userId is already covered in "Assignment
+    // operations"; this block adds the userNameOrEmail and group-criteria paths.)
+    let folderId!: number;
+    let userNameOrEmail!: string;
+    let groupId!: number;
+    let criteriaTaskId!: number;
+
+    beforeAll(async () => {
+      const { tasks } = getServices();
+      const config = getTestConfig();
+
+      if (!config.folderId) {
+        throw new Error('folderId is required in the test config for assignment-criteria tests');
+      }
+      folderId = Number(config.folderId);
+
+      const users = await tasks.getUsers(folderId);
+
+      const individual = users.items.find(
+        (u) => u.type === TaskUserType.User || u.type === TaskUserType.DirectoryUser,
+      );
+      if (!individual) {
+        throw new Error('No individual user (User/DirectoryUser) in the folder to test single-user assignment');
+      }
+      userNameOrEmail = individual.emailAddress || individual.userName;
+
+      const group = users.items.find((u) => u.type === TaskUserType.DirectoryGroup);
+      if (!group) {
+        throw new Error('No DirectoryGroup in the folder to test group assignment');
+      }
+      groupId = group.id;
+
+      // One reusable External task; unassigned between cases so each assign
+      // starts from a clean state. Tasks have no delete API, so cleanup only
+      // unassigns — register it for the shared teardown.
+      const created = await tasks.create(
+        { title: generateTestResourceName(`CriteriaTask_${mode}`), priority: TaskPriority.Medium },
+        folderId,
+      );
+      criteriaTaskId = created.id;
+      registerResource('tasks', { id: criteriaTaskId, folderId });
+    });
+
+    it('should assign to a single user by userNameOrEmail', async () => {
+      const { tasks } = getServices();
+
+      const result = await tasks.assign({ taskId: criteriaTaskId, userNameOrEmail });
+
+      expect(result.success).toBe(true);
+
+      const task = await tasks.getById(criteriaTaskId, {}, folderId);
+      expect(task.assignedToUser).toBeDefined();
+
+      await tasks.unassign(criteriaTaskId);
+    });
+
+    it('should assign to a directory group with the AllUsers criteria', async () => {
+      const { tasks } = getServices();
+
+      const result = await tasks.assign({
+        taskId: criteriaTaskId,
+        userId: groupId,
+        assignmentCriteria: TaskAssignmentCriteria.AllUsers,
+      });
+
+      expect(result.success).toBe(true);
     });
   });
 

--- a/tests/unit/models/action-center/tasks.test.ts
+++ b/tests/unit/models/action-center/tasks.test.ts
@@ -44,11 +44,13 @@ describe('Task Models', () => {
         
         const result = await task.assign({ userId: TASK_TEST_CONSTANTS.USER_ID });
 
-        
+
         expect(mockService.assign).toHaveBeenCalledWith({
           taskId: TASK_TEST_CONSTANTS.TASK_ID,
           userId: TASK_TEST_CONSTANTS.USER_ID
         });
+        // No criteria supplied — the key must be omitted, not forwarded as undefined.
+        expect(vi.mocked(mockService.assign).mock.calls[0][0]).not.toHaveProperty('assignmentCriteria');
         expect(result).toEqual(mockResponse);
       });
 

--- a/tests/unit/models/action-center/tasks.test.ts
+++ b/tests/unit/models/action-center/tasks.test.ts
@@ -94,6 +94,28 @@ describe('Task Models', () => {
         expect(result).toEqual(mockResponse);
       });
 
+      it('should forward assignmentCriteria when assigning by email to a group', async () => {
+        const taskData = createBasicTask();
+        const task = createTaskWithMethods(taskData, mockService);
+
+        const mockResponse = createMockOperationResponse([
+          { taskId: TASK_TEST_CONSTANTS.TASK_ID, userNameOrEmail: TASK_TEST_CONSTANTS.USER_EMAIL }
+        ]);
+        mockService.assign = vi.fn().mockResolvedValue(mockResponse);
+
+        const result = await task.assign({
+          userNameOrEmail: TASK_TEST_CONSTANTS.USER_EMAIL,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+
+        expect(mockService.assign).toHaveBeenCalledWith({
+          taskId: TASK_TEST_CONSTANTS.TASK_ID,
+          userNameOrEmail: TASK_TEST_CONSTANTS.USER_EMAIL,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+        expect(result).toEqual(mockResponse);
+      });
+
       it('should throw error if taskId is undefined', async () => {
         const taskData = createBasicTask({ id: undefined });
         const task = createTaskWithMethods(taskData, mockService);
@@ -161,6 +183,28 @@ describe('Task Models', () => {
         expect(mockService.reassign).toHaveBeenCalledWith({
           taskId: TASK_TEST_CONSTANTS.TASK_ID,
           userId: TASK_TEST_CONSTANTS.USER_ID,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+        expect(result).toEqual(mockResponse);
+      });
+
+      it('should forward assignmentCriteria when reassigning by email to a group', async () => {
+        const taskData = createBasicTask();
+        const task = createTaskWithMethods(taskData, mockService);
+
+        const mockResponse = createMockOperationResponse([
+          { taskId: TASK_TEST_CONSTANTS.TASK_ID, userNameOrEmail: TASK_TEST_CONSTANTS.USER_EMAIL }
+        ]);
+        mockService.reassign = vi.fn().mockResolvedValue(mockResponse);
+
+        const result = await task.reassign({
+          userNameOrEmail: TASK_TEST_CONSTANTS.USER_EMAIL,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+
+        expect(mockService.reassign).toHaveBeenCalledWith({
+          taskId: TASK_TEST_CONSTANTS.TASK_ID,
+          userNameOrEmail: TASK_TEST_CONSTANTS.USER_EMAIL,
           assignmentCriteria: TaskAssignmentCriteria.AllUsers
         });
         expect(result).toEqual(mockResponse);

--- a/tests/unit/models/action-center/tasks.test.ts
+++ b/tests/unit/models/action-center/tasks.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTaskWithMethods } from '../../../../src/models/action-center/tasks.models';
 import type { TaskServiceModel } from '../../../../src/models/action-center/tasks.models';
-import { TaskType, TaskPriority} from '../../../../src/models/action-center/tasks.types';
+import { TaskType, TaskPriority, TaskAssignmentCriteria } from '../../../../src/models/action-center/tasks.types';
 import { createBasicTask } from '../../../utils/mocks/tasks';
 import { createMockOperationResponse } from '../../../utils/mocks/core';
 import { TASK_TEST_CONSTANTS } from '../../../utils/constants/tasks';
@@ -72,11 +72,33 @@ describe('Task Models', () => {
         expect(result).toEqual(mockResponse);
       });
 
+      it('should forward assignmentCriteria for group assignment', async () => {
+        const taskData = createBasicTask();
+        const task = createTaskWithMethods(taskData, mockService);
+
+        const mockResponse = createMockOperationResponse([
+          { taskId: TASK_TEST_CONSTANTS.TASK_ID, userId: TASK_TEST_CONSTANTS.USER_ID }
+        ]);
+        mockService.assign = vi.fn().mockResolvedValue(mockResponse);
+
+        const result = await task.assign({
+          userId: TASK_TEST_CONSTANTS.USER_ID,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+
+        expect(mockService.assign).toHaveBeenCalledWith({
+          taskId: TASK_TEST_CONSTANTS.TASK_ID,
+          userId: TASK_TEST_CONSTANTS.USER_ID,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+        expect(result).toEqual(mockResponse);
+      });
+
       it('should throw error if taskId is undefined', async () => {
         const taskData = createBasicTask({ id: undefined });
         const task = createTaskWithMethods(taskData, mockService);
 
-        
+
         await expect(task.assign({ userId: TASK_TEST_CONSTANTS.USER_ID })).rejects.toThrow('Task ID is undefined');
       });
     });
@@ -122,11 +144,33 @@ describe('Task Models', () => {
         expect(result).toEqual(mockResponse);
       });
 
+      it('should forward assignmentCriteria for group reassignment', async () => {
+        const taskData = createBasicTask();
+        const task = createTaskWithMethods(taskData, mockService);
+
+        const mockResponse = createMockOperationResponse([
+          { taskId: TASK_TEST_CONSTANTS.TASK_ID, userId: TASK_TEST_CONSTANTS.USER_ID }
+        ]);
+        mockService.reassign = vi.fn().mockResolvedValue(mockResponse);
+
+        const result = await task.reassign({
+          userId: TASK_TEST_CONSTANTS.USER_ID,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+
+        expect(mockService.reassign).toHaveBeenCalledWith({
+          taskId: TASK_TEST_CONSTANTS.TASK_ID,
+          userId: TASK_TEST_CONSTANTS.USER_ID,
+          assignmentCriteria: TaskAssignmentCriteria.AllUsers
+        });
+        expect(result).toEqual(mockResponse);
+      });
+
       it('should throw error if taskId is undefined', async () => {
         const taskData = createBasicTask({ id: undefined });
         const task = createTaskWithMethods(taskData, mockService);
 
-        
+
         await expect(task.reassign({ userId: TASK_TEST_CONSTANTS.USER_ID })).rejects.toThrow('Task ID is undefined');
       });
     });

--- a/tests/unit/services/action-center/tasks.test.ts
+++ b/tests/unit/services/action-center/tasks.test.ts
@@ -245,6 +245,7 @@ describe('TaskService Unit Tests', () => {
       const result = await taskService.assign(assignment);
 
       expect(result.success).toBe(true);
+      expect(result.data).toEqual([assignment]);
       expect(mockApiClient.post).toHaveBeenCalledWith(
         TASK_ENDPOINTS.ASSIGN_TASKS,
         expect.objectContaining({
@@ -368,6 +369,7 @@ describe('TaskService Unit Tests', () => {
       const result = await taskService.reassign(assignment);
 
       expect(result.success).toBe(true);
+      expect(result.data).toEqual([assignment]);
       expect(mockApiClient.post).toHaveBeenCalledWith(
         TASK_ENDPOINTS.REASSIGN_TASKS,
         expect.objectContaining({

--- a/tests/unit/services/action-center/tasks.test.ts
+++ b/tests/unit/services/action-center/tasks.test.ts
@@ -1,9 +1,10 @@
 // ===== IMPORTS =====
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TaskService } from '../../../../src/services/action-center/tasks';
-import { 
-  TaskType, 
-  TaskPriority, 
+import {
+  TaskType,
+  TaskPriority,
+  TaskAssignmentCriteria,
   TaskAssignmentOptions,
   TaskCompletionOptions,
   TaskCreateOptions,
@@ -231,6 +232,33 @@ describe('TaskService Unit Tests', () => {
         expect.any(Object)
       );
     });
+
+    it('should include assignmentCriteria when assigning to a group', async () => {
+      const assignment = {
+        taskId: TASK_TEST_CONSTANTS.TASK_ID,
+        userId: TASK_TEST_CONSTANTS.USER_ID,
+        assignmentCriteria: TaskAssignmentCriteria.AllUsers
+      } as TaskAssignmentOptions;
+
+      mockApiClient.post.mockResolvedValue({ value: [] });
+
+      const result = await taskService.assign(assignment);
+
+      expect(result.success).toBe(true);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        TASK_ENDPOINTS.ASSIGN_TASKS,
+        expect.objectContaining({
+          taskAssignments: expect.arrayContaining([
+            expect.objectContaining({
+              taskId: assignment.taskId,
+              userId: assignment.userId,
+              assignmentCriteria: TaskAssignmentCriteria.AllUsers
+            })
+          ])
+        }),
+        expect.any(Object)
+      );
+    });
   });
 
   describe('reassign', () => {
@@ -321,6 +349,33 @@ describe('TaskService Unit Tests', () => {
             expect.objectContaining({
               taskId: TASK_TEST_CONSTANTS.TASK_ID,
               userNameOrEmail: TASK_TEST_CONSTANTS.USER_EMAIL
+            })
+          ])
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('should include assignmentCriteria when reassigning to a group', async () => {
+      const assignment = {
+        taskId: TASK_TEST_CONSTANTS.TASK_ID,
+        userId: TASK_TEST_CONSTANTS.USER_ID,
+        assignmentCriteria: TaskAssignmentCriteria.AllUsers
+      } as TaskAssignmentOptions;
+
+      mockApiClient.post.mockResolvedValue({ value: [] });
+
+      const result = await taskService.reassign(assignment);
+
+      expect(result.success).toBe(true);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        TASK_ENDPOINTS.REASSIGN_TASKS,
+        expect.objectContaining({
+          taskAssignments: expect.arrayContaining([
+            expect.objectContaining({
+              taskId: assignment.taskId,
+              userId: assignment.userId,
+              assignmentCriteria: TaskAssignmentCriteria.AllUsers
             })
           ])
         }),


### PR DESCRIPTION
The SDK couldn't assign Action Center tasks to directory groups — only individual users.
Action Center's AssignTasks API requires an AssignmentCriteria field when a task is assigned to a directory group (e.g. AllUsers, Workload, RoundRobin). The SDK's assign/reassign did not expose it and the task-bound methods dropped it, so assignments to a group failed.

Add a TaskAssignmentCriteria enum and an optional assignmentCriteria on the assignment options, forwarded through the bound task.assign()/reassign() methods. Backward compatible: omitting it preserves the existing single-user assignment behaviour.