### PR TITLE
feat(subscriptions): topic-level updates (PR 5/7)

### DIFF
--- a/src/models/notification/subscriptions.models.ts
+++ b/src/models/notification/subscriptions.models.ts
@@ -4,11 +4,15 @@
  */
 
 import type {
+  CategorySubscriptionUpdate,
   SubscriptionGetAllOptions,
   SubscriptionGetPublishersOptions,
   SubscriptionGetPublishersResponse,
   SubscriptionGetResponse,
   SubscriptionGetSupportedChannelsResponse,
+  SubscriptionUpdateCategoriesResponse,
+  SubscriptionUpdateTopicsResponse,
+  TopicSubscriptionUpdate,
 } from './subscriptions.types';
 
 /**
@@ -101,4 +105,51 @@ export interface SubscriptionServiceModel {
    * @internal
    */
   getSupportedChannels(tenantId: string): Promise<SubscriptionGetSupportedChannelsResponse>;
+
+  /**
+   * Updates topic-level subscription preferences. Each entry sets the subscription state
+   * (`isSubscribed`) for a single (topic, mode) pair.
+   *
+   * @param tenantId - Tenant GUID
+   * @param subscriptions - Topic subscription updates
+   * @returns Operation result echoing the submitted updates
+   * {@link SubscriptionUpdateTopicsResponse}
+   *
+   * @example Unsubscribe a topic from a single channel
+   * ```typescript
+   * import { NotificationMode } from '@uipath/uipath-typescript/notifications';
+   *
+   * await subscriptions.updateTopics('<tenantId>', [
+   *   { topicId: '<topicId>', isSubscribed: false, notificationMode: NotificationMode.Email },
+   * ]);
+   * ```
+   * @internal
+   */
+  updateTopics(tenantId: string, subscriptions: TopicSubscriptionUpdate[]): Promise<SubscriptionUpdateTopicsResponse>;
+
+  /**
+   * Updates category-level subscription preferences for a publisher. Each entry sets
+   * the subscription state for all topics of a given category via a given mode.
+   *
+   * @param tenantId - Tenant GUID
+   * @param subscriptions - Category subscription updates
+   * @returns Operation result echoing the submitted updates
+   * {@link SubscriptionUpdateCategoriesResponse}
+   *
+   * @example Unsubscribe from all `Error` topics via email for one publisher
+   * ```typescript
+   * import { NotificationCategory, NotificationMode } from '@uipath/uipath-typescript/notifications';
+   *
+   * await subscriptions.updateCategories('<tenantId>', [
+   *   {
+   *     publisherId: '<publisherId>',
+   *     category: NotificationCategory.Error,
+   *     isSubscribed: false,
+   *     notificationMode: NotificationMode.Email,
+   *   },
+   * ]);
+   * ```
+   * @internal
+   */
+  updateCategories(tenantId: string, subscriptions: CategorySubscriptionUpdate[]): Promise<SubscriptionUpdateCategoriesResponse>;
 }

--- a/src/models/notification/subscriptions.types.ts
+++ b/src/models/notification/subscriptions.types.ts
@@ -2,6 +2,8 @@
  * Subscription service types — request/response shapes for user subscription preferences.
  */
 
+import type { OperationResponse } from '../common/types';
+
 import { NotificationCategory, NotificationMode } from './notifications.types';
 
 /**
@@ -198,6 +200,32 @@ export interface SupportedChannel {
 }
 
 /**
+ * Update payload for a topic-level subscription change.
+ */
+export interface TopicSubscriptionUpdate {
+  /** Topic GUID. */
+  topicId: string;
+  /** Whether the user should be subscribed to this topic via the chosen mode. */
+  isSubscribed: boolean;
+  /** Notification channel this update applies to. */
+  notificationMode: NotificationMode;
+}
+
+/**
+ * Update payload for a category-level subscription change.
+ */
+export interface CategorySubscriptionUpdate {
+  /** Publisher GUID. */
+  publisherId: string;
+  /** Category to update. */
+  category: NotificationCategory;
+  /** Whether the user should be subscribed to topics of this category via the chosen mode. */
+  isSubscribed: boolean;
+  /** Notification channel this update applies to. */
+  notificationMode: NotificationMode;
+}
+
+/**
  * Options for `Subscriptions.getAll()`.
  */
 export interface SubscriptionGetAllOptions {
@@ -239,3 +267,13 @@ export interface SubscriptionGetSupportedChannelsResponse {
   /** Notification channels supported in the current tenant. `InApp` is not listed — it is always available. */
   channels: SupportedChannel[];
 }
+
+/** Response from `updateTopics()`. */
+export type SubscriptionUpdateTopicsResponse = OperationResponse<{
+  subscriptions: TopicSubscriptionUpdate[];
+}>;
+
+/** Response from `updateCategories()`. */
+export type SubscriptionUpdateCategoriesResponse = OperationResponse<{
+  subscriptions: CategorySubscriptionUpdate[];
+}>;

--- a/src/services/notification/subscriptions.ts
+++ b/src/services/notification/subscriptions.ts
@@ -6,15 +6,17 @@ import { track } from '../../core/telemetry';
 import { BaseService } from '../base';
 
 import type {
+  CategorySubscriptionUpdate,
   SubscriptionGetAllOptions,
   SubscriptionGetPublishersOptions,
   SubscriptionGetPublishersResponse,
   SubscriptionGetResponse,
   SubscriptionGetSupportedChannelsResponse,
+  SubscriptionUpdateCategoriesResponse,
+  SubscriptionUpdateTopicsResponse,
+  TopicSubscriptionUpdate,
 } from '../../models/notification/subscriptions.types';
-import type {
-  SubscriptionServiceModel,
-} from '../../models/notification/subscriptions.models';
+import type { SubscriptionServiceModel } from '../../models/notification/subscriptions.models';
 
 import { SUBSCRIPTION_ENDPOINTS } from '../../utils/constants/endpoints';
 import { TENANT_ID } from '../../utils/constants/headers';
@@ -62,5 +64,21 @@ export class SubscriptionService extends BaseService implements SubscriptionServ
       { headers: createHeaders({ [TENANT_ID]: tenantId }) }
     );
     return response.data;
+  }
+
+  @track('Subscriptions.UpdateTopics')
+  async updateTopics(tenantId: string, subscriptions: TopicSubscriptionUpdate[]): Promise<SubscriptionUpdateTopicsResponse> {
+    await this.post(SUBSCRIPTION_ENDPOINTS.UPDATE_TOPIC, {
+      userSubscriptions: subscriptions,
+    }, { headers: createHeaders({ [TENANT_ID]: tenantId }) });
+    return { success: true, data: { subscriptions } };
+  }
+
+  @track('Subscriptions.UpdateCategories')
+  async updateCategories(tenantId: string, subscriptions: CategorySubscriptionUpdate[]): Promise<SubscriptionUpdateCategoriesResponse> {
+    await this.post(SUBSCRIPTION_ENDPOINTS.UPDATE_CATEGORY, {
+      categorySubscriptions: subscriptions,
+    }, { headers: createHeaders({ [TENANT_ID]: tenantId }) });
+    return { success: true, data: { subscriptions } };
   }
 }

--- a/src/utils/constants/endpoints/notification.ts
+++ b/src/utils/constants/endpoints/notification.ts
@@ -29,4 +29,7 @@ export const SUBSCRIPTION_ENDPOINTS = {
   GET_ALL: `${SUBSCRIPTION_API_BASE}/api/v1/UserSubscription`,
   GET_PUBLISHERS: `${SUBSCRIPTION_API_BASE}/api/v1/UserSubscription/GetPublishers`,
   GET_SUPPORTED_CHANNELS: `${SUBSCRIPTION_API_BASE}/api/v1/UserSubscription/GetSupportedChannelStatus`,
+  // Intentional duplicate URL of GET_ALL: same path, POST vs GET differentiates the operation.
+  UPDATE_TOPIC: `${SUBSCRIPTION_API_BASE}/api/v1/UserSubscription`,
+  UPDATE_CATEGORY: `${SUBSCRIPTION_API_BASE}/api/v1/UserSubscription/CategorySubscription`,
 } as const;

--- a/tests/integration/shared/notification/subscriptions.integration.test.ts
+++ b/tests/integration/shared/notification/subscriptions.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import type { Subscriptions } from '../../../../src/services/notification';
-import { NotificationMode, type SubscriptionPublisher } from '../../../../src/models/notification';
+import { NotificationCategory, NotificationMode, type SubscriptionPublisher } from '../../../../src/models/notification';
 
 const modes: InitMode[] = ['v1'];
 
@@ -105,6 +105,65 @@ describe.skip.each(modes)('Subscriptions - Integration Tests [%s]', (mode) => {
         expect(channel.name).toBeDefined();
         expect(typeof channel.isEnabled).toBe('boolean');
       }
+    });
+  });
+
+  describe('updateTopics', () => {
+    it('should round-trip a topic subscription change', async () => {
+      // Find a non-mandatory topic with at least one mode we can toggle
+      const topic = firstPublisher.topics.find((t) => t.isMandatory === false && (t.modes?.length ?? 0) > 0);
+      if (!topic) {
+        throw new Error('No non-mandatory topics with toggleable modes — cannot run updateTopics round-trip.');
+      }
+      const mode = topic.modes![0];
+      const originalState = mode.isSubscribed;
+
+      // Flip the state
+      const flip = await subscriptions.updateTopics(tenantId, [
+        { topicId: topic.id, isSubscribed: !originalState, notificationMode: mode.name },
+      ]);
+      expect(flip.success).toBe(true);
+
+      // Restore — leave the tenant in its original state
+      const restore = await subscriptions.updateTopics(tenantId, [
+        { topicId: topic.id, isSubscribed: originalState, notificationMode: mode.name },
+      ]);
+      expect(restore.success).toBe(true);
+    });
+  });
+
+  describe('updateCategories', () => {
+    it('should round-trip a category subscription change', async () => {
+      // Snapshot the current Email state of an Error-category topic so we restore to it verbatim
+      const errorTopic = firstPublisher.topics.find(
+        (t) => t.category === NotificationCategory.Error && (t.modes?.some((m) => m.name === NotificationMode.Email) ?? false),
+      );
+      if (!errorTopic) {
+        throw new Error('No Error-category topic with an Email mode — cannot run updateCategories round-trip.');
+      }
+      const originalEmailState = errorTopic.modes.find((m) => m.name === NotificationMode.Email)!.isSubscribed;
+
+      // Flip the category subscription
+      const flip = await subscriptions.updateCategories(tenantId, [
+        {
+          publisherId: firstPublisher.id,
+          category: NotificationCategory.Error,
+          isSubscribed: !originalEmailState,
+          notificationMode: NotificationMode.Email,
+        },
+      ]);
+      expect(flip.success).toBe(true);
+
+      // Restore — leave the tenant in its original state
+      const restore = await subscriptions.updateCategories(tenantId, [
+        {
+          publisherId: firstPublisher.id,
+          category: NotificationCategory.Error,
+          isSubscribed: originalEmailState,
+          notificationMode: NotificationMode.Email,
+        },
+      ]);
+      expect(restore.success).toBe(true);
     });
   });
 });

--- a/tests/unit/services/notification/subscriptions.test.ts
+++ b/tests/unit/services/notification/subscriptions.test.ts
@@ -13,7 +13,12 @@ import {
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { SUBSCRIPTION_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { TENANT_ID } from '../../../../src/utils/constants/headers';
-import { NotificationMode } from '../../../../src/models/notification';
+import {
+  NotificationCategory,
+  NotificationMode,
+  type CategorySubscriptionUpdate,
+  type TopicSubscriptionUpdate,
+} from '../../../../src/models/notification';
 
 // ===== MOCKING =====
 vi.mock('../../../../src/core/http/api-client');
@@ -142,6 +147,80 @@ describe('SubscriptionService Unit Tests', () => {
       await expect(
         subscriptionService.getSupportedChannels(NOTIFICATION_TEST_CONSTANTS.TENANT_ID)
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('updateTopics', () => {
+    it('should POST userSubscriptions with tenant header and echo input', async () => {
+      mockApiClient.post.mockResolvedValue(undefined);
+      const subscriptions: TopicSubscriptionUpdate[] = [
+        {
+          topicId: NOTIFICATION_TEST_CONSTANTS.TOPIC_ID,
+          isSubscribed: false,
+          notificationMode: NotificationMode.Email,
+        },
+      ];
+
+      const result = await subscriptionService.updateTopics(NOTIFICATION_TEST_CONSTANTS.TENANT_ID, subscriptions);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        SUBSCRIPTION_ENDPOINTS.UPDATE_TOPIC,
+        { userSubscriptions: subscriptions },
+        { headers: TENANT_HEADER }
+      );
+      expect(result).toEqual({ success: true, data: { subscriptions } });
+    });
+
+    it('should propagate errors', async () => {
+      mockApiClient.post.mockRejectedValue(createMockError(NOTIFICATION_TEST_CONSTANTS.ERROR_SUBSCRIPTION_INVALID));
+
+      await expect(
+        subscriptionService.updateTopics(NOTIFICATION_TEST_CONSTANTS.TENANT_ID, [
+          {
+            topicId: NOTIFICATION_TEST_CONSTANTS.TOPIC_ID,
+            isSubscribed: true,
+            notificationMode: NotificationMode.InApp,
+          },
+        ])
+      ).rejects.toThrow(NOTIFICATION_TEST_CONSTANTS.ERROR_SUBSCRIPTION_INVALID);
+    });
+  });
+
+  describe('updateCategories', () => {
+    it('should POST categorySubscriptions with tenant header and echo input', async () => {
+      mockApiClient.post.mockResolvedValue(undefined);
+      const subscriptions: CategorySubscriptionUpdate[] = [
+        {
+          publisherId: NOTIFICATION_TEST_CONSTANTS.PUBLISHER_ID,
+          category: NotificationCategory.Error,
+          isSubscribed: false,
+          notificationMode: NotificationMode.Email,
+        },
+      ];
+
+      const result = await subscriptionService.updateCategories(NOTIFICATION_TEST_CONSTANTS.TENANT_ID, subscriptions);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        SUBSCRIPTION_ENDPOINTS.UPDATE_CATEGORY,
+        { categorySubscriptions: subscriptions },
+        { headers: TENANT_HEADER }
+      );
+      expect(result).toEqual({ success: true, data: { subscriptions } });
+    });
+
+    it('should propagate errors', async () => {
+      mockApiClient.post.mockRejectedValue(createMockError(NOTIFICATION_TEST_CONSTANTS.ERROR_SUBSCRIPTION_INVALID));
+
+      await expect(
+        subscriptionService.updateCategories(NOTIFICATION_TEST_CONSTANTS.TENANT_ID, [
+          {
+            publisherId: NOTIFICATION_TEST_CONSTANTS.PUBLISHER_ID,
+            category: NotificationCategory.Info,
+            isSubscribed: true,
+            notificationMode: NotificationMode.InApp,
+          },
+        ])
+      ).rejects.toThrow(NOTIFICATION_TEST_CONSTANTS.ERROR_SUBSCRIPTION_INVALID);
     });
   });
 });

--- a/tests/utils/constants/notification.ts
+++ b/tests/utils/constants/notification.ts
@@ -35,4 +35,5 @@ export const NOTIFICATION_TEST_CONSTANTS = {
   // Error messages
   ERROR_NOTIFICATION_NOT_FOUND: 'Notification not found',
   ERROR_PUBLISHER_NOT_FOUND: 'Publisher not found',
+  ERROR_SUBSCRIPTION_INVALID: 'Subscription request is invalid',
 } as const;


### PR DESCRIPTION
**PR 5/7** in the Notification SDK stack. Stacked on top of #516.

Adds the topic-scoped subscription writes. Each method takes an array of update entries, letting callers batch many subscription toggles into one request.

## Methods Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `subscriptions.updateTopics()` | `updateTopics(tenantId: string, subscriptions: TopicSubscriptionUpdate[]): Promise<SubscriptionUpdateTopicsResponse>` |
| Service | `subscriptions.updateCategories()` | `updateCategories(tenantId: string, subscriptions: CategorySubscriptionUpdate[]): Promise<SubscriptionUpdateCategoriesResponse>` |

## Endpoints Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `updateTopics()` | POST | `notificationservice_/usersubscriptionservice/api/v1/UserSubscription` | `NotificationService` |
| `updateCategories()` | POST | `notificationservice_/usersubscriptionservice/api/v1/UserSubscription/CategorySubscription` | `NotificationService` |

- **`UPDATE_TOPIC` reuses the same URL as `GET_ALL`** — POST vs GET differentiates the operation. Documented inline in the endpoint constants.
- `updateTopics` sends `{ userSubscriptions: [...] }`; `updateCategories` sends `{ categorySubscriptions: [...] }`.
- Each entry is a `(topicId|publisherId, isSubscribed, notificationMode)` triple.
- Both methods are plural — they take an array of updates (batch), per the SDK singular/plural cardinality convention.

## Example Usage

```typescript
import { NotificationMode, NotificationCategory } from '@uipath/uipath-typescript/notifications';

// Unsubscribe a single topic from a single channel
await subscriptions.updateTopics(tenantId, [
  { topicId: '<topicId>', isSubscribed: false, notificationMode: NotificationMode.Email },
]);

// Unsubscribe from all Error topics under one publisher via email
await subscriptions.updateCategories(tenantId, [
  {
    publisherId: '<publisherId>',
    category: NotificationCategory.Error,
    isSubscribed: false,
    notificationMode: NotificationMode.Email,
  },
]);
```

## API Response vs SDK Response

| Method | SDK Response |
|---|---|
| `updateTopics` | `{ success: true, data: { subscriptions } }` (echoes input) |
| `updateCategories` | `{ success: true, data: { subscriptions } }` (echoes input) |

## Verification

| Check | Status |
|---|---|
| `npm run typecheck` | ✅ clean |
| `npm run lint` | ✅ 0 warnings, 0 errors |
| `npm run test:unit` | ✅ notification suite (updateTopics/updateCategories covered) |

Integration: both `updateTopics` and `updateCategories` have round-trip tests (flip → restore) in the `describe.skip` block — ready to run once OAuth is wired into the integration harness (the subscription API rejects PAT auth).

## Files

| Area | Files |
|---|---|
| Endpoint constants | `src/utils/constants/endpoints/notification.ts` (`UPDATE_TOPIC`, `UPDATE_CATEGORY`) |
| Types | `src/models/notification/subscriptions.types.ts` (`TopicSubscriptionUpdate`, `CategorySubscriptionUpdate`) |
| Models | `src/models/notification/subscriptions.models.ts` (response types + ServiceModel methods) |
| Service | `src/services/notification/subscriptions.ts` |
| Unit tests | `tests/unit/services/notification/subscriptions.test.ts` |
| Integration tests | `tests/integration/shared/notification/subscriptions.integration.test.ts` |
| Test utils | `tests/utils/constants/notification.ts` (`ERROR_SUBSCRIPTION_INVALID`) |

## PR Stack

| # | Branch | Status |
|---|--------|--------|
| 1 | `feat/notifications-sdk` | #512 |
| 2 | `feat/notifications-mark-read` | #513 |
| 3 | `feat/notifications-delete` | #514 |
| 4 | `feat/subscriptions-sdk` | #516 |
| 5 | `feat/subscriptions-topic-updates` *(this PR)* | — |
| 6 | `feat/subscriptions-publisher-updates` | upcoming |
| 7 | `feat/subscriptions-mode-reset` | upcoming |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
