### PR TITLE
feat(agents): timeline services — errors/consumption/latency (4/5) [PLT-103787]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -245,6 +245,9 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 |--------|-------------|
 | `getAll()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getErrors()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getErrorsTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getConsumptionTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getLatencyTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Agent Traces
 

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -1,14 +1,14 @@
 import type {
-  AgentConsumptionTimelineOptions,
-  AgentConsumptionTimelineResponse,
+  AgentGetConsumptionTimelineOptions,
+  AgentGetConsumptionTimelineResponse,
   AgentError,
-  AgentErrorsOptions,
-  AgentErrorsTimelineOptions,
-  AgentErrorsTimelineResponse,
-  AgentLatencyTimelineOptions,
-  AgentLatencyTimelineResponse,
+  AgentGetErrorsOptions,
+  AgentGetErrorsTimelineOptions,
+  AgentGetErrorsTimelineResponse,
+  AgentGetLatencyTimelineOptions,
+  AgentGetLatencyTimelineResponse,
   AgentListItem,
-  AgentListOptions,
+  AgentGetAllOptions,
 } from './agents.types';
 import type {
   HasPaginationOptions,
@@ -70,7 +70,7 @@ export interface AgentServiceModel {
    * }
    * ```
    */
-  getAll<T extends AgentListOptions = AgentListOptions>(
+  getAll<T extends AgentGetAllOptions = AgentGetAllOptions>(
     startTime: Date,
     endTime: Date,
     options?: T,
@@ -126,7 +126,7 @@ export interface AgentServiceModel {
    * }
    * ```
    */
-  getErrors<T extends AgentErrorsOptions = AgentErrorsOptions>(
+  getErrors<T extends AgentGetErrorsOptions = AgentGetErrorsOptions>(
     startTime: Date,
     endTime: Date,
     options?: T,
@@ -139,14 +139,10 @@ export interface AgentServiceModel {
   /**
    * Retrieves a time-series of error counts grouped by agent over the requested window.
    *
-   * Returns one data point per (agent, time bucket). Bucket size is chosen
-   * server-side based on the window length. Optionally filter by folder, agent
-   * name, project, or process version.
-   *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
-   * @param options - Optional filters {@link AgentErrorsTimelineOptions}
-   * @returns Promise resolving to {@link AgentErrorsTimelineResponse}
+   * @param options - Optional filters
+   * @returns Promise resolving to an array of {@link AgentGetErrorsTimelineResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
@@ -158,7 +154,7 @@ export interface AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((point) => {
+   * result.forEach((point) => {
    *   console.log(`${point.date} ${point.name}: ${point.value} errors`);
    * });
    * ```
@@ -179,20 +175,16 @@ export interface AgentServiceModel {
   getErrorsTimeline(
     startTime: Date,
     endTime: Date,
-    options?: AgentErrorsTimelineOptions,
-  ): Promise<AgentErrorsTimelineResponse>;
+    options?: AgentGetErrorsTimelineOptions,
+  ): Promise<AgentGetErrorsTimelineResponse[]>;
 
   /**
-   * Retrieves a time-series of AGU consumption over the requested window.
-   *
-   * Returns one data point per time bucket; bucket size is chosen server-side
-   * based on the window length. Optionally filter by folder, agent, project,
-   * or process version.
+   * Retrieves a time-series of AGU (Agent Units) consumption over the requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
-   * @param options - Optional filters {@link AgentConsumptionTimelineOptions}
-   * @returns Promise resolving to {@link AgentConsumptionTimelineResponse}
+   * @param options - Optional filters
+   * @returns Promise resolving to an array of {@link AgentGetConsumptionTimelineResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
@@ -204,7 +196,7 @@ export interface AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((point) => {
+   * result.forEach((point) => {
    *   console.log(`${point.timeSlice}: ${point.aguConsumption} AGU`);
    * });
    * ```
@@ -224,22 +216,17 @@ export interface AgentServiceModel {
   getConsumptionTimeline(
     startTime: Date,
     endTime: Date,
-    options?: AgentConsumptionTimelineOptions,
-  ): Promise<AgentConsumptionTimelineResponse>;
+    options?: AgentGetConsumptionTimelineOptions,
+  ): Promise<AgentGetConsumptionTimelineResponse[]>;
 
   /**
    * Retrieves a time-series of agent latency (milliseconds) over the requested
    * window.
    *
-   * The API emits one row per percentile per time bucket — typically a P50 row
-   * and a P95 row per bucket. Bucket size is chosen server-side based on the
-   * window length. Optionally filter by folder, agent, project, or process
-   * version.
-   *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
-   * @param options - Optional filters {@link AgentLatencyTimelineOptions}
-   * @returns Promise resolving to {@link AgentLatencyTimelineResponse}
+   * @param options - Optional filters
+   * @returns Promise resolving to an array of {@link AgentGetLatencyTimelineResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
@@ -251,7 +238,7 @@ export interface AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((point) => {
+   * result.forEach((point) => {
    *   console.log(`${point.date} ${point.name}: ${point.value} ms`);
    * });
    * ```
@@ -271,6 +258,6 @@ export interface AgentServiceModel {
   getLatencyTimeline(
     startTime: Date,
     endTime: Date,
-    options?: AgentLatencyTimelineOptions,
-  ): Promise<AgentLatencyTimelineResponse>;
+    options?: AgentGetLatencyTimelineOptions,
+  ): Promise<AgentGetLatencyTimelineResponse[]>;
 }

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -1,6 +1,12 @@
 import type {
+  AgentConsumptionTimelineOptions,
+  AgentConsumptionTimelineResponse,
   AgentError,
   AgentErrorsOptions,
+  AgentErrorsTimelineOptions,
+  AgentErrorsTimelineResponse,
+  AgentLatencyTimelineOptions,
+  AgentLatencyTimelineResponse,
   AgentListItem,
   AgentListOptions,
 } from './agents.types';
@@ -129,4 +135,142 @@ export interface AgentServiceModel {
       ? PaginatedResponse<AgentError>
       : NonPaginatedResponse<AgentError>
   >;
+
+  /**
+   * Retrieves a time-series of error counts grouped by agent over the requested window.
+   *
+   * Returns one data point per (agent, time bucket). Bucket size is chosen
+   * server-side based on the window length. Optionally filter by folder, agent
+   * name, project, or process version.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters {@link AgentErrorsTimelineOptions}
+   * @returns Promise resolving to {@link AgentErrorsTimelineResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // All errors in May 2025
+   * const result = await agents.getErrorsTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((point) => {
+   *   console.log(`${point.date} ${point.name}: ${point.value} errors`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and top 5 agents
+   * const result = await agents.getErrorsTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     agentNames: ['JokeAgent', 'StoryAgent'],
+   *     limit: 5,
+   *   },
+   * );
+   * ```
+   */
+  getErrorsTimeline(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentErrorsTimelineOptions,
+  ): Promise<AgentErrorsTimelineResponse>;
+
+  /**
+   * Retrieves a time-series of AGU consumption over the requested window.
+   *
+   * Returns one data point per time bucket; bucket size is chosen server-side
+   * based on the window length. Optionally filter by folder, agent, project,
+   * or process version.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters {@link AgentConsumptionTimelineOptions}
+   * @returns Promise resolving to {@link AgentConsumptionTimelineResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // AGU consumption timeline in May 2025
+   * const result = await agents.getConsumptionTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((point) => {
+   *   console.log(`${point.timeSlice}: ${point.aguConsumption} AGU`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and agents
+   * const result = await agents.getConsumptionTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     agentNames: ['JokeAgent'],
+   *   },
+   * );
+   * ```
+   */
+  getConsumptionTimeline(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentConsumptionTimelineOptions,
+  ): Promise<AgentConsumptionTimelineResponse>;
+
+  /**
+   * Retrieves a time-series of agent latency (milliseconds) over the requested
+   * window.
+   *
+   * The API emits one row per percentile per time bucket — typically a P50 row
+   * and a P95 row per bucket. Bucket size is chosen server-side based on the
+   * window length. Optionally filter by folder, agent, project, or process
+   * version.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters {@link AgentLatencyTimelineOptions}
+   * @returns Promise resolving to {@link AgentLatencyTimelineResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Latency timeline in May 2025
+   * const result = await agents.getLatencyTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((point) => {
+   *   console.log(`${point.date} ${point.name}: ${point.value} ms`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and a single agent
+   * const result = await agents.getLatencyTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     agentId: '<agentId>',
+   *   },
+   * );
+   * ```
+   */
+  getLatencyTimeline(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentLatencyTimelineOptions,
+  ): Promise<AgentLatencyTimelineResponse>;
 }

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -184,3 +184,95 @@ export type AgentErrorsOptions = AgentFilterOptions & PaginationOptions & {
   /** Group results by one or more columns. */
   groupBy?: AgentErrorSortColumn[];
 };
+
+/**
+ * One point on an agent's errors timeline — error count for a single time bucket.
+ */
+export interface AgentErrorsTimelinePoint {
+  /** Agent name */
+  name: string;
+  /** Error count in this time bucket */
+  value: number;
+  /** Bucket timestamp (ISO 8601, UTC) */
+  date: string;
+}
+
+/**
+ * Response from {@link AgentServiceModel.getErrorsTimeline}.
+ */
+export interface AgentErrorsTimelineResponse {
+  /** Time-series points, one per (agent, time bucket). May be absent when no data matches. */
+  data?: AgentErrorsTimelinePoint[];
+}
+
+/**
+ * Options for {@link AgentServiceModel.getErrorsTimeline}.
+ */
+export interface AgentErrorsTimelineOptions extends AgentFilterOptions {
+  /** Max number of agents to return. Defaults to 10 server-side. */
+  limit?: number;
+}
+
+/**
+ * One point on an agent's consumption timeline — AGU consumption for a single
+ * time bucket.
+ */
+export interface AgentConsumptionTimelinePoint {
+  /** Bucket timestamp (ISO 8601, UTC) */
+  timeSlice: string;
+  /** AGU quantity consumed in this time bucket */
+  aguConsumption: number;
+}
+
+/**
+ * Response from {@link AgentServiceModel.getConsumptionTimeline}.
+ */
+export interface AgentConsumptionTimelineResponse {
+  /** Time-series points, one per bucket. May be absent when no data matches. */
+  data?: AgentConsumptionTimelinePoint[];
+}
+
+/**
+ * Options for {@link AgentServiceModel.getConsumptionTimeline}.
+ *
+ * Currently identical to {@link AgentFilterOptions}; named distinctly so that
+ * future per-method filters can be added without a breaking change.
+ */
+export interface AgentConsumptionTimelineOptions extends AgentFilterOptions {}
+
+/**
+ * One point on an agent's latency timeline — a single (percentile, time bucket)
+ * combination. The API emits one row per percentile per bucket, so a typical
+ * response includes two points per bucket (one each for P50 and P95).
+ */
+export interface AgentLatencyTimelinePoint {
+  /**
+   * Percentile label for this point — observed values: `"P50"`, `"P95"`.
+   * The SDK leaves this as a plain string because the API does not publish a
+   * closed set of percentiles.
+   */
+  name: string;
+  /** Latency value in milliseconds. */
+  value: number;
+  /** Bucket timestamp (ISO 8601, UTC) */
+  date: string;
+}
+
+/**
+ * Response from {@link AgentServiceModel.getLatencyTimeline}.
+ */
+export interface AgentLatencyTimelineResponse {
+  /**
+   * Time-series points, two per bucket (one per percentile). May be absent
+   * when no data matches.
+   */
+  data?: AgentLatencyTimelinePoint[];
+}
+
+/**
+ * Options for {@link AgentServiceModel.getLatencyTimeline}.
+ *
+ * Currently identical to {@link AgentFilterOptions}; named distinctly so that
+ * future per-method filters can be added without a breaking change.
+ */
+export interface AgentLatencyTimelineOptions extends AgentFilterOptions {}

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -193,7 +193,7 @@ export interface AgentGetErrorsTimelineResponse {
   name: string;
   /** Error count in this time bucket */
   value: number;
-  /** Bucket timestamp*/
+  /** Bucket timestamp (ISO 8601, UTC) */
   date: string;
 }
 
@@ -209,7 +209,7 @@ export interface AgentGetErrorsTimelineOptions extends AgentFilterOptions {
  * A single point on the agent consumption timeline
  */
 export interface AgentGetConsumptionTimelineResponse {
-  /** Bucket timestamp */
+  /** Bucket timestamp (ISO 8601, UTC) */
   timeSlice: string;
   /** AGU quantity consumed in this time bucket */
   aguConsumption: number;
@@ -230,7 +230,7 @@ export interface AgentGetLatencyTimelineResponse {
   name: string;
   /** Latency value in milliseconds. */
   value: number;
-  /** Bucket timestamp */
+  /** Bucket timestamp (ISO 8601, UTC) */
   date: string;
 }
 

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -82,11 +82,11 @@ export interface AgentListItem {
 }
 
 /**
- * Options for {@link AgentServiceModel.getAll}.
+ * Options for getting the list of agents.
  *
  * Composes filter, pagination, and sort options.
  */
-export type AgentListOptions = AgentFilterOptions & PaginationOptions & {
+export type AgentGetAllOptions = AgentFilterOptions & PaginationOptions & {
   /** Sort order for the result set. */
   orderBy?: AgentListOrderBy;
 };
@@ -178,7 +178,7 @@ export interface AgentError {
  *
  * Composes filter, pagination, and sort/group options.
  */
-export type AgentErrorsOptions = AgentFilterOptions & PaginationOptions & {
+export type AgentGetErrorsOptions = AgentFilterOptions & PaginationOptions & {
   /** Sort order for the result set. */
   orderBy?: AgentErrorOrderBy;
   /** Group results by one or more columns. */
@@ -186,93 +186,55 @@ export type AgentErrorsOptions = AgentFilterOptions & PaginationOptions & {
 };
 
 /**
- * One point on an agent's errors timeline — error count for a single time bucket.
+ * A single point on the agent errors timeline
  */
-export interface AgentErrorsTimelinePoint {
+export interface AgentGetErrorsTimelineResponse {
   /** Agent name */
   name: string;
   /** Error count in this time bucket */
   value: number;
-  /** Bucket timestamp (ISO 8601, UTC) */
+  /** Bucket timestamp*/
   date: string;
 }
 
 /**
- * Response from {@link AgentServiceModel.getErrorsTimeline}.
+ * Options for getting the agent errors timeline.
  */
-export interface AgentErrorsTimelineResponse {
-  /** Time-series points, one per (agent, time bucket). May be absent when no data matches. */
-  data?: AgentErrorsTimelinePoint[];
-}
-
-/**
- * Options for {@link AgentServiceModel.getErrorsTimeline}.
- */
-export interface AgentErrorsTimelineOptions extends AgentFilterOptions {
+export interface AgentGetErrorsTimelineOptions extends AgentFilterOptions {
   /** Max number of agents to return. Defaults to 10 server-side. */
   limit?: number;
 }
 
 /**
- * One point on an agent's consumption timeline — AGU consumption for a single
- * time bucket.
+ * A single point on the agent consumption timeline
  */
-export interface AgentConsumptionTimelinePoint {
-  /** Bucket timestamp (ISO 8601, UTC) */
+export interface AgentGetConsumptionTimelineResponse {
+  /** Bucket timestamp */
   timeSlice: string;
   /** AGU quantity consumed in this time bucket */
   aguConsumption: number;
 }
 
 /**
- * Response from {@link AgentServiceModel.getConsumptionTimeline}.
+ * Options for getting the agent consumption timeline.
  */
-export interface AgentConsumptionTimelineResponse {
-  /** Time-series points, one per bucket. May be absent when no data matches. */
-  data?: AgentConsumptionTimelinePoint[];
-}
+export interface AgentGetConsumptionTimelineOptions extends AgentFilterOptions {}
 
 /**
- * Options for {@link AgentServiceModel.getConsumptionTimeline}.
- *
- * Currently identical to {@link AgentFilterOptions}; named distinctly so that
- * future per-method filters can be added without a breaking change.
+ * A single point on the agent latency timeline
  */
-export interface AgentConsumptionTimelineOptions extends AgentFilterOptions {}
-
-/**
- * One point on an agent's latency timeline — a single (percentile, time bucket)
- * combination. The API emits one row per percentile per bucket, so a typical
- * response includes two points per bucket (one each for P50 and P95).
- */
-export interface AgentLatencyTimelinePoint {
+export interface AgentGetLatencyTimelineResponse {
   /**
    * Percentile label for this point — observed values: `"P50"`, `"P95"`.
-   * The SDK leaves this as a plain string because the API does not publish a
-   * closed set of percentiles.
    */
   name: string;
   /** Latency value in milliseconds. */
   value: number;
-  /** Bucket timestamp (ISO 8601, UTC) */
+  /** Bucket timestamp */
   date: string;
 }
 
 /**
- * Response from {@link AgentServiceModel.getLatencyTimeline}.
+ * Options for getting the agent latency timeline.
  */
-export interface AgentLatencyTimelineResponse {
-  /**
-   * Time-series points, two per bucket (one per percentile). May be absent
-   * when no data matches.
-   */
-  data?: AgentLatencyTimelinePoint[];
-}
-
-/**
- * Options for {@link AgentServiceModel.getLatencyTimeline}.
- *
- * Currently identical to {@link AgentFilterOptions}; named distinctly so that
- * future per-method filters can be added without a breaking change.
- */
-export interface AgentLatencyTimelineOptions extends AgentFilterOptions {}
+export interface AgentGetLatencyTimelineOptions extends AgentFilterOptions {}

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -1,7 +1,14 @@
 import { BaseService } from '../base';
 import {
+  AgentConsumptionTimelineOptions,
+  AgentConsumptionTimelineResponse,
   AgentError,
   AgentErrorsOptions,
+  AgentErrorsTimelineOptions,
+  AgentErrorsTimelineResponse,
+  AgentFilterOptions,
+  AgentLatencyTimelineOptions,
+  AgentLatencyTimelineResponse,
   AgentListItem,
   AgentListOptions,
 } from '../../models/agents/agents.types';
@@ -189,5 +196,196 @@ export class AgentService extends BaseService implements AgentServiceModel {
         ? PaginatedResponse<AgentError>
         : NonPaginatedResponse<AgentError>
     >;
+  }
+
+  /**
+   * Retrieves a time-series of error counts grouped by agent over the requested window.
+   *
+   * Returns one data point per (agent, time bucket). Bucket size is chosen
+   * server-side based on the window length. Optionally filter by folder, agent
+   * name, project, or process version.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters {@link AgentErrorsTimelineOptions}
+   * @returns Promise resolving to {@link AgentErrorsTimelineResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // All errors in May 2025
+   * const result = await agents.getErrorsTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((point) => {
+   *   console.log(`${point.date} ${point.name}: ${point.value} errors`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and top 5 agents
+   * const result = await agents.getErrorsTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     agentNames: ['JokeAgent', 'StoryAgent'],
+   *     limit: 5,
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetErrorsTimeline')
+  async getErrorsTimeline(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentErrorsTimelineOptions,
+  ): Promise<AgentErrorsTimelineResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+
+    const response = await this.post<AgentErrorsTimelineResponse>(
+      AGENTS_ENDPOINTS.GET_ERRORS_TIMELINE,
+      body,
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Retrieves a time-series of AGU consumption over the requested window.
+   *
+   * Returns one data point per time bucket; bucket size is chosen server-side
+   * based on the window length. Optionally filter by folder, agent, project,
+   * or process version.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters {@link AgentConsumptionTimelineOptions}
+   * @returns Promise resolving to {@link AgentConsumptionTimelineResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // AGU consumption timeline in May 2025
+   * const result = await agents.getConsumptionTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((point) => {
+   *   console.log(`${point.timeSlice}: ${point.aguConsumption} AGU`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and agents
+   * const result = await agents.getConsumptionTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     agentNames: ['JokeAgent'],
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetConsumptionTimeline')
+  async getConsumptionTimeline(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentConsumptionTimelineOptions,
+  ): Promise<AgentConsumptionTimelineResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+
+    const response = await this.post<AgentConsumptionTimelineResponse>(
+      AGENTS_ENDPOINTS.GET_CONSUMPTION_TIMELINE,
+      body,
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Retrieves a time-series of agent latency (milliseconds) over the requested
+   * window.
+   *
+   * The API emits one row per percentile per time bucket — typically a P50 row
+   * and a P95 row per bucket. Bucket size is chosen server-side based on the
+   * window length. Optionally filter by folder, agent, project, or process
+   * version.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters {@link AgentLatencyTimelineOptions}
+   * @returns Promise resolving to {@link AgentLatencyTimelineResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Latency timeline in May 2025
+   * const result = await agents.getLatencyTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((point) => {
+   *   console.log(`${point.date} ${point.name}: ${point.value} ms`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and a single agent
+   * const result = await agents.getLatencyTimeline(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     agentId: '<agentId>',
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetLatencyTimeline')
+  async getLatencyTimeline(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentLatencyTimelineOptions,
+  ): Promise<AgentLatencyTimelineResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+
+    const response = await this.post<AgentLatencyTimelineResponse>(
+      AGENTS_ENDPOINTS.GET_LATENCY_TIMELINE,
+      body,
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Builds the common POST request body shared by the agent filter endpoints —
+   * the required time window plus any optional folder/agent/project/process
+   * filters. Undefined options are omitted so the server applies its defaults.
+   */
+  private buildAgentFilterBody(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentFilterOptions & { limit?: number },
+  ): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+    };
+    if (options?.folderKeys !== undefined) body.folderKeys = options.folderKeys;
+    if (options?.agentNames !== undefined) body.agentNames = options.agentNames;
+    if (options?.projectKeys !== undefined) body.projectKeys = options.projectKeys;
+    if (options?.agentId !== undefined) body.agentId = options.agentId;
+    if (options?.processVersion !== undefined) body.processVersion = options.processVersion;
+    if (options?.limit !== undefined) body.limit = options.limit;
+    return body;
   }
 }

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -1,16 +1,16 @@
 import { BaseService } from '../base';
 import {
-  AgentConsumptionTimelineOptions,
-  AgentConsumptionTimelineResponse,
+  AgentGetConsumptionTimelineOptions,
+  AgentGetConsumptionTimelineResponse,
   AgentError,
-  AgentErrorsOptions,
-  AgentErrorsTimelineOptions,
-  AgentErrorsTimelineResponse,
+  AgentGetErrorsOptions,
+  AgentGetErrorsTimelineOptions,
+  AgentGetErrorsTimelineResponse,
   AgentFilterOptions,
-  AgentLatencyTimelineOptions,
-  AgentLatencyTimelineResponse,
+  AgentGetLatencyTimelineOptions,
+  AgentGetLatencyTimelineResponse,
   AgentListItem,
-  AgentListOptions,
+  AgentGetAllOptions,
 } from '../../models/agents/agents.types';
 import { AgentServiceModel } from '../../models/agents/agents.models';
 import { AGENTS_ENDPOINTS } from '../../utils/constants/endpoints';
@@ -81,7 +81,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * ```
    */
   @track('Agents.GetAll')
-  async getAll<T extends AgentListOptions = AgentListOptions>(
+  async getAll<T extends AgentGetAllOptions = AgentGetAllOptions>(
     startTime: Date,
     endTime: Date,
     options?: T,
@@ -163,7 +163,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * ```
    */
   @track('Agents.GetErrors')
-  async getErrors<T extends AgentErrorsOptions = AgentErrorsOptions>(
+  async getErrors<T extends AgentGetErrorsOptions = AgentGetErrorsOptions>(
     startTime: Date,
     endTime: Date,
     options?: T,
@@ -201,14 +201,10 @@ export class AgentService extends BaseService implements AgentServiceModel {
   /**
    * Retrieves a time-series of error counts grouped by agent over the requested window.
    *
-   * Returns one data point per (agent, time bucket). Bucket size is chosen
-   * server-side based on the window length. Optionally filter by folder, agent
-   * name, project, or process version.
-   *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
-   * @param options - Optional filters {@link AgentErrorsTimelineOptions}
-   * @returns Promise resolving to {@link AgentErrorsTimelineResponse}
+   * @param options - Optional filters
+   * @returns Promise resolving to an array of {@link AgentGetErrorsTimelineResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
@@ -220,7 +216,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((point) => {
+   * result.forEach((point) => {
    *   console.log(`${point.date} ${point.name}: ${point.value} errors`);
    * });
    * ```
@@ -242,29 +238,25 @@ export class AgentService extends BaseService implements AgentServiceModel {
   async getErrorsTimeline(
     startTime: Date,
     endTime: Date,
-    options?: AgentErrorsTimelineOptions,
-  ): Promise<AgentErrorsTimelineResponse> {
+    options?: AgentGetErrorsTimelineOptions,
+  ): Promise<AgentGetErrorsTimelineResponse[]> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<AgentErrorsTimelineResponse>(
+    const response = await this.post<{ data?: AgentGetErrorsTimelineResponse[] }>(
       AGENTS_ENDPOINTS.GET_ERRORS_TIMELINE,
       body,
     );
 
-    return response.data;
+    return response.data.data ?? [];
   }
 
   /**
-   * Retrieves a time-series of AGU consumption over the requested window.
-   *
-   * Returns one data point per time bucket; bucket size is chosen server-side
-   * based on the window length. Optionally filter by folder, agent, project,
-   * or process version.
+   * Retrieves a time-series of AGU (Agent Units) consumption over the requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
-   * @param options - Optional filters {@link AgentConsumptionTimelineOptions}
-   * @returns Promise resolving to {@link AgentConsumptionTimelineResponse}
+   * @param options - Optional filters
+   * @returns Promise resolving to an array of {@link AgentGetConsumptionTimelineResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
@@ -276,7 +268,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((point) => {
+   * result.forEach((point) => {
    *   console.log(`${point.timeSlice}: ${point.aguConsumption} AGU`);
    * });
    * ```
@@ -297,31 +289,26 @@ export class AgentService extends BaseService implements AgentServiceModel {
   async getConsumptionTimeline(
     startTime: Date,
     endTime: Date,
-    options?: AgentConsumptionTimelineOptions,
-  ): Promise<AgentConsumptionTimelineResponse> {
+    options?: AgentGetConsumptionTimelineOptions,
+  ): Promise<AgentGetConsumptionTimelineResponse[]> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<AgentConsumptionTimelineResponse>(
+    const response = await this.post<{ data?: AgentGetConsumptionTimelineResponse[] }>(
       AGENTS_ENDPOINTS.GET_CONSUMPTION_TIMELINE,
       body,
     );
 
-    return response.data;
+    return response.data.data ?? [];
   }
 
   /**
    * Retrieves a time-series of agent latency (milliseconds) over the requested
    * window.
    *
-   * The API emits one row per percentile per time bucket — typically a P50 row
-   * and a P95 row per bucket. Bucket size is chosen server-side based on the
-   * window length. Optionally filter by folder, agent, project, or process
-   * version.
-   *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
-   * @param options - Optional filters {@link AgentLatencyTimelineOptions}
-   * @returns Promise resolving to {@link AgentLatencyTimelineResponse}
+   * @param options - Optional filters
+   * @returns Promise resolving to an array of {@link AgentGetLatencyTimelineResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
@@ -333,7 +320,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((point) => {
+   * result.forEach((point) => {
    *   console.log(`${point.date} ${point.name}: ${point.value} ms`);
    * });
    * ```
@@ -354,16 +341,16 @@ export class AgentService extends BaseService implements AgentServiceModel {
   async getLatencyTimeline(
     startTime: Date,
     endTime: Date,
-    options?: AgentLatencyTimelineOptions,
-  ): Promise<AgentLatencyTimelineResponse> {
+    options?: AgentGetLatencyTimelineOptions,
+  ): Promise<AgentGetLatencyTimelineResponse[]> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<AgentLatencyTimelineResponse>(
+    const response = await this.post<{ data?: AgentGetLatencyTimelineResponse[] }>(
       AGENTS_ENDPOINTS.GET_LATENCY_TIMELINE,
       body,
     );
 
-    return response.data;
+    return response.data.data ?? [];
   }
 
   /**

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -242,12 +242,12 @@ export class AgentService extends BaseService implements AgentServiceModel {
   ): Promise<AgentGetErrorsTimelineResponse[]> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<{ data?: AgentGetErrorsTimelineResponse[] }>(
+    const response = await this.post<{ data: AgentGetErrorsTimelineResponse[] }>(
       AGENTS_ENDPOINTS.GET_ERRORS_TIMELINE,
       body,
     );
 
-    return response.data.data ?? [];
+    return response.data.data;
   }
 
   /**
@@ -293,12 +293,12 @@ export class AgentService extends BaseService implements AgentServiceModel {
   ): Promise<AgentGetConsumptionTimelineResponse[]> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<{ data?: AgentGetConsumptionTimelineResponse[] }>(
+    const response = await this.post<{ data: AgentGetConsumptionTimelineResponse[] }>(
       AGENTS_ENDPOINTS.GET_CONSUMPTION_TIMELINE,
       body,
     );
 
-    return response.data.data ?? [];
+    return response.data.data;
   }
 
   /**
@@ -345,12 +345,12 @@ export class AgentService extends BaseService implements AgentServiceModel {
   ): Promise<AgentGetLatencyTimelineResponse[]> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<{ data?: AgentGetLatencyTimelineResponse[] }>(
+    const response = await this.post<{ data: AgentGetLatencyTimelineResponse[] }>(
       AGENTS_ENDPOINTS.GET_LATENCY_TIMELINE,
       body,
     );
 
-    return response.data.data ?? [];
+    return response.data.data;
   }
 
   /**

--- a/src/utils/constants/endpoints/agents.ts
+++ b/src/utils/constants/endpoints/agents.ts
@@ -9,4 +9,10 @@ export const AGENTS_ENDPOINTS = {
   GET_AGENTS: `${INSIGHTS_RTM_BASE}/Agents/agents`,
   /** Paginated list of agent incidents (errors) over the requested window. */
   GET_INCIDENTS: `${INSIGHTS_RTM_BASE}/Agents/incidents`,
+  /** Time-series of error counts grouped by agent over the requested window. */
+  GET_ERRORS_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/errors`,
+  /** Time-series of AGU consumption over the requested window. */
+  GET_CONSUMPTION_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/consumptionTimeline`,
+  /** Time-series of agent latency (per-percentile) over the requested window. */
+  GET_LATENCY_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/latencyTimeline`,
 } as const;

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -154,14 +154,14 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     it('should retrieve the errors timeline', async () => {
       const result = await agents.getErrorsTimeline(startTime, endTime);
 
-      expect(result).toBeDefined();
-      if (!result.data || result.data.length === 0) {
+      expect(Array.isArray(result)).toBe(true);
+      if (result.length === 0) {
         throw new Error(
           'No error timeline points in the test tenant for the configured window — ' +
           'cannot verify response shape. Run errored agents in the tenant or widen the window.',
         );
       }
-      const point = result.data[0];
+      const point = result[0];
       expect(typeof point.name).toBe('string');
       expect(typeof point.value).toBe('number');
       expect(typeof point.date).toBe('string');
@@ -171,8 +171,8 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     it('should apply the limit filter', async () => {
       const result = await agents.getErrorsTimeline(startTime, endTime, { limit: 1 });
 
-      expect(result).toBeDefined();
-      const agentNames = new Set((result.data ?? []).map((point) => point.name));
+      expect(Array.isArray(result)).toBe(true);
+      const agentNames = new Set(result.map((point) => point.name));
       expect(agentNames.size).toBeLessThanOrEqual(1);
     });
   });
@@ -184,14 +184,14 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     it('should retrieve the AGU consumption timeline', async () => {
       const result = await agents.getConsumptionTimeline(startTime, endTime);
 
-      expect(result).toBeDefined();
-      if (!result.data || result.data.length === 0) {
+      expect(Array.isArray(result)).toBe(true);
+      if (result.length === 0) {
         throw new Error(
           'No consumption timeline points in the test tenant for the configured window — ' +
           'cannot verify response shape. Run agents in the tenant or widen the window.',
         );
       }
-      const point = result.data[0];
+      const point = result[0];
       expect(typeof point.timeSlice).toBe('string');
       expect(typeof point.aguConsumption).toBe('number');
     });
@@ -201,8 +201,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
         folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
       });
 
-      expect(result).toBeDefined();
-      expect(Array.isArray(result.data ?? [])).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
   });
 
@@ -213,14 +212,14 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     it('should retrieve the per-percentile latency timeline', async () => {
       const result = await agents.getLatencyTimeline(startTime, endTime);
 
-      expect(result).toBeDefined();
-      if (!result.data || result.data.length === 0) {
+      expect(Array.isArray(result)).toBe(true);
+      if (result.length === 0) {
         throw new Error(
           'No latency timeline points in the test tenant for the configured window — ' +
           'cannot verify response shape. Run agents in the tenant or widen the window.',
         );
       }
-      const point = result.data[0];
+      const point = result[0];
       expect(typeof point.name).toBe('string');
       expect(typeof point.value).toBe('number');
       expect(typeof point.date).toBe('string');
@@ -232,8 +231,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
         agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
       });
 
-      expect(result).toBeDefined();
-      expect(Array.isArray(result.data ?? [])).toBe(true);
+      expect(Array.isArray(result)).toBe(true);
     });
   });
 });

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -146,4 +146,94 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
       expect(second.previousCursor).toBeDefined();
     });
   });
+
+  describe('getErrorsTimeline', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve the errors timeline', async () => {
+      const result = await agents.getErrorsTimeline(startTime, endTime);
+
+      expect(result).toBeDefined();
+      if (!result.data || result.data.length === 0) {
+        throw new Error(
+          'No error timeline points in the test tenant for the configured window — ' +
+          'cannot verify response shape. Run errored agents in the tenant or widen the window.',
+        );
+      }
+      const point = result.data[0];
+      expect(typeof point.name).toBe('string');
+      expect(typeof point.value).toBe('number');
+      expect(typeof point.date).toBe('string');
+      expect(Number.isNaN(new Date(point.date).getTime())).toBe(false);
+    });
+
+    it('should apply the limit filter', async () => {
+      const result = await agents.getErrorsTimeline(startTime, endTime, { limit: 1 });
+
+      expect(result).toBeDefined();
+      const agentNames = new Set((result.data ?? []).map((point) => point.name));
+      expect(agentNames.size).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('getConsumptionTimeline', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve the AGU consumption timeline', async () => {
+      const result = await agents.getConsumptionTimeline(startTime, endTime);
+
+      expect(result).toBeDefined();
+      if (!result.data || result.data.length === 0) {
+        throw new Error(
+          'No consumption timeline points in the test tenant for the configured window — ' +
+          'cannot verify response shape. Run agents in the tenant or widen the window.',
+        );
+      }
+      const point = result.data[0];
+      expect(typeof point.timeSlice).toBe('string');
+      expect(typeof point.aguConsumption).toBe('number');
+    });
+
+    it('should scope to a single folder', async () => {
+      const result = await agents.getConsumptionTimeline(startTime, endTime, {
+        folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data ?? [])).toBe(true);
+    });
+  });
+
+  describe('getLatencyTimeline', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve the per-percentile latency timeline', async () => {
+      const result = await agents.getLatencyTimeline(startTime, endTime);
+
+      expect(result).toBeDefined();
+      if (!result.data || result.data.length === 0) {
+        throw new Error(
+          'No latency timeline points in the test tenant for the configured window — ' +
+          'cannot verify response shape. Run agents in the tenant or widen the window.',
+        );
+      }
+      const point = result.data[0];
+      expect(typeof point.name).toBe('string');
+      expect(typeof point.value).toBe('number');
+      expect(typeof point.date).toBe('string');
+      expect(Number.isNaN(new Date(point.date).getTime())).toBe(false);
+    });
+
+    it('should scope to a single agent', async () => {
+      const result = await agents.getLatencyTimeline(startTime, endTime, {
+        agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data ?? [])).toBe(true);
+    });
+  });
 });

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -406,6 +406,21 @@ describe('AgentService Unit Tests', () => {
       expect('limit' in body).toBe(false);
     });
 
+    it('should omit undefined options from the body', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
+
+      await agentService.getConsumptionTimeline(startTime, endTime, {
+        folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual([AGENT_TEST_CONSTANTS.FOLDER_KEY_1]);
+      expect('agentNames' in body).toBe(false);
+      expect('agentId' in body).toBe(false);
+      expect('projectKeys' in body).toBe(false);
+      expect('processVersion' in body).toBe(false);
+    });
+
     it('should return an empty array when the timeline has no points', async () => {
       mockApiClient.post.mockResolvedValue({ data: [] });
 
@@ -469,6 +484,21 @@ describe('AgentService Unit Tests', () => {
       expect(body.agentId).toBe(AGENT_TEST_CONSTANTS.AGENT_ID);
       expect(body.processVersion).toBe(AGENT_TEST_CONSTANTS.PROCESS_VERSION);
       expect(body['$folderKeys']).toBeUndefined();
+    });
+
+    it('should omit undefined options from the body', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
+
+      await agentService.getLatencyTimeline(startTime, endTime, {
+        folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual([AGENT_TEST_CONSTANTS.FOLDER_KEY_1]);
+      expect('agentNames' in body).toBe(false);
+      expect('agentId' in body).toBe(false);
+      expect('projectKeys' in body).toBe(false);
+      expect('processVersion' in body).toBe(false);
     });
 
     it('should return an empty array when the timeline has no points', async () => {

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -279,4 +279,212 @@ describe('AgentService Unit Tests', () => {
       ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
     });
   });
+
+  describe('getErrorsTimeline', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockPoint = {
+      name: AGENT_TEST_CONSTANTS.AGENT_NAME_1,
+      value: 4,
+      date: AGENT_TEST_CONSTANTS.TIMELINE_DATE,
+    };
+
+    it('should return the timeline points with only the window in the body when no options are provided', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [mockPoint] });
+
+      const result = await agentService.getErrorsTimeline(startTime, endTime);
+
+      expect(result.data).toEqual([mockPoint]);
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_ERRORS_TIMELINE);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+      expect(body.folderKeys).toBeUndefined();
+      expect(body.limit).toBeUndefined();
+    });
+
+    it('should include all filters in the body without OData prefixing', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
+
+      const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
+      const agentNames = [AGENT_TEST_CONSTANTS.AGENT_NAME_1, AGENT_TEST_CONSTANTS.AGENT_NAME_2];
+      const projectKeys = [AGENT_TEST_CONSTANTS.PROJECT_KEY];
+
+      await agentService.getErrorsTimeline(startTime, endTime, {
+        folderKeys,
+        agentNames,
+        projectKeys,
+        agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+        processVersion: AGENT_TEST_CONSTANTS.PROCESS_VERSION,
+        limit: 5,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual(folderKeys);
+      expect(body.agentNames).toEqual(agentNames);
+      expect(body.projectKeys).toEqual(projectKeys);
+      expect(body.agentId).toBe(AGENT_TEST_CONSTANTS.AGENT_ID);
+      expect(body.processVersion).toBe(AGENT_TEST_CONSTANTS.PROCESS_VERSION);
+      expect(body.limit).toBe(5);
+      expect(body['$folderKeys']).toBeUndefined();
+    });
+
+    it('should omit undefined options from the body', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
+
+      await agentService.getErrorsTimeline(startTime, endTime, {
+        folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual([AGENT_TEST_CONSTANTS.FOLDER_KEY_1]);
+      expect('agentNames' in body).toBe(false);
+      expect('agentId' in body).toBe(false);
+      expect('limit' in body).toBe(false);
+    });
+
+    it('should return undefined data when the envelope omits it', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getErrorsTimeline(startTime, endTime, {});
+
+      expect(result.data).toBeUndefined();
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getErrorsTimeline(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
+
+  describe('getConsumptionTimeline', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockPoint = {
+      timeSlice: AGENT_TEST_CONSTANTS.TIMELINE_DATE,
+      aguConsumption: 1.4,
+    };
+
+    it('should return the timeline points with only the window in the body when no options are provided', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [mockPoint] });
+
+      const result = await agentService.getConsumptionTimeline(startTime, endTime);
+
+      expect(result.data).toEqual([mockPoint]);
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_CONSUMPTION_TIMELINE);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+      expect(body.folderKeys).toBeUndefined();
+    });
+
+    it('should include all filters in the body without OData prefixing', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
+
+      const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
+      const agentNames = [AGENT_TEST_CONSTANTS.AGENT_NAME_1];
+
+      await agentService.getConsumptionTimeline(startTime, endTime, {
+        folderKeys,
+        agentNames,
+        projectKeys: [AGENT_TEST_CONSTANTS.PROJECT_KEY],
+        agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+        processVersion: AGENT_TEST_CONSTANTS.PROCESS_VERSION,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual(folderKeys);
+      expect(body.agentNames).toEqual(agentNames);
+      expect(body.agentId).toBe(AGENT_TEST_CONSTANTS.AGENT_ID);
+      expect(body['$folderKeys']).toBeUndefined();
+      // consumption timeline has no limit option
+      expect('limit' in body).toBe(false);
+    });
+
+    it('should return undefined data when the envelope omits it', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getConsumptionTimeline(startTime, endTime, {});
+
+      expect(result.data).toBeUndefined();
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getConsumptionTimeline(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
+
+  describe('getLatencyTimeline', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockPoints = [
+      {
+        name: AGENT_TEST_CONSTANTS.LATENCY_PERCENTILE_P50,
+        value: 120,
+        date: AGENT_TEST_CONSTANTS.TIMELINE_DATE,
+      },
+      {
+        name: AGENT_TEST_CONSTANTS.LATENCY_PERCENTILE_P95,
+        value: 480,
+        date: AGENT_TEST_CONSTANTS.TIMELINE_DATE,
+      },
+    ];
+
+    it('should return the per-percentile timeline points with only the window in the body when no options are provided', async () => {
+      mockApiClient.post.mockResolvedValue({ data: mockPoints });
+
+      const result = await agentService.getLatencyTimeline(startTime, endTime);
+
+      expect(result.data).toEqual(mockPoints);
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_LATENCY_TIMELINE);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+      expect(body.folderKeys).toBeUndefined();
+    });
+
+    it('should include all filters in the body without OData prefixing', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
+
+      const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
+
+      await agentService.getLatencyTimeline(startTime, endTime, {
+        folderKeys,
+        agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+        processVersion: AGENT_TEST_CONSTANTS.PROCESS_VERSION,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual(folderKeys);
+      expect(body.agentId).toBe(AGENT_TEST_CONSTANTS.AGENT_ID);
+      expect(body.processVersion).toBe(AGENT_TEST_CONSTANTS.PROCESS_VERSION);
+      expect(body['$folderKeys']).toBeUndefined();
+    });
+
+    it('should return undefined data when the envelope omits it', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getLatencyTimeline(startTime, endTime, {});
+
+      expect(result.data).toBeUndefined();
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getLatencyTimeline(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
 });

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -344,8 +344,8 @@ describe('AgentService Unit Tests', () => {
       expect('limit' in body).toBe(false);
     });
 
-    it('should return an empty array when the envelope omits the data field', async () => {
-      mockApiClient.post.mockResolvedValue({});
+    it('should return an empty array when the timeline has no points', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
 
       const result = await agentService.getErrorsTimeline(startTime, endTime, {});
 
@@ -406,8 +406,8 @@ describe('AgentService Unit Tests', () => {
       expect('limit' in body).toBe(false);
     });
 
-    it('should return an empty array when the envelope omits the data field', async () => {
-      mockApiClient.post.mockResolvedValue({});
+    it('should return an empty array when the timeline has no points', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
 
       const result = await agentService.getConsumptionTimeline(startTime, endTime, {});
 
@@ -471,8 +471,8 @@ describe('AgentService Unit Tests', () => {
       expect(body['$folderKeys']).toBeUndefined();
     });
 
-    it('should return an empty array when the envelope omits the data field', async () => {
-      mockApiClient.post.mockResolvedValue({});
+    it('should return an empty array when the timeline has no points', async () => {
+      mockApiClient.post.mockResolvedValue({ data: [] });
 
       const result = await agentService.getLatencyTimeline(startTime, endTime, {});
 

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -294,7 +294,7 @@ describe('AgentService Unit Tests', () => {
 
       const result = await agentService.getErrorsTimeline(startTime, endTime);
 
-      expect(result.data).toEqual([mockPoint]);
+      expect(result).toEqual([mockPoint]);
 
       const [endpoint, body] = mockApiClient.post.mock.calls[0];
       expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_ERRORS_TIMELINE);
@@ -344,12 +344,12 @@ describe('AgentService Unit Tests', () => {
       expect('limit' in body).toBe(false);
     });
 
-    it('should return undefined data when the envelope omits it', async () => {
+    it('should return an empty array when the envelope omits the data field', async () => {
       mockApiClient.post.mockResolvedValue({});
 
       const result = await agentService.getErrorsTimeline(startTime, endTime, {});
 
-      expect(result.data).toBeUndefined();
+      expect(result).toEqual([]);
     });
 
     it('should propagate API errors', async () => {
@@ -374,7 +374,7 @@ describe('AgentService Unit Tests', () => {
 
       const result = await agentService.getConsumptionTimeline(startTime, endTime);
 
-      expect(result.data).toEqual([mockPoint]);
+      expect(result).toEqual([mockPoint]);
 
       const [endpoint, body] = mockApiClient.post.mock.calls[0];
       expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_CONSUMPTION_TIMELINE);
@@ -406,12 +406,12 @@ describe('AgentService Unit Tests', () => {
       expect('limit' in body).toBe(false);
     });
 
-    it('should return undefined data when the envelope omits it', async () => {
+    it('should return an empty array when the envelope omits the data field', async () => {
       mockApiClient.post.mockResolvedValue({});
 
       const result = await agentService.getConsumptionTimeline(startTime, endTime, {});
 
-      expect(result.data).toBeUndefined();
+      expect(result).toEqual([]);
     });
 
     it('should propagate API errors', async () => {
@@ -444,7 +444,7 @@ describe('AgentService Unit Tests', () => {
 
       const result = await agentService.getLatencyTimeline(startTime, endTime);
 
-      expect(result.data).toEqual(mockPoints);
+      expect(result).toEqual(mockPoints);
 
       const [endpoint, body] = mockApiClient.post.mock.calls[0];
       expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_LATENCY_TIMELINE);
@@ -471,12 +471,12 @@ describe('AgentService Unit Tests', () => {
       expect(body['$folderKeys']).toBeUndefined();
     });
 
-    it('should return undefined data when the envelope omits it', async () => {
+    it('should return an empty array when the envelope omits the data field', async () => {
       mockApiClient.post.mockResolvedValue({});
 
       const result = await agentService.getLatencyTimeline(startTime, endTime, {});
 
-      expect(result.data).toBeUndefined();
+      expect(result).toEqual([]);
     });
 
     it('should propagate API errors', async () => {


### PR DESCRIPTION
## Summary

Fourth split PR from the fat Agents PR #438 (PLT-103787), branched off `main` per the fan-out + rebase-on-merge model (follows #492, #503, #505).

Adds three agent-level **timeline** methods to the `Agents` service:

| Method | Endpoint (`INSIGHTS_RTM_BASE`) | Returns |
|--------|--------------------------------|---------|
| `getErrorsTimeline(startTime, endTime, options?)` | `POST /Agents/errors` | `AgentGetErrorsTimelineResponse[]` — error counts grouped by agent |
| `getConsumptionTimeline(startTime, endTime, options?)` | `POST /Agents/consumptionTimeline` | `AgentGetConsumptionTimelineResponse[]` — AGU (Agent Units) consumption time-series |
| `getLatencyTimeline(startTime, endTime, options?)` | `POST /Agents/latencyTimeline` | `AgentGetLatencyTimelineResponse[]` — per-percentile (P50/P95) latency |

All three are non-paginated POSTs. The API always returns a `{ data: [...] }` envelope (the array present, empty or populated); the SDK unwraps it and returns the point array directly, matching the sibling Agent timeline services (memory, traces). They share the private `buildAgentFilterBody` helper, which serializes the required `startTime`/`endTime` window (`Date` → ISO 8601) plus optional `folderKeys`/`agentNames`/`projectKeys`/`agentId`/`processVersion` (and `limit`, errors-timeline only) from `AgentFilterOptions`.

## Example Usage

```typescript
import { Agents } from '@uipath/uipath-typescript/agents';

const agents = new Agents(sdk);

// Latency timeline in May 2025
const result = await agents.getLatencyTimeline(
  new Date('2025-05-01T00:00:00Z'),
  new Date('2025-06-01T00:00:00Z'),
);
result.forEach((point) => {
  console.log(`${point.date} ${point.name}: ${point.value} ms`);
});

// Scoped — errors timeline, top 5 agents in specific folders
const errors = await agents.getErrorsTimeline(
  new Date('2025-05-01T00:00:00Z'),
  new Date('2025-06-01T00:00:00Z'),
  { folderKeys: ['<folderKey1>'], agentNames: ['JokeAgent', 'StoryAgent'], limit: 5 },
);
```

## Types & naming

Each method exposes a **response/options pair** following the `{Entity}Get{Operation}` convention:

| Method | Response (array element) | Options |
|--------|--------------------------|---------|
| `getErrorsTimeline` | `AgentGetErrorsTimelineResponse` | `AgentGetErrorsTimelineOptions` (`extends AgentFilterOptions`, adds `limit`) |
| `getConsumptionTimeline` | `AgentGetConsumptionTimelineResponse` | `AgentGetConsumptionTimelineOptions` (`extends AgentFilterOptions`) |
| `getLatencyTimeline` | `AgentGetLatencyTimelineResponse` | `AgentGetLatencyTimelineOptions` (`extends AgentFilterOptions`) |

- The response type **is** the per-bucket point (the element of the returned array) — no single-field `{ data }` wrapper type.
- Type↔model JSDoc linking is one-directional: the `AgentServiceModel` methods `{@link}` the types; the types do not link back.

## Changes

- **Types** (`agents.types.ts`): 6 timeline types — response + options pair per method.
- **Endpoints** (`endpoints/agents.ts`): 3 new constants.
- **Service** (`agents.ts`): 3 `@track`-decorated methods + `buildAgentFilterBody`.
- **Model** (`agents.models.ts`): 3 `AgentServiceModel` signatures with JSDoc (byte-identical to service-class JSDoc).
- **Tests**: 15 unit tests (no-options / all-filters / undefined-omitted / empty-envelope→`[]` / error-propagation per method); 6 integration tests under the existing `describe.skip` suite.
- **Docs**: 3 rows in `docs/oauth-scopes.md` (scope `Insights.RealTimeData Insights OR.Folders.Read`).

## Out of scope (other split PRs)
- `getNames` — dropped from the effort.
- Trace-controller methods — shipped in #505 (`AgentTraces`).
- Summaries & distributions group — separate PR.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run test:unit` — agents suite (29 tests) passing
- `npm run build` — succeeds
- sdk-review — clean (no Critical/Important)

## Notes
- Integration tests are `describe.skip`'d: `insightsrtm_` endpoints reject PAT tokens (401) and require OAuth. E2E validation needs an OAuth session.
- Endpoint naming asymmetry is intentional and preserved from the original impl: the paginated `getErrors()` targets `/Agents/incidents`, while `getErrorsTimeline()` targets `/Agents/errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

