### PR TITLE
feat(notifications): delete flows (PR 3/7)

### DIFF
--- a/src/models/notification/notifications.models.ts
+++ b/src/models/notification/notifications.models.ts
@@ -10,6 +10,8 @@ import type {
 } from '../../utils/pagination/types';
 
 import type {
+  NotificationDeleteAllResponse,
+  NotificationDeleteResponse,
   NotificationGetAllOptions,
   NotificationGetResponse,
   NotificationMarkAllReadResponse,
@@ -116,4 +118,35 @@ export interface NotificationServiceModel {
    * @internal
    */
   markAllAsRead(tenantId: string): Promise<NotificationMarkAllReadResponse>;
+
+  /**
+   * Deletes the given notifications.
+   *
+   * @param tenantId - Tenant GUID
+   * @param notificationIds - GUIDs of notifications to delete. Must be non-empty.
+   * @returns Operation result echoing the deleted IDs
+   * {@link NotificationDeleteResponse}
+   *
+   * @example
+   * ```typescript
+   * await notifications.deleteByIds('<tenantId>', ['<notificationId-1>', '<notificationId-2>']);
+   * ```
+   * @internal
+   */
+  deleteByIds(tenantId: string, notificationIds: string[]): Promise<NotificationDeleteResponse>;
+
+  /**
+   * Deletes all notifications from the current user's inbox.
+   *
+   * @param tenantId - Tenant GUID
+   * @returns Operation result confirming the bulk delete
+   * {@link NotificationDeleteAllResponse}
+   *
+   * @example
+   * ```typescript
+   * await notifications.deleteAll('<tenantId>');
+   * ```
+   * @internal
+   */
+  deleteAll(tenantId: string): Promise<NotificationDeleteAllResponse>;
 }

--- a/src/models/notification/notifications.types.ts
+++ b/src/models/notification/notifications.types.ts
@@ -105,3 +105,19 @@ export type NotificationMarkAllReadResponse = OperationResponse<{
   all: true;
   read: true;
 }>;
+
+/**
+ * Response from `deleteByIds()`.
+ *
+ * `notificationIds` echoes the IDs that were deleted.
+ */
+export type NotificationDeleteResponse = OperationResponse<{
+  notificationIds: string[];
+}>;
+
+/**
+ * Response from `deleteAll()`.
+ */
+export type NotificationDeleteAllResponse = OperationResponse<{
+  all: true;
+}>;

--- a/src/services/notification/notifications.ts
+++ b/src/services/notification/notifications.ts
@@ -6,6 +6,8 @@ import { track } from '../../core/telemetry';
 import { BaseService } from '../base';
 
 import type {
+  NotificationDeleteAllResponse,
+  NotificationDeleteResponse,
   NotificationGetAllOptions,
   NotificationGetResponse,
   NotificationMarkAllReadResponse,
@@ -185,6 +187,53 @@ export class NotificationService extends BaseService implements NotificationServ
       forceAllRead: true,
     }, { headers: createHeaders({ [TENANT_ID]: tenantId }) });
     return { success: true, data: { all: true, read: true } };
+  }
+
+  /**
+   * Deletes the given notifications.
+   *
+   * @param tenantId - Tenant GUID
+   * @param notificationIds - GUIDs of notifications to delete. Must be non-empty.
+   * @returns Operation result echoing the deleted IDs
+   * {@link NotificationDeleteResponse}
+   *
+   * @example
+   * ```typescript
+   * await notifications.deleteByIds('<tenantId>', ['<notificationId-1>', '<notificationId-2>']);
+   * ```
+   * @internal
+   */
+  @track('Notifications.DeleteByIds')
+  async deleteByIds(tenantId: string, notificationIds: string[]): Promise<NotificationDeleteResponse> {
+    await this.post(NOTIFICATION_ENDPOINTS.DELETE_BULK, {
+      // API spec misspells the key as `notifcationIds` — preserve it.
+      notifcationIds: notificationIds,
+      deleteAll: false,
+    }, { headers: createHeaders({ [TENANT_ID]: tenantId }) });
+    return { success: true, data: { notificationIds } };
+  }
+
+  /**
+   * Deletes all notifications from the current user's inbox.
+   *
+   * @param tenantId - Tenant GUID
+   * @returns Operation result confirming the bulk delete
+   * {@link NotificationDeleteAllResponse}
+   *
+   * @example
+   * ```typescript
+   * await notifications.deleteAll('<tenantId>');
+   * ```
+   * @internal
+   */
+  @track('Notifications.DeleteAll')
+  async deleteAll(tenantId: string): Promise<NotificationDeleteAllResponse> {
+    await this.post(NOTIFICATION_ENDPOINTS.DELETE_BULK, {
+      // API spec misspells the key as `notifcationIds` — preserve it.
+      notifcationIds: [],
+      deleteAll: true,
+    }, { headers: createHeaders({ [TENANT_ID]: tenantId }) });
+    return { success: true, data: { all: true } };
   }
 
   private async updateRead(

--- a/src/utils/constants/endpoints/notification.ts
+++ b/src/utils/constants/endpoints/notification.ts
@@ -16,4 +16,5 @@ const NOTIFICATION_API_BASE = `${NOTIFICATION_BASE}/notificationserviceapi`;
 export const NOTIFICATION_ENDPOINTS = {
   GET_ALL: `${NOTIFICATION_API_BASE}/odata/v1/NotificationEntry`,
   UPDATE_READ: `${NOTIFICATION_API_BASE}/odata/v1/NotificationEntry/UiPath.NotificationService.Api.UpdateRead`,
+  DELETE_BULK: `${NOTIFICATION_API_BASE}/odata/v1/NotificationEntry/UiPath.NotificationService.Api.DeleteBulk`,
 } as const;

--- a/tests/unit/services/notification/notifications.test.ts
+++ b/tests/unit/services/notification/notifications.test.ts
@@ -186,6 +186,56 @@ describe('NotificationService Unit Tests', () => {
     });
   });
 
+  describe('deleteByIds', () => {
+    it('should POST notifcationIds (preserving the API typo), deleteAll=false, and tenant header', async () => {
+      mockApiClient.post.mockResolvedValue(undefined);
+      const ids = [
+        NOTIFICATION_TEST_CONSTANTS.NOTIFICATION_ID,
+        NOTIFICATION_TEST_CONSTANTS.NOTIFICATION_ID_2,
+      ];
+
+      const result = await notificationService.deleteByIds(NOTIFICATION_TEST_CONSTANTS.TENANT_ID, ids);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        NOTIFICATION_ENDPOINTS.DELETE_BULK,
+        { notifcationIds: ids, deleteAll: false },
+        { headers: TENANT_HEADER }
+      );
+      expect(result).toEqual({ success: true, data: { notificationIds: ids } });
+    });
+
+    it('should propagate errors', async () => {
+      mockApiClient.post.mockRejectedValue(createMockError(NOTIFICATION_TEST_CONSTANTS.ERROR_NOTIFICATION_NOT_FOUND));
+
+      await expect(
+        notificationService.deleteByIds(NOTIFICATION_TEST_CONSTANTS.TENANT_ID, [NOTIFICATION_TEST_CONSTANTS.NOTIFICATION_ID])
+      ).rejects.toThrow(NOTIFICATION_TEST_CONSTANTS.ERROR_NOTIFICATION_NOT_FOUND);
+    });
+  });
+
+  describe('deleteAll', () => {
+    it('should POST deleteAll=true with empty notifcationIds array and tenant header', async () => {
+      mockApiClient.post.mockResolvedValue(undefined);
+
+      const result = await notificationService.deleteAll(NOTIFICATION_TEST_CONSTANTS.TENANT_ID);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        NOTIFICATION_ENDPOINTS.DELETE_BULK,
+        { notifcationIds: [], deleteAll: true },
+        { headers: TENANT_HEADER }
+      );
+      expect(result).toEqual({ success: true, data: { all: true } });
+    });
+
+    it('should propagate errors', async () => {
+      mockApiClient.post.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(
+        notificationService.deleteAll(NOTIFICATION_TEST_CONSTANTS.TENANT_ID)
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
   describe('response transformation', () => {
     it('strips internal fields and renames isRead → hasRead in the returned notifications', async () => {
       const raw: RawNotificationEntry = createBasicNotificationEntry();


### PR DESCRIPTION
**PR 3/7** in the Notification SDK stack. Rebased onto `main` (foundation #512 and mark-read #513 are now merged).

Adds the two delete methods. Both POST to the same `DeleteBulk` OData action endpoint; `deleteAll` uses the server-side `deleteAll` flag.

## Methods Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `notifications.deleteByIds()` | `deleteByIds(tenantId: string, notificationIds: string[]): Promise<NotificationDeleteResponse>` |
| Service | `notifications.deleteAll()` | `deleteAll(tenantId: string): Promise<NotificationDeleteAllResponse>` |

Both methods are tagged `@internal` (consistent with the rest of the notification service), so no `docs/oauth-scopes.md` entry is added.

## Endpoint Called

| Method | HTTP | Endpoint |
|--------|------|----------|
| `deleteByIds()` / `deleteAll()` | POST | `notificationservice_/notificationserviceapi/odata/v1/NotificationEntry/UiPath.NotificationService.Api.DeleteBulk` |

## Implementation Notes

- **Tenant forwarding**: every method takes the acting tenant GUID as its first argument; the SDK forwards it to the notification API via the `X-UIPATH-Internal-TenantId` header on each call.
- **API spec misspelling preserved**: the server expects the request body key as `notifcationIds` (sic), not `notificationIds`. The SDK preserves the typo to match the live API; the SDK's public surface uses the correct spelling.
- `deleteByIds` rejects empty arrays at the server with HTTP 400 — documented in JSDoc; the SDK doesn't add a client-side guard to avoid drift if the server relaxes that constraint.
- `deleteAll` sends `{ notifcationIds: [], deleteAll: true }` — the server deletes everything for the acting user regardless.

## Example Usage

```typescript
import { Notifications } from '@uipath/uipath-typescript/notifications';

const notifications = new Notifications(sdk);
const tenantId = '<tenant-guid>';

await notifications.deleteByIds(tenantId, ['<notificationId-1>', '<notificationId-2>']);
await notifications.deleteAll(tenantId);
```

## API Response vs SDK Response

| Method | SDK Response |
|---|---|
| `deleteByIds` | `{ success: true, data: { notificationIds } }` |
| `deleteAll` | `{ success: true, data: { all: true } }` |

## Verification

| Check | Status |
|---|---|
| `npm run typecheck` | ✅ clean |
| `npm run lint` | ✅ 0 warnings, 0 errors |
| `npm run test:unit` | ✅ 16 tests in notification suite |

**No integration tests** for the delete methods — they destructively mutate the inbox with no SDK-level undo and would be hostile to repeat-run CI. Covered by unit tests for SDK shape and by manual smoke tests for live behaviour.

## Files

| Area | Files |
|---|---|
| Endpoint constants | `src/utils/constants/endpoints/notification.ts` (`DELETE_BULK`) |
| Models | `src/models/notification/notifications.types.ts` (response types), `src/models/notification/notifications.models.ts` (ServiceModel methods) |
| Service | `src/services/notification/notifications.ts` |
| Unit tests | `tests/unit/services/notification/notifications.test.ts` (+4 tests) |
| Integration tests | `tests/integration/shared/notification/notifications.integration.test.ts` (note added explaining why no tests) |

## PR Stack

| # | Branch | Status |
|---|--------|--------|
| 1 | `feat/notifications-sdk` | #512 (merged) |
| 2 | `feat/notifications-mark-read` | #513 (merged) |
| 3 | `feat/notifications-delete` *(this PR)* | — |
| 4 | `feat/subscriptions-sdk` | upcoming |
| 5 | `feat/subscriptions-topic-updates` | upcoming |
| 6 | `feat/subscriptions-publisher-updates` | upcoming |
| 7 | `feat/subscriptions-mode-reset` | upcoming |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

