### PR TITLE
feat(document-understanding): expose DU framework types as nameable named exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export * from './models/orchestrator';
 export * from './models/action-center';
 export * from './models/conversational-agent';
 export * from './models/agents';
-export * from './models/document-understanding';
+export * as DuFramework from './models/document-understanding/framework';
 export * from './models/governance';
 export * from './models/observability';
 

--- a/src/models/document-understanding/index.ts
+++ b/src/models/document-understanding/index.ts
@@ -1,1 +1,12 @@
+// Direct named exports for the DU framework contracts. Re-exporting them flat on
+// this dedicated subpath entry (where the generic DU names can't collide with the
+// top-level barrel) lets consumers import them by name, e.g.
+//   import type { DocumentTaxonomy, ExtractionResult } from '@uipath/uipath-typescript/document-understanding';
+// Unlike the `export * as DuFramework` namespace form below, direct named exports
+// remain nameable in a consumer's generated .d.ts when the type flows through an
+// inferred public surface (Angular/ngrx output()/input(), signalStore state) — the
+// namespace form trips TS4023 "cannot be named" there.
+export * from './framework';
+
+// Namespace form, kept for discoverability and back-compat (`DuFramework.X`).
 export * as DuFramework from './framework';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -14,4 +14,4 @@ export * from './orchestrator';
 export * from './action-center';
 
 // Document Understanding models
-export * from './document-understanding';
+export * as DuFramework from './document-understanding/framework';


### PR DESCRIPTION
## Summary

Re-export the `DuFramework` document-understanding contracts as **flat named exports** on the `@uipath/uipath-typescript/document-understanding` subpath entry, alongside the existing `DuFramework` namespace, so downstream libraries can reference the DU types without TypeScript's "cannot be named" declaration-emit error.

## Problem

The DU contracts are exposed only via `export * as DuFramework`, which `rollup-plugin-dts` bundles into:

```ts
declare namespace index { export type { index_DocumentTaxonomy as DocumentTaxonomy, ... }; }
export { index as DuFramework };
```

When a consumer references `DuFramework.X` through an **inferred** public surface in a library that emits declaration files — e.g. an Angular/NgRx `output<DuFramework.ExtractionResult>()` or a signalStore state field in an `ng-packagr` library — TypeScript can't name the namespace member and fails declaration emit with **TS4023 / TS4029 / TS4053** ("… has or is using name 'X' from external module … but cannot be named").

Today the only consumer workaround is a local nominal shim for every type:

```ts
export interface ExtractionResult extends DuFramework.ExtractionResult {}
```

— which is what the UiPath DU frontend currently has to do across its libraries.

## Fix

Add direct named exports on the dedicated subpath entry (where the generic DU names can't collide with the top-level barrel). Direct named exports **are** nameable in inferred declaration-emit positions, so consumers can write:

```ts
import type { DocumentTaxonomy, ExtractionResult, Field } from '@uipath/uipath-typescript/document-understanding';

// in a publishable lib — no "cannot be named", no local alias needed:
readonly extractionResultChanged = output<ExtractionResult>();
```

## Changes
- `src/models/document-understanding/index.ts` — add `export * from './framework'` (flat named exports) next to the existing `export * as DuFramework from './framework'`.
- `src/index.ts` and `src/models/index.ts` — keep surfacing DU only via the `DuFramework` namespace (the flat names would collide with other modules — e.g. data-fabric's `Field` / `LogicalOperator` — in the flat barrels).

## Compatibility
**Additive and non-breaking.** The top-level `DuFramework` namespace is unchanged; existing `DuFramework.*` usage keeps working. The subpath simply gains the flat named exports.

## Verification
- `npm run build` — clean across all entries.
- `npm run typecheck` — clean.
- Emitted `dist/document-understanding/index.d.ts` now carries direct `export type { DocumentTaxonomy, ExtractionResult, Field, … }`; `dist/index.d.ts` still exposes DU only via `DuFramework` (no flat-name collisions).

## Tests
Types-only change with no runtime behavior, so no integration test applies — verification is the emitted `.d.ts` shape plus a downstream `ng-packagr` build consuming the new named exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)