### PR TITLE
test(action-center): assign tasks to a configured group in integratio…

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,6 +70,7 @@ jobs:
           echo "jobs_test_folder_id=${{ secrets.UIPATH_JOBS_TEST_FOLDER_ID_DEV || secrets.UIPATH_JOBS_TEST_FOLDER_ID }}" >> $GITHUB_OUTPUT
           echo "traces_test_trace_id=${{ secrets.UIPATH_TRACES_TEST_TRACE_ID_DEV || secrets.UIPATH_TRACES_TEST_TRACE_ID }}" >> $GITHUB_OUTPUT
           echo "tasks_test_user_group_id=${{ secrets.UIPATH_TASKS_TEST_USER_GROUP_ID_DEV || secrets.UIPATH_TASKS_TEST_USER_GROUP_ID }}" >> $GITHUB_OUTPUT
+          echo "tasks_test_user_id=${{ secrets.UIPATH_TASKS_TEST_USER_ID_DEV || secrets.UIPATH_TASKS_TEST_USER_ID }}" >> $GITHUB_OUTPUT
 
       - name: Create Integration Test Configuration
         if: github.base_ref == 'main'
@@ -94,6 +95,7 @@ jobs:
           JOBS_TEST_FOLDER_ID=${{ steps.config.outputs.jobs_test_folder_id }}
           TRACES_TEST_TRACE_ID=${{ steps.config.outputs.traces_test_trace_id }}
           TASKS_TEST_USER_GROUP_ID=${{ steps.config.outputs.tasks_test_user_group_id }}
+          TASKS_TEST_USER_ID=${{ steps.config.outputs.tasks_test_user_id }}
           EOF
 
       - name: Run Integration Tests

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,6 +69,7 @@ jobs:
           echo "orchestrator_attachment_id=${{ secrets.UIPATH_ORCHESTRATOR_ATTACHMENT_ID_DEV || secrets.UIPATH_ORCHESTRATOR_ATTACHMENT_ID }}" >> $GITHUB_OUTPUT
           echo "jobs_test_folder_id=${{ secrets.UIPATH_JOBS_TEST_FOLDER_ID_DEV || secrets.UIPATH_JOBS_TEST_FOLDER_ID }}" >> $GITHUB_OUTPUT
           echo "traces_test_trace_id=${{ secrets.UIPATH_TRACES_TEST_TRACE_ID_DEV || secrets.UIPATH_TRACES_TEST_TRACE_ID }}" >> $GITHUB_OUTPUT
+          echo "tasks_test_user_group_id=${{ secrets.UIPATH_TASKS_TEST_USER_GROUP_ID_DEV || secrets.UIPATH_TASKS_TEST_USER_GROUP_ID }}" >> $GITHUB_OUTPUT
 
       - name: Create Integration Test Configuration
         if: github.base_ref == 'main'
@@ -92,6 +93,7 @@ jobs:
           ORCHESTRATOR_ATTACHMENT_ID=${{ steps.config.outputs.orchestrator_attachment_id }}
           JOBS_TEST_FOLDER_ID=${{ steps.config.outputs.jobs_test_folder_id }}
           TRACES_TEST_TRACE_ID=${{ steps.config.outputs.traces_test_trace_id }}
+          TASKS_TEST_USER_GROUP_ID=${{ steps.config.outputs.tasks_test_user_group_id }}
           EOF
 
       - name: Run Integration Tests

--- a/tests/.env.integration.example
+++ b/tests/.env.integration.example
@@ -70,3 +70,7 @@ ORCHESTRATOR_ATTACHMENT_ID=
 # Directory group ID used by the task assignment-criteria integration tests.
 # The group must be assigned to the folder identified by INTEGRATION_TEST_FOLDER_ID.
 TASKS_TEST_USER_GROUP_ID=
+
+# User ID (from tasks.getUsers()) used by the single-user task assignment tests.
+# The user must have task permissions in the folder identified by INTEGRATION_TEST_FOLDER_ID.
+TASKS_TEST_USER_ID=

--- a/tests/.env.integration.example
+++ b/tests/.env.integration.example
@@ -66,3 +66,7 @@ JOBS_TEST_FOLDER_ID=
 
 # Orchestrator attachment ID (UUID) for attachment getById tests
 ORCHESTRATOR_ATTACHMENT_ID=
+
+# Directory group ID used by the task assignment-criteria integration tests.
+# The group must be assigned to the folder identified by INTEGRATION_TEST_FOLDER_ID.
+TASKS_TEST_USER_GROUP_ID=

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -22,6 +22,7 @@ export interface IntegrationConfig {
   dataFabricTestAttachmentField?: string;
   orchestratorAttachmentId?: string;
   jobsTestFolderId?: string;
+  tasksTestUserGroupId?: string;
 }
 
 function isValidUrl(value: string): boolean {
@@ -75,6 +76,7 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     dataFabricTestAttachmentField: typeof rawConfig.dataFabricTestAttachmentField === 'string' ? rawConfig.dataFabricTestAttachmentField : undefined,
     orchestratorAttachmentId: typeof rawConfig.orchestratorAttachmentId === 'string' ? rawConfig.orchestratorAttachmentId : undefined,
     jobsTestFolderId: typeof rawConfig.jobsTestFolderId === 'string' ? rawConfig.jobsTestFolderId : undefined,
+    tasksTestUserGroupId: typeof rawConfig.tasksTestUserGroupId === 'string' ? rawConfig.tasksTestUserGroupId : undefined,
   };
 }
 
@@ -112,6 +114,7 @@ export function loadIntegrationConfig(): IntegrationConfig {
     dataFabricTestAttachmentField: process.env.DATA_FABRIC_TEST_ATTACHMENT_FIELD || undefined,
     orchestratorAttachmentId: process.env.ORCHESTRATOR_ATTACHMENT_ID || undefined,
     jobsTestFolderId: process.env.JOBS_TEST_FOLDER_ID || undefined,
+    tasksTestUserGroupId: process.env.TASKS_TEST_USER_GROUP_ID || undefined,
   };
 
   cachedConfig = validateConfig(rawConfig);

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -23,6 +23,7 @@ export interface IntegrationConfig {
   orchestratorAttachmentId?: string;
   jobsTestFolderId?: string;
   tasksTestUserGroupId?: string;
+  tasksTestUserId?: string;
 }
 
 function isValidUrl(value: string): boolean {
@@ -77,6 +78,7 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     orchestratorAttachmentId: typeof rawConfig.orchestratorAttachmentId === 'string' ? rawConfig.orchestratorAttachmentId : undefined,
     jobsTestFolderId: typeof rawConfig.jobsTestFolderId === 'string' ? rawConfig.jobsTestFolderId : undefined,
     tasksTestUserGroupId: typeof rawConfig.tasksTestUserGroupId === 'string' ? rawConfig.tasksTestUserGroupId : undefined,
+    tasksTestUserId: typeof rawConfig.tasksTestUserId === 'string' ? rawConfig.tasksTestUserId : undefined,
   };
 }
 
@@ -115,6 +117,7 @@ export function loadIntegrationConfig(): IntegrationConfig {
     orchestratorAttachmentId: process.env.ORCHESTRATOR_ATTACHMENT_ID || undefined,
     jobsTestFolderId: process.env.JOBS_TEST_FOLDER_ID || undefined,
     tasksTestUserGroupId: process.env.TASKS_TEST_USER_GROUP_ID || undefined,
+    tasksTestUserId: process.env.TASKS_TEST_USER_ID || undefined,
   };
 
   cachedConfig = validateConfig(rawConfig);

--- a/tests/integration/shared/action-center/tasks.integration.test.ts
+++ b/tests/integration/shared/action-center/tasks.integration.test.ts
@@ -280,6 +280,11 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
       }
       folderId = Number(config.folderId);
 
+      if (!config.tasksTestUserGroupId) {
+        throw new Error('TASKS_TEST_USER_GROUP_ID is required in the test config for group assignment-criteria tests');
+      }
+      groupId = Number(config.tasksTestUserGroupId);
+
       const users = await tasks.getUsers(folderId);
 
       const individual = users.items.find(
@@ -289,12 +294,6 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
         throw new Error('No individual user (User/DirectoryUser) in the folder to test single-user assignment');
       }
       userNameOrEmail = individual.emailAddress || individual.userName;
-
-      const group = users.items.find((u) => u.type === TaskUserType.DirectoryGroup);
-      if (!group) {
-        throw new Error('No DirectoryGroup in the folder to test group assignment');
-      }
-      groupId = group.id;
 
       // One reusable External task; unassigned between cases so each assign
       // starts from a clean state. Tasks have no delete API, so cleanup only

--- a/tests/integration/shared/action-center/tasks.integration.test.ts
+++ b/tests/integration/shared/action-center/tasks.integration.test.ts
@@ -193,14 +193,10 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
       const folderId = config.folderId ? Number(config.folderId) : undefined;
 
       try {
-        const users = await tasks.getUsers(folderId!);
-
-        const user = users.items.find((u) => u.type === TaskUserType.DirectoryUser || u.type === TaskUserType.User);
-        if (!user) {
-          throw new Error('No DirectoryUser available to assign task');
+        if (!config.tasksTestUserId) {
+          throw new Error('TASKS_TEST_USER_ID is required in the test config for single-user assignment');
         }
-
-        const userId = user.id;
+        const userId = Number(config.tasksTestUserId);
 
         const result = await tasks.assign({
           taskId: createdTaskId,
@@ -231,14 +227,10 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
         let task = await tasks.getById(createdTaskId, {}, folderId!);
 
         if (!task.assignedToUser) {
-          const users = await tasks.getUsers(folderId!);
-
-          const user = users.items.find((u) => u.type === TaskUserType.DirectoryUser || u.type === TaskUserType.User);
-          if (!user) {
-            throw new Error('No DirectoryUser available to assign task');
+          if (!config.tasksTestUserId) {
+            throw new Error('TASKS_TEST_USER_ID is required in the test config for single-user assignment');
           }
-
-          const userId = user.id;
+          const userId = Number(config.tasksTestUserId);
 
           const assignResult = await tasks.assign({
             taskId: createdTaskId,
@@ -285,15 +277,32 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
       }
       groupId = Number(config.tasksTestUserGroupId);
 
+      if (!config.tasksTestUserId) {
+        throw new Error('TASKS_TEST_USER_ID is required in the test config for single-user assignment-criteria tests');
+      }
+
       const users = await tasks.getUsers(folderId);
 
-      const individual = users.items.find(
-        (u) => u.type === TaskUserType.User || u.type === TaskUserType.DirectoryUser,
-      );
-      if (!individual) {
-        throw new Error('No individual user (User/DirectoryUser) in the folder to test single-user assignment');
+      // Resolve the configured user's name/email for the userNameOrEmail path.
+      const configuredUser = users.items.find((u) => u.id === Number(config.tasksTestUserId));
+      if (!configuredUser) {
+        throw new Error(
+          `TASKS_TEST_USER_ID (${config.tasksTestUserId}) is not a user with task permissions in folder ${folderId}`,
+        );
       }
-      userNameOrEmail = individual.emailAddress || individual.userName;
+      userNameOrEmail = configuredUser.emailAddress || configuredUser.userName;
+
+      // Fail fast with a clear message if the configured group isn't an
+      // assignable directory group in this folder — otherwise the group
+      // assignment below fails opaquely as success=false.
+      const configuredGroup = users.items.find(
+        (u) => u.type === TaskUserType.DirectoryGroup && u.id === groupId,
+      );
+      if (!configuredGroup) {
+        throw new Error(
+          `TASKS_TEST_USER_GROUP_ID (${groupId}) is not a directory group with task permissions in folder ${folderId}`,
+        );
+      }
 
       // One reusable External task; unassigned between cases so each assign
       // starts from a clean state. Tasks have no delete API, so cleanup only
@@ -311,7 +320,8 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
 
       const result = await tasks.assign({ taskId: criteriaTaskId, userNameOrEmail });
 
-      expect(result.success).toBe(true);
+      // On failure, result.data holds Action Center's per-item error details — surface them.
+      expect(result.success, `assign by userNameOrEmail failed: ${JSON.stringify(result.data)}`).toBe(true);
 
       const task = await tasks.getById(criteriaTaskId, {}, folderId);
       expect(task.assignedToUser).toBeDefined();
@@ -333,7 +343,8 @@ describe.each(modes)('Action Center Tasks - Integration Tests [%s]', (mode) => {
       // fails. The SDK maps the empty body to success=true and echoes the request
       // as `data`; a failure would instead surface error items here. Asserting the
       // exact echoed payload proves the response carried no failure details.
-      expect(result.success).toBe(true);
+      // On failure, result.data holds Action Center's per-item error details — surface them.
+      expect(result.success, `group assign failed: ${JSON.stringify(result.data)}`).toBe(true);
       expect(result.data).toEqual([
         { taskId: criteriaTaskId, userId: groupId, assignmentCriteria: TaskAssignmentCriteria.AllUsers },
       ]);


### PR DESCRIPTION
…n tests

Added TASKS_TEST_USER_GROUP_ID (following the {SERVICE}_TEST_* convention) and wire it into IntegrationConfig as tasksTestUserGroupId. The task assignment-criteria test now assigns to this configured directory group instead of scanning getUsers() for the first DirectoryGroup, and throws when the var is unset.