### PR TITLE
fix(data-fabric): route expansionLevel to URL query string on queryRecordsById

### DIFF
--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -560,8 +560,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
     id: string,
     options?: T
   ): Promise<T extends HasPaginationOptions<T> ? PaginatedResponse<EntityRecord> : NonPaginatedResponse<EntityRecord>> {
-    // folderKey is header-only — destructure it out so PaginationHelpers doesn't include
-    // it in the POST body alongside the query filters.
+    // folderKey is header-only; expansionLevel must travel as a URL query param (see keepAsQueryParams below).
     const { folderKey, ...rest } = options ?? {} as T;
     const downstreamOptions = options === undefined ? undefined : (rest as T);
     return PaginationHelpers.getAll({
@@ -579,7 +578,8 @@ export class EntityService extends BaseService implements EntityServiceModel {
           countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
         }
       },
-      excludeFromPrefix: ['expansionLevel', 'filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy']
+      excludeFromPrefix: ['filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy', 'expansionLevel'],
+      keepAsQueryParams: ['expansionLevel']
     }, downstreamOptions);
   }
 

--- a/src/utils/pagination/helpers.ts
+++ b/src/utils/pagination/helpers.ts
@@ -316,17 +316,25 @@ export class PaginationHelpers {
       config.keepAsQueryParams?.length &&
       (config.method ?? HTTP_METHODS.GET) === HTTP_METHODS.POST
     ) {
-      const queryString = config.keepAsQueryParams
-        .filter(k => prefixedOptions[k] !== undefined && prefixedOptions[k] !== null)
-        .map(k => {
-          const encoded = `${encodeURIComponent(k)}=${encodeURIComponent(String(prefixedOptions[k]))}`;
-          delete prefixedOptions[k];
-          return encoded;
-        })
+      const urlKeys = config.keepAsQueryParams.filter(
+        k => prefixedOptions[k] !== undefined && prefixedOptions[k] !== null
+      );
+      const queryString = urlKeys
+        .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(String(prefixedOptions[k]))}`)
         .join('&');
+      for (const k of urlKeys) {
+        delete prefixedOptions[k];
+      }
       if (queryString) {
+        const appendQs = (url: string) => `${url}${url.includes('?') ? '&' : '?'}${queryString}`;
         const baseGetEndpoint = config.getEndpoint;
-        config = { ...config, getEndpoint: (fid?: number) => `${baseGetEndpoint(fid)}?${queryString}` };
+        config = {
+          ...config,
+          getEndpoint: (fid?: number) => appendQs(baseGetEndpoint(fid)),
+          ...(config.getByFolderEndpoint
+            ? { getByFolderEndpoint: appendQs(config.getByFolderEndpoint) }
+            : {}),
+        };
       }
     }
 

--- a/src/utils/pagination/helpers.ts
+++ b/src/utils/pagination/helpers.ts
@@ -309,7 +309,27 @@ export class PaginationHelpers {
     const excludeKeys = config.excludeFromPrefix || [];
     const keysToPrefix = Object.keys(processedOptions).filter(k => !excludeKeys.includes(k));
     const prefixedOptions = addPrefixToKeys(processedOptions, ODATA_PREFIX, keysToPrefix);
-    
+
+    // Bake `keepAsQueryParams` keys into the endpoint URL on POST so they aren't merged
+    // into the request body (some APIs only read these from the URL). No-op on GET.
+    if (
+      config.keepAsQueryParams?.length &&
+      (config.method ?? HTTP_METHODS.GET).toUpperCase() === HTTP_METHODS.POST
+    ) {
+      const queryString = config.keepAsQueryParams
+        .filter(k => prefixedOptions[k] !== undefined && prefixedOptions[k] !== null)
+        .map(k => {
+          const encoded = `${encodeURIComponent(k)}=${encodeURIComponent(String(prefixedOptions[k]))}`;
+          delete prefixedOptions[k];
+          return encoded;
+        })
+        .join('&');
+      if (queryString) {
+        const baseGetEndpoint = config.getEndpoint;
+        config = { ...config, getEndpoint: (fid?: number) => `${baseGetEndpoint(fid)}?${queryString}` };
+      }
+    }
+
     // Default pagination options
     const paginationOptions = {
       paginationType: PaginationType.OFFSET,

--- a/src/utils/pagination/helpers.ts
+++ b/src/utils/pagination/helpers.ts
@@ -314,7 +314,7 @@ export class PaginationHelpers {
     // into the request body (some APIs only read these from the URL). No-op on GET.
     if (
       config.keepAsQueryParams?.length &&
-      (config.method ?? HTTP_METHODS.GET).toUpperCase() === HTTP_METHODS.POST
+      (config.method ?? HTTP_METHODS.GET) === HTTP_METHODS.POST
     ) {
       const queryString = config.keepAsQueryParams
         .filter(k => prefixedOptions[k] !== undefined && prefixedOptions[k] !== null)

--- a/src/utils/pagination/internal-types.ts
+++ b/src/utils/pagination/internal-types.ts
@@ -236,7 +236,11 @@ export interface GetAllConfig<TRaw, TTransformed = TRaw> {
   /** Keys to exclude from ODATA prefix transformation */
   excludeFromPrefix?: string[];
 
-  /** Keys baked into the endpoint URL query string on POST instead of the body. No-op on GET. */
+  /**
+   * Keys baked into the endpoint URL query string on POST instead of the body. No-op on GET.
+   * Each key listed here must also appear in `excludeFromPrefix` — otherwise the OData
+   * prefix step renames it to `$<key>` and the URL-baking step won't find it.
+   */
   keepAsQueryParams?: string[];
 
   /** HTTP method to use for the request (default: 'GET') */

--- a/src/utils/pagination/internal-types.ts
+++ b/src/utils/pagination/internal-types.ts
@@ -236,9 +236,12 @@ export interface GetAllConfig<TRaw, TTransformed = TRaw> {
   /** Keys to exclude from ODATA prefix transformation */
   excludeFromPrefix?: string[];
 
+  /** Keys baked into the endpoint URL query string on POST instead of the body. No-op on GET. */
+  keepAsQueryParams?: string[];
+
   /** HTTP method to use for the request (default: 'GET') */
   method?: HttpMethodType;
 
   /** Pre-resolved request headers. Overrides the helper's auto-built folder header from `folderId`. */
   headers?: Record<string, string>;
-} 
+}

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -762,6 +762,130 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(typeof row.total).toBe('number');
       expect(row.total).toBeGreaterThanOrEqual(0);
     });
+
+    // Regression guard: DF reads `expansionLevel` only from the URL on POST record endpoints.
+    // If the SDK sends it in the body, DF silently ignores it and every level collapses to L0.
+    it('should expand reference fields at each expansionLevel (0-3)', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+
+      const levels = [0, 1, 2, 3] as const;
+      const responses = await Promise.all(
+        levels.map(level => entities.queryRecordsById(entityId, { expansionLevel: level, pageSize: 1 })),
+      );
+
+      responses.forEach((resp, i) => {
+        expect(resp, `expansionLevel=${levels[i]} returned no response`).toBeDefined();
+        expect(Array.isArray(resp.items), `expansionLevel=${levels[i]} items not an array`).toBe(true);
+      });
+
+      if (responses.some(r => r.items.length === 0)) {
+        throw new Error('Test entity has no records — expansionLevel diff cannot be verified. Insert at least one record into DATA_FABRIC_TEST_ENTITY_ID.');
+      }
+
+      const records = responses.map(r => r.items[0] as Record<string, any>);
+      const [l0Record, l1Record, l2Record, l3Record] = records;
+
+      // CreatedBy is a system reference field on every DF record.
+      // L0: raw GUID string. L1+: object envelope with Id.
+      expect(typeof l0Record.CreatedBy).toBe('string');
+
+      for (const [level, rec] of [[1, l1Record], [2, l2Record], [3, l3Record]] as const) {
+        expect(typeof rec.CreatedBy, `L${level} CreatedBy should be object`).toBe('object');
+        expect(rec.CreatedBy, `L${level} CreatedBy should not be null`).not.toBeNull();
+        expect(rec.CreatedBy, `L${level} CreatedBy should have Id`).toHaveProperty('Id');
+      }
+
+      // L2 inflates the L1 envelope into the referenced user's full record.
+      expect(Object.keys(l2Record.CreatedBy).length).toBeGreaterThan(
+        Object.keys(l1Record.CreatedBy).length,
+      );
+
+      // L3 must remain at least as expanded as L2 (deeper nesting is schema-dependent, but never shrinks).
+      expect(Object.keys(l3Record.CreatedBy).length).toBeGreaterThanOrEqual(
+        Object.keys(l2Record.CreatedBy).length,
+      );
+    });
+
+    // Custom user-defined RELATIONSHIP fields must follow the same expansion rules as
+    // system reference fields. This builds an isolated source→target schema, inserts a
+    // record on each side, and verifies the FK column inflates correctly per level.
+    it('should expand a custom RELATIONSHIP field at each expansionLevel (0-3)', async () => {
+      const { entities } = getServices();
+      const stamp = generateRandomString(8).toLowerCase();
+
+      // 1. Target entity with a user-defined string field we can assert on at L2+.
+      const targetId = await entities.create(`sdk_target_${stamp}`, [
+        { fieldName: 'label', type: EntityFieldDataType.STRING, isRequired: true },
+      ]);
+      createdEntityIds.push(targetId);
+
+      const targetMeta = await entities.getById(targetId);
+      const targetPk = targetMeta.fields.find(f => f.isPrimaryKey);
+      if (!targetPk?.id) {
+        throw new Error(`Target entity ${targetId} has no primary-key field`);
+      }
+
+      // 2. Source entity with a RELATIONSHIP field bound to target.Id.
+      const sourceId = await entities.create(`sdk_source_${stamp}`, [
+        { fieldName: 'name', type: EntityFieldDataType.STRING },
+        {
+          fieldName: 'parent',
+          type: EntityFieldDataType.RELATIONSHIP,
+          referenceEntityId: targetId,
+          referenceFieldId: targetPk.id,
+        },
+      ]);
+      createdEntityIds.push(sourceId);
+
+      // 3. Insert a target record so the FK has something to resolve.
+      const labelValue = `Target_${stamp}`;
+      const targetInsert = await entities.insertRecordById(targetId, { label: labelValue });
+      const targetRecordId = targetInsert.Id;
+      registerResource('entityRecords', { entityId: targetId, recordIds: [targetRecordId] });
+
+      // 4. Insert the source record with the FK populated.
+      const sourceInsert = await entities.insertRecordById(sourceId, {
+        name: `Source_${stamp}`,
+        parent: targetRecordId,
+      });
+      registerResource('entityRecords', { entityId: sourceId, recordIds: [sourceInsert.Id] });
+
+      // 5. Query the source at every expansion level.
+      const levels = [0, 1, 2, 3] as const;
+      const responses = await Promise.all(
+        levels.map(level => entities.queryRecordsById(sourceId, { expansionLevel: level, pageSize: 10 })),
+      );
+
+      const sourceRecords = responses.map(r =>
+        (r.items as Record<string, any>[]).find(item => item.Id === sourceInsert.Id),
+      );
+      sourceRecords.forEach((rec, i) => {
+        expect(rec, `expansionLevel=${levels[i]} did not return the inserted source record`).toBeDefined();
+      });
+      const [l0, l1, l2, l3] = sourceRecords as Record<string, any>[];
+
+      // L0: FK is the raw target record Id string.
+      expect(typeof l0.parent).toBe('string');
+      expect(l0.parent).toBe(targetRecordId);
+
+      // L1+: FK inflates into an object envelope carrying the target Id.
+      for (const [level, rec] of [[1, l1], [2, l2], [3, l3]] as const) {
+        expect(typeof rec.parent, `L${level} parent should be object`).toBe('object');
+        expect(rec.parent, `L${level} parent should not be null`).not.toBeNull();
+        expect(rec.parent, `L${level} parent should carry target Id`).toHaveProperty('Id', targetRecordId);
+      }
+
+      // L2 surfaces the user-defined `label` field from the target record.
+      expect(l2.parent.label).toBe(labelValue);
+
+      // L3 cannot shrink relative to L2.
+      expect(Object.keys(l3.parent).length).toBeGreaterThanOrEqual(Object.keys(l2.parent).length);
+    });
   });
 
   describe('importRecordsById', () => {

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -1455,7 +1455,7 @@ describe("EntityService Unit Tests", () => {
             itemsField: "value",
             totalCountField: "totalRecordCount",
           }),
-          excludeFromPrefix: expect.arrayContaining(["expansionLevel", "filterGroup", "sortOptions"]),
+          excludeFromPrefix: expect.arrayContaining(["filterGroup", "sortOptions"]),
         }),
         undefined,
       );
@@ -1507,10 +1507,12 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should pass expansionLevel through excludeFromPrefix without ODATA prefix", async () => {
+    it("should declare expansionLevel via keepAsQueryParams so the helper routes it to the URL on POST", async () => {
       let capturedConfig: any;
-      vi.mocked(PaginationHelpers.getAll).mockImplementation(async (config) => {
+      let capturedDownstream: any;
+      vi.mocked(PaginationHelpers.getAll).mockImplementation(async (config, downstream) => {
         capturedConfig = config;
+        capturedDownstream = downstream;
         return { items: [], totalCount: 0 };
       });
 
@@ -1518,13 +1520,12 @@ describe("EntityService Unit Tests", () => {
         expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
       });
 
-      // expansionLevel is in excludeFromPrefix — no URL manipulation
       expect(capturedConfig.getEndpoint()).toBe(
         DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
       );
-      expect(capturedConfig.getEndpoint()).not.toContain("expansionLevel");
+      expect(capturedConfig.keepAsQueryParams).toContain("expansionLevel");
       expect(capturedConfig.excludeFromPrefix).toContain("expansionLevel");
-      // no processParametersFn — same pattern as getAllRecords
+      expect(capturedDownstream).toHaveProperty("expansionLevel", ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL);
       expect(capturedConfig.processParametersFn).toBeUndefined();
     });
 

--- a/tests/unit/utils/pagination/helpers.test.ts
+++ b/tests/unit/utils/pagination/helpers.test.ts
@@ -907,6 +907,53 @@ describe('PaginationHelpers Unit Tests', () => {
         );
       });
 
+      it('should also bake declared keys into getByFolderEndpoint when folderId is supplied (POST, non-paginated)', async () => {
+        const apiResponse = createMockApiResponse([], 0);
+        vi.mocked(mockServiceAccess.post).mockResolvedValue(apiResponse);
+
+        const postConfig = {
+          ...mockConfig,
+          method: 'POST',
+          excludeFromPrefix: ['filterGroup', 'expansionLevel'],
+          keepAsQueryParams: ['expansionLevel'],
+        };
+
+        await PaginationHelpers.getAll(postConfig, {
+          filterGroup: { fieldName: 'name', value: 'x' },
+          expansionLevel: 2,
+          folderId: TEST_CONSTANTS.FOLDER_ID,
+        });
+
+        expect(mockServiceAccess.post).toHaveBeenCalledWith(
+          `${PAGINATION_TEST_CONSTANTS.ENDPOINT_API_FOLDERS_ITEMS}?expansionLevel=2`,
+          { filterGroup: { fieldName: 'name', value: 'x' } },
+          expect.objectContaining({ headers: { [FOLDER_ID]: TEST_CONSTANTS.FOLDER_ID.toString() } }),
+        );
+      });
+
+      it('should append with & when the base endpoint already contains a ? query string', async () => {
+        const apiResponse = createMockApiResponse([], 0);
+        vi.mocked(mockServiceAccess.post).mockResolvedValue(apiResponse);
+
+        const preResolvedWithQuery = `${PAGINATION_TEST_CONSTANTS.ENDPOINT_API_ITEMS}?source=preset`;
+        const postConfig = {
+          ...mockConfig,
+          method: 'POST',
+          getEndpoint: () => preResolvedWithQuery,
+          getByFolderEndpoint: undefined,
+          excludeFromPrefix: ['expansionLevel'],
+          keepAsQueryParams: ['expansionLevel'],
+        };
+
+        await PaginationHelpers.getAll(postConfig, { expansionLevel: 1 });
+
+        expect(mockServiceAccess.post).toHaveBeenCalledWith(
+          `${preResolvedWithQuery}&expansionLevel=1`,
+          {},
+          expect.anything(),
+        );
+      });
+
       it('should not touch the URL on GET (no-op, keys flow through normal additionalParams)', async () => {
         const apiResponse = createMockApiResponse([], 0);
         vi.mocked(mockServiceAccess.get).mockResolvedValue(apiResponse);

--- a/tests/unit/utils/pagination/helpers.test.ts
+++ b/tests/unit/utils/pagination/helpers.test.ts
@@ -855,5 +855,83 @@ describe('PaginationHelpers Unit Tests', () => {
       expect(mockServiceAccess.get).toHaveBeenCalled();
       expect(result.items).toEqual([]);
     });
+
+    describe('keepAsQueryParams', () => {
+      it('should bake declared keys into the endpoint URL and remove them from the body on POST (non-paginated)', async () => {
+        const apiResponse = createMockApiResponse([], 0);
+        vi.mocked(mockServiceAccess.post).mockResolvedValue(apiResponse);
+
+        const postConfig = {
+          ...mockConfig,
+          method: 'POST',
+          excludeFromPrefix: ['filterGroup', 'expansionLevel'],
+          keepAsQueryParams: ['expansionLevel'],
+        };
+
+        await PaginationHelpers.getAll(postConfig, {
+          filterGroup: { fieldName: 'name', value: 'x' },
+          expansionLevel: 2,
+        });
+
+        expect(mockServiceAccess.post).toHaveBeenCalledWith(
+          `${PAGINATION_TEST_CONSTANTS.ENDPOINT_API_ITEMS}?expansionLevel=2`,
+          { filterGroup: { fieldName: 'name', value: 'x' } },
+          expect.not.objectContaining({ params: expect.anything() }),
+        );
+      });
+
+      it('should bake declared keys into the endpoint URL on POST (paginated)', async () => {
+        const mockResponse = createMockPaginatedResponse([]);
+        vi.mocked(mockServiceAccess.requestWithPagination).mockResolvedValue(mockResponse);
+
+        const postConfig = {
+          ...mockConfig,
+          method: 'POST',
+          excludeFromPrefix: ['filterGroup', 'expansionLevel'],
+          keepAsQueryParams: ['expansionLevel'],
+        };
+
+        await PaginationHelpers.getAll(postConfig, {
+          filterGroup: { fieldName: 'name', value: 'x' },
+          expansionLevel: 2,
+          pageSize: PAGINATION_TEST_CONSTANTS.PAGE_SIZE,
+        });
+
+        expect(mockServiceAccess.requestWithPagination).toHaveBeenCalledWith(
+          'POST',
+          `${PAGINATION_TEST_CONSTANTS.ENDPOINT_API_ITEMS}?expansionLevel=2`,
+          expect.objectContaining({ pageSize: PAGINATION_TEST_CONSTANTS.PAGE_SIZE }),
+          expect.objectContaining({
+            params: { filterGroup: { fieldName: 'name', value: 'x' } },
+          }),
+        );
+      });
+
+      it('should not touch the URL on GET (no-op, keys flow through normal additionalParams)', async () => {
+        const apiResponse = createMockApiResponse([], 0);
+        vi.mocked(mockServiceAccess.get).mockResolvedValue(apiResponse);
+
+        const getConfig = {
+          ...mockConfig,
+          excludeFromPrefix: ['filter', 'expansionLevel'],
+          keepAsQueryParams: ['expansionLevel'],
+        };
+
+        await PaginationHelpers.getAll(getConfig, {
+          filter: PAGINATION_TEST_CONSTANTS.FILTER_NAME_EQ_TEST,
+          expansionLevel: 1,
+        });
+
+        expect(mockServiceAccess.get).toHaveBeenCalledWith(
+          PAGINATION_TEST_CONSTANTS.ENDPOINT_API_ITEMS,
+          expect.objectContaining({
+            params: {
+              filter: PAGINATION_TEST_CONSTANTS.FILTER_NAME_EQ_TEST,
+              expansionLevel: 1,
+            },
+          }),
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- DF record POST endpoints honour `expansionLevel` only as a URL query param, never from the request body. The current SDK sends it in the body, so every non-zero level silently collapses to L0 (raw FK strings).
- Adds a generic `keepAsQueryParams` hook to `PaginationHelpers.getAll` that bakes declared keys into the endpoint URL on POST (no-op on GET), and wires `expansionLevel` through it for `queryRecordsById`.
- The service layer no longer hand-rolls the URL — the helper owns the split.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 238/238 in the touched suites pass
- [x] New unit tests: `keepAsQueryParams` contract covered for POST (paginated + non-paginated) and verified no-op on GET in `tests/unit/utils/pagination/helpers.test.ts`
- [x] New unit test: `queryRecordsById` declares `expansionLevel` via `keepAsQueryParams` + `excludeFromPrefix` and forwards the value verbatim downstream
- [ ] Integration tests (run against a live tenant with `DATA_FABRIC_TEST_ENTITY_ID` set):
  - `should expand reference fields at each expansionLevel (0-3)` — system reference field `CreatedBy`
  - `should expand a custom RELATIONSHIP field at each expansionLevel (0-3)` — builds an isolated source→target schema with a user-defined RELATIONSHIP field and asserts the user-defined column inflates at L2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)