### PR TITLE
feat(data-fabric): add includeAllFolders option to entities.getAll

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -43,6 +43,8 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 
 ## Entities
 
+> **Folder-scoped entities require `OR.Users` in addition to the scope below.** Any CRUD operation on a folder entity (passing `folderKey`), and `getAll({ includeAllFolders: true })` which lists all tenant and folder entities, need `OR.Users` as well.
+
 | Method | OAuth Scope |
 |--------|-------------|
 | `getAll()` | `DataFabric.Schema.Read` |

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -55,13 +55,14 @@ export interface EntityServiceModel {
   /**
    * Gets entities in the system
    *
-   * The Data Fabric entity list is scoped exclusively, not additively:
-   * omitting `folderKey` returns only tenant-level entities; passing
-   * `folderKey` returns only entities in that folder. To enumerate
-   * every entity across folders, call `getAll()` once per folder
-   * plus once with no `folderKey` for the tenant scope.
+   * By default the entity list is scoped exclusively: omitting `folderKey`
+   * returns only tenant-level entities; passing `folderKey` returns only
+   * entities in that folder. To list tenant-level and folder-level entities
+   * together in a single call, pass `includeAllFolders: true` (with no
+   * `folderKey`). When `folderKey` is provided it always wins, scoping the
+   * result to that single folder and ignoring `includeAllFolders`.
    *
-   * @param options - Optional {@link EntityGetAllOptions} (e.g. `folderKey` to list folder-scoped entities)
+   * @param options - Optional {@link EntityGetAllOptions} (`folderKey` to list a single folder's entities, `includeAllFolders` to list tenant and folder entities together)
    * @returns Promise resolving to an array of entity metadata
    * {@link EntityGetResponse}
    * @example
@@ -69,7 +70,10 @@ export interface EntityServiceModel {
    * // Get tenant-level entities
    * const tenantEntities = await entities.getAll();
    *
-   * // Get folder-scoped entities for a specific folder
+   * // Get tenant-level and folder-level entities together
+   * const allEntities = await entities.getAll({ includeAllFolders: true });
+   *
+   * // Get a single folder's entities
    * const folderEntities = await entities.getAll({ folderKey: "<folderKey>" });
    *
    * // Iterate through entities

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -325,7 +325,14 @@ export interface EntityFolderScopedOptions {
 /**
  * Options for {@link EntityServiceModel.getAll}
  */
-export interface EntityGetAllOptions extends EntityFolderScopedOptions {}
+export interface EntityGetAllOptions extends EntityFolderScopedOptions {
+  /**
+   * When `true`, returns tenant-level and folder-level entities together.
+   * Omit (or `false`) to return only tenant-level entities.
+   * Ignored when `folderKey` is provided — `folderKey` always scopes the result to that single folder.
+   */
+  includeAllFolders?: boolean;
+}
 
 /**
  * Options for {@link EntityServiceModel.getById}

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -504,13 +504,14 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /**
    * Gets all entities in the system
    *
-   * The Data Fabric entity list is scoped exclusively, not additively:
-   * omitting `folderKey` returns only tenant-level entities; passing
-   * `folderKey` returns only entities in that folder. To enumerate
-   * every entity across folders, call `getAll()` once per folder
-   * plus once with no `folderKey` for the tenant scope.
+   * By default the entity list is scoped exclusively: omitting `folderKey`
+   * returns only tenant-level entities; passing `folderKey` returns only
+   * entities in that folder. To list tenant-level and folder-level entities
+   * together in a single call, pass `includeAllFolders: true` (with no
+   * `folderKey`). When `folderKey` is provided it always wins, scoping the
+   * result to that single folder and ignoring `includeAllFolders`.
    *
-   * @param options - Optional {@link EntityGetAllOptions} (e.g. `folderKey` to list folder-scoped entities)
+   * @param options - Optional {@link EntityGetAllOptions} (`folderKey` to list a single folder's entities, `includeAllFolders` to list tenant and folder entities together)
    * @returns Promise resolving to an array of entity metadata
    *
    * @example
@@ -522,7 +523,10 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * // Get tenant-level entities
    * const tenantEntities = await entities.getAll();
    *
-   * // Get folder-scoped entities
+   * // Get tenant-level and folder-level entities together
+   * const allEntities = await entities.getAll({ includeAllFolders: true });
+   *
+   * // Get a single folder's entities
    * const folderEntities = await entities.getAll({ folderKey: "<folderKey>" });
    *
    * // Call operations on an entity
@@ -531,8 +535,15 @@ export class EntityService extends BaseService implements EntityServiceModel {
    */
   @track('Entities.GetAll')
   async getAll(options?: EntityGetAllOptions): Promise<EntityGetResponse[]> {
+    // folderKey always wins: when present, scope to that folder via the v1 endpoint + header.
+    // Only when no folderKey is given does includeAllFolders switch to the v2 endpoint,
+    // which returns tenant-level and folder-level entities together.
+    const endpoint = !options?.folderKey && options?.includeAllFolders
+      ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2
+      : DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL;
+
     const response = await this.get<RawEntityGetResponse[]>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+      endpoint,
       { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
     );
     

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -17,6 +17,8 @@ export const DATA_FABRIC_TENANT_FOLDER_ID = '00000000-0000-0000-0000-00000000000
 export const DATA_FABRIC_ENDPOINTS = {
   ENTITY: {
     GET_ALL: `${DATAFABRIC_BASE}/api/Entity`,
+    // Lists tenant-level and folder-level entities together (used by getAll when includeAllFolders is set)
+    GET_ALL_V2: `${DATAFABRIC_BASE}/api/v2/Entity`,
     GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read`,
     GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
     GET_RECORD_BY_ID: (entityId: string, recordId: string) =>

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -228,6 +228,32 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
         expect(folderIds.has(tenantEntity.id)).toBe(false);
       }
     });
+
+    // includeAllFolders switches to the v2 endpoint, which returns tenant-level and
+    // folder-level entities together — a superset of the default tenant-only result.
+    it('should return tenant and folder entities together when includeAllFolders is true', async () => {
+      const { entities } = getServices();
+
+      const [tenantEntities, allEntities] = await Promise.all([
+        entities.getAll(),
+        entities.getAll({ includeAllFolders: true }),
+      ]);
+
+      expect(Array.isArray(allEntities)).toBe(true);
+      // The combined list is a superset of the tenant-only list
+      expect(allEntities.length).toBeGreaterThanOrEqual(tenantEntities.length);
+
+      const allIds = new Set(allEntities.map((e) => e.id));
+      for (const tenantEntity of tenantEntities) {
+        expect(allIds.has(tenantEntity.id)).toBe(true);
+      }
+
+      // Each entity still carries metadata with methods attached
+      for (const entity of allEntities) {
+        expect(entity.id).toBeDefined();
+        expect(typeof entity.getAllRecords).toBe('function');
+      }
+    });
   });
 
   describe('getById', () => {

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -421,6 +421,42 @@ describe("EntityService Unit Tests", () => {
         { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
+
+    it("should call the v2 endpoint when includeAllFolders is true", async () => {
+      mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
+
+      await entityService.getAll({ includeAllFolders: true });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2,
+        { headers: {} },
+      );
+    });
+
+    it("should call the v1 endpoint when includeAllFolders is false", async () => {
+      mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
+
+      await entityService.getAll({ includeAllFolders: false });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        { headers: {} },
+      );
+    });
+
+    it("should let folderKey win and call v1 with the header when both folderKey and includeAllFolders are provided", async () => {
+      mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
+
+      await entityService.getAll({
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+        includeAllFolders: true,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
+      );
+    });
   });
 
   describe("getAllRecords", () => {


### PR DESCRIPTION
Add an optional `includeAllFolders` flag to `EntityGetAllOptions`. When true (and no `folderKey` is provided), `getAll` lists tenant-level and folder-level entities together via the v2 entity endpoint. Existing behavior is unchanged: no flag lists only tenant entities, and a `folderKey` always wins — scoping to that single folder and ignoring `includeAllFolders`.

Documents the additional `OR.Users` scope required for folder-scoped entity operations and the combined listing.