### PR TITLE
fix(data-fabric): make importRecordsById public and enable integration test

### DIFF
--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -437,7 +437,6 @@ export interface EntityServiceModel {
    * // Folder-scoped entity: pass the entity's folder key
    * await entities.importRecordsById(<id>, fileInput.files[0], { folderKey: "<folderKey>" });
    * ```
-   * @internal
    */
   importRecordsById(id: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>;
 

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -613,7 +613,6 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * // Folder-scoped entity: pass the entity's folder key
    * await entities.importRecordsById("<entityId>", fileInput.files[0], { folderKey: "<folderKey>" });
    * ```
-   * @internal
    */
   @track('Entities.ImportRecordsById')
   async importRecordsById(id: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse> {

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -764,8 +764,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
     });
   });
 
-  // Bulk import requires DataFabric.Data.Write scope — not supported via PAT token yet
-  describe.skip('importRecordsById', () => {
+  describe('importRecordsById', () => {
     it('should import records from a CSV blob', async () => {
       const { entities } = getServices();
       const config = getTestConfig();


### PR DESCRIPTION
## Summary

`importRecordsById` is made public as we can give `DataFabric.Data.Write` scope to PAT token

## Changes

| Layer | Change |
|-------|--------|
| `EntityServiceModel.importRecordsById` | Removed `@internal` JSDoc tag (controls docs rendering) |
| `EntityService.importRecordsById` | Removed matching `@internal` tag to keep layers in sync |
| Integration test | `describe.skip('importRecordsById')` → `describe(...)`; removed stale "not supported via PAT" comment |

## Method (now public)

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `entities.importRecordsById()` | `importRecordsById(id: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>` |
| Entity (bound) | `entity.importRecords()` | `importRecords(file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>` |

## Endpoint Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `importRecordsById()` | POST | `DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_ID(id)` | `DataFabric.Data.Write` |

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { Entities } from '@uipath/uipath-typescript/entities';

const sdk = new UiPath(config);
await sdk.initialize();
const entities = new Entities(sdk);

// Browser: upload from file input
const fileInput = document.getElementById('csv-input') as HTMLInputElement;
const result = await entities.importRecordsById("<entityId>", fileInput.files[0]);
console.log(`Inserted ${result.insertedRecords} of ${result.totalRecords} records`);

// Folder-scoped entity: pass the entity's folder key
await entities.importRecordsById("<entityId>", fileInput.files[0], { folderKey: "<folderKey>" });
```

## Files

| Area | Files |
|------|-------|
| Models | `src/models/data-fabric/entities.models.ts` |
| Service | `src/services/data-fabric/entities.ts` |
| Integration tests | `tests/integration/shared/data-fabric/entities.integration.test.ts` |

## Notes

No new endpoints — no Cloudflare whitelisting required. The `importRecordsById` endpoint was already implemented and whitelisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)