### PR TITLE
feat(agents): summary & distribution services (5/5) [PLT-103787]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -248,8 +248,8 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getErrorsTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getConsumptionTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getLatencyTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getTopErroredAgents()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getTopConsumingAgents()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopErrorCount()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopConsumption()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getIncidentDistribution()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getSummary()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getUnitConsumptionSummary()` | `Insights.RealTimeData Insights OR.Folders.Read` |

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -248,6 +248,11 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getErrorsTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getConsumptionTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getLatencyTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopErroredAgents()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopConsumingAgents()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getIncidentDistribution()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getSummary()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getUnitConsumptionSummary()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Agent Traces
 

--- a/src/models/agents/agents.internal-types.ts
+++ b/src/models/agents/agents.internal-types.ts
@@ -35,6 +35,6 @@ export interface RawAgentSummaryPeriod {
  * {@link AgentGetSummaryResponse}.
  */
 export interface RawAgentGetSummaryResponse {
-  currentPeriodSummary?: RawAgentSummaryPeriod;
+  currentPeriodSummary: RawAgentSummaryPeriod;
   lookbackPeriodSummary?: RawAgentSummaryPeriod;
 }

--- a/src/models/agents/agents.internal-types.ts
+++ b/src/models/agents/agents.internal-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Raw per-agent summary entry exactly as the agent-summary API returns it.
+ */
+export interface RawAgentSummaryEntry {
+  processKey: string;
+  folderKey: string;
+  processVersion: string;
+  totalJobs: number;
+  successfulJobs: number;
+  successRate: number;
+  averageDurationSeconds: number;
+  firstJobFinished: string;
+  lastJobFinished: string;
+  /** Raw status string of the most recent run. */
+  lastJobStatus: string;
+}
+
+/**
+ * Raw summary period exactly as the API returns it — its agents carry raw
+ * `lastJobStatus` strings.
+ */
+export interface RawAgentSummaryPeriod {
+  totalJobs: number;
+  successfulJobs: number;
+  successRate: number;
+  averageDurationSeconds: number;
+  startTime: string;
+  endTime: string;
+  agents: RawAgentSummaryEntry[];
+}
+
+/**
+ * Raw agent summary response exactly as the API returns it, before
+ * `lastJobStatus` normalization. The service transforms this into an
+ * {@link AgentGetSummaryResponse}.
+ */
+export interface RawAgentGetSummaryResponse {
+  currentPeriodSummary?: RawAgentSummaryPeriod;
+  lookbackPeriodSummary?: RawAgentSummaryPeriod;
+}

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -7,6 +7,16 @@ import type {
   AgentGetErrorsTimelineResponse,
   AgentGetLatencyTimelineOptions,
   AgentGetLatencyTimelineResponse,
+  AgentGetTopErroredAgentsOptions,
+  AgentGetTopErroredAgentsResponse,
+  AgentGetTopConsumingAgentsOptions,
+  AgentGetTopConsumingAgentsResponse,
+  AgentGetIncidentDistributionOptions,
+  AgentGetIncidentDistributionResponse,
+  AgentGetSummaryOptions,
+  AgentGetSummaryResponse,
+  AgentGetUnitConsumptionSummaryOptions,
+  AgentGetUnitConsumptionSummaryResponse,
   AgentListItem,
   AgentGetAllOptions,
 } from './agents.types';
@@ -260,4 +270,219 @@ export interface AgentServiceModel {
     endTime: Date,
     options?: AgentGetLatencyTimelineOptions,
   ): Promise<AgentGetLatencyTimelineResponse[]>;
+
+  /**
+   * Retrieves the top-N agents ranked by error count over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetTopErroredAgentsResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Top errored agents in May 2025
+   * const result = await agents.getTopErroredAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((agent) => {
+   *   console.log(`${agent.name}: ${agent.count} errors`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and top 5 agents
+   * const result = await agents.getTopErroredAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     limit: 5,
+   *   },
+   * );
+   * ```
+   */
+  getTopErroredAgents(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetTopErroredAgentsOptions,
+  ): Promise<AgentGetTopErroredAgentsResponse>;
+
+  /**
+   * Retrieves the top-N agents ranked by unit consumption over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetTopConsumingAgentsResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Top consuming agents in May 2025
+   * const result = await agents.getTopConsumingAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`Total consumed: ${result.totalConsumed}`);
+   * result.agents?.forEach((agent) => {
+   *   console.log(`${agent.agentName}: ${agent.consumedQuantity}`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * import { Agents, AgentType } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Top 5 healthy autonomous agents
+   * const result = await agents.getTopConsumingAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     limit: 5,
+   *     healthy: true,
+   *     agentTypes: [AgentType.Autonomous],
+   *   },
+   * );
+   * ```
+   */
+  getTopConsumingAgents(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetTopConsumingAgentsOptions,
+  ): Promise<AgentGetTopConsumingAgentsResponse>;
+
+  /**
+   * Retrieves the distribution of incidents across types — errors, escalations,
+   * and policy violations — over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetIncidentDistributionResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Incident distribution in May 2025
+   * const result = await agents.getIncidentDistribution(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`Errors: ${result.errorCount}, Escalations: ${result.escalationCount}, Policy: ${result.policyCount}`);
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders
+   * const result = await agents.getIncidentDistribution(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *   },
+   * );
+   * ```
+   */
+  getIncidentDistribution(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetIncidentDistributionOptions,
+  ): Promise<AgentGetIncidentDistributionResponse>;
+
+  /**
+   * Retrieves an aggregate per-agent and overall job/success/duration summary
+   * over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetSummaryResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Summary for May 2025
+   * const result = await agents.getSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`Success rate: ${result.currentPeriodSummary?.successRate}%`);
+   * ```
+   * @example
+   * ```typescript
+   * import { Agents, AgentExecutionType } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Runtime-only summary with lookback comparison
+   * const result = await agents.getSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     lookbackPeriodAnalysis: true,
+   *     executionType: AgentExecutionType.Runtime,
+   *   },
+   * );
+   * ```
+   */
+  getSummary(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetSummaryOptions,
+  ): Promise<AgentGetSummaryResponse>;
+
+  /**
+   * Retrieves an aggregate AGU/PLTU unit consumption summary per agent over the
+   * requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetUnitConsumptionSummaryResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Unit consumption summary for May 2025
+   * const result = await agents.getUnitConsumptionSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`AGU complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
+   * ```
+   * @example
+   * ```typescript
+   * import { Agents, AgentExecutionType } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Runtime-only summary with lookback comparison
+   * const result = await agents.getUnitConsumptionSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     lookbackPeriodAnalysis: true,
+   *     executionType: AgentExecutionType.Runtime,
+   *   },
+   * );
+   * ```
+   */
+  getUnitConsumptionSummary(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetUnitConsumptionSummaryOptions,
+  ): Promise<AgentGetUnitConsumptionSummaryResponse>;
 }

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -331,7 +331,7 @@ export interface AgentServiceModel {
    *   new Date('2025-06-01T00:00:00Z'),
    * );
    * console.log(`Total consumed: ${result.totalConsumed}`);
-   * result.agents?.forEach((agent) => {
+   * result.agents.forEach((agent) => {
    *   console.log(`${agent.agentName}: ${agent.consumedQuantity}`);
    * });
    * ```
@@ -419,7 +419,7 @@ export interface AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * console.log(`Success rate: ${result.currentPeriodSummary?.successRate}%`);
+   * console.log(`Success rate: ${result.currentPeriodSummary.successRate}%`);
    * ```
    * @example
    * ```typescript
@@ -463,7 +463,7 @@ export interface AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * console.log(`Agent Units complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
+   * console.log(`Agent Units complete jobs: ${result.currentPeriodSummary.totalAgentUnitConsumption.completeJobs}`);
    * ```
    * @example
    * ```typescript

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -360,8 +360,8 @@ export interface AgentServiceModel {
   ): Promise<AgentGetTopConsumptionResponse>;
 
   /**
-   * Retrieves the distribution of incidents across types — errors, escalations,
-   * and policy violations — over the requested window.
+   * Retrieves breakdown of agent incidents count — errors, escalations,
+   * and policy violations over a requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
@@ -399,8 +399,10 @@ export interface AgentServiceModel {
   ): Promise<AgentGetIncidentDistributionResponse>;
 
   /**
-   * Retrieves an aggregate per-agent and overall job/success/duration summary
-   * over the requested window.
+   * Retrieves a job-execution summary for the requested window: overall totals
+   * (total jobs, successful jobs, success rate, average duration) alongside a
+   * per-agent breakdown. When `lookbackPeriodAnalysis` is enabled, a comparable
+   * summary for the preceding window of equal length is included too.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -289,7 +289,7 @@ export interface AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((agent) => {
+   * result.data.forEach((agent) => {
    *   console.log(`${agent.name}: ${agent.count} errors`);
    * });
    * ```

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -7,10 +7,10 @@ import type {
   AgentGetErrorsTimelineResponse,
   AgentGetLatencyTimelineOptions,
   AgentGetLatencyTimelineResponse,
-  AgentGetTopErroredAgentsOptions,
-  AgentGetTopErroredAgentsResponse,
-  AgentGetTopConsumingAgentsOptions,
-  AgentGetTopConsumingAgentsResponse,
+  AgentGetTopErrorCountOptions,
+  AgentGetTopErrorCountResponse,
+  AgentGetTopConsumptionOptions,
+  AgentGetTopConsumptionResponse,
   AgentGetIncidentDistributionOptions,
   AgentGetIncidentDistributionResponse,
   AgentGetSummaryOptions,
@@ -277,15 +277,15 @@ export interface AgentServiceModel {
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
    * @param options - Optional filters
-   * @returns Promise resolving to {@link AgentGetTopErroredAgentsResponse}
+   * @returns Promise resolving to {@link AgentGetTopErrorCountResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
    *
    * const agents = new Agents(sdk);
    *
-   * // Top errored agents in May 2025
-   * const result = await agents.getTopErroredAgents(
+   * // Top agents by error count in May 2025
+   * const result = await agents.getTopErrorCount(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
@@ -296,7 +296,7 @@ export interface AgentServiceModel {
    * @example
    * ```typescript
    * // Scope to specific folders and top 5 agents
-   * const result = await agents.getTopErroredAgents(
+   * const result = await agents.getTopErrorCount(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    *   {
@@ -306,11 +306,11 @@ export interface AgentServiceModel {
    * );
    * ```
    */
-  getTopErroredAgents(
+  getTopErrorCount(
     startTime: Date,
     endTime: Date,
-    options?: AgentGetTopErroredAgentsOptions,
-  ): Promise<AgentGetTopErroredAgentsResponse>;
+    options?: AgentGetTopErrorCountOptions,
+  ): Promise<AgentGetTopErrorCountResponse>;
 
   /**
    * Retrieves the top-N agents ranked by unit consumption over the requested window.
@@ -318,15 +318,15 @@ export interface AgentServiceModel {
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
    * @param options - Optional filters
-   * @returns Promise resolving to {@link AgentGetTopConsumingAgentsResponse}
+   * @returns Promise resolving to {@link AgentGetTopConsumptionResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
    *
    * const agents = new Agents(sdk);
    *
-   * // Top consuming agents in May 2025
-   * const result = await agents.getTopConsumingAgents(
+   * // Top agents by consumption in May 2025
+   * const result = await agents.getTopConsumption(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
@@ -342,7 +342,7 @@ export interface AgentServiceModel {
    * const agents = new Agents(sdk);
    *
    * // Top 5 healthy autonomous agents
-   * const result = await agents.getTopConsumingAgents(
+   * const result = await agents.getTopConsumption(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    *   {
@@ -353,11 +353,11 @@ export interface AgentServiceModel {
    * );
    * ```
    */
-  getTopConsumingAgents(
+  getTopConsumption(
     startTime: Date,
     endTime: Date,
-    options?: AgentGetTopConsumingAgentsOptions,
-  ): Promise<AgentGetTopConsumingAgentsResponse>;
+    options?: AgentGetTopConsumptionOptions,
+  ): Promise<AgentGetTopConsumptionResponse>;
 
   /**
    * Retrieves the distribution of incidents across types — errors, escalations,

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -189,7 +189,7 @@ export interface AgentServiceModel {
   ): Promise<AgentGetErrorsTimelineResponse[]>;
 
   /**
-   * Retrieves a time-series of AGU (Agent Units) consumption over the requested window.
+   * Retrieves a time-series of Agent Units consumption over the requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
@@ -201,13 +201,13 @@ export interface AgentServiceModel {
    *
    * const agents = new Agents(sdk);
    *
-   * // AGU consumption timeline in May 2025
+   * // Agent Units consumption timeline in May 2025
    * const result = await agents.getConsumptionTimeline(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
    * result.forEach((point) => {
-   *   console.log(`${point.timeSlice}: ${point.aguConsumption} AGU`);
+   *   console.log(`${point.timeSlice}: ${point.aguConsumption} Agent Units`);
    * });
    * ```
    * @example
@@ -341,7 +341,7 @@ export interface AgentServiceModel {
    *
    * const agents = new Agents(sdk);
    *
-   * // Top 5 healthy autonomous agents
+   * // Top 5 healthy autonomous agents by consumption
    * const result = await agents.getTopConsumption(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
@@ -443,7 +443,7 @@ export interface AgentServiceModel {
   ): Promise<AgentGetSummaryResponse>;
 
   /**
-   * Retrieves an aggregate AGU/PLTU unit consumption summary per agent over the
+   * Retrieves an aggregate Agent Units and Platform Units consumption summary per agent over the
    * requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
@@ -461,7 +461,7 @@ export interface AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * console.log(`AGU complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
+   * console.log(`Agent Units complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
    * ```
    * @example
    * ```typescript

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -320,19 +320,11 @@ export interface AgentConsumption {
 
 /**
  * Response from getting the top agents by consumption.
- *
- * The API wraps this payload in a `data` envelope; the SDK unwraps it so the
- * fields below are returned directly.
  */
 export interface AgentGetTopConsumptionResponse {
-  /**
-   * Window start date as the API returned it.
-   *
-   * Format: .NET default `M/d/yyyy h:mm:ss tt` (e.g., `"5/1/2025 12:00:00 AM"`)
-   * — NOT ISO 8601. Use `new Date(value)` to parse into a Date.
-   */
+  /** Window start date. */
   startDate?: string;
-  /** Window end date. Same format as `startDate`. */
+  /** Window end date. */
   endDate?: string;
   /** Total quantity consumed across all matching agents in the window. */
   totalConsumed?: number;
@@ -375,11 +367,6 @@ export interface AgentGetTopConsumptionOptions extends AgentFilterOptions {
 
 /**
  * Distribution of incidents across types over the requested window.
- *
- * The API wraps this payload in a `data` envelope (and emits a vestigial
- * `pagination` object alongside it that carries no useful information on this
- * non-paginated endpoint); the SDK unwraps the `data` and drops `pagination`
- * so the fields below are returned directly.
  */
 export interface AgentGetIncidentDistributionResponse {
   /** Number of error-type incidents in the window */

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -241,10 +241,10 @@ export interface AgentGetLatencyTimelineResponse {
 export interface AgentGetLatencyTimelineOptions extends AgentFilterOptions {}
 
 /**
- * One entry in the top-errored agents list — one agent with its error count
+ * One entry in the top-error-count list — one agent with its error count
  * and first/last observed failing jobs.
  */
-export interface AgentTopErroredAgent {
+export interface AgentTopErrorCount {
   /** Agent name */
   name: string;
   /** Error count for this agent over the requested window */
@@ -258,19 +258,19 @@ export interface AgentTopErroredAgent {
 }
 
 /**
- * Response from getting the top-errored agents.
+ * Response from getting the top agents by error count.
  */
-export interface AgentGetTopErroredAgentsResponse {
+export interface AgentGetTopErrorCountResponse {
   /** Total error count across all agents in the window. */
   totalErrors?: number;
   /** Top-N agents ranked by error count. May be absent when no data matches. */
-  data?: AgentTopErroredAgent[];
+  data?: AgentTopErrorCount[];
 }
 
 /**
- * Options for getting the top-errored agents.
+ * Options for getting the top agents by error count.
  */
-export interface AgentGetTopErroredAgentsOptions extends AgentFilterOptions {
+export interface AgentGetTopErrorCountOptions extends AgentFilterOptions {
   /** Max number of agents to return. Defaults to 10 server-side. */
   limit?: number;
 }
@@ -287,7 +287,7 @@ export enum AgentType {
 }
 
 /**
- * Per-agent consumption entry returned by getting the top-consuming agents.
+ * Per-agent consumption entry returned by getting the top agents by consumption.
  */
 export interface AgentConsumption {
   /** Agent ID (GUID) */
@@ -307,12 +307,12 @@ export interface AgentConsumption {
 }
 
 /**
- * Response from getting the top-consuming agents.
+ * Response from getting the top agents by consumption.
  *
  * The API wraps this payload in a `data` envelope; the SDK unwraps it so the
  * fields below are returned directly.
  */
-export interface AgentGetTopConsumingAgentsResponse {
+export interface AgentGetTopConsumptionResponse {
   /**
    * Window start date as the API returned it.
    *
@@ -335,9 +335,9 @@ export interface AgentGetTopConsumingAgentsResponse {
 }
 
 /**
- * Options for getting the top-consuming agents.
+ * Options for getting the top agents by consumption.
  */
-export interface AgentGetTopConsumingAgentsOptions extends AgentFilterOptions {
+export interface AgentGetTopConsumptionOptions extends AgentFilterOptions {
   /** Max number of agents to return. Defaults to 10 server-side. */
   limit?: number;
   /**

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -262,9 +262,9 @@ export interface AgentTopErrorCount {
  */
 export interface AgentGetTopErrorCountResponse {
   /** Total error count across all agents in the window. */
-  totalErrors?: number;
-  /** Top-N agents ranked by error count. May be absent when no data matches. */
-  data?: AgentTopErrorCount[];
+  totalErrors: number;
+  /** Top-N agents ranked by error count. */
+  data: AgentTopErrorCount[];
 }
 
 /**

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -465,7 +465,7 @@ export enum AgentExecutionType {
  */
 export interface AgentGetSummaryOptions extends AgentFilterOptions {
   /**
-   * When `true`, It also computes a `lookbackPeriodSummary` for the
+   * When `true`, it also computes a `lookbackPeriodSummary` for the
    * prior window of equal length. Defaults to `false` server-side.
    * @default false
    */

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -42,7 +42,7 @@ export interface AgentListOrderBy {
   /** Column to sort by */
   column: AgentListSortColumn;
   /**
-   * Sort descending. Defaults to false.
+   * Sort descending.
    * @default false
    */
   desc?: boolean;
@@ -141,7 +141,7 @@ export interface AgentErrorOrderBy {
   /** Column to sort by */
   column: AgentErrorSortColumn;
   /**
-   * Sort descending. Defaults to false (ascending) server-side.
+   * Sort descending.
    * @default false
    */
   desc?: boolean;
@@ -209,7 +209,7 @@ export interface AgentGetErrorsTimelineResponse {
  */
 export interface AgentGetErrorsTimelineOptions extends AgentFilterOptions {
   /**
-   * Max number of agents to return. Defaults to 10 server-side.
+   * Max number of agents to return.
    * @default 10
    */
   limit?: number;
@@ -250,8 +250,8 @@ export interface AgentGetLatencyTimelineResponse {
 export interface AgentGetLatencyTimelineOptions extends AgentFilterOptions {}
 
 /**
- * One entry in the top-error-count list — one agent with its error count
- * and first/last observed failing jobs.
+ * A single agent's error count over the requested window, with the first and
+ * last jobs where errors were observed.
  */
 export interface AgentTopErrorCount {
   /** Agent name */
@@ -299,7 +299,8 @@ export enum AgentType {
 }
 
 /**
- * Per-agent consumption entry returned by getting the top agents by consumption.
+ * A single agent's unit consumption over the requested window, with the first
+ * and last jobs where consumption was recorded.
  */
 export interface AgentConsumption {
   /** Agent ID (GUID) */

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -1,4 +1,5 @@
 import type { PaginationOptions } from '../../utils/pagination/types';
+import { JobState } from '../common/types';
 
 /**
  * Filter fields shared by agent endpoints that accept a
@@ -403,8 +404,12 @@ export interface AgentSummaryEntry {
   firstJobFinished: string;
   /** Last job completion timestamp (ISO 8601, UTC) */
   lastJobFinished: string;
-  /** Status of the most recent run (e.g., "Success", "Faulted", "Running") */
-  lastJobStatus: string;
+  /**
+   * Status of the most recent run, normalized to {@link JobState}. The API's
+   * `Success` label maps to {@link JobState.Successful}; any unrecognized value
+   * becomes {@link JobState.Unknown}.
+   */
+  lastJobStatus: JobState;
 }
 
 /**
@@ -431,11 +436,6 @@ export interface AgentSummaryPeriod {
 
 /**
  * Response from getting the agent summary.
- *
- * The API wraps this payload in a `data` envelope; the SDK unwraps it so the
- * period summaries are returned directly. `lookbackPeriodSummary` is only
- * present when the request set `lookbackPeriodAnalysis: true` (the API uses
- * Newtonsoft `NullValueHandling.Ignore` and omits the key otherwise).
  */
 export interface AgentGetSummaryResponse {
   /** Aggregate stats for the requested window */
@@ -462,7 +462,7 @@ export enum AgentExecutionType {
  */
 export interface AgentGetSummaryOptions extends AgentFilterOptions {
   /**
-   * When `true`, the API also computes a `lookbackPeriodSummary` for the
+   * When `true`, It also computes a `lookbackPeriodSummary` for the
    * prior window of equal length. Defaults to `false` server-side.
    */
   lookbackPeriodAnalysis?: boolean;
@@ -471,8 +471,7 @@ export interface AgentGetSummaryOptions extends AgentFilterOptions {
   /**
    * Filter to a specific folder by key (GUID).
    *
-   * Note: this is a distinct field from the inherited {@link AgentFilterOptions.folderKeys}
-   * (plural array). The summary endpoint accepts both — `folderKey` selects a
+   * The summary endpoint accepts both — `folderKey` selects a
    * single folder, `folderKeys` filters the lookup to a list of folders.
    */
   folderKey?: string;
@@ -497,10 +496,6 @@ export interface AgentJobConsumptionSummary {
 /**
  * Per-agent (process + folder) unit consumption entry within an
  * {@link AgentUnitConsumptionPeriod}.
- *
- * Note: `firstJobFinished` and `lastJobFinished` come back as
- * `"0001-01-01T00:00:00"` (.NET `DateTime.MinValue` sentinel) when the period
- * had no completed jobs for this agent — treat that value as "no completion".
  */
 export interface AgentUnitConsumptionEntry {
   /** Folder key (GUID) the agent ran in */
@@ -539,11 +534,6 @@ export interface AgentUnitConsumptionPeriod {
 
 /**
  * Response from getting the agent unit consumption summary.
- *
- * The API wraps this payload in a `data` envelope; the SDK unwraps it so the
- * period summaries are returned directly. `lookbackPeriodSummary` is only
- * present when the request set `lookbackPeriodAnalysis: true` (the API uses
- * Newtonsoft `NullValueHandling.Ignore` and omits the key otherwise).
  */
 export interface AgentGetUnitConsumptionSummaryResponse {
   /** Aggregate consumption for the requested window */

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -323,19 +323,19 @@ export interface AgentConsumption {
  */
 export interface AgentGetTopConsumptionResponse {
   /** Window start date. */
-  startDate?: string;
+  startDate: string;
   /** Window end date. */
-  endDate?: string;
+  endDate: string;
   /** Total quantity consumed across all matching agents in the window. */
-  totalConsumed?: number;
+  totalConsumed: number;
   /** Total Agent Units quantity consumed. */
-  totalAGUConsumed?: number;
+  totalAGUConsumed: number;
   /** Total Platform Units quantity consumed. */
-  totalPLTUConsumed?: number;
+  totalPLTUConsumed: number;
   /** Limit applied (echoed from the request). */
-  limit?: number;
-  /** Top-N agents ranked by consumption. May be absent when no data matches. */
-  agents?: AgentConsumption[];
+  limit: number;
+  /** Top-N agents ranked by consumption. Empty array when no agents matched. */
+  agents: AgentConsumption[];
 }
 
 /**
@@ -370,11 +370,11 @@ export interface AgentGetTopConsumptionOptions extends AgentFilterOptions {
  */
 export interface AgentGetIncidentDistributionResponse {
   /** Number of error-type incidents in the window */
-  errorCount?: number;
+  errorCount: number;
   /** Number of escalation-type incidents in the window */
-  escalationCount?: number;
+  escalationCount: number;
   /** Number of policy-type incidents in the window */
-  policyCount?: number;
+  policyCount: number;
 }
 
 /**
@@ -441,8 +441,8 @@ export interface AgentSummaryPeriod {
  * Response from getting the agent summary.
  */
 export interface AgentGetSummaryResponse {
-  /** Aggregate stats for the requested window */
-  currentPeriodSummary?: AgentSummaryPeriod;
+  /** Aggregate stats for the requested window. Always present. */
+  currentPeriodSummary: AgentSummaryPeriod;
   /** Aggregate stats for the prior window of equal length. Only present when `lookbackPeriodAnalysis: true` was sent. */
   lookbackPeriodSummary?: AgentSummaryPeriod;
 }
@@ -540,8 +540,8 @@ export interface AgentUnitConsumptionPeriod {
  * Response from getting the agent unit consumption summary.
  */
 export interface AgentGetUnitConsumptionSummaryResponse {
-  /** Aggregate consumption for the requested window */
-  currentPeriodSummary?: AgentUnitConsumptionPeriod;
+  /** Aggregate consumption for the requested window. Always present. */
+  currentPeriodSummary: AgentUnitConsumptionPeriod;
   /** Aggregate consumption for the prior window of equal length. Only present when `lookbackPeriodAnalysis: true` was sent. */
   lookbackPeriodSummary?: AgentUnitConsumptionPeriod;
 }

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -28,9 +28,9 @@ export enum AgentListSortColumn {
   HealthScore = 'HealthScore',
   LastIncident = 'LastIncident',
   FolderName = 'FolderName',
-  /** Quantity of AGU (Agent Units) consumed */
+  /** Quantity of Agent Units consumed */
   QuantityAGU = 'QuantityAGU',
-  /** Quantity of PLTU (Platform Units) consumed */
+  /** Quantity of Platform Units consumed */
   QuantityPLTU = 'QuantityPLTU',
   FolderPath = 'FolderPath',
 }
@@ -41,7 +41,10 @@ export enum AgentListSortColumn {
 export interface AgentListOrderBy {
   /** Column to sort by */
   column: AgentListSortColumn;
-  /** Sort descending. Defaults to false. */
+  /**
+   * Sort descending. Defaults to false.
+   * @default false
+   */
   desc?: boolean;
 }
 
@@ -76,9 +79,9 @@ export interface AgentListItem {
   unitsQuantity: number;
   /** Display name of the units (if any). May be `null` or `""`. */
   unitsName: string | null;
-  /** Quantity of AGU (Agent Units) consumed by this agent */
+  /** Quantity of Agent Units consumed by this agent */
   quantityAGU: number;
-  /** Quantity of PLTU (Platform Units) consumed by this agent */
+  /** Quantity of Platform Units consumed by this agent */
   quantityPLTU: number;
 }
 
@@ -137,7 +140,10 @@ export enum AgentErrorSortColumn {
 export interface AgentErrorOrderBy {
   /** Column to sort by */
   column: AgentErrorSortColumn;
-  /** Sort descending. Defaults to false (ascending) server-side. */
+  /**
+   * Sort descending. Defaults to false (ascending) server-side.
+   * @default false
+   */
   desc?: boolean;
 }
 
@@ -202,7 +208,10 @@ export interface AgentGetErrorsTimelineResponse {
  * Options for getting the agent errors timeline.
  */
 export interface AgentGetErrorsTimelineOptions extends AgentFilterOptions {
-  /** Max number of agents to return. Defaults to 10 server-side. */
+  /**
+   * Max number of agents to return. Defaults to 10 server-side.
+   * @default 10
+   */
   limit?: number;
 }
 
@@ -212,7 +221,7 @@ export interface AgentGetErrorsTimelineOptions extends AgentFilterOptions {
 export interface AgentGetConsumptionTimelineResponse {
   /** Bucket timestamp (ISO 8601, UTC) */
   timeSlice: string;
-  /** AGU quantity consumed in this time bucket */
+  /** Agent Units quantity consumed in this time bucket */
   aguConsumption: number;
 }
 
@@ -271,7 +280,10 @@ export interface AgentGetTopErrorCountResponse {
  * Options for getting the top agents by error count.
  */
 export interface AgentGetTopErrorCountOptions extends AgentFilterOptions {
-  /** Max number of agents to return. Defaults to 10 server-side. */
+  /**
+   * Max number of agents to return. Defaults to 10 server-side.
+   * @default 10
+   */
   limit?: number;
 }
 
@@ -296,9 +308,9 @@ export interface AgentConsumption {
   agentName: string;
   /** Total quantity consumed by this agent. `null` if no consumption is recorded. */
   consumedQuantity: number | null;
-  /** AGU quantity consumed. `null` if no consumption is recorded. */
+  /** Agent Units quantity consumed. `null` if no consumption is recorded. */
   consumedAGUQuantity: number | null;
-  /** PLTU quantity consumed. `null` if no consumption is recorded. */
+  /** Platform Units quantity consumed. `null` if no consumption is recorded. */
   consumedPLTUQuantity: number | null;
   /** First job in the window where this agent recorded consumption */
   firstSeenJob: AgentJobInfo;
@@ -324,9 +336,9 @@ export interface AgentGetTopConsumptionResponse {
   endDate?: string;
   /** Total quantity consumed across all matching agents in the window. */
   totalConsumed?: number;
-  /** Total AGU quantity consumed. */
+  /** Total Agent Units quantity consumed. */
   totalAGUConsumed?: number;
-  /** Total PLTU quantity consumed. */
+  /** Total Platform Units quantity consumed. */
   totalPLTUConsumed?: number;
   /** Limit applied (echoed from the request). */
   limit?: number;
@@ -338,7 +350,10 @@ export interface AgentGetTopConsumptionResponse {
  * Options for getting the top agents by consumption.
  */
 export interface AgentGetTopConsumptionOptions extends AgentFilterOptions {
-  /** Max number of agents to return. Defaults to 10 server-side. */
+  /**
+   * Max number of agents to return. Defaults to 10 server-side.
+   * @default 10
+   */
   limit?: number;
   /**
    * Health-based filter. `true` returns only healthy agents, `false` only
@@ -348,6 +363,7 @@ export interface AgentGetTopConsumptionOptions extends AgentFilterOptions {
   /**
    * Health-score cutoff used when `healthy` is set. Defaults to 75.0
    * server-side.
+   * @default 75.0
    */
   healthThreshold?: number;
   /**
@@ -464,6 +480,7 @@ export interface AgentGetSummaryOptions extends AgentFilterOptions {
   /**
    * When `true`, It also computes a `lookbackPeriodSummary` for the
    * prior window of equal length. Defaults to `false` server-side.
+   * @default false
    */
   lookbackPeriodAnalysis?: boolean;
   /** Filter to a specific process by key (GUID). */
@@ -508,21 +525,21 @@ export interface AgentUnitConsumptionEntry {
   firstJobFinished: string;
   /** Last job completion timestamp (ISO 8601). `"0001-01-01T00:00:00"` if no completion in the period. */
   lastJobFinished: string;
-  /** AGU consumption for this agent, split by job completion status */
+  /** Agent Units consumption for this agent, split by job completion status */
   agentUnitConsumption: AgentJobConsumptionSummary;
-  /** Platform unit (PLTU) consumption for this agent, split by job completion status */
+  /** Platform Units consumption for this agent, split by job completion status */
   platformUnitConsumption: AgentJobConsumptionSummary;
 }
 
 /**
- * Aggregate AGU/PLTU consumption for a single period within an
+ * Aggregate Agent Units and Platform Units consumption for a single period within an
  * {@link AgentGetUnitConsumptionSummaryResponse} — covers the requested window
  * for either the current period or an optional lookback period.
  */
 export interface AgentUnitConsumptionPeriod {
-  /** Total AGU consumed across all agents in the period, split by job completion */
+  /** Total Agent Units consumed across all agents in the period, split by job completion */
   totalAgentUnitConsumption: AgentJobConsumptionSummary;
-  /** Total platform units (PLTU) consumed across all agents in the period, split by job completion */
+  /** Total Platform Units consumed across all agents in the period, split by job completion */
   totalPlatformUnitConsumption: AgentJobConsumptionSummary;
   /** Period start time (ISO 8601, UTC) */
   startTime: string;

--- a/src/models/agents/agents.types.ts
+++ b/src/models/agents/agents.types.ts
@@ -238,3 +238,325 @@ export interface AgentGetLatencyTimelineResponse {
  * Options for getting the agent latency timeline.
  */
 export interface AgentGetLatencyTimelineOptions extends AgentFilterOptions {}
+
+/**
+ * One entry in the top-errored agents list — one agent with its error count
+ * and first/last observed failing jobs.
+ */
+export interface AgentTopErroredAgent {
+  /** Agent name */
+  name: string;
+  /** Error count for this agent over the requested window */
+  count: number;
+  /** Agent ID (GUID) */
+  agentId: string;
+  /** First job in the window where this agent reported errors */
+  firstSeenJob: AgentJobInfo;
+  /** Last job in the window where this agent reported errors */
+  lastSeenJob: AgentJobInfo;
+}
+
+/**
+ * Response from getting the top-errored agents.
+ */
+export interface AgentGetTopErroredAgentsResponse {
+  /** Total error count across all agents in the window. */
+  totalErrors?: number;
+  /** Top-N agents ranked by error count. May be absent when no data matches. */
+  data?: AgentTopErroredAgent[];
+}
+
+/**
+ * Options for getting the top-errored agents.
+ */
+export interface AgentGetTopErroredAgentsOptions extends AgentFilterOptions {
+  /** Max number of agents to return. Defaults to 10 server-side. */
+  limit?: number;
+}
+
+/**
+ * Agent type, used to filter consumption results.
+ *
+ * Wire format is the string name, per the API's `StringEnumConverter` serialization.
+ */
+export enum AgentType {
+  Autonomous = 'Autonomous',
+  Conversational = 'Conversational',
+  Coded = 'Coded',
+}
+
+/**
+ * Per-agent consumption entry returned by getting the top-consuming agents.
+ */
+export interface AgentConsumption {
+  /** Agent ID (GUID) */
+  agentId: string;
+  /** Agent display name */
+  agentName: string;
+  /** Total quantity consumed by this agent. `null` if no consumption is recorded. */
+  consumedQuantity: number | null;
+  /** AGU quantity consumed. `null` if no consumption is recorded. */
+  consumedAGUQuantity: number | null;
+  /** PLTU quantity consumed. `null` if no consumption is recorded. */
+  consumedPLTUQuantity: number | null;
+  /** First job in the window where this agent recorded consumption */
+  firstSeenJob: AgentJobInfo;
+  /** Last job in the window where this agent recorded consumption */
+  lastSeenJob: AgentJobInfo;
+}
+
+/**
+ * Response from getting the top-consuming agents.
+ *
+ * The API wraps this payload in a `data` envelope; the SDK unwraps it so the
+ * fields below are returned directly.
+ */
+export interface AgentGetTopConsumingAgentsResponse {
+  /**
+   * Window start date as the API returned it.
+   *
+   * Format: .NET default `M/d/yyyy h:mm:ss tt` (e.g., `"5/1/2025 12:00:00 AM"`)
+   * — NOT ISO 8601. Use `new Date(value)` to parse into a Date.
+   */
+  startDate?: string;
+  /** Window end date. Same format as `startDate`. */
+  endDate?: string;
+  /** Total quantity consumed across all matching agents in the window. */
+  totalConsumed?: number;
+  /** Total AGU quantity consumed. */
+  totalAGUConsumed?: number;
+  /** Total PLTU quantity consumed. */
+  totalPLTUConsumed?: number;
+  /** Limit applied (echoed from the request). */
+  limit?: number;
+  /** Top-N agents ranked by consumption. May be absent when no data matches. */
+  agents?: AgentConsumption[];
+}
+
+/**
+ * Options for getting the top-consuming agents.
+ */
+export interface AgentGetTopConsumingAgentsOptions extends AgentFilterOptions {
+  /** Max number of agents to return. Defaults to 10 server-side. */
+  limit?: number;
+  /**
+   * Health-based filter. `true` returns only healthy agents, `false` only
+   * unhealthy. Omit to include both.
+   */
+  healthy?: boolean;
+  /**
+   * Health-score cutoff used when `healthy` is set. Defaults to 75.0
+   * server-side.
+   */
+  healthThreshold?: number;
+  /**
+   * Filter to specific agent types. Multiple types are combined with `OR` and
+   * sent to the API as a comma-separated string.
+   */
+  agentTypes?: AgentType[];
+}
+
+/**
+ * Distribution of incidents across types over the requested window.
+ *
+ * The API wraps this payload in a `data` envelope (and emits a vestigial
+ * `pagination` object alongside it that carries no useful information on this
+ * non-paginated endpoint); the SDK unwraps the `data` and drops `pagination`
+ * so the fields below are returned directly.
+ */
+export interface AgentGetIncidentDistributionResponse {
+  /** Number of error-type incidents in the window */
+  errorCount?: number;
+  /** Number of escalation-type incidents in the window */
+  escalationCount?: number;
+  /** Number of policy-type incidents in the window */
+  policyCount?: number;
+}
+
+/**
+ * Options for getting the incident distribution.
+ *
+ * Currently identical to {@link AgentFilterOptions}; named distinctly so that
+ * future per-method filters can be added without a breaking change.
+ */
+export interface AgentGetIncidentDistributionOptions extends AgentFilterOptions {}
+
+/**
+ * Per-agent (process + folder) stats within an {@link AgentSummaryPeriod}.
+ */
+export interface AgentSummaryEntry {
+  /** Process key (GUID) */
+  processKey: string;
+  /** Folder key (GUID) the agent ran in */
+  folderKey: string;
+  /** Process version */
+  processVersion: string;
+  /** Total job runs in the period */
+  totalJobs: number;
+  /** Number of successful runs in the period */
+  successfulJobs: number;
+  /** Success rate as a percentage (0-100) */
+  successRate: number;
+  /** Average run duration in seconds */
+  averageDurationSeconds: number;
+  /** First job completion timestamp (ISO 8601, UTC) */
+  firstJobFinished: string;
+  /** Last job completion timestamp (ISO 8601, UTC) */
+  lastJobFinished: string;
+  /** Status of the most recent run (e.g., "Success", "Faulted", "Running") */
+  lastJobStatus: string;
+}
+
+/**
+ * Aggregate stats for a single period within an {@link AgentGetSummaryResponse}
+ * — covers the requested window for either the current period or an optional
+ * lookback period.
+ */
+export interface AgentSummaryPeriod {
+  /** Total job runs across all agents in the period */
+  totalJobs: number;
+  /** Number of successful runs across all agents in the period */
+  successfulJobs: number;
+  /** Overall success rate as a percentage (0-100) */
+  successRate: number;
+  /** Average run duration in seconds across all agents in the period */
+  averageDurationSeconds: number;
+  /** Period start time (ISO 8601, UTC) */
+  startTime: string;
+  /** Period end time (ISO 8601, UTC) */
+  endTime: string;
+  /** Per-agent breakdown */
+  agents: AgentSummaryEntry[];
+}
+
+/**
+ * Response from getting the agent summary.
+ *
+ * The API wraps this payload in a `data` envelope; the SDK unwraps it so the
+ * period summaries are returned directly. `lookbackPeriodSummary` is only
+ * present when the request set `lookbackPeriodAnalysis: true` (the API uses
+ * Newtonsoft `NullValueHandling.Ignore` and omits the key otherwise).
+ */
+export interface AgentGetSummaryResponse {
+  /** Aggregate stats for the requested window */
+  currentPeriodSummary?: AgentSummaryPeriod;
+  /** Aggregate stats for the prior window of equal length. Only present when `lookbackPeriodAnalysis: true` was sent. */
+  lookbackPeriodSummary?: AgentSummaryPeriod;
+}
+
+/**
+ * Job execution mode filter accepted by the summary endpoints.
+ *
+ * Wire format is the string name (`"Debug"` / `"Runtime"`), per the API's
+ * `StringEnumConverter` serialization.
+ */
+export enum AgentExecutionType {
+  /** Test runs */
+  Debug = 'Debug',
+  /** Production runs */
+  Runtime = 'Runtime',
+}
+
+/**
+ * Options for getting the agent summary.
+ */
+export interface AgentGetSummaryOptions extends AgentFilterOptions {
+  /**
+   * When `true`, the API also computes a `lookbackPeriodSummary` for the
+   * prior window of equal length. Defaults to `false` server-side.
+   */
+  lookbackPeriodAnalysis?: boolean;
+  /** Filter to a specific process by key (GUID). */
+  processKey?: string;
+  /**
+   * Filter to a specific folder by key (GUID).
+   *
+   * Note: this is a distinct field from the inherited {@link AgentFilterOptions.folderKeys}
+   * (plural array). The summary endpoint accepts both — `folderKey` selects a
+   * single folder, `folderKeys` filters the lookup to a list of folders.
+   */
+  folderKey?: string;
+  /**
+   * Filter to a specific execution type — `Debug` (test runs) or
+   * `Runtime` (production runs).
+   */
+  executionType?: AgentExecutionType;
+}
+
+/**
+ * Job-type breakdown of unit consumption — completed jobs vs jobs still in
+ * progress at query time.
+ */
+export interface AgentJobConsumptionSummary {
+  /** Units consumed by jobs that have completed in the period */
+  completeJobs: number;
+  /** Units consumed by jobs still in progress at query time */
+  incompleteJobs: number;
+}
+
+/**
+ * Per-agent (process + folder) unit consumption entry within an
+ * {@link AgentUnitConsumptionPeriod}.
+ *
+ * Note: `firstJobFinished` and `lastJobFinished` come back as
+ * `"0001-01-01T00:00:00"` (.NET `DateTime.MinValue` sentinel) when the period
+ * had no completed jobs for this agent — treat that value as "no completion".
+ */
+export interface AgentUnitConsumptionEntry {
+  /** Folder key (GUID) the agent ran in */
+  folderKey: string;
+  /** Process key (GUID) */
+  processKey: string;
+  /** Process version */
+  processVersion: string;
+  /** First job completion timestamp (ISO 8601). `"0001-01-01T00:00:00"` if no completion in the period. */
+  firstJobFinished: string;
+  /** Last job completion timestamp (ISO 8601). `"0001-01-01T00:00:00"` if no completion in the period. */
+  lastJobFinished: string;
+  /** AGU consumption for this agent, split by job completion status */
+  agentUnitConsumption: AgentJobConsumptionSummary;
+  /** Platform unit (PLTU) consumption for this agent, split by job completion status */
+  platformUnitConsumption: AgentJobConsumptionSummary;
+}
+
+/**
+ * Aggregate AGU/PLTU consumption for a single period within an
+ * {@link AgentGetUnitConsumptionSummaryResponse} — covers the requested window
+ * for either the current period or an optional lookback period.
+ */
+export interface AgentUnitConsumptionPeriod {
+  /** Total AGU consumed across all agents in the period, split by job completion */
+  totalAgentUnitConsumption: AgentJobConsumptionSummary;
+  /** Total platform units (PLTU) consumed across all agents in the period, split by job completion */
+  totalPlatformUnitConsumption: AgentJobConsumptionSummary;
+  /** Period start time (ISO 8601, UTC) */
+  startTime: string;
+  /** Period end time (ISO 8601, UTC) */
+  endTime: string;
+  /** Per-agent consumption breakdown */
+  agentConsumption: AgentUnitConsumptionEntry[];
+}
+
+/**
+ * Response from getting the agent unit consumption summary.
+ *
+ * The API wraps this payload in a `data` envelope; the SDK unwraps it so the
+ * period summaries are returned directly. `lookbackPeriodSummary` is only
+ * present when the request set `lookbackPeriodAnalysis: true` (the API uses
+ * Newtonsoft `NullValueHandling.Ignore` and omits the key otherwise).
+ */
+export interface AgentGetUnitConsumptionSummaryResponse {
+  /** Aggregate consumption for the requested window */
+  currentPeriodSummary?: AgentUnitConsumptionPeriod;
+  /** Aggregate consumption for the prior window of equal length. Only present when `lookbackPeriodAnalysis: true` was sent. */
+  lookbackPeriodSummary?: AgentUnitConsumptionPeriod;
+}
+
+/**
+ * Options for getting the agent unit consumption summary.
+ *
+ * Currently identical to {@link AgentGetSummaryOptions} (the API uses the same
+ * `AgentsSummaryRequest` schema for both endpoints); named distinctly so that
+ * future per-method filters can be added without a breaking change.
+ */
+export interface AgentGetUnitConsumptionSummaryOptions extends AgentGetSummaryOptions {}

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -49,7 +49,7 @@ export interface AgentMemoryGetCallsTimelineOptions extends AgentMemoryFilterOpt
  */
 export interface AgentMemoryGetTopSpacesOptions extends AgentMemoryFilterOptions {
   /**
-   * Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 when omitted.
+   * Maximum number of memory spaces to return, ranked by memory count.
    * @default 5
    */
   limit?: number;

--- a/src/models/agents/memory/memory.types.ts
+++ b/src/models/agents/memory/memory.types.ts
@@ -48,7 +48,10 @@ export interface AgentMemoryGetCallsTimelineOptions extends AgentMemoryFilterOpt
  * Options for retrieving the top memory spaces.
  */
 export interface AgentMemoryGetTopSpacesOptions extends AgentMemoryFilterOptions {
-  /** Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 when omitted. */
+  /**
+   * Maximum number of memory spaces to return, ranked by memory count. Defaults to 5 when omitted.
+   * @default 5
+   */
   limit?: number;
 }
 

--- a/src/models/common/types.ts
+++ b/src/models/common/types.ts
@@ -30,7 +30,10 @@ export enum JobState {
   Successful = 'Successful',
   Stopped = 'Stopped',
   Suspended = 'Suspended',
-  Resumed = 'Resumed'
+  Resumed = 'Resumed',
+  Cancelled = 'Cancelled',
+  /** Server-side fallback for an unrecognized or missing job state. */
+  Unknown = 'Unknown'
 }
 
 export interface BaseOptions {

--- a/src/models/observability/traces/agent/agent.models.ts
+++ b/src/models/observability/traces/agent/agent.models.ts
@@ -102,7 +102,7 @@ export interface AgentTracesServiceModel {
    * // Get per-agent unit consumption
    * const result = await trace.getUnitConsumption();
    * result.forEach((row) => {
-   *   console.log(`${row.agentId}: ${row.agentUnitsConsumed} AGU, ${row.platformUnitsConsumed} PLTU`);
+   *   console.log(`${row.agentId}: ${row.agentUnitsConsumed} Agent Units, ${row.platformUnitsConsumed} Platform Units`);
    * });
    * ```
    * @example

--- a/src/models/observability/traces/agent/agent.types.ts
+++ b/src/models/observability/traces/agent/agent.types.ts
@@ -63,7 +63,7 @@ export interface AgentTraceGetLatencyTimelineOptions extends AgentTraceFilterOpt
 
 /**
  * Per-agent unit consumption totals over the requested window (trace-level) —
- * a flat per-(agent, version, folder) breakdown of AGU and PLTU consumed.
+ * a flat per-(agent, version, folder) breakdown of Agent Units and Platform Units consumed.
  */
 export interface AgentTraceGetUnitConsumptionResponse {
   /** Agent ID these totals belong to. */

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -453,8 +453,6 @@ export class AgentService extends BaseService implements AgentServiceModel {
       body,
     );
 
-    // The endpoint always returns the full shape — { totalErrors: 0, data: [] }
-    // even when nothing matched (and on the 403 path) — so no fallback is needed.
     return response.data;
   }
 
@@ -487,7 +485,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *
    * const agents = new Agents(sdk);
    *
-   * // Top 5 healthy autonomous agents
+   * // Top 5 healthy autonomous agents by consumption
    * const result = await agents.getTopConsumption(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -519,8 +519,8 @@ export class AgentService extends BaseService implements AgentServiceModel {
   }
 
   /**
-   * Retrieves the distribution of incidents across types — errors, escalations,
-   * and policy violations — over the requested window.
+   * Retrieves breakdown of agent incidents count — errors, escalations,
+   * and policy violations over a requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
@@ -568,8 +568,10 @@ export class AgentService extends BaseService implements AgentServiceModel {
   }
 
   /**
-   * Retrieves an aggregate per-agent and overall job/success/duration summary
-   * over the requested window.
+   * Retrieves a job-execution summary for the requested window: overall totals
+   * (total jobs, successful jobs, success rate, average duration) alongside a
+   * per-agent breakdown. When `lookbackPeriodAnalysis` is enabled, a comparable
+   * summary for the preceding window of equal length is included too.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -303,7 +303,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
   }
 
   /**
-   * Retrieves a time-series of AGU (Agent Units) consumption over the requested window.
+   * Retrieves a time-series of Agent Units consumption over the requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
@@ -315,13 +315,13 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *
    * const agents = new Agents(sdk);
    *
-   * // AGU consumption timeline in May 2025
+   * // Agent Units consumption timeline in May 2025
    * const result = await agents.getConsumptionTimeline(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
    * result.forEach((point) => {
-   *   console.log(`${point.timeSlice}: ${point.aguConsumption} AGU`);
+   *   console.log(`${point.timeSlice}: ${point.aguConsumption} Agent Units`);
    * });
    * ```
    * @example
@@ -633,7 +633,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
   }
 
   /**
-   * Retrieves an aggregate AGU/PLTU unit consumption summary per agent over the
+   * Retrieves an aggregate Agent Units and Platform Units consumption summary per agent over the
    * requested window.
    *
    * @param startTime - Inclusive lower bound for the query window
@@ -651,7 +651,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * console.log(`AGU complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
+   * console.log(`Agent Units complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
    * ```
    * @example
    * ```typescript

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -9,10 +9,10 @@ import {
   AgentFilterOptions,
   AgentGetLatencyTimelineOptions,
   AgentGetLatencyTimelineResponse,
-  AgentGetTopErroredAgentsOptions,
-  AgentGetTopErroredAgentsResponse,
-  AgentGetTopConsumingAgentsOptions,
-  AgentGetTopConsumingAgentsResponse,
+  AgentGetTopErrorCountOptions,
+  AgentGetTopErrorCountResponse,
+  AgentGetTopConsumptionOptions,
+  AgentGetTopConsumptionResponse,
   AgentGetIncidentDistributionOptions,
   AgentGetIncidentDistributionResponse,
   AgentGetSummaryOptions,
@@ -406,15 +406,15 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
    * @param options - Optional filters
-   * @returns Promise resolving to {@link AgentGetTopErroredAgentsResponse}
+   * @returns Promise resolving to {@link AgentGetTopErrorCountResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
    *
    * const agents = new Agents(sdk);
    *
-   * // Top errored agents in May 2025
-   * const result = await agents.getTopErroredAgents(
+   * // Top agents by error count in May 2025
+   * const result = await agents.getTopErrorCount(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
@@ -425,7 +425,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * @example
    * ```typescript
    * // Scope to specific folders and top 5 agents
-   * const result = await agents.getTopErroredAgents(
+   * const result = await agents.getTopErrorCount(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    *   {
@@ -435,16 +435,16 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * );
    * ```
    */
-  @track('Agents.GetTopErroredAgents')
-  async getTopErroredAgents(
+  @track('Agents.GetTopErrorCount')
+  async getTopErrorCount(
     startTime: Date,
     endTime: Date,
-    options?: AgentGetTopErroredAgentsOptions,
-  ): Promise<AgentGetTopErroredAgentsResponse> {
+    options?: AgentGetTopErrorCountOptions,
+  ): Promise<AgentGetTopErrorCountResponse> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<AgentGetTopErroredAgentsResponse>(
-      AGENTS_ENDPOINTS.GET_TOP_ERRORED_AGENTS,
+    const response = await this.post<AgentGetTopErrorCountResponse>(
+      AGENTS_ENDPOINTS.GET_TOP_ERROR_COUNT,
       body,
     );
 
@@ -457,15 +457,15 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * @param startTime - Inclusive lower bound for the query window
    * @param endTime - Exclusive upper bound for the query window
    * @param options - Optional filters
-   * @returns Promise resolving to {@link AgentGetTopConsumingAgentsResponse}
+   * @returns Promise resolving to {@link AgentGetTopConsumptionResponse}
    * @example
    * ```typescript
    * import { Agents } from '@uipath/uipath-typescript/agents';
    *
    * const agents = new Agents(sdk);
    *
-   * // Top consuming agents in May 2025
-   * const result = await agents.getTopConsumingAgents(
+   * // Top agents by consumption in May 2025
+   * const result = await agents.getTopConsumption(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
@@ -481,7 +481,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * const agents = new Agents(sdk);
    *
    * // Top 5 healthy autonomous agents
-   * const result = await agents.getTopConsumingAgents(
+   * const result = await agents.getTopConsumption(
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    *   {
@@ -492,19 +492,19 @@ export class AgentService extends BaseService implements AgentServiceModel {
    * );
    * ```
    */
-  @track('Agents.GetTopConsumingAgents')
-  async getTopConsumingAgents(
+  @track('Agents.GetTopConsumption')
+  async getTopConsumption(
     startTime: Date,
     endTime: Date,
-    options?: AgentGetTopConsumingAgentsOptions,
-  ): Promise<AgentGetTopConsumingAgentsResponse> {
+    options?: AgentGetTopConsumptionOptions,
+  ): Promise<AgentGetTopConsumptionResponse> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
     if (options?.healthy !== undefined) body.healthy = options.healthy;
     if (options?.healthThreshold !== undefined) body.healthThreshold = options.healthThreshold;
     if (options?.agentTypes?.length) body.agentTypes = options.agentTypes.join(',');
 
-    const response = await this.post<{ data?: AgentGetTopConsumingAgentsResponse }>(
-      AGENTS_ENDPOINTS.GET_TOP_CONSUMING_AGENTS,
+    const response = await this.post<{ data?: AgentGetTopConsumptionResponse }>(
+      AGENTS_ENDPOINTS.GET_TOP_CONSUMPTION,
       body,
     );
 

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -24,6 +24,10 @@ import {
   AgentGetAllOptions,
 } from '../../models/agents/agents.types';
 import { AgentServiceModel } from '../../models/agents/agents.models';
+import type {
+  RawAgentGetSummaryResponse,
+  RawAgentSummaryPeriod,
+} from '../../models/agents/agents.internal-types';
 import { JobState } from '../../models/common/types';
 import { AGENTS_ENDPOINTS } from '../../utils/constants/endpoints';
 import {
@@ -65,14 +69,15 @@ function toJobState(raw: string): JobState {
 }
 
 /**
- * Returns a copy of a summary period with every agent's `lastJobStatus`
- * normalized to a {@link JobState}.
+ * Transforms a raw summary period into the public shape, normalizing every
+ * agent's raw `lastJobStatus` string to a {@link JobState}. Tolerates a missing
+ * `agents` array (treated as empty).
  */
-function normalizeSummaryPeriod(period?: AgentSummaryPeriod): AgentSummaryPeriod | undefined {
+function normalizeSummaryPeriod(period?: RawAgentSummaryPeriod): AgentSummaryPeriod | undefined {
   if (!period) return period;
   return {
     ...period,
-    agents: period.agents.map((agent) => ({ ...agent, lastJobStatus: toJobState(agent.lastJobStatus) })),
+    agents: (period.agents ?? []).map((agent) => ({ ...agent, lastJobStatus: toJobState(agent.lastJobStatus) })),
   };
 }
 
@@ -418,7 +423,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * result.data?.forEach((agent) => {
+   * result.data.forEach((agent) => {
    *   console.log(`${agent.name}: ${agent.count} errors`);
    * });
    * ```
@@ -448,7 +453,9 @@ export class AgentService extends BaseService implements AgentServiceModel {
       body,
     );
 
-    return response.data ?? {};
+    // The endpoint always returns the full shape — { totalErrors: 0, data: [] }
+    // even when nothing matched (and on the 403 path) — so no fallback is needed.
+    return response.data;
   }
 
   /**
@@ -610,7 +617,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
     if (options?.folderKey !== undefined) body.folderKey = options.folderKey;
     if (options?.executionType !== undefined) body.executionType = options.executionType;
 
-    const response = await this.post<{ data?: AgentGetSummaryResponse }>(
+    const response = await this.post<{ data?: RawAgentGetSummaryResponse }>(
       AGENTS_ENDPOINTS.GET_SUMMARY,
       body,
     );

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -63,7 +63,7 @@ const VALID_JOB_STATES = new Set<string>(Object.values(JobState));
  * unrecognized falls back to {@link JobState.Unknown} rather than throwing.
  */
 function toJobState(raw: string): JobState {
-  if (raw in JOB_STATUS_ALIASES) return JOB_STATUS_ALIASES[raw];
+  if (Object.prototype.hasOwnProperty.call(JOB_STATUS_ALIASES, raw)) return JOB_STATUS_ALIASES[raw];
   if (VALID_JOB_STATES.has(raw)) return raw as JobState;
   return JobState.Unknown;
 }
@@ -73,8 +73,7 @@ function toJobState(raw: string): JobState {
  * agent's raw `lastJobStatus` string to a {@link JobState}. Tolerates a missing
  * `agents` array (treated as empty).
  */
-function normalizeSummaryPeriod(period?: RawAgentSummaryPeriod): AgentSummaryPeriod | undefined {
-  if (!period) return period;
+function normalizeSummaryPeriod(period: RawAgentSummaryPeriod): AgentSummaryPeriod {
   return {
     ...period,
     agents: (period.agents ?? []).map((agent) => ({ ...agent, lastJobStatus: toJobState(agent.lastJobStatus) })),
@@ -475,7 +474,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-06-01T00:00:00Z'),
    * );
    * console.log(`Total consumed: ${result.totalConsumed}`);
-   * result.agents?.forEach((agent) => {
+   * result.agents.forEach((agent) => {
    *   console.log(`${agent.agentName}: ${agent.consumedQuantity}`);
    * });
    * ```
@@ -508,12 +507,12 @@ export class AgentService extends BaseService implements AgentServiceModel {
     if (options?.healthThreshold !== undefined) body.healthThreshold = options.healthThreshold;
     if (options?.agentTypes?.length) body.agentTypes = options.agentTypes.join(',');
 
-    const response = await this.post<{ data?: AgentGetTopConsumptionResponse }>(
+    const response = await this.post<{ data: AgentGetTopConsumptionResponse }>(
       AGENTS_ENDPOINTS.GET_TOP_CONSUMPTION,
       body,
     );
 
-    return response.data.data ?? {};
+    return response.data.data;
   }
 
   /**
@@ -557,12 +556,12 @@ export class AgentService extends BaseService implements AgentServiceModel {
   ): Promise<AgentGetIncidentDistributionResponse> {
     const body = this.buildAgentFilterBody(startTime, endTime, options);
 
-    const response = await this.post<{ data?: AgentGetIncidentDistributionResponse }>(
+    const response = await this.post<{ data: AgentGetIncidentDistributionResponse }>(
       AGENTS_ENDPOINTS.GET_INCIDENT_DISTRIBUTION,
       body,
     );
 
-    return response.data.data ?? {};
+    return response.data.data;
   }
 
   /**
@@ -586,7 +585,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * console.log(`Success rate: ${result.currentPeriodSummary?.successRate}%`);
+   * console.log(`Success rate: ${result.currentPeriodSummary.successRate}%`);
    * ```
    * @example
    * ```typescript
@@ -617,18 +616,17 @@ export class AgentService extends BaseService implements AgentServiceModel {
     if (options?.folderKey !== undefined) body.folderKey = options.folderKey;
     if (options?.executionType !== undefined) body.executionType = options.executionType;
 
-    const response = await this.post<{ data?: RawAgentGetSummaryResponse }>(
+    const response = await this.post<{ data: RawAgentGetSummaryResponse }>(
       AGENTS_ENDPOINTS.GET_SUMMARY,
       body,
     );
 
     const summary = response.data.data;
-    if (!summary) return {};
-
     return {
-      ...summary,
       currentPeriodSummary: normalizeSummaryPeriod(summary.currentPeriodSummary),
-      lookbackPeriodSummary: normalizeSummaryPeriod(summary.lookbackPeriodSummary),
+      lookbackPeriodSummary: summary.lookbackPeriodSummary
+        ? normalizeSummaryPeriod(summary.lookbackPeriodSummary)
+        : undefined,
     };
   }
 
@@ -651,7 +649,7 @@ export class AgentService extends BaseService implements AgentServiceModel {
    *   new Date('2025-05-01T00:00:00Z'),
    *   new Date('2025-06-01T00:00:00Z'),
    * );
-   * console.log(`Agent Units complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
+   * console.log(`Agent Units complete jobs: ${result.currentPeriodSummary.totalAgentUnitConsumption.completeJobs}`);
    * ```
    * @example
    * ```typescript
@@ -682,12 +680,12 @@ export class AgentService extends BaseService implements AgentServiceModel {
     if (options?.folderKey !== undefined) body.folderKey = options.folderKey;
     if (options?.executionType !== undefined) body.executionType = options.executionType;
 
-    const response = await this.post<{ data?: AgentGetUnitConsumptionSummaryResponse }>(
+    const response = await this.post<{ data: AgentGetUnitConsumptionSummaryResponse }>(
       AGENTS_ENDPOINTS.GET_UNIT_CONSUMPTION_SUMMARY,
       body,
     );
 
-    return response.data.data ?? {};
+    return response.data.data;
   }
 
   /**

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -9,6 +9,16 @@ import {
   AgentFilterOptions,
   AgentGetLatencyTimelineOptions,
   AgentGetLatencyTimelineResponse,
+  AgentGetTopErroredAgentsOptions,
+  AgentGetTopErroredAgentsResponse,
+  AgentGetTopConsumingAgentsOptions,
+  AgentGetTopConsumingAgentsResponse,
+  AgentGetIncidentDistributionOptions,
+  AgentGetIncidentDistributionResponse,
+  AgentGetSummaryOptions,
+  AgentGetSummaryResponse,
+  AgentGetUnitConsumptionSummaryOptions,
+  AgentGetUnitConsumptionSummaryResponse,
   AgentListItem,
   AgentGetAllOptions,
 } from '../../models/agents/agents.types';
@@ -351,6 +361,282 @@ export class AgentService extends BaseService implements AgentServiceModel {
     );
 
     return response.data.data;
+  }
+
+  /**
+   * Retrieves the top-N agents ranked by error count over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetTopErroredAgentsResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Top errored agents in May 2025
+   * const result = await agents.getTopErroredAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * result.data?.forEach((agent) => {
+   *   console.log(`${agent.name}: ${agent.count} errors`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders and top 5 agents
+   * const result = await agents.getTopErroredAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *     limit: 5,
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetTopErroredAgents')
+  async getTopErroredAgents(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetTopErroredAgentsOptions,
+  ): Promise<AgentGetTopErroredAgentsResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+
+    const response = await this.post<AgentGetTopErroredAgentsResponse>(
+      AGENTS_ENDPOINTS.GET_TOP_ERRORED_AGENTS,
+      body,
+    );
+
+    return response.data ?? {};
+  }
+
+  /**
+   * Retrieves the top-N agents ranked by unit consumption over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetTopConsumingAgentsResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Top consuming agents in May 2025
+   * const result = await agents.getTopConsumingAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`Total consumed: ${result.totalConsumed}`);
+   * result.agents?.forEach((agent) => {
+   *   console.log(`${agent.agentName}: ${agent.consumedQuantity}`);
+   * });
+   * ```
+   * @example
+   * ```typescript
+   * import { Agents, AgentType } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Top 5 healthy autonomous agents
+   * const result = await agents.getTopConsumingAgents(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     limit: 5,
+   *     healthy: true,
+   *     agentTypes: [AgentType.Autonomous],
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetTopConsumingAgents')
+  async getTopConsumingAgents(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetTopConsumingAgentsOptions,
+  ): Promise<AgentGetTopConsumingAgentsResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+    if (options?.healthy !== undefined) body.healthy = options.healthy;
+    if (options?.healthThreshold !== undefined) body.healthThreshold = options.healthThreshold;
+    if (options?.agentTypes?.length) body.agentTypes = options.agentTypes.join(',');
+
+    const response = await this.post<{ data?: AgentGetTopConsumingAgentsResponse }>(
+      AGENTS_ENDPOINTS.GET_TOP_CONSUMING_AGENTS,
+      body,
+    );
+
+    return response.data.data ?? {};
+  }
+
+  /**
+   * Retrieves the distribution of incidents across types — errors, escalations,
+   * and policy violations — over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetIncidentDistributionResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Incident distribution in May 2025
+   * const result = await agents.getIncidentDistribution(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`Errors: ${result.errorCount}, Escalations: ${result.escalationCount}, Policy: ${result.policyCount}`);
+   * ```
+   * @example
+   * ```typescript
+   * // Scope to specific folders
+   * const result = await agents.getIncidentDistribution(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     folderKeys: ['<folderKey1>'],
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetIncidentDistribution')
+  async getIncidentDistribution(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetIncidentDistributionOptions,
+  ): Promise<AgentGetIncidentDistributionResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+
+    const response = await this.post<{ data?: AgentGetIncidentDistributionResponse }>(
+      AGENTS_ENDPOINTS.GET_INCIDENT_DISTRIBUTION,
+      body,
+    );
+
+    return response.data.data ?? {};
+  }
+
+  /**
+   * Retrieves an aggregate per-agent and overall job/success/duration summary
+   * over the requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetSummaryResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Summary for May 2025
+   * const result = await agents.getSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`Success rate: ${result.currentPeriodSummary?.successRate}%`);
+   * ```
+   * @example
+   * ```typescript
+   * import { Agents, AgentExecutionType } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Runtime-only summary with lookback comparison
+   * const result = await agents.getSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     lookbackPeriodAnalysis: true,
+   *     executionType: AgentExecutionType.Runtime,
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetSummary')
+  async getSummary(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetSummaryOptions,
+  ): Promise<AgentGetSummaryResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+    if (options?.lookbackPeriodAnalysis !== undefined) body.lookbackPeriodAnalysis = options.lookbackPeriodAnalysis;
+    if (options?.processKey !== undefined) body.processKey = options.processKey;
+    if (options?.folderKey !== undefined) body.folderKey = options.folderKey;
+    if (options?.executionType !== undefined) body.executionType = options.executionType;
+
+    const response = await this.post<{ data?: AgentGetSummaryResponse }>(
+      AGENTS_ENDPOINTS.GET_SUMMARY,
+      body,
+    );
+
+    return response.data.data ?? {};
+  }
+
+  /**
+   * Retrieves an aggregate AGU/PLTU unit consumption summary per agent over the
+   * requested window.
+   *
+   * @param startTime - Inclusive lower bound for the query window
+   * @param endTime - Exclusive upper bound for the query window
+   * @param options - Optional filters
+   * @returns Promise resolving to {@link AgentGetUnitConsumptionSummaryResponse}
+   * @example
+   * ```typescript
+   * import { Agents } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Unit consumption summary for May 2025
+   * const result = await agents.getUnitConsumptionSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   * );
+   * console.log(`AGU complete jobs: ${result.currentPeriodSummary?.totalAgentUnitConsumption.completeJobs}`);
+   * ```
+   * @example
+   * ```typescript
+   * import { Agents, AgentExecutionType } from '@uipath/uipath-typescript/agents';
+   *
+   * const agents = new Agents(sdk);
+   *
+   * // Runtime-only summary with lookback comparison
+   * const result = await agents.getUnitConsumptionSummary(
+   *   new Date('2025-05-01T00:00:00Z'),
+   *   new Date('2025-06-01T00:00:00Z'),
+   *   {
+   *     lookbackPeriodAnalysis: true,
+   *     executionType: AgentExecutionType.Runtime,
+   *   },
+   * );
+   * ```
+   */
+  @track('Agents.GetUnitConsumptionSummary')
+  async getUnitConsumptionSummary(
+    startTime: Date,
+    endTime: Date,
+    options?: AgentGetUnitConsumptionSummaryOptions,
+  ): Promise<AgentGetUnitConsumptionSummaryResponse> {
+    const body = this.buildAgentFilterBody(startTime, endTime, options);
+    if (options?.lookbackPeriodAnalysis !== undefined) body.lookbackPeriodAnalysis = options.lookbackPeriodAnalysis;
+    if (options?.processKey !== undefined) body.processKey = options.processKey;
+    if (options?.folderKey !== undefined) body.folderKey = options.folderKey;
+    if (options?.executionType !== undefined) body.executionType = options.executionType;
+
+    const response = await this.post<{ data?: AgentGetUnitConsumptionSummaryResponse }>(
+      AGENTS_ENDPOINTS.GET_UNIT_CONSUMPTION_SUMMARY,
+      body,
+    );
+
+    return response.data.data ?? {};
   }
 
   /**

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -17,12 +17,14 @@ import {
   AgentGetIncidentDistributionResponse,
   AgentGetSummaryOptions,
   AgentGetSummaryResponse,
+  AgentSummaryPeriod,
   AgentGetUnitConsumptionSummaryOptions,
   AgentGetUnitConsumptionSummaryResponse,
   AgentListItem,
   AgentGetAllOptions,
 } from '../../models/agents/agents.types';
 import { AgentServiceModel } from '../../models/agents/agents.models';
+import { JobState } from '../../models/common/types';
 import { AGENTS_ENDPOINTS } from '../../utils/constants/endpoints';
 import {
   HTTP_METHODS,
@@ -38,6 +40,41 @@ import type {
   NonPaginatedResponse,
   PaginatedResponse,
 } from '../../utils/pagination/types';
+
+/**
+ * Raw `lastJobStatus` strings the agent-summary API emits that don't match a
+ * {@link JobState} value verbatim. `Success` is the API's short label for a
+ * successful run, normalized to `Successful`. (`Cancelled` is a canonical
+ * JobState value and passes through unchanged — it is not aliased to `Stopped`.)
+ */
+const JOB_STATUS_ALIASES: Record<string, JobState> = {
+  Success: JobState.Successful,
+};
+
+const VALID_JOB_STATES = new Set<string>(Object.values(JobState));
+
+/**
+ * Permissively maps a raw `lastJobStatus` string to a {@link JobState}. Known
+ * aliases are translated first, canonical values pass through, and anything
+ * unrecognized falls back to {@link JobState.Unknown} rather than throwing.
+ */
+function toJobState(raw: string): JobState {
+  if (raw in JOB_STATUS_ALIASES) return JOB_STATUS_ALIASES[raw];
+  if (VALID_JOB_STATES.has(raw)) return raw as JobState;
+  return JobState.Unknown;
+}
+
+/**
+ * Returns a copy of a summary period with every agent's `lastJobStatus`
+ * normalized to a {@link JobState}.
+ */
+function normalizeSummaryPeriod(period?: AgentSummaryPeriod): AgentSummaryPeriod | undefined {
+  if (!period) return period;
+  return {
+    ...period,
+    agents: period.agents.map((agent) => ({ ...agent, lastJobStatus: toJobState(agent.lastJobStatus) })),
+  };
+}
 
 /**
  * Service for interacting with the UiPath Agents API.
@@ -578,7 +615,14 @@ export class AgentService extends BaseService implements AgentServiceModel {
       body,
     );
 
-    return response.data.data ?? {};
+    const summary = response.data.data;
+    if (!summary) return {};
+
+    return {
+      ...summary,
+      currentPeriodSummary: normalizeSummaryPeriod(summary.currentPeriodSummary),
+      lookbackPeriodSummary: normalizeSummaryPeriod(summary.lookbackPeriodSummary),
+    };
   }
 
   /**

--- a/src/services/agents/agents.ts
+++ b/src/services/agents/agents.ts
@@ -45,12 +45,6 @@ import type {
   PaginatedResponse,
 } from '../../utils/pagination/types';
 
-/**
- * Raw `lastJobStatus` strings the agent-summary API emits that don't match a
- * {@link JobState} value verbatim. `Success` is the API's short label for a
- * successful run, normalized to `Successful`. (`Cancelled` is a canonical
- * JobState value and passes through unchanged — it is not aliased to `Stopped`.)
- */
 const JOB_STATUS_ALIASES: Record<string, JobState> = {
   Success: JobState.Successful,
 };

--- a/src/services/observability/traces/agent/agent.ts
+++ b/src/services/observability/traces/agent/agent.ts
@@ -138,7 +138,7 @@ export class AgentTracesService extends BaseService implements AgentTracesServic
    * // Get per-agent unit consumption
    * const result = await trace.getUnitConsumption();
    * result.forEach((row) => {
-   *   console.log(`${row.agentId}: ${row.agentUnitsConsumed} AGU, ${row.platformUnitsConsumed} PLTU`);
+   *   console.log(`${row.agentId}: ${row.agentUnitsConsumed} Agent Units, ${row.platformUnitsConsumed} Platform Units`);
    * });
    * ```
    * @example

--- a/src/utils/constants/endpoints/agent-traces.ts
+++ b/src/utils/constants/endpoints/agent-traces.ts
@@ -8,7 +8,7 @@ export const AGENT_TRACES_ENDPOINTS = {
   GET_ERRORS_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/errorsTimeline`,
   /** Trace-level time-series of latency (decimal seconds per series). */
   GET_LATENCY_TIMELINE: `${INSIGHTS_RTM_BASE}/Traceview/latencyTimeline`,
-  /** Trace-level per-agent AGU/PLTU consumption totals. */
+  /** Trace-level per-agent Agent Units and Platform Units consumption totals. */
   GET_UNIT_CONSUMPTION: `${INSIGHTS_RTM_BASE}/Traceview/unitConsumption`,
   /** All spans for a single trace (flat array, not paginated). */
   GET_SPANS_BY_TRACE_ID: (traceId: string) => `${INSIGHTS_RTM_BASE}/Traceview/spans/${traceId}`,

--- a/src/utils/constants/endpoints/agents.ts
+++ b/src/utils/constants/endpoints/agents.ts
@@ -15,4 +15,14 @@ export const AGENTS_ENDPOINTS = {
   GET_CONSUMPTION_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/consumptionTimeline`,
   /** Time-series of agent latency (per-percentile) over the requested window. */
   GET_LATENCY_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/latencyTimeline`,
+  /** Top-N agents by error count over the requested window. */
+  GET_TOP_ERRORED_AGENTS: `${INSIGHTS_RTM_BASE}/Agents/topErroredAgents`,
+  /** Top-N agents by unit consumption over the requested window. */
+  GET_TOP_CONSUMING_AGENTS: `${INSIGHTS_RTM_BASE}/Agents/consumption`,
+  /** Distribution of incidents across types (errors, escalations, policy). */
+  GET_INCIDENT_DISTRIBUTION: `${INSIGHTS_RTM_BASE}/Agents/incidentDistribution`,
+  /** Aggregate per-agent and overall job/success/duration summary over the requested window. */
+  GET_SUMMARY: `${INSIGHTS_RTM_BASE}/Agents/summary`,
+  /** Aggregate AGU/PLTU consumption per agent over the requested window. */
+  GET_UNIT_CONSUMPTION_SUMMARY: `${INSIGHTS_RTM_BASE}/Agents/summary/unit-consumption`,
 } as const;

--- a/src/utils/constants/endpoints/agents.ts
+++ b/src/utils/constants/endpoints/agents.ts
@@ -16,9 +16,9 @@ export const AGENTS_ENDPOINTS = {
   /** Time-series of agent latency (per-percentile) over the requested window. */
   GET_LATENCY_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/latencyTimeline`,
   /** Top-N agents by error count over the requested window. */
-  GET_TOP_ERRORED_AGENTS: `${INSIGHTS_RTM_BASE}/Agents/topErroredAgents`,
+  GET_TOP_ERROR_COUNT: `${INSIGHTS_RTM_BASE}/Agents/topErroredAgents`,
   /** Top-N agents by unit consumption over the requested window. */
-  GET_TOP_CONSUMING_AGENTS: `${INSIGHTS_RTM_BASE}/Agents/consumption`,
+  GET_TOP_CONSUMPTION: `${INSIGHTS_RTM_BASE}/Agents/consumption`,
   /** Distribution of incidents across types (errors, escalations, policy). */
   GET_INCIDENT_DISTRIBUTION: `${INSIGHTS_RTM_BASE}/Agents/incidentDistribution`,
   /** Aggregate per-agent and overall job/success/duration summary over the requested window. */

--- a/src/utils/constants/endpoints/agents.ts
+++ b/src/utils/constants/endpoints/agents.ts
@@ -11,7 +11,7 @@ export const AGENTS_ENDPOINTS = {
   GET_INCIDENTS: `${INSIGHTS_RTM_BASE}/Agents/incidents`,
   /** Time-series of error counts grouped by agent over the requested window. */
   GET_ERRORS_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/errors`,
-  /** Time-series of AGU consumption over the requested window. */
+  /** Time-series of Agent Units consumption over the requested window. */
   GET_CONSUMPTION_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/consumptionTimeline`,
   /** Time-series of agent latency (per-percentile) over the requested window. */
   GET_LATENCY_TIMELINE: `${INSIGHTS_RTM_BASE}/Agents/latencyTimeline`,
@@ -23,6 +23,6 @@ export const AGENTS_ENDPOINTS = {
   GET_INCIDENT_DISTRIBUTION: `${INSIGHTS_RTM_BASE}/Agents/incidentDistribution`,
   /** Aggregate per-agent and overall job/success/duration summary over the requested window. */
   GET_SUMMARY: `${INSIGHTS_RTM_BASE}/Agents/summary`,
-  /** Aggregate AGU/PLTU consumption per agent over the requested window. */
+  /** Aggregate Agent Units and Platform Units consumption per agent over the requested window. */
   GET_UNIT_CONSUMPTION_SUMMARY: `${INSIGHTS_RTM_BASE}/Agents/summary/unit-consumption`,
 } as const;

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -245,10 +245,11 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
       const result = await agents.getTopErrorCount(startTime, endTime);
 
       expect(result).toBeDefined();
-      if (typeof result.totalErrors === 'number') {
-        expect(result.totalErrors).toBeGreaterThanOrEqual(0);
-      }
-      if (!result.data || result.data.length === 0) {
+      // totalErrors and data are always present — 0 / [] when nothing matched.
+      expect(typeof result.totalErrors).toBe('number');
+      expect(result.totalErrors).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(result.data)).toBe(true);
+      if (result.data.length === 0) {
         throw new Error(
           'No errored agents in the test tenant for the configured window — ' +
           'cannot verify response shape. Run errored agents in the tenant or widen the window.',
@@ -265,7 +266,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     it('should respect the limit option', async () => {
       const result = await agents.getTopErrorCount(startTime, endTime, { limit: 3 });
 
-      if (!result.data || result.data.length === 0) {
+      if (result.data.length === 0) {
         throw new Error(
           'No errored agents in the test tenant for the configured window — ' +
           'cannot verify limit option. Run errored agents in the tenant or widen the window.',

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -284,12 +284,13 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
       const result = await agents.getTopConsumption(startTime, endTime);
 
       expect(result).toBeDefined();
-      // Window dates are echoed as .NET-formatted strings (not ISO)
-      if (result.startDate !== undefined) expect(typeof result.startDate).toBe('string');
-      if (typeof result.totalConsumed === 'number') {
-        expect(result.totalConsumed).toBeGreaterThanOrEqual(0);
-      }
-      if (!result.agents || result.agents.length === 0) {
+      // Totals and window dates are always present; agents is [] when none matched.
+      expect(typeof result.startDate).toBe('string');
+      expect(typeof result.endDate).toBe('string');
+      expect(typeof result.totalConsumed).toBe('number');
+      expect(result.totalConsumed).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(result.agents)).toBe(true);
+      if (result.agents.length === 0) {
         throw new Error(
           'No consuming agents in the test tenant for the configured window — ' +
           'cannot verify response shape. Run agents in the tenant or widen the window.',
@@ -309,9 +310,8 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
       });
 
       expect(result).toBeDefined();
-      if (result.agents && result.agents.length > 0) {
-        expect(result.agents.length).toBeLessThanOrEqual(3);
-      }
+      expect(Array.isArray(result.agents)).toBe(true);
+      expect(result.agents.length).toBeLessThanOrEqual(3);
     });
   });
 
@@ -324,15 +324,13 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
 
       expect(result).toBeDefined();
       expect((result as { pagination?: unknown }).pagination).toBeUndefined();
-      if (typeof result.errorCount === 'number') {
-        expect(result.errorCount).toBeGreaterThanOrEqual(0);
-      }
-      if (typeof result.escalationCount === 'number') {
-        expect(result.escalationCount).toBeGreaterThanOrEqual(0);
-      }
-      if (typeof result.policyCount === 'number') {
-        expect(result.policyCount).toBeGreaterThanOrEqual(0);
-      }
+      // All three counts are always present (default 0).
+      expect(typeof result.errorCount).toBe('number');
+      expect(result.errorCount).toBeGreaterThanOrEqual(0);
+      expect(typeof result.escalationCount).toBe('number');
+      expect(result.escalationCount).toBeGreaterThanOrEqual(0);
+      expect(typeof result.policyCount).toBe('number');
+      expect(result.policyCount).toBeGreaterThanOrEqual(0);
     });
 
     it('should scope to a single folder', async () => {
@@ -353,12 +351,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
 
       expect(result).toBeDefined();
       expect(result.lookbackPeriodSummary).toBeUndefined();
-      if (!result.currentPeriodSummary) {
-        throw new Error(
-          'No summary data in the test tenant for the configured window — ' +
-          'cannot verify response shape. Run agents in the tenant or widen the window.',
-        );
-      }
+      // currentPeriodSummary is always present.
       const period = result.currentPeriodSummary;
       expect(typeof period.totalJobs).toBe('number');
       expect(typeof period.successRate).toBe('number');
@@ -377,12 +370,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
         executionType: AgentExecutionType.Runtime,
       });
 
-      if (!result.currentPeriodSummary) {
-        throw new Error(
-          'No summary data in the test tenant for the configured window — ' +
-          'cannot verify lookback. Run agents in the tenant or widen the window.',
-        );
-      }
+      expect(result.currentPeriodSummary).toBeDefined();
       expect(result.lookbackPeriodSummary).toBeDefined();
     });
   });
@@ -396,12 +384,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
 
       expect(result).toBeDefined();
       expect(result.lookbackPeriodSummary).toBeUndefined();
-      if (!result.currentPeriodSummary) {
-        throw new Error(
-          'No unit-consumption summary in the test tenant for the configured window — ' +
-          'cannot verify response shape. Run agents in the tenant or widen the window.',
-        );
-      }
+      // currentPeriodSummary is always present.
       const period = result.currentPeriodSummary;
       expect(typeof period.totalAgentUnitConsumption.completeJobs).toBe('number');
       expect(typeof period.totalPlatformUnitConsumption.completeJobs).toBe('number');
@@ -414,12 +397,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
         executionType: AgentExecutionType.Runtime,
       });
 
-      if (!result.currentPeriodSummary) {
-        throw new Error(
-          'No unit-consumption summary in the test tenant for the configured window — ' +
-          'cannot verify lookback. Run agents in the tenant or widen the window.',
-        );
-      }
+      expect(result.currentPeriodSummary).toBeDefined();
       expect(result.lookbackPeriodSummary).toBeDefined();
     });
   });

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -237,12 +237,12 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopErroredAgents', () => {
+  describe('getTopErrorCount', () => {
     const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
     const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
 
     it('should retrieve top-N agents ranked by error count', async () => {
-      const result = await agents.getTopErroredAgents(startTime, endTime);
+      const result = await agents.getTopErrorCount(startTime, endTime);
 
       expect(result).toBeDefined();
       if (typeof result.totalErrors === 'number') {
@@ -263,7 +263,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     });
 
     it('should respect the limit option', async () => {
-      const result = await agents.getTopErroredAgents(startTime, endTime, { limit: 3 });
+      const result = await agents.getTopErrorCount(startTime, endTime, { limit: 3 });
 
       if (!result.data || result.data.length === 0) {
         throw new Error(
@@ -275,12 +275,12 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopConsumingAgents', () => {
+  describe('getTopConsumption', () => {
     const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
     const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
 
     it('should retrieve top-N consuming agents with aggregate totals', async () => {
-      const result = await agents.getTopConsumingAgents(startTime, endTime);
+      const result = await agents.getTopConsumption(startTime, endTime);
 
       expect(result).toBeDefined();
       // Window dates are echoed as .NET-formatted strings (not ISO)
@@ -302,7 +302,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     });
 
     it('should accept a limit and an agentTypes filter', async () => {
-      const result = await agents.getTopConsumingAgents(startTime, endTime, {
+      const result = await agents.getTopConsumption(startTime, endTime, {
         limit: 3,
         agentTypes: [AgentType.Autonomous],
       });

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { Agents } from '../../../../src/services/agents';
 import { AgentType, AgentExecutionType } from '../../../../src/models/agents/agents.types';
+import { JobState } from '../../../../src/models/common/types';
 import { AGENT_TEST_CONSTANTS } from '../../../utils/constants';
 
 /**
@@ -361,6 +362,12 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
       expect(typeof period.totalJobs).toBe('number');
       expect(typeof period.successRate).toBe('number');
       expect(Array.isArray(period.agents)).toBe(true);
+      // Every lastJobStatus must be normalized to a valid JobState — no raw
+      // labels (e.g. 'Success', 'Cancelled') leaking through the transform.
+      const validStates = new Set<string>(Object.values(JobState));
+      for (const agent of period.agents) {
+        expect(validStates.has(agent.lastJobStatus)).toBe(true);
+      }
     });
 
     it('should include a lookback summary when requested', async () => {

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -183,7 +183,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
     const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
 
-    it('should retrieve the AGU consumption timeline', async () => {
+    it('should retrieve the Agent Units consumption timeline', async () => {
       const result = await agents.getConsumptionTimeline(startTime, endTime);
 
       expect(Array.isArray(result)).toBe(true);
@@ -391,7 +391,7 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
     const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
     const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
 
-    it('should retrieve an aggregate AGU/PLTU summary with a per-agent breakdown', async () => {
+    it('should retrieve an aggregate Agent Units and Platform Units summary with a per-agent breakdown', async () => {
       const result = await agents.getUnitConsumptionSummary(startTime, endTime);
 
       expect(result).toBeDefined();

--- a/tests/integration/shared/agents/agents.integration.test.ts
+++ b/tests/integration/shared/agents/agents.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { getServices, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { Agents } from '../../../../src/services/agents';
+import { AgentType, AgentExecutionType } from '../../../../src/models/agents/agents.types';
 import { AGENT_TEST_CONSTANTS } from '../../../utils/constants';
 
 /**
@@ -232,6 +233,186 @@ describe.skip.each(modes)('Agents - Integration Tests [%s]', (mode) => {
       });
 
       expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('getTopErroredAgents', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve top-N agents ranked by error count', async () => {
+      const result = await agents.getTopErroredAgents(startTime, endTime);
+
+      expect(result).toBeDefined();
+      if (typeof result.totalErrors === 'number') {
+        expect(result.totalErrors).toBeGreaterThanOrEqual(0);
+      }
+      if (!result.data || result.data.length === 0) {
+        throw new Error(
+          'No errored agents in the test tenant for the configured window — ' +
+          'cannot verify response shape. Run errored agents in the tenant or widen the window.',
+        );
+      }
+      const entry = result.data[0];
+      expect(typeof entry.name).toBe('string');
+      expect(typeof entry.count).toBe('number');
+      expect(typeof entry.agentId).toBe('string');
+      expect(typeof entry.firstSeenJob.jobKey).toBe('string');
+      expect(entry.lastSeenJob).toBeDefined();
+    });
+
+    it('should respect the limit option', async () => {
+      const result = await agents.getTopErroredAgents(startTime, endTime, { limit: 3 });
+
+      if (!result.data || result.data.length === 0) {
+        throw new Error(
+          'No errored agents in the test tenant for the configured window — ' +
+          'cannot verify limit option. Run errored agents in the tenant or widen the window.',
+        );
+      }
+      expect(result.data.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('getTopConsumingAgents', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve top-N consuming agents with aggregate totals', async () => {
+      const result = await agents.getTopConsumingAgents(startTime, endTime);
+
+      expect(result).toBeDefined();
+      // Window dates are echoed as .NET-formatted strings (not ISO)
+      if (result.startDate !== undefined) expect(typeof result.startDate).toBe('string');
+      if (typeof result.totalConsumed === 'number') {
+        expect(result.totalConsumed).toBeGreaterThanOrEqual(0);
+      }
+      if (!result.agents || result.agents.length === 0) {
+        throw new Error(
+          'No consuming agents in the test tenant for the configured window — ' +
+          'cannot verify response shape. Run agents in the tenant or widen the window.',
+        );
+      }
+      const agent = result.agents[0];
+      expect(typeof agent.agentId).toBe('string');
+      expect(typeof agent.agentName).toBe('string');
+      expect(agent.firstSeenJob).toBeDefined();
+      expect(agent.lastSeenJob).toBeDefined();
+    });
+
+    it('should accept a limit and an agentTypes filter', async () => {
+      const result = await agents.getTopConsumingAgents(startTime, endTime, {
+        limit: 3,
+        agentTypes: [AgentType.Autonomous],
+      });
+
+      expect(result).toBeDefined();
+      if (result.agents && result.agents.length > 0) {
+        expect(result.agents.length).toBeLessThanOrEqual(3);
+      }
+    });
+  });
+
+  describe('getIncidentDistribution', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve incident counts across categories without a pagination field', async () => {
+      const result = await agents.getIncidentDistribution(startTime, endTime);
+
+      expect(result).toBeDefined();
+      expect((result as { pagination?: unknown }).pagination).toBeUndefined();
+      if (typeof result.errorCount === 'number') {
+        expect(result.errorCount).toBeGreaterThanOrEqual(0);
+      }
+      if (typeof result.escalationCount === 'number') {
+        expect(result.escalationCount).toBeGreaterThanOrEqual(0);
+      }
+      if (typeof result.policyCount === 'number') {
+        expect(result.policyCount).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('should scope to a single folder', async () => {
+      const result = await agents.getIncidentDistribution(startTime, endTime, {
+        folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
+      });
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('getSummary', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve an aggregate summary with a per-agent breakdown', async () => {
+      const result = await agents.getSummary(startTime, endTime);
+
+      expect(result).toBeDefined();
+      expect(result.lookbackPeriodSummary).toBeUndefined();
+      if (!result.currentPeriodSummary) {
+        throw new Error(
+          'No summary data in the test tenant for the configured window — ' +
+          'cannot verify response shape. Run agents in the tenant or widen the window.',
+        );
+      }
+      const period = result.currentPeriodSummary;
+      expect(typeof period.totalJobs).toBe('number');
+      expect(typeof period.successRate).toBe('number');
+      expect(Array.isArray(period.agents)).toBe(true);
+    });
+
+    it('should include a lookback summary when requested', async () => {
+      const result = await agents.getSummary(startTime, endTime, {
+        lookbackPeriodAnalysis: true,
+        executionType: AgentExecutionType.Runtime,
+      });
+
+      if (!result.currentPeriodSummary) {
+        throw new Error(
+          'No summary data in the test tenant for the configured window — ' +
+          'cannot verify lookback. Run agents in the tenant or widen the window.',
+        );
+      }
+      expect(result.lookbackPeriodSummary).toBeDefined();
+    });
+  });
+
+  describe('getUnitConsumptionSummary', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+
+    it('should retrieve an aggregate AGU/PLTU summary with a per-agent breakdown', async () => {
+      const result = await agents.getUnitConsumptionSummary(startTime, endTime);
+
+      expect(result).toBeDefined();
+      expect(result.lookbackPeriodSummary).toBeUndefined();
+      if (!result.currentPeriodSummary) {
+        throw new Error(
+          'No unit-consumption summary in the test tenant for the configured window — ' +
+          'cannot verify response shape. Run agents in the tenant or widen the window.',
+        );
+      }
+      const period = result.currentPeriodSummary;
+      expect(typeof period.totalAgentUnitConsumption.completeJobs).toBe('number');
+      expect(typeof period.totalPlatformUnitConsumption.completeJobs).toBe('number');
+      expect(Array.isArray(period.agentConsumption)).toBe(true);
+    });
+
+    it('should include a lookback summary when requested', async () => {
+      const result = await agents.getUnitConsumptionSummary(startTime, endTime, {
+        lookbackPeriodAnalysis: true,
+        executionType: AgentExecutionType.Runtime,
+      });
+
+      if (!result.currentPeriodSummary) {
+        throw new Error(
+          'No unit-consumption summary in the test tenant for the configured window — ' +
+          'cannot verify lookback. Run agents in the tenant or widen the window.',
+        );
+      }
+      expect(result.lookbackPeriodSummary).toBeDefined();
     });
   });
 });

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -643,10 +643,12 @@ describe('AgentService Unit Tests', () => {
       expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_TOP_CONSUMPTION);
       expect(body.startTime).toBe(startTime.toISOString());
       expect(body.endTime).toBe(endTime.toISOString());
+      // healthy omitted → absent from the body (distinct from healthy:false)
+      expect('healthy' in body).toBe(false);
     });
 
     it('should send health filters and join agentTypes into a comma-separated string', async () => {
-      mockApiClient.post.mockResolvedValue({ data: {} });
+      mockApiClient.post.mockResolvedValue({ data: mockPayload });
 
       await agentService.getTopConsumption(startTime, endTime, {
         limit: 5,
@@ -663,20 +665,12 @@ describe('AgentService Unit Tests', () => {
     });
 
     it('should send healthy:false distinct from unset', async () => {
-      mockApiClient.post.mockResolvedValue({ data: {} });
+      mockApiClient.post.mockResolvedValue({ data: mockPayload });
 
       await agentService.getTopConsumption(startTime, endTime, { healthy: false });
 
       const [, body] = mockApiClient.post.mock.calls[0];
       expect(body.healthy).toBe(false);
-    });
-
-    it('should return an empty object when the envelope data is absent', async () => {
-      mockApiClient.post.mockResolvedValue({});
-
-      const result = await agentService.getTopConsumption(startTime, endTime);
-
-      expect(result).toEqual({});
     });
 
     it('should propagate API errors', async () => {
@@ -715,7 +709,7 @@ describe('AgentService Unit Tests', () => {
     });
 
     it('should include filters in the body', async () => {
-      mockApiClient.post.mockResolvedValue({ data: {} });
+      mockApiClient.post.mockResolvedValue({ data: mockPayload });
 
       const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
       await agentService.getIncidentDistribution(startTime, endTime, {
@@ -726,14 +720,6 @@ describe('AgentService Unit Tests', () => {
       const [, body] = mockApiClient.post.mock.calls[0];
       expect(body.folderKeys).toEqual(folderKeys);
       expect(body.agentId).toBe(AGENT_TEST_CONSTANTS.AGENT_ID);
-    });
-
-    it('should return an empty object when the envelope data is absent', async () => {
-      mockApiClient.post.mockResolvedValue({});
-
-      const result = await agentService.getIncidentDistribution(startTime, endTime);
-
-      expect(result).toEqual({});
     });
 
     it('should propagate API errors', async () => {
@@ -792,7 +778,7 @@ describe('AgentService Unit Tests', () => {
     });
 
     it('should send lookbackPeriodAnalysis, processKey and folderKey (singular, distinct from folderKeys)', async () => {
-      mockApiClient.post.mockResolvedValue({ data: {} });
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
 
       await agentService.getSummary(startTime, endTime, {
         folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
@@ -808,8 +794,17 @@ describe('AgentService Unit Tests', () => {
       expect(body.folderKeys).toEqual([AGENT_TEST_CONSTANTS.FOLDER_KEY_1]);
     });
 
+    it('should send lookbackPeriodAnalysis:false distinct from unset', async () => {
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
+
+      await agentService.getSummary(startTime, endTime, { lookbackPeriodAnalysis: false });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.lookbackPeriodAnalysis).toBe(false);
+    });
+
     it('should send executionType as its string name', async () => {
-      mockApiClient.post.mockResolvedValue({ data: {} });
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
 
       await agentService.getSummary(startTime, endTime, {
         executionType: AgentExecutionType.Runtime,
@@ -855,7 +850,7 @@ describe('AgentService Unit Tests', () => {
 
       const result = await agentService.getSummary(startTime, endTime, { lookbackPeriodAnalysis: true });
 
-      expect(result.currentPeriodSummary?.agents.map((a) => a.lastJobStatus)).toEqual([
+      expect(result.currentPeriodSummary.agents.map((a) => a.lastJobStatus)).toEqual([
         JobState.Successful,
         JobState.Cancelled,
         JobState.Running,
@@ -865,15 +860,7 @@ describe('AgentService Unit Tests', () => {
       // Normalization is applied to the lookback period too, not just the current one.
       expect(result.lookbackPeriodSummary?.agents[0].lastJobStatus).toBe(JobState.Successful);
       // The raw API label must not leak through.
-      expect(result.currentPeriodSummary?.agents[0].lastJobStatus).not.toBe('Success');
-    });
-
-    it('should return an empty object when the envelope data is absent', async () => {
-      mockApiClient.post.mockResolvedValue({});
-
-      const result = await agentService.getSummary(startTime, endTime);
-
-      expect(result).toEqual({});
+      expect(result.currentPeriodSummary.agents[0].lastJobStatus).not.toBe('Success');
     });
 
     it('should not throw when a period omits the agents array', async () => {
@@ -882,7 +869,7 @@ describe('AgentService Unit Tests', () => {
 
       const result = await agentService.getSummary(startTime, endTime);
 
-      expect(result.currentPeriodSummary?.agents).toEqual([]);
+      expect(result.currentPeriodSummary.agents).toEqual([]);
     });
 
     it('should propagate API errors', async () => {
@@ -932,7 +919,7 @@ describe('AgentService Unit Tests', () => {
     });
 
     it('should send lookbackPeriodAnalysis, processKey, folderKey and executionType', async () => {
-      mockApiClient.post.mockResolvedValue({ data: {} });
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
 
       await agentService.getUnitConsumptionSummary(startTime, endTime, {
         lookbackPeriodAnalysis: true,
@@ -948,6 +935,15 @@ describe('AgentService Unit Tests', () => {
       expect(body.executionType).toBe('Runtime');
     });
 
+    it('should send lookbackPeriodAnalysis:false distinct from unset', async () => {
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
+
+      await agentService.getUnitConsumptionSummary(startTime, endTime, { lookbackPeriodAnalysis: false });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.lookbackPeriodAnalysis).toBe(false);
+    });
+
     it('should return both periods when the API includes a lookback summary', async () => {
       mockApiClient.post.mockResolvedValue({
         data: { currentPeriodSummary: mockPeriod, lookbackPeriodSummary: mockPeriod },
@@ -959,14 +955,6 @@ describe('AgentService Unit Tests', () => {
 
       expect(result.currentPeriodSummary).toEqual(mockPeriod);
       expect(result.lookbackPeriodSummary).toEqual(mockPeriod);
-    });
-
-    it('should return an empty object when the envelope data is absent', async () => {
-      mockApiClient.post.mockResolvedValue({});
-
-      const result = await agentService.getUnitConsumptionSummary(startTime, endTime);
-
-      expect(result).toEqual({});
     });
 
     it('should propagate API errors', async () => {

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -4,7 +4,7 @@ import { AgentService } from '../../../../src/services/agents/agents';
 import { ApiClient } from '../../../../src/core/http/api-client';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { AGENTS_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
-import { AgentErrorSortColumn, AgentListSortColumn } from '../../../../src/models/agents/agents.types';
+import { AgentErrorSortColumn, AgentListSortColumn, AgentType, AgentExecutionType } from '../../../../src/models/agents/agents.types';
 import { AGENT_TEST_CONSTANTS } from '../../../utils/constants';
 
 // ===== MOCKING =====
@@ -514,6 +514,412 @@ describe('AgentService Unit Tests', () => {
 
       await expect(
         agentService.getLatencyTimeline(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
+
+  describe('getTopErroredAgents', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockJob = {
+      jobKey: AGENT_TEST_CONSTANTS.JOB_KEY,
+      folderKey: AGENT_TEST_CONSTANTS.FOLDER_KEY_1,
+      folderName: AGENT_TEST_CONSTANTS.FOLDER_NAME,
+      folderPath: AGENT_TEST_CONSTANTS.FOLDER_PATH,
+      startTime: AGENT_TEST_CONSTANTS.JOB_START_TIME,
+      endTime: AGENT_TEST_CONSTANTS.JOB_END_TIME,
+      processKey: AGENT_TEST_CONSTANTS.PROCESS_KEY,
+    };
+    const mockResponse = {
+      totalErrors: 68,
+      data: [
+        {
+          name: AGENT_TEST_CONSTANTS.AGENT_NAME_1,
+          count: 12,
+          agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+          firstSeenJob: mockJob,
+          lastSeenJob: mockJob,
+        },
+      ],
+    };
+
+    it('should return the object with only the window in the body when no options are provided', async () => {
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const result = await agentService.getTopErroredAgents(startTime, endTime);
+
+      expect(result.totalErrors).toBe(68);
+      expect(result.data).toEqual(mockResponse.data);
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_TOP_ERRORED_AGENTS);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+      expect('limit' in body).toBe(false);
+    });
+
+    it('should include all filters in the body without OData prefixing', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
+      await agentService.getTopErroredAgents(startTime, endTime, {
+        folderKeys,
+        agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+        processVersion: AGENT_TEST_CONSTANTS.PROCESS_VERSION,
+        limit: 5,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual(folderKeys);
+      expect(body.agentId).toBe(AGENT_TEST_CONSTANTS.AGENT_ID);
+      expect(body.processVersion).toBe(AGENT_TEST_CONSTANTS.PROCESS_VERSION);
+      expect(body.limit).toBe(5);
+      expect(body['$folderKeys']).toBeUndefined();
+    });
+
+    it('should omit undefined fields when the API returns an empty object', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getTopErroredAgents(startTime, endTime);
+
+      expect(result.totalErrors).toBeUndefined();
+      expect(result.data).toBeUndefined();
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getTopErroredAgents(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
+
+  describe('getTopConsumingAgents', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockJob = {
+      jobKey: AGENT_TEST_CONSTANTS.JOB_KEY,
+      folderKey: AGENT_TEST_CONSTANTS.FOLDER_KEY_1,
+      folderName: AGENT_TEST_CONSTANTS.FOLDER_NAME,
+      folderPath: AGENT_TEST_CONSTANTS.FOLDER_PATH,
+      startTime: AGENT_TEST_CONSTANTS.JOB_START_TIME,
+      endTime: AGENT_TEST_CONSTANTS.JOB_END_TIME,
+      processKey: AGENT_TEST_CONSTANTS.PROCESS_KEY,
+    };
+    const mockPayload = {
+      startDate: AGENT_TEST_CONSTANTS.CONSUMPTION_START_DATE,
+      endDate: AGENT_TEST_CONSTANTS.CONSUMPTION_END_DATE,
+      totalConsumed: 42.5,
+      totalAGUConsumed: 30,
+      totalPLTUConsumed: 12.5,
+      limit: 10,
+      agents: [
+        {
+          agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+          agentName: AGENT_TEST_CONSTANTS.AGENT_NAME_1,
+          consumedQuantity: 5,
+          consumedAGUQuantity: 3,
+          consumedPLTUQuantity: 2,
+          firstSeenJob: mockJob,
+          lastSeenJob: mockJob,
+        },
+      ],
+    };
+
+    it('should unwrap the data envelope and return the flat payload', async () => {
+      mockApiClient.post.mockResolvedValue({ data: mockPayload });
+
+      const result = await agentService.getTopConsumingAgents(startTime, endTime);
+
+      expect(result.totalConsumed).toBe(42.5);
+      expect(result.agents).toEqual(mockPayload.agents);
+      // envelope is unwrapped — no nested data field
+      expect((result as { data?: unknown }).data).toBeUndefined();
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_TOP_CONSUMING_AGENTS);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+    });
+
+    it('should send health filters and join agentTypes into a comma-separated string', async () => {
+      mockApiClient.post.mockResolvedValue({ data: {} });
+
+      await agentService.getTopConsumingAgents(startTime, endTime, {
+        limit: 5,
+        healthy: true,
+        healthThreshold: 80,
+        agentTypes: [AgentType.Autonomous, AgentType.Coded],
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.limit).toBe(5);
+      expect(body.healthy).toBe(true);
+      expect(body.healthThreshold).toBe(80);
+      expect(body.agentTypes).toBe('Autonomous,Coded');
+    });
+
+    it('should send healthy:false distinct from unset', async () => {
+      mockApiClient.post.mockResolvedValue({ data: {} });
+
+      await agentService.getTopConsumingAgents(startTime, endTime, { healthy: false });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.healthy).toBe(false);
+    });
+
+    it('should return an empty object when the envelope data is absent', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getTopConsumingAgents(startTime, endTime);
+
+      expect(result).toEqual({});
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getTopConsumingAgents(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
+
+  describe('getIncidentDistribution', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockPayload = {
+      errorCount: 10,
+      escalationCount: 3,
+      policyCount: 1,
+    };
+
+    it('should unwrap the data envelope and drop the vestigial pagination sibling', async () => {
+      mockApiClient.post.mockResolvedValue({ pagination: { totalCount: 14 }, data: mockPayload });
+
+      const result = await agentService.getIncidentDistribution(startTime, endTime);
+
+      expect(result.errorCount).toBe(10);
+      expect(result.escalationCount).toBe(3);
+      expect(result.policyCount).toBe(1);
+      expect((result as { pagination?: unknown }).pagination).toBeUndefined();
+      expect((result as { data?: unknown }).data).toBeUndefined();
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_INCIDENT_DISTRIBUTION);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+    });
+
+    it('should include filters in the body', async () => {
+      mockApiClient.post.mockResolvedValue({ data: {} });
+
+      const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
+      await agentService.getIncidentDistribution(startTime, endTime, {
+        folderKeys,
+        agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.folderKeys).toEqual(folderKeys);
+      expect(body.agentId).toBe(AGENT_TEST_CONSTANTS.AGENT_ID);
+    });
+
+    it('should return an empty object when the envelope data is absent', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getIncidentDistribution(startTime, endTime);
+
+      expect(result).toEqual({});
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getIncidentDistribution(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
+
+  describe('getSummary', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockPeriod = {
+      totalJobs: 100,
+      successfulJobs: 95,
+      successRate: 95,
+      averageDurationSeconds: 12.3,
+      startTime: AGENT_TEST_CONSTANTS.JOB_START_TIME,
+      endTime: AGENT_TEST_CONSTANTS.JOB_END_TIME,
+      agents: [
+        {
+          processKey: AGENT_TEST_CONSTANTS.PROCESS_KEY,
+          folderKey: AGENT_TEST_CONSTANTS.FOLDER_KEY_1,
+          processVersion: AGENT_TEST_CONSTANTS.PROCESS_VERSION,
+          totalJobs: 100,
+          successfulJobs: 95,
+          successRate: 95,
+          averageDurationSeconds: 12.3,
+          firstJobFinished: AGENT_TEST_CONSTANTS.JOB_START_TIME,
+          lastJobFinished: AGENT_TEST_CONSTANTS.JOB_END_TIME,
+          lastJobStatus: AGENT_TEST_CONSTANTS.SUMMARY_LAST_JOB_STATUS,
+        },
+      ],
+    };
+
+    it('should unwrap the data envelope; lookback is undefined when not requested', async () => {
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
+
+      const result = await agentService.getSummary(startTime, endTime);
+
+      expect(result.currentPeriodSummary).toEqual(mockPeriod);
+      expect(result.lookbackPeriodSummary).toBeUndefined();
+      expect((result as { data?: unknown }).data).toBeUndefined();
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_SUMMARY);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+    });
+
+    it('should send lookbackPeriodAnalysis, processKey and folderKey (singular, distinct from folderKeys)', async () => {
+      mockApiClient.post.mockResolvedValue({ data: {} });
+
+      await agentService.getSummary(startTime, endTime, {
+        folderKeys: [AGENT_TEST_CONSTANTS.FOLDER_KEY_1],
+        lookbackPeriodAnalysis: true,
+        processKey: AGENT_TEST_CONSTANTS.PROCESS_KEY,
+        folderKey: AGENT_TEST_CONSTANTS.FOLDER_KEY_2,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.lookbackPeriodAnalysis).toBe(true);
+      expect(body.processKey).toBe(AGENT_TEST_CONSTANTS.PROCESS_KEY);
+      expect(body.folderKey).toBe(AGENT_TEST_CONSTANTS.FOLDER_KEY_2);
+      expect(body.folderKeys).toEqual([AGENT_TEST_CONSTANTS.FOLDER_KEY_1]);
+    });
+
+    it('should send executionType as its string name', async () => {
+      mockApiClient.post.mockResolvedValue({ data: {} });
+
+      await agentService.getSummary(startTime, endTime, {
+        executionType: AgentExecutionType.Runtime,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.executionType).toBe('Runtime');
+    });
+
+    it('should return both periods when the API includes a lookback summary', async () => {
+      mockApiClient.post.mockResolvedValue({
+        data: { currentPeriodSummary: mockPeriod, lookbackPeriodSummary: mockPeriod },
+      });
+
+      const result = await agentService.getSummary(startTime, endTime, { lookbackPeriodAnalysis: true });
+
+      expect(result.currentPeriodSummary).toEqual(mockPeriod);
+      expect(result.lookbackPeriodSummary).toEqual(mockPeriod);
+    });
+
+    it('should return an empty object when the envelope data is absent', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getSummary(startTime, endTime);
+
+      expect(result).toEqual({});
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getSummary(startTime, endTime),
+      ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
+    });
+  });
+
+  describe('getUnitConsumptionSummary', () => {
+    const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
+    const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
+    const mockConsumption = { completeJobs: 8, incompleteJobs: 2 };
+    const mockPeriod = {
+      totalAgentUnitConsumption: mockConsumption,
+      totalPlatformUnitConsumption: mockConsumption,
+      startTime: AGENT_TEST_CONSTANTS.JOB_START_TIME,
+      endTime: AGENT_TEST_CONSTANTS.JOB_END_TIME,
+      agentConsumption: [
+        {
+          folderKey: AGENT_TEST_CONSTANTS.FOLDER_KEY_1,
+          processKey: AGENT_TEST_CONSTANTS.PROCESS_KEY,
+          processVersion: AGENT_TEST_CONSTANTS.PROCESS_VERSION,
+          firstJobFinished: AGENT_TEST_CONSTANTS.JOB_START_TIME,
+          lastJobFinished: AGENT_TEST_CONSTANTS.JOB_END_TIME,
+          agentUnitConsumption: mockConsumption,
+          platformUnitConsumption: mockConsumption,
+        },
+      ],
+    };
+
+    it('should unwrap the data envelope; lookback is undefined when not requested', async () => {
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
+
+      const result = await agentService.getUnitConsumptionSummary(startTime, endTime);
+
+      expect(result.currentPeriodSummary).toEqual(mockPeriod);
+      expect(result.lookbackPeriodSummary).toBeUndefined();
+      expect((result as { data?: unknown }).data).toBeUndefined();
+
+      const [endpoint, body] = mockApiClient.post.mock.calls[0];
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_UNIT_CONSUMPTION_SUMMARY);
+      expect(body.startTime).toBe(startTime.toISOString());
+      expect(body.endTime).toBe(endTime.toISOString());
+    });
+
+    it('should send lookbackPeriodAnalysis, processKey, folderKey and executionType', async () => {
+      mockApiClient.post.mockResolvedValue({ data: {} });
+
+      await agentService.getUnitConsumptionSummary(startTime, endTime, {
+        lookbackPeriodAnalysis: true,
+        processKey: AGENT_TEST_CONSTANTS.PROCESS_KEY,
+        folderKey: AGENT_TEST_CONSTANTS.FOLDER_KEY_1,
+        executionType: AgentExecutionType.Runtime,
+      });
+
+      const [, body] = mockApiClient.post.mock.calls[0];
+      expect(body.lookbackPeriodAnalysis).toBe(true);
+      expect(body.processKey).toBe(AGENT_TEST_CONSTANTS.PROCESS_KEY);
+      expect(body.folderKey).toBe(AGENT_TEST_CONSTANTS.FOLDER_KEY_1);
+      expect(body.executionType).toBe('Runtime');
+    });
+
+    it('should return both periods when the API includes a lookback summary', async () => {
+      mockApiClient.post.mockResolvedValue({
+        data: { currentPeriodSummary: mockPeriod, lookbackPeriodSummary: mockPeriod },
+      });
+
+      const result = await agentService.getUnitConsumptionSummary(startTime, endTime, {
+        lookbackPeriodAnalysis: true,
+      });
+
+      expect(result.currentPeriodSummary).toEqual(mockPeriod);
+      expect(result.lookbackPeriodSummary).toEqual(mockPeriod);
+    });
+
+    it('should return an empty object when the envelope data is absent', async () => {
+      mockApiClient.post.mockResolvedValue({});
+
+      const result = await agentService.getUnitConsumptionSummary(startTime, endTime);
+
+      expect(result).toEqual({});
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
+
+      await expect(
+        agentService.getUnitConsumptionSummary(startTime, endTime),
       ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
     });
   });

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -519,7 +519,7 @@ describe('AgentService Unit Tests', () => {
     });
   });
 
-  describe('getTopErroredAgents', () => {
+  describe('getTopErrorCount', () => {
     const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
     const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
     const mockJob = {
@@ -547,13 +547,13 @@ describe('AgentService Unit Tests', () => {
     it('should return the object with only the window in the body when no options are provided', async () => {
       mockApiClient.post.mockResolvedValue(mockResponse);
 
-      const result = await agentService.getTopErroredAgents(startTime, endTime);
+      const result = await agentService.getTopErrorCount(startTime, endTime);
 
       expect(result.totalErrors).toBe(68);
       expect(result.data).toEqual(mockResponse.data);
 
       const [endpoint, body] = mockApiClient.post.mock.calls[0];
-      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_TOP_ERRORED_AGENTS);
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_TOP_ERROR_COUNT);
       expect(body.startTime).toBe(startTime.toISOString());
       expect(body.endTime).toBe(endTime.toISOString());
       expect('limit' in body).toBe(false);
@@ -563,7 +563,7 @@ describe('AgentService Unit Tests', () => {
       mockApiClient.post.mockResolvedValue({});
 
       const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
-      await agentService.getTopErroredAgents(startTime, endTime, {
+      await agentService.getTopErrorCount(startTime, endTime, {
         folderKeys,
         agentId: AGENT_TEST_CONSTANTS.AGENT_ID,
         processVersion: AGENT_TEST_CONSTANTS.PROCESS_VERSION,
@@ -581,7 +581,7 @@ describe('AgentService Unit Tests', () => {
     it('should omit undefined fields when the API returns an empty object', async () => {
       mockApiClient.post.mockResolvedValue({});
 
-      const result = await agentService.getTopErroredAgents(startTime, endTime);
+      const result = await agentService.getTopErrorCount(startTime, endTime);
 
       expect(result.totalErrors).toBeUndefined();
       expect(result.data).toBeUndefined();
@@ -591,12 +591,12 @@ describe('AgentService Unit Tests', () => {
       mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
 
       await expect(
-        agentService.getTopErroredAgents(startTime, endTime),
+        agentService.getTopErrorCount(startTime, endTime),
       ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
     });
   });
 
-  describe('getTopConsumingAgents', () => {
+  describe('getTopConsumption', () => {
     const startTime = new Date(AGENT_TEST_CONSTANTS.START_TIME);
     const endTime = new Date(AGENT_TEST_CONSTANTS.END_TIME);
     const mockJob = {
@@ -631,7 +631,7 @@ describe('AgentService Unit Tests', () => {
     it('should unwrap the data envelope and return the flat payload', async () => {
       mockApiClient.post.mockResolvedValue({ data: mockPayload });
 
-      const result = await agentService.getTopConsumingAgents(startTime, endTime);
+      const result = await agentService.getTopConsumption(startTime, endTime);
 
       expect(result.totalConsumed).toBe(42.5);
       expect(result.agents).toEqual(mockPayload.agents);
@@ -639,7 +639,7 @@ describe('AgentService Unit Tests', () => {
       expect((result as { data?: unknown }).data).toBeUndefined();
 
       const [endpoint, body] = mockApiClient.post.mock.calls[0];
-      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_TOP_CONSUMING_AGENTS);
+      expect(endpoint).toBe(AGENTS_ENDPOINTS.GET_TOP_CONSUMPTION);
       expect(body.startTime).toBe(startTime.toISOString());
       expect(body.endTime).toBe(endTime.toISOString());
     });
@@ -647,7 +647,7 @@ describe('AgentService Unit Tests', () => {
     it('should send health filters and join agentTypes into a comma-separated string', async () => {
       mockApiClient.post.mockResolvedValue({ data: {} });
 
-      await agentService.getTopConsumingAgents(startTime, endTime, {
+      await agentService.getTopConsumption(startTime, endTime, {
         limit: 5,
         healthy: true,
         healthThreshold: 80,
@@ -664,7 +664,7 @@ describe('AgentService Unit Tests', () => {
     it('should send healthy:false distinct from unset', async () => {
       mockApiClient.post.mockResolvedValue({ data: {} });
 
-      await agentService.getTopConsumingAgents(startTime, endTime, { healthy: false });
+      await agentService.getTopConsumption(startTime, endTime, { healthy: false });
 
       const [, body] = mockApiClient.post.mock.calls[0];
       expect(body.healthy).toBe(false);
@@ -673,7 +673,7 @@ describe('AgentService Unit Tests', () => {
     it('should return an empty object when the envelope data is absent', async () => {
       mockApiClient.post.mockResolvedValue({});
 
-      const result = await agentService.getTopConsumingAgents(startTime, endTime);
+      const result = await agentService.getTopConsumption(startTime, endTime);
 
       expect(result).toEqual({});
     });
@@ -682,7 +682,7 @@ describe('AgentService Unit Tests', () => {
       mockApiClient.post.mockRejectedValue(new Error(AGENT_TEST_CONSTANTS.ERROR_GENERIC));
 
       await expect(
-        agentService.getTopConsumingAgents(startTime, endTime),
+        agentService.getTopConsumption(startTime, endTime),
       ).rejects.toThrow(AGENT_TEST_CONSTANTS.ERROR_GENERIC);
     });
   });

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -578,13 +578,14 @@ describe('AgentService Unit Tests', () => {
       expect(body['$folderKeys']).toBeUndefined();
     });
 
-    it('should omit undefined fields when the API returns an empty object', async () => {
-      mockApiClient.post.mockResolvedValue({});
+    it('should return totalErrors 0 and an empty data array when no agents matched', async () => {
+      // The endpoint always serializes the full shape, even when empty.
+      mockApiClient.post.mockResolvedValue({ totalErrors: 0, data: [] });
 
       const result = await agentService.getTopErrorCount(startTime, endTime);
 
-      expect(result.totalErrors).toBeUndefined();
-      expect(result.data).toBeUndefined();
+      expect(result.totalErrors).toBe(0);
+      expect(result.data).toEqual([]);
     });
 
     it('should propagate API errors', async () => {
@@ -873,6 +874,15 @@ describe('AgentService Unit Tests', () => {
       const result = await agentService.getSummary(startTime, endTime);
 
       expect(result).toEqual({});
+    });
+
+    it('should not throw when a period omits the agents array', async () => {
+      const { agents: _agents, ...periodWithoutAgents } = mockPeriod;
+      mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: periodWithoutAgents } });
+
+      const result = await agentService.getSummary(startTime, endTime);
+
+      expect(result.currentPeriodSummary?.agents).toEqual([]);
     });
 
     it('should propagate API errors', async () => {

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -560,7 +560,7 @@ describe('AgentService Unit Tests', () => {
     });
 
     it('should include all filters in the body without OData prefixing', async () => {
-      mockApiClient.post.mockResolvedValue({});
+      mockApiClient.post.mockResolvedValue({ totalErrors: 0, data: [] });
 
       const folderKeys = [AGENT_TEST_CONSTANTS.FOLDER_KEY_1];
       await agentService.getTopErrorCount(startTime, endTime, {

--- a/tests/unit/services/agents/agents.test.ts
+++ b/tests/unit/services/agents/agents.test.ts
@@ -5,6 +5,7 @@ import { ApiClient } from '../../../../src/core/http/api-client';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { AGENTS_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { AgentErrorSortColumn, AgentListSortColumn, AgentType, AgentExecutionType } from '../../../../src/models/agents/agents.types';
+import { JobState } from '../../../../src/models/common/types';
 import { AGENT_TEST_CONSTANTS } from '../../../utils/constants';
 
 // ===== MOCKING =====
@@ -768,13 +769,18 @@ describe('AgentService Unit Tests', () => {
         },
       ],
     };
+    // Same period with lastJobStatus normalized from the raw 'Success' to JobState.Successful.
+    const expectedPeriod = {
+      ...mockPeriod,
+      agents: [{ ...mockPeriod.agents[0], lastJobStatus: JobState.Successful }],
+    };
 
     it('should unwrap the data envelope; lookback is undefined when not requested', async () => {
       mockApiClient.post.mockResolvedValue({ data: { currentPeriodSummary: mockPeriod } });
 
       const result = await agentService.getSummary(startTime, endTime);
 
-      expect(result.currentPeriodSummary).toEqual(mockPeriod);
+      expect(result.currentPeriodSummary).toEqual(expectedPeriod);
       expect(result.lookbackPeriodSummary).toBeUndefined();
       expect((result as { data?: unknown }).data).toBeUndefined();
 
@@ -819,8 +825,46 @@ describe('AgentService Unit Tests', () => {
 
       const result = await agentService.getSummary(startTime, endTime, { lookbackPeriodAnalysis: true });
 
-      expect(result.currentPeriodSummary).toEqual(mockPeriod);
-      expect(result.lookbackPeriodSummary).toEqual(mockPeriod);
+      expect(result.currentPeriodSummary).toEqual(expectedPeriod);
+      expect(result.lookbackPeriodSummary).toEqual(expectedPeriod);
+    });
+
+    it('should normalize lastJobStatus across both periods, mapping aliases and unknowns to JobState', async () => {
+      const makeAgent = (lastJobStatus: string) => ({
+        ...mockPeriod.agents[0],
+        lastJobStatus,
+      });
+      mockApiClient.post.mockResolvedValue({
+        data: {
+          currentPeriodSummary: {
+            ...mockPeriod,
+            // raw -> expected: Success->Successful (aliased); Cancelled,
+            // Running, Faulted pass through unchanged; garbage->Unknown
+            agents: [
+              makeAgent('Success'),
+              makeAgent('Cancelled'),
+              makeAgent('Running'),
+              makeAgent('Faulted'),
+              makeAgent('NotARealStatus'),
+            ],
+          },
+          lookbackPeriodSummary: { ...mockPeriod, agents: [makeAgent('Success')] },
+        },
+      });
+
+      const result = await agentService.getSummary(startTime, endTime, { lookbackPeriodAnalysis: true });
+
+      expect(result.currentPeriodSummary?.agents.map((a) => a.lastJobStatus)).toEqual([
+        JobState.Successful,
+        JobState.Cancelled,
+        JobState.Running,
+        JobState.Faulted,
+        JobState.Unknown,
+      ]);
+      // Normalization is applied to the lookback period too, not just the current one.
+      expect(result.lookbackPeriodSummary?.agents[0].lastJobStatus).toBe(JobState.Successful);
+      // The raw API label must not leak through.
+      expect(result.currentPeriodSummary?.agents[0].lastJobStatus).not.toBe('Success');
     });
 
     it('should return an empty object when the envelope data is absent', async () => {


### PR DESCRIPTION
## Methods Added

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `agents.getTopErrorCount()` | `getTopErrorCount(startTime: Date, endTime: Date, options?: AgentGetTopErrorCountOptions): Promise<AgentGetTopErrorCountResponse>` |
| Service | `agents.getTopConsumption()` | `getTopConsumption(startTime: Date, endTime: Date, options?: AgentGetTopConsumptionOptions): Promise<AgentGetTopConsumptionResponse>` |
| Service | `agents.getIncidentDistribution()` | `getIncidentDistribution(startTime: Date, endTime: Date, options?: AgentGetIncidentDistributionOptions): Promise<AgentGetIncidentDistributionResponse>` |
| Service | `agents.getSummary()` | `getSummary(startTime: Date, endTime: Date, options?: AgentGetSummaryOptions): Promise<AgentGetSummaryResponse>` |
| Service | `agents.getUnitConsumptionSummary()` | `getUnitConsumptionSummary(startTime: Date, endTime: Date, options?: AgentGetUnitConsumptionSummaryOptions): Promise<AgentGetUnitConsumptionSummaryResponse>` |

This is the **final** split PR from the fat Agents PR #438 (PLT-103787), branched off `main` per the fan-out + rebase-on-merge model (follows #492, #503, #505, #525).

## Endpoints Called

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `getTopErrorCount()` | POST | `${INSIGHTS_RTM_BASE}/Agents/topErroredAgents` | `Insights.RealTimeData Insights OR.Folders.Read` |
| `getTopConsumption()` | POST | `${INSIGHTS_RTM_BASE}/Agents/consumption` | `Insights.RealTimeData Insights OR.Folders.Read` |
| `getIncidentDistribution()` | POST | `${INSIGHTS_RTM_BASE}/Agents/incidentDistribution` | `Insights.RealTimeData Insights OR.Folders.Read` |
| `getSummary()` | POST | `${INSIGHTS_RTM_BASE}/Agents/summary` | `Insights.RealTimeData Insights OR.Folders.Read` |
| `getUnitConsumptionSummary()` | POST | `${INSIGHTS_RTM_BASE}/Agents/summary/unit-consumption` | `Insights.RealTimeData Insights OR.Folders.Read` |

- All five are **non-paginated** POSTs sharing the private `buildAgentFilterBody` helper (required `startTime`/`endTime` → ISO 8601, plus optional `folderKeys`/`agentNames`/`projectKeys`/`agentId`/`processVersion`).
- `getTopConsumption` additionally accepts `healthy`/`healthThreshold` filters and `agentTypes` (serialized to a comma-separated string).
- `getSummary`/`getUnitConsumptionSummary` accept `lookbackPeriodAnalysis` (adds a prior-window comparison), `processKey`, `folderKey` (singular, distinct from inherited `folderKeys`), and `executionType`.
- Adds two enums: `AgentType` (Autonomous/Conversational/Coded) and `AgentExecutionType` (Debug/Runtime).

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { Agents, AgentExecutionType } from '@uipath/uipath-typescript/agents';

const sdk = new UiPath(config);
await sdk.initialize();
const agents = new Agents(sdk);

// Basic — top agents by error count over a window
const topErrors = await agents.getTopErrorCount(
  new Date('2025-05-01T00:00:00Z'),
  new Date('2025-06-01T00:00:00Z'),
);
topErrors.data.forEach((a) => console.log(`${a.name}: ${a.count} errors`));

// With options — runtime-only summary with lookback comparison
const summary = await agents.getSummary(
  new Date('2025-05-01T00:00:00Z'),
  new Date('2025-06-01T00:00:00Z'),
  { lookbackPeriodAnalysis: true, executionType: AgentExecutionType.Runtime },
);
console.log(`Success rate: ${summary.currentPeriodSummary?.successRate}%`);
```

## API Response vs SDK Response

### Transform pipeline
No field-rename/case transform (the insightsrtm_ Agents API is camelCase-native, consistent with the merged `getAll`/`getErrors`/timeline methods). Two reshaping steps:

**1. Envelope unwrapping** — most endpoints wrap the payload in a `data` envelope; `getTopErrorCount` is the exception (flat body):

| Method | `this.post<...>` type | Return |
|--------|------------------------|--------|
| `getTopErrorCount` | `AgentGetTopErrorCountResponse` | `response.data` (flat — `totalErrors`/`data` are **required**, the endpoint always serializes the full shape) |
| `getTopConsumption` | `{ data?: ... }` | `response.data.data ?? {}` |
| `getIncidentDistribution` | `{ data?: ... }` | `response.data.data ?? {}` |
| `getSummary` | `{ data?: RawAgentGetSummaryResponse }` | normalized (see below), `{}` when absent |
| `getUnitConsumptionSummary` | `{ data?: ... }` | `response.data.data ?? {}` |

**2. `lastJobStatus` normalization** (`getSummary`) — the API emits raw status strings; the SDK maps each `AgentSummaryEntry.lastJobStatus` to the shared `JobState` enum across both the current and lookback periods:
- `"Success"` → `JobState.Successful`; canonical values (`Running`, `Faulted`, `Cancelled`, …) pass through; anything unrecognized → `JobState.Unknown` (permissive — never throws).
- Adds `Cancelled` and `Unknown` to the shared `JobState` enum (`src/models/common/types.ts`) — an additive, cross-service change (no exhaustive switches depend on it).
- The raw wire shape is typed separately in `agents.internal-types.ts` (`RawAgentSummaryEntry`/`RawAgentSummaryPeriod`/`RawAgentGetSummaryResponse`, `lastJobStatus: string`) so the public types accurately describe the normalized result.

### Notable field semantics
- `AgentGetTopConsumptionResponse.startDate`/`endDate` are returned as date strings.
- `AgentUnitConsumptionEntry.firstJobFinished`/`lastJobFinished` may be the `"0001-01-01T00:00:00"` sentinel when there was no completion in the period.
- `lookbackPeriodSummary` is only present when `lookbackPeriodAnalysis: true` was sent.

## Sample SDK Response

`getTopErrorCount` (flat `{ totalErrors, data }`, trimmed to one entry):

```json
{
  "totalErrors": 86,
  "data": [
    {
      "agentId": "632fabd7-891d-425f-ad5d-1b3a4ce9ba4b",
      "name": "Agent",
      "count": 27,
      "firstSeenJob": {
        "jobKey": "fa574767-4544-4949-ac6f-bc178ecaf0df",
        "folderKey": "ca3dc56f-93a8-46fb-b8e4-9584a4714ef2",
        "folderName": "conv_agent",
        "folderPath": "APPS_TestPass_Folder/conv_agent",
        "startTime": "2025-06-11T12:24:58Z",
        "endTime": "2025-06-11T12:25:05Z",
        "processKey": "eb19ab4e-7fc6-48ed-b43f-8f3ec322cf77"
      },
      "lastSeenJob": { "...": "same shape as firstSeenJob" }
    }
  ]
}
```

`getSummary` — note `lastJobStatus` is normalized from the raw `"Success"` to `JobState.Successful`:

```json
{
  "currentPeriodSummary": {
    "totalJobs": 6,
    "successfulJobs": 2,
    "successRate": 33.33,
    "averageDurationSeconds": 4.72,
    "startTime": "2026-01-01T00:00:00Z",
    "endTime": "2026-05-14T00:00:00Z",
    "agents": [
      {
        "processKey": "bd2a6d82-71d8-46cb-8d11-bed78202808e",
        "folderKey": "c2751834-1f05-4f4e-9cb8-509406f6faac",
        "processVersion": "1.0.6",
        "totalJobs": 5,
        "successfulJobs": 2,
        "successRate": 40.0,
        "averageDurationSeconds": 4.03,
        "firstJobFinished": "2026-04-16T10:34:05Z",
        "lastJobFinished": "2026-04-28T13:50:40Z",
        "lastJobStatus": "Successful"
      }
    ]
  }
}
```

> insightsrtm_ endpoints reject PAT tokens (401) and require OAuth; the samples above were captured via the OAuth flow against the `appsdev` tenant.

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/agents.ts` (5 constants) |
| Common | `src/models/common/types.ts` (`JobState` += `Cancelled`, `Unknown`) |
| Types | `src/models/agents/agents.types.ts` (2 enums + interfaces) |
| Internal types | `src/models/agents/agents.internal-types.ts` (raw summary shapes) |
| Models | `src/models/agents/agents.models.ts` (5 ServiceModel signatures + JSDoc) |
| Service | `src/services/agents/agents.ts` (5 methods + `lastJobStatus` normalization) |
| Unit tests | `tests/unit/services/agents/agents.test.ts` |
| Integration tests | `tests/integration/shared/agents/agents.integration.test.ts` (describe.skip — OAuth-only) |
| Docs | `docs/oauth-scopes.md` (5 rows) |

## Naming & docs notes
- Methods are named for what they return: `getTopErrorCount` / `getTopConsumption` (not `…ErroredAgents` / `…ConsumingAgents`). Backend endpoint URLs are unchanged.
- `@default` tags added to option fields with a concrete server default (`limit`, `desc`, `healthThreshold`, `lookbackPeriodAnalysis`).
- AGU/PLTU abbreviations expanded to "Agent Units"/"Platform Units" in user-facing JSDoc; internal protocol/envelope/format details removed from the generated docs.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run test:unit` — 1905 passing (57 in the agents suite)
- `npm run build` — succeeds
- Multi-agent code review — confirmed no correctness bugs in this PR's methods (the `getTopErrorCount` flat unwrap was verified correct against the live response above).

## Out of scope
- Merged timeline APIs (`getErrorsTimeline`/`getConsumptionTimeline`/`getLatencyTimeline`, #525) are **not** modified by this PR.
- `getNames` — dropped from the effort.
- Trace-controller methods — shipped in #505 (`AgentTraces`).

With this PR the split is complete; #438 can be closed/superseded.

Refs PLT-103787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
