### PR TITLE
feat: add client-side tool support [JAR-9962]

### DIFF
--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -109,6 +109,16 @@ export interface SessionEndingEvent {
 }
 
 /**
+ * A client-side tool that the client supports, declared during exchange start
+ * so the server knows which tools to route client-side.
+ */
+export interface ClientSideTool {
+  name: string;
+  inputSchema?: JSONValue;
+  outputSchema?: JSONValue;
+}
+
+/**
  * Signals the start of an exchange of messages within a conversation.
  */
 export interface ExchangeStartEvent {
@@ -128,7 +138,7 @@ export interface ExchangeStartEvent {
    * Optional list of client-side tools the client supports. The server validates these against the agent's
    * design-time definitions and forwards them to the runtime so it knows which tools to route client-side.
    */
-  clientSideTools?: Array<{ name: string; inputSchema?: JSONValue; outputSchema?: JSONValue }>;
+  clientSideTools?: ClientSideTool[];
 }
 
 /**
@@ -452,6 +462,9 @@ export interface ToolCallEndEvent {
  * executing its registered handler upon receiving this event.
  */
 export interface ExecutingToolCallEvent {
+  /**
+   * The time the tool call began executing.
+   */
   timestamp?: string;
   /** The final tool input, reflecting any modifications made during tool-call confirmation. */
   input?: ToolCallInputValue;

--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -124,6 +124,11 @@ export interface ExchangeStartEvent {
    * The time the exchange started.
    */
   timestamp?: string;
+  /**
+   * Optional list of client-side tools the client supports. The server validates these against the agent's
+   * design-time definitions and forwards them to the runtime so it knows which tools to route client-side.
+   */
+  clientSideTools?: Array<{ name: string; inputSchema?: JSONValue; outputSchema?: JSONValue }>;
 }
 
 /**
@@ -392,6 +397,14 @@ export interface ToolCallStartEvent {
    * `requireConfirmation` is true so the client can render an editable form.
    */
   inputSchema?: JSONValue;
+  /**
+   * Output schema — used by the client to render the result form for client-side tools.
+   */
+  outputSchema?: JSONValue;
+  /**
+   * Indicates this tool call should be executed client-side rather than server-side.
+   */
+  isClientSideTool?: boolean;
 }
 
 /**
@@ -431,6 +444,17 @@ export interface ToolCallEndEvent {
    * Metadata pertaining to the tool call's execution or result.
    */
   metaData?: MetaData;
+}
+
+/**
+ * Signals to the client that the tool is about to be executed. Emitted in all scenarios
+ * (server-side and client-side tools). For client-side tools, the client should begin
+ * executing its registered handler upon receiving this event.
+ */
+export interface ExecutingToolCallEvent {
+  timestamp?: string;
+  /** The final tool input, reflecting any modifications made during tool-call confirmation. */
+  input?: ToolCallInputValue;
 }
 
 /**
@@ -475,6 +499,11 @@ export interface ToolCallEvent {
    * emitted with `requireConfirmation: true`.
    */
   confirmToolCall?: ToolCallConfirmationEvent;
+  /**
+   * Signals that the tool is about to be executed. For client-side tools,
+   * the client should begin executing its handler upon receiving this event.
+   */
+  executingToolCall?: ExecutingToolCallEvent;
   /**
    * Allows additional events to be sent in the context of the enclosing event stream.
    */

--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -111,6 +111,7 @@ export interface SessionEndingEvent {
 /**
  * A client-side tool that the client supports, declared during exchange start
  * so the server knows which tools to route client-side.
+ * @internal
  */
 export interface ClientSideTool {
   name: string;
@@ -137,6 +138,7 @@ export interface ExchangeStartEvent {
   /**
    * Optional list of client-side tools the client supports. The server validates these against the agent's
    * design-time definitions and forwards them to the runtime so it knows which tools to route client-side.
+   * @internal
    */
   clientSideTools?: ClientSideTool[];
 }
@@ -409,10 +411,12 @@ export interface ToolCallStartEvent {
   inputSchema?: JSONValue;
   /**
    * Output schema — used by the client to render the result form for client-side tools.
+   * @internal
    */
   outputSchema?: JSONValue;
   /**
    * Indicates this tool call should be executed client-side rather than server-side.
+   * @internal
    */
   isClientSideTool?: boolean;
 }
@@ -460,6 +464,7 @@ export interface ToolCallEndEvent {
  * Signals to the client that the tool is about to be executed. Emitted in all scenarios
  * (server-side and client-side tools). For client-side tools, the client should begin
  * executing its registered handler upon receiving this event.
+ * @internal
  */
 export interface ExecutingToolCallEvent {
   /**
@@ -515,6 +520,7 @@ export interface ToolCallEvent {
   /**
    * Signals that the tool is about to be executed. For client-side tools,
    * the client should begin executing its handler upon receiving this event.
+   * @internal
    */
   executingToolCall?: ExecutingToolCallEvent;
   /**

--- a/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
@@ -7,7 +7,7 @@
  */
 
 import type { MakeRequired } from '..';
-import type { ErrorEndEvent, ErrorStartEvent, MetaEvent, ToolCallConfirmationEvent, ToolCallEndEvent, ToolCallEvent, ToolCallStartEvent } from './protocol.types';
+import type { ErrorEndEvent, ErrorStartEvent, ExecutingToolCallEvent, MetaEvent, ToolCallConfirmationEvent, ToolCallEndEvent, ToolCallEvent, ToolCallStartEvent } from './protocol.types';
 
 /**
  * Aggregated data for a completed tool call
@@ -93,6 +93,19 @@ export type CompletedToolCall = ToolCallStartEvent & ToolCallEndEvent & {
  *   }
  * });
  * ```
+ *
+ * @example Handling client-side tool execution
+ * ```typescript
+ * message.onToolCallStart((toolCall) => {
+ *   const { isClientSideTool, toolName } = toolCall.startEvent;
+ *   if (!isClientSideTool) return;
+ *
+ *   toolCall.onExecutingToolCall(async (event) => {
+ *     const result = await runLocalProcess(toolName, event.input);
+ *     toolCall.sendToolCallEnd({ output: result });
+ *   });
+ * });
+ * ```
  */
 export interface ToolCallStream {
   /** Unique identifier for this tool call */
@@ -167,6 +180,24 @@ export interface ToolCallStream {
    * ```
    */
   onToolCallConfirm(callback: (confirmToolCall: ToolCallConfirmationEvent) => void): () => void;
+
+  /**
+   * Registers a handler for executingToolCall events. Fired when the tool is about
+   * to be executed. For client-side tools, the client should begin executing its
+   * handler upon receiving this event.
+   *
+   * @param cb - Callback receiving the executing event
+   * @returns Cleanup function to remove the handler
+   *
+   * @example Handling client-side tool execution
+   * ```typescript
+   * toolCall.onExecutingToolCall(async (event) => {
+   *   const result = await executeLocally(toolCall.startEvent.toolName, event.input);
+   *   toolCall.sendToolCallEnd({ output: result });
+   * });
+   * ```
+   */
+  onExecutingToolCall(cb: (event: ExecutingToolCallEvent) => void): () => void;
 
   // ==================== Sending ====================
 

--- a/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
@@ -196,6 +196,7 @@ export interface ToolCallStream {
    *   toolCall.sendToolCallEnd({ output: result });
    * });
    * ```
+   * @internal
    */
   onExecutingToolCall(cb: (event: ExecutingToolCallEvent) => void): () => void;
 

--- a/src/services/conversational-agent/helpers/conversation-event-helper-common.ts
+++ b/src/services/conversational-agent/helpers/conversation-event-helper-common.ts
@@ -23,6 +23,7 @@ import type {
   SessionStartedEvent,
   SessionStartEvent,
   Simplify,
+  ExecutingToolCallEvent,
   ToolCallConfirmationEvent,
   ToolCallEndEvent,
   ToolCallStartEvent
@@ -78,6 +79,7 @@ export type ToolCallEndHandler = (endToolCall: ToolCallEndEvent) => void;
 export type ToolCallStartHandler = (toolCall: ToolCallEventHelper) => void;
 export type ToolCallStartHandlerAsync = (toolCall: ToolCallEventHelper) => Promise<ToolCallEndEvent | void>;
 export type ToolCallConfirmationHandler = (confirmToolCall: ToolCallConfirmationEvent) => void;
+export type ExecutingToolCallHandler = (event: ExecutingToolCallEvent) => void;
 export type ToolCallConfirmHandler = (args: ToolCallConfirmationHandlerArgs) => void;
 export type ToolCallCompletedHandler = (completedToolCall: CompletedToolCall) => void;
 export type ContentPartCompletedHandler = (completedContentPart: CompletedContentPart) => void;

--- a/src/services/conversational-agent/helpers/tool-call-event-helper.ts
+++ b/src/services/conversational-agent/helpers/tool-call-event-helper.ts
@@ -13,6 +13,7 @@ import {
   ConversationEventValidationError,
   type ErrorEndEventOptions,
   type ErrorStartEventOptions,
+  type ExecutingToolCallHandler,
   type ToolCallConfirmationHandler,
   type ToolCallEndHandler
 } from './conversation-event-helper-common';
@@ -30,6 +31,7 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
 
   protected readonly _endHandlers = new Array<ToolCallEndHandler>();
   protected readonly _confirmHandlers = new Array<ToolCallConfirmationHandler>();
+  protected readonly _executingHandlers = new Array<ExecutingToolCallHandler>();
 
   constructor(
     public readonly message: MessageEventHelper,
@@ -134,6 +136,20 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
   }
 
   /**
+   * Registers a handler for executingToolCall events.
+   * Fired when the tool is about to be executed. For client-side tools,
+   * the client should begin executing its handler upon receiving this.
+   * @returns Cleanup function to remove the handler.
+   */
+  public onExecutingToolCall(cb: ExecutingToolCallHandler) {
+    this._executingHandlers.push(cb);
+    return () => {
+      const index = this._executingHandlers.indexOf(cb);
+      if (index >= 0) this._executingHandlers.splice(index, 1);
+    };
+  }
+
+  /**
    * Sends an error start event for this tool call.
    */
   public sendErrorStart(args: ErrorStartEventOptions) {
@@ -224,6 +240,11 @@ export class ToolCallEventHelperImpl extends ToolCallEventHelper {
     if (toolCallEvent.confirmToolCall) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this._confirmHandlers.forEach(cb => cb(toolCallEvent.confirmToolCall!));
+    }
+
+    if (toolCallEvent.executingToolCall) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this._executingHandlers.forEach(cb => cb(toolCallEvent.executingToolCall!));
     }
 
     if (toolCallEvent.endToolCall) {

--- a/src/services/conversational-agent/helpers/tool-call-event-helper.ts
+++ b/src/services/conversational-agent/helpers/tool-call-event-helper.ts
@@ -140,6 +140,7 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
    * Fired when the tool is about to be executed. For client-side tools,
    * the client should begin executing its handler upon receiving this.
    * @returns Cleanup function to remove the handler.
+   * @internal
    */
   public onExecutingToolCall(cb: ExecutingToolCallHandler) {
     this._executingHandlers.push(cb);

--- a/tests/unit/helpers/conversational-agent/tool-call-event-helper.test.ts
+++ b/tests/unit/helpers/conversational-agent/tool-call-event-helper.test.ts
@@ -200,6 +200,19 @@ describe('ToolCallEventHelper', () => {
       expect((toolCall as any)._endHandlers).toHaveLength(0);
     });
 
+    it('should register and unregister onExecutingToolCall handler', () => {
+      const { toolCall } = createToolCall();
+      const handler = vi.fn();
+      const cleanup = toolCall.onExecutingToolCall(handler);
+
+      toolCall.dispatch({ toolCallId: TOOL_CALL_ID, executingToolCall: { input: { a: 1 } } });
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      cleanup();
+      toolCall.dispatch({ toolCallId: TOOL_CALL_ID, executingToolCall: { input: { a: 2 } } });
+      expect(handler).toHaveBeenCalledTimes(1); // not called again after cleanup
+    });
+
     it('should register and unregister onToolCallConfirm handler', () => {
       const { toolCall } = createToolCall();
       const handler = vi.fn();
@@ -346,6 +359,59 @@ describe('ToolCallEventHelper', () => {
 
       expect(confirmSpy).toHaveBeenCalledWith({ approved: true, input: { query: 'q' } });
       expect(toolCall.ended).toBe(false);
+    });
+
+    it('should dispatch executingToolCall to executing handlers', () => {
+      const { toolCall } = createToolCall();
+      const executingSpy = vi.fn();
+      toolCall.onExecutingToolCall(executingSpy);
+
+      toolCall.dispatch({
+        toolCallId: TOOL_CALL_ID,
+        executingToolCall: { input: { expression: '2+2' } },
+      });
+
+      expect(executingSpy).toHaveBeenCalledWith({ input: { expression: '2+2' } });
+      expect(toolCall.ended).toBe(false);
+    });
+
+    it('should dispatch executingToolCall with timestamp', () => {
+      const { toolCall } = createToolCall();
+      const executingSpy = vi.fn();
+      toolCall.onExecutingToolCall(executingSpy);
+
+      toolCall.dispatch({
+        toolCallId: TOOL_CALL_ID,
+        executingToolCall: { timestamp: '2025-06-05T10:00:02Z', input: { query: 'test' } },
+      });
+
+      expect(executingSpy).toHaveBeenCalledWith({ timestamp: '2025-06-05T10:00:02Z', input: { query: 'test' } });
+    });
+
+    it('should not invoke end handlers when dispatching executingToolCall', () => {
+      const { toolCall } = createToolCall();
+      const endSpy = vi.fn();
+      toolCall.onToolCallEnd(endSpy);
+
+      toolCall.dispatch({
+        toolCallId: TOOL_CALL_ID,
+        executingToolCall: { input: {} },
+      });
+
+      expect(endSpy).not.toHaveBeenCalled();
+    });
+
+    it('should ignore executingToolCall events for different toolCallId', () => {
+      const { toolCall } = createToolCall();
+      const executingSpy = vi.fn();
+      toolCall.onExecutingToolCall(executingSpy);
+
+      toolCall.dispatch({
+        toolCallId: 'other-tc',
+        executingToolCall: { input: {} },
+      });
+
+      expect(executingSpy).not.toHaveBeenCalled();
     });
 
     it('should not invoke end handlers when dispatching confirmToolCall', () => {
@@ -580,6 +646,19 @@ describe('ToolCallEventHelper', () => {
 
       toolCall.resume();
       expect(metaSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should buffer executingToolCall event when paused', () => {
+      const { toolCall } = createToolCall();
+      const executingSpy = vi.fn();
+      toolCall.onExecutingToolCall(executingSpy);
+
+      toolCall.pause();
+      toolCall.dispatch({ toolCallId: TOOL_CALL_ID, executingToolCall: { input: { x: 1 } } });
+      expect(executingSpy).not.toHaveBeenCalled();
+
+      toolCall.resume();
+      expect(executingSpy).toHaveBeenCalledWith({ input: { x: 1 } });
     });
 
     it('should buffer tool call end event when paused', () => {


### PR DESCRIPTION

### Summary
- Adds support for client-side tools — tools that execute on the client rather than server-side (CAS PR here: https://github.com/UiPath/AgentInterfaces/pull/949)
- Clients can declare supported tools on exchange start, detect client-side tool calls via `isClientSideTool`, and respond to the `executingToolCall` signal to begin local execution

### What's new

- **`ExchangeStartEvent.clientSideTools`** — declare which client-side tools the client supports so the server can filter accordingly. When omitted, all agent-defined client-side tools are assumed available.
- **`ToolCallStartEvent.isClientSideTool`** — server-set flag indicating the tool should be executed client-side
- **`ToolCallStartEvent.outputSchema`** — JSON schema describing the expected result shape, used by the client to render a result form if needed
- **`ExecutingToolCallEvent`** — new event signaling the client to begin execution (fires after optional confirmation)
- **`ToolCallStream.onExecutingToolCall()`** — register a handler for the executing signal

### Usage

```typescript
// Declare client-side tools when starting an exchange
const exchange = session.startExchange({
  clientSideTools: [{ name: 'launch-calculator' }]
});

// Handle client-side tool execution
message.onToolCallStart((toolCall) => {
  const { isClientSideTool, toolName } = toolCall.startEvent;
  if (!isClientSideTool) return;

  toolCall.onExecutingToolCall(async (event) => {
    const result = await runLocalProcess(toolName, event.input);
    toolCall.sendToolCallEnd({ output: result });
  });
});
```

### Tests
- Dispatch, handler registration/unregistration, event buffering when paused, ID filtering