### PR TITLE
fix: rewrite SDK field names in OData options for remaining services [PLT-106297]

### DIFF
--- a/src/services/action-center/tasks.ts
+++ b/src/services/action-center/tasks.ts
@@ -29,7 +29,7 @@ import { processODataArrayResponse } from '../../utils/object';
 import { HasPaginationOptions, NonPaginatedResponse, PaginatedResponse } from '../../utils/pagination';
 import { PaginationHelpers } from '../../utils/pagination/helpers';
 import { PaginationType } from '../../utils/pagination/internal-types';
-import { addPrefixToKeys, applyDataTransforms, camelToPascalCaseKeys, pascalToCamelCaseKeys, transformData } from '../../utils/transform';
+import { addPrefixToKeys, applyDataTransforms, camelToPascalCaseKeys, pascalToCamelCaseKeys, transformData, transformOptions } from '../../utils/transform';
 import { BaseService } from '../base';
 
 /**
@@ -214,6 +214,11 @@ export class TaskService extends BaseService implements TaskServiceModel {
       ) as TaskGetResponse;
     };
 
+    // Rewrite renamed SDK field names → API names inside OData strings
+    // before delegating, mirroring the transformRequest pattern used for
+    // request bodies.
+    const apiOptions = options ? transformOptions(options, TaskMap) : options;
+
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => endpoint,
@@ -230,7 +235,7 @@ export class TaskService extends BaseService implements TaskServiceModel {
           countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM              // OData OFFSET parameter
         }
       }
-    }, options) as any;
+    }, apiOptions) as any;
   }
 
   /**
@@ -272,9 +277,10 @@ export class TaskService extends BaseService implements TaskServiceModel {
     // Add default expand parameters
     const modifiedOptions = this.addDefaultExpand(restOptions);
 
-    // prefix all keys in options
-    const keysToPrefix = Object.keys(modifiedOptions);
-    const apiOptions = addPrefixToKeys(modifiedOptions, ODATA_PREFIX, keysToPrefix);
+    // Rewrite renamed SDK field names → API names inside OData strings,
+    // then prefix all keys for OData.
+    const apiFieldOptions = transformOptions(modifiedOptions, TaskMap);
+    const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
     const response = await this.get<TaskGetResponse>(
       TASK_ENDPOINTS.GET_BY_ID(id),
       {

--- a/src/services/folder-scoped.ts
+++ b/src/services/folder-scoped.ts
@@ -80,8 +80,9 @@ export class FolderScopedService extends BaseService {
    * @param name - Resource name to search for
    * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) + OData query options (`expand`, `select`)
    * @param transform - Maps a raw OData item to the typed response (e.g. PascalCase → camelCase via field map)
-   * @param requestFieldMap - Optional response field map (API → SDK) used to rewrite SDK field
-   *   names back to API names in user-supplied `expand` / `select` (symmetric counterpart to `transform`)
+   * @param responseFieldMap - Optional response field map (API → SDK), reversed internally by
+   *   `transformOptions` to rewrite SDK field names back to API names in user-supplied
+   *   `expand` / `select` (symmetric counterpart to `transform`)
    * @throws ValidationError when inputs are malformed; NotFoundError when no match
    */
   protected async getByNameLookup<TRaw extends object, T>(
@@ -90,7 +91,7 @@ export class FolderScopedService extends BaseService {
     name: string,
     options: FolderScopedOptions,
     transform: (raw: TRaw) => T,
-    requestFieldMap?: FieldMapping,
+    responseFieldMap?: FieldMapping,
   ): Promise<T> {
     const validatedName = validateName(resourceType, name);
     const { folderId, folderKey, folderPath, ...queryOptions } = options;
@@ -103,8 +104,8 @@ export class FolderScopedService extends BaseService {
       fallbackFolderKey: this.config.folderKey,
     });
 
-    const apiFieldOptions = requestFieldMap
-      ? transformOptions(queryOptions, requestFieldMap)
+    const apiFieldOptions = responseFieldMap
+      ? transformOptions(queryOptions, responseFieldMap)
       : queryOptions;
 
     const apiOptions = {

--- a/src/services/folder-scoped.ts
+++ b/src/services/folder-scoped.ts
@@ -3,7 +3,7 @@ import { CollectionResponse, FolderScopedOptions } from '../models/common/types'
 import { createHeaders } from '../utils/http/headers';
 import { FOLDER_ID } from '../utils/constants/headers';
 import { ODATA_PREFIX } from '../utils/constants/common';
-import { addPrefixToKeys } from '../utils/transform';
+import { addPrefixToKeys, transformOptions, FieldMapping } from '../utils/transform';
 import { NotFoundError } from '../core/errors';
 import { validateName } from '../utils/validation/name-validator';
 import { resolveFolderHeaders } from '../utils/folder/folder-headers';
@@ -80,6 +80,8 @@ export class FolderScopedService extends BaseService {
    * @param name - Resource name to search for
    * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) + OData query options (`expand`, `select`)
    * @param transform - Maps a raw OData item to the typed response (e.g. PascalCase → camelCase via field map)
+   * @param requestFieldMap - Optional response field map (API → SDK) used to rewrite SDK field
+   *   names back to API names in user-supplied `expand` / `select` (symmetric counterpart to `transform`)
    * @throws ValidationError when inputs are malformed; NotFoundError when no match
    */
   protected async getByNameLookup<TRaw extends object, T>(
@@ -88,6 +90,7 @@ export class FolderScopedService extends BaseService {
     name: string,
     options: FolderScopedOptions,
     transform: (raw: TRaw) => T,
+    requestFieldMap?: FieldMapping,
   ): Promise<T> {
     const validatedName = validateName(resourceType, name);
     const { folderId, folderKey, folderPath, ...queryOptions } = options;
@@ -100,8 +103,12 @@ export class FolderScopedService extends BaseService {
       fallbackFolderKey: this.config.folderKey,
     });
 
+    const apiFieldOptions = requestFieldMap
+      ? transformOptions(queryOptions, requestFieldMap)
+      : queryOptions;
+
     const apiOptions = {
-      ...addPrefixToKeys(queryOptions, ODATA_PREFIX, Object.keys(queryOptions)),
+      ...addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions)),
       '$filter': `Name eq '${validatedName.replace(SINGLE_QUOTE_RE, "''")}'`,
       '$top': '1',
     };

--- a/src/services/orchestrator/assets/assets.ts
+++ b/src/services/orchestrator/assets/assets.ts
@@ -1,7 +1,7 @@
 import { FolderScopedService } from '../../folder-scoped';
 import { AssetGetResponse, AssetGetAllOptions, AssetGetByIdOptions, AssetGetByNameOptions, AssetNewValue, AssetUpdateValueByIdOptions, AssetValueScope, AssetValueType } from '../../../models/orchestrator/assets.types';
 import { AssetServiceModel } from '../../../models/orchestrator/assets.models';
-import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
+import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformOptions } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
 import { FOLDER_ID } from '../../../utils/constants/headers';
 import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
@@ -62,8 +62,13 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
       : NonPaginatedResponse<AssetGetResponse>
   > {
     // Transformation function for assets
-    const transformAssetResponse = (asset: any) => 
+    const transformAssetResponse = (asset: any) =>
       transformData(pascalToCamelCaseKeys(asset) as AssetGetResponse, AssetMap);
+
+    // Rewrite renamed SDK field names → API names inside OData strings
+    // before delegating, mirroring the transformRequest pattern used for
+    // request bodies.
+    const apiOptions = options ? transformOptions(options, AssetMap) : options;
 
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
@@ -80,7 +85,7 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
           countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM              
         }
       }
-    }, options) as any;
+    }, apiOptions) as any;
   }
 
   /**
@@ -104,10 +109,10 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
   @track('Assets.GetById')
   async getById(id: number, folderId: number, options: AssetGetByIdOptions = {}): Promise<AssetGetResponse> {
     const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
+
+    const apiFieldOptions = transformOptions(options, AssetMap);
+    const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
+
     const response = await this.get<AssetGetResponse>(
       ASSET_ENDPOINTS.GET_BY_ID(id),
       { 
@@ -155,6 +160,7 @@ export class AssetService extends FolderScopedService implements AssetServiceMod
       name,
       options,
       (raw) => transformData(pascalToCamelCaseKeys(raw), AssetMap),
+      AssetMap,
     );
   }
 

--- a/src/services/orchestrator/attachments/attachments.ts
+++ b/src/services/orchestrator/attachments/attachments.ts
@@ -33,16 +33,8 @@ export class AttachmentService extends BaseService implements AttachmentServiceM
       throw new ValidationError({ message: 'id is required for getById' });
     }
 
-    // Rewrite renamed SDK field names → API names inside OData strings,
-    // then prefix all keys with $ for OData. The response applies BOTH
-    // AttachmentsMap (top-level time fields) and BucketMap (on the nested
-    // blobFileAccess), so user-supplied OData strings may reference either
-    // namespace (e.g. createdTime, blobFileAccess/path).
-    //
-    // Merge into a single map and apply once so the existing no-chaining
-    // guarantee in transformOptions covers us — sequential calls would
-    // chain if a future entry in one map produced a value that became a
-    // key in the other.
+    // Response applies both maps (BucketMap on blobFileAccess, AttachmentsMap on top-level);
+    // merge so SDK names from either are rewritten in one pass.
     const apiFieldOptions = transformOptions(options, { ...AttachmentsMap, ...BucketMap });
     const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
 

--- a/src/services/orchestrator/attachments/attachments.ts
+++ b/src/services/orchestrator/attachments/attachments.ts
@@ -4,7 +4,7 @@ import {
   AttachmentGetByIdOptions,
 } from '../../../models/orchestrator/attachments.types';
 import { AttachmentServiceModel } from '../../../models/orchestrator/attachments.models';
-import { pascalToCamelCaseKeys, addPrefixToKeys, transformData } from '../../../utils/transform';
+import { pascalToCamelCaseKeys, addPrefixToKeys, transformData, transformOptions } from '../../../utils/transform';
 import { ORCHESTRATOR_ATTACHMENT_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX } from '../../../utils/constants/common';
 import { track } from '../../../core/telemetry';
@@ -33,9 +33,10 @@ export class AttachmentService extends BaseService implements AttachmentServiceM
       throw new ValidationError({ message: 'id is required for getById' });
     }
 
-    // Prefix all keys in options with $ for OData
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
+    // Rewrite renamed SDK field names → API names inside OData strings,
+    // then prefix all keys with $ for OData.
+    const apiFieldOptions = transformOptions(options, AttachmentsMap);
+    const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
 
     const response = await this.get<AttachmentResponse>(
       ORCHESTRATOR_ATTACHMENT_ENDPOINTS.GET_BY_ID(id),

--- a/src/services/orchestrator/attachments/attachments.ts
+++ b/src/services/orchestrator/attachments/attachments.ts
@@ -34,8 +34,16 @@ export class AttachmentService extends BaseService implements AttachmentServiceM
     }
 
     // Rewrite renamed SDK field names → API names inside OData strings,
-    // then prefix all keys with $ for OData.
-    const apiFieldOptions = transformOptions(options, AttachmentsMap);
+    // then prefix all keys with $ for OData. The response applies BOTH
+    // AttachmentsMap (top-level time fields) and BucketMap (on the nested
+    // blobFileAccess), so user-supplied OData strings may reference either
+    // namespace (e.g. createdTime, blobFileAccess/path).
+    //
+    // Merge into a single map and apply once so the existing no-chaining
+    // guarantee in transformOptions covers us — sequential calls would
+    // chain if a future entry in one map produced a value that became a
+    // key in the other.
+    const apiFieldOptions = transformOptions(options, { ...AttachmentsMap, ...BucketMap });
     const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
 
     const response = await this.get<AttachmentResponse>(

--- a/src/services/orchestrator/buckets/buckets.ts
+++ b/src/services/orchestrator/buckets/buckets.ts
@@ -19,7 +19,7 @@ import {
   BucketDeleteFileOptions
 } from '../../../models/orchestrator/buckets.types';
 import { BucketServiceModel } from '../../../models/orchestrator/buckets.models';
-import { pascalToCamelCaseKeys, addPrefixToKeys, transformData, arrayDictionaryToRecord } from '../../../utils/transform';
+import { pascalToCamelCaseKeys, addPrefixToKeys, transformData, transformOptions, arrayDictionaryToRecord } from '../../../utils/transform';
 import { filterUndefined } from '../../../utils/object';
 import { createHeaders } from '../../../utils/http/headers';
 import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
@@ -299,6 +299,10 @@ export class BucketService extends FolderScopedService implements BucketServiceM
     const transformBlobItem = (item: any) =>
       transformData(item, BucketMap) as BlobItem;
 
+    // Rewrite renamed SDK field names → API names inside OData strings
+    // before delegating.
+    const apiRestOptions = transformOptions(restOptions, BucketMap);
+
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => BUCKET_ENDPOINTS.GET_FILE_META_DATA(bucketId),
@@ -314,7 +318,7 @@ export class BucketService extends FolderScopedService implements BucketServiceM
       },
       excludeFromPrefix: ['prefix'], // Bucket-specific param, not OData
       headers,
-    }, restOptions) as any;
+    }, apiRestOptions) as any;
   }
 
   /**
@@ -513,9 +517,10 @@ export class BucketService extends FolderScopedService implements BucketServiceM
       fallbackFolderKey: this.config.folderKey,
     });
 
+    const apiRestOptions = transformOptions(restOptions, BucketMap);
     const queryOptions = {
       expiryInMinutes,
-      ...addPrefixToKeys(restOptions, ODATA_PREFIX, Object.keys(restOptions))
+      ...addPrefixToKeys(apiRestOptions, ODATA_PREFIX, Object.keys(apiRestOptions))
     };
 
     return this._getUri(
@@ -682,6 +687,10 @@ export class BucketService extends FolderScopedService implements BucketServiceM
     const transformBucketFile = (file: Record<string, unknown>) =>
       transformData(pascalToCamelCaseKeys(file), BucketMap) as BucketFile;
 
+    // Rewrite renamed SDK field names → API names inside OData strings
+    // before delegating.
+    const apiRestOptions = transformOptions(restOptions, BucketMap);
+
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
       getEndpoint: () => BUCKET_ENDPOINTS.GET_FILES(bucketId),
@@ -698,7 +707,7 @@ export class BucketService extends FolderScopedService implements BucketServiceM
       },
       excludeFromPrefix: ['directory', 'recursive', 'fileNameRegex'],
       headers,
-    }, { ...restOptions, directory: '/', recursive: true }) as any;
+    }, { ...apiRestOptions, directory: '/', recursive: true }) as any;
   }
 
   /**
@@ -757,9 +766,10 @@ export class BucketService extends FolderScopedService implements BucketServiceM
   ): Promise<BucketGetUriResponse> {
     const { bucketId, path, expiryInMinutes, headers, ...restOptions } = options;
 
+    const apiRestOptions = transformOptions(restOptions, BucketMap);
     const queryOptions = {
       expiryInMinutes,
-      ...addPrefixToKeys(restOptions, ODATA_PREFIX, Object.keys(restOptions))
+      ...addPrefixToKeys(apiRestOptions, ODATA_PREFIX, Object.keys(apiRestOptions))
     };
 
     return this._getUri(

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -10,7 +10,7 @@ import {
   ProcessStartOptions,
 } from '../../../models/orchestrator/processes.types';
 import { ProcessServiceModel } from '../../../models/orchestrator/processes.models';
-import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest } from '../../../utils/transform';
+import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformRequest, transformOptions } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
 import { ProcessMap } from '../../../models/orchestrator/processes.constants';
 import { FOLDER_ID } from '../../../utils/constants/headers';
@@ -79,8 +79,13 @@ export class ProcessService extends FolderScopedService implements ProcessServic
       : NonPaginatedResponse<ProcessGetResponse>
   > {
     // Transformation function for processes
-    const transformProcessResponse = (process: any) => 
+    const transformProcessResponse = (process: any) =>
       transformData(pascalToCamelCaseKeys(process) as ProcessGetResponse, ProcessMap);
+
+    // Rewrite renamed SDK field names → API names inside OData strings
+    // before delegating, mirroring the transformRequest pattern used for
+    // request bodies.
+    const apiOptions = options ? transformOptions(options, ProcessMap) : options;
 
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
@@ -97,7 +102,7 @@ export class ProcessService extends FolderScopedService implements ProcessServic
           countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM              
         }
       }
-    }, options) as any;
+    }, apiOptions) as any;
   }
 
   /**
@@ -187,9 +192,10 @@ export class ProcessService extends FolderScopedService implements ProcessServic
       startInfo: apiRequest
     };
 
-    // Prefix all query parameter keys with '$' for OData
-    const keysToPrefix = Object.keys(queryOptions);
-    const apiOptions = addPrefixToKeys(queryOptions, ODATA_PREFIX, keysToPrefix);
+    // Rewrite renamed SDK field names → API names inside OData strings,
+    // then prefix all query parameter keys with '$' for OData.
+    const apiFieldOptions = transformOptions(queryOptions, ProcessMap);
+    const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
 
     const response = await this.post<CollectionResponse<ProcessStartResponse>>(
       PROCESS_ENDPOINTS.START_PROCESS,
@@ -228,10 +234,10 @@ export class ProcessService extends FolderScopedService implements ProcessServic
   @track('Processes.GetById')
   async getById(id: number, folderId: number, options: ProcessGetByIdOptions = {}): Promise<ProcessGetResponse> {
     const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
-    
+
+    const apiFieldOptions = transformOptions(options, ProcessMap);
+    const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
+
     const response = await this.get<ProcessGetResponse>(
       PROCESS_ENDPOINTS.GET_BY_ID(id),
       { 
@@ -279,6 +285,7 @@ export class ProcessService extends FolderScopedService implements ProcessServic
       name,
       options,
       (raw) => transformData(pascalToCamelCaseKeys(raw), ProcessMap),
+      ProcessMap,
     );
   }
 }

--- a/src/services/orchestrator/queues/queues.ts
+++ b/src/services/orchestrator/queues/queues.ts
@@ -5,7 +5,7 @@ import {
   QueueGetByIdOptions
 } from '../../../models/orchestrator/queues.types';
 import { QueueServiceModel } from '../../../models/orchestrator/queues.models';
-import { addPrefixToKeys, pascalToCamelCaseKeys, transformData } from '../../../utils/transform';
+import { addPrefixToKeys, pascalToCamelCaseKeys, transformData, transformOptions } from '../../../utils/transform';
 import { createHeaders } from '../../../utils/http/headers';
 import { FOLDER_ID } from '../../../utils/constants/headers';
 import { QUEUE_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -73,8 +73,13 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
       : NonPaginatedResponse<QueueGetResponse>
   > {
     // Transformation function for queues
-    const transformQueueResponse = (queue: any) => 
+    const transformQueueResponse = (queue: any) =>
       transformData(pascalToCamelCaseKeys(queue) as QueueGetResponse, QueueMap);
+
+    // Rewrite renamed SDK field names → API names inside OData strings
+    // before delegating, mirroring the transformRequest pattern used for
+    // request bodies.
+    const apiOptions = options ? transformOptions(options, QueueMap) : options;
 
     return PaginationHelpers.getAll({
       serviceAccess: this.createPaginationServiceAccess(),
@@ -91,7 +96,7 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
           countParam: ODATA_OFFSET_PARAMS.COUNT_PARAM              
         }
       }
-    }, options) as any;
+    }, apiOptions) as any;
   }
 
   /**
@@ -114,9 +119,9 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
   @track('Queues.GetById')
   async getById(id: number, folderId: number, options: QueueGetByIdOptions = {}): Promise<QueueGetResponse> {
     const headers = createHeaders({ [FOLDER_ID]: folderId });
-    
-    const keysToPrefix = Object.keys(options);
-    const apiOptions = addPrefixToKeys(options, ODATA_PREFIX, keysToPrefix);
+
+    const apiFieldOptions = transformOptions(options, QueueMap);
+    const apiOptions = addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions));
     
     const response = await this.get<QueueGetResponse>(
       QUEUE_ENDPOINTS.GET_BY_ID(id),

--- a/tests/unit/services/action-center/tasks.test.ts
+++ b/tests/unit/services/action-center/tasks.test.ts
@@ -21,7 +21,8 @@ import {
   createMockUsers 
 } from '../../../utils/mocks/tasks';
 import { createMockError } from '../../../utils/mocks/core';
-import { DEFAULT_TASK_EXPAND } from '../../../../src/models/action-center/tasks.constants';
+import { DEFAULT_TASK_EXPAND, TaskMap } from '../../../../src/models/action-center/tasks.constants';
+import { transformOptions } from '../../../../src/utils/transform';
 import { TASK_TEST_CONSTANTS } from '../../../utils/constants/tasks';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
 import { TASK_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
@@ -905,6 +906,30 @@ describe('TaskService Unit Tests', () => {
         })
       );
     });
+
+    it('should run options through transformOptions with TaskMap before prefixing for OData', async () => {
+      const taskId = 123;
+      const mockTask = createMockTasks(1)[0];
+      mockApiClient.get.mockResolvedValue(mockTask);
+      vi.mocked(transformOptions).mockClear();
+
+      await taskService.getById(
+        taskId,
+        { select: 'title,createdTime,completedTime' },
+        TEST_CONSTANTS.FOLDER_ID,
+      );
+
+      // transformOptions is invoked with the default-expand-augmented options
+      // + TaskMap so SDK names in select get rewritten to API names before
+      // addPrefixToKeys runs.
+      expect(transformOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: 'title,createdTime,completedTime',
+          expand: DEFAULT_TASK_EXPAND,
+        }),
+        TaskMap,
+      );
+    });
   });
 
   describe('getAll', () => {
@@ -1082,6 +1107,25 @@ describe('TaskService Unit Tests', () => {
 
       // Verify the non-admin endpoint was used (default behavior)
       expect(capturedEndpoint).toBe(TASK_ENDPOINTS.GET_TASKS_ACROSS_FOLDERS);
+    });
+
+    it('should run options through transformOptions with TaskMap before delegating', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({
+        items: createMockTasks(0),
+        totalCount: 0,
+      });
+      vi.mocked(transformOptions).mockClear();
+
+      const options = {
+        filter: "createdTime gt 2026-01-01 and folderId eq 7",
+        orderby: 'completedTime desc',
+      };
+      await taskService.getAll(options);
+
+      // transformOptions is invoked with the user's options + TaskMap so SDK
+      // field names like createdTime / folderId / completedTime are rewritten
+      // to API names before the request is built.
+      expect(transformOptions).toHaveBeenCalledWith(options, TaskMap);
     });
   });
 

--- a/tests/unit/services/orchestrator/assets.test.ts
+++ b/tests/unit/services/orchestrator/assets.test.ts
@@ -305,6 +305,25 @@ describe('AssetService Unit Tests', () => {
       );
     });
 
+    it('should rewrite renamed SDK field names in select before calling the API', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
+
+      await assetService.getByName(ASSET_TEST_CONSTANTS.ASSET_NAME, {
+        folderId: TEST_CONSTANTS.FOLDER_ID,
+        select: 'name,createdTime,lastModifiedTime',
+      });
+
+      // createdTime → creationTime, lastModifiedTime → lastModificationTime.
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ASSET_ENDPOINTS.GET_BY_FOLDER,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'name,creationTime,lastModificationTime',
+          }),
+        }),
+      );
+    });
+
     it('should route a numeric folderId to X-UIPATH-OrganizationUnitId', async () => {
       mockApiClient.get.mockResolvedValue({ value: [createMockRawAsset()] });
 

--- a/tests/unit/services/orchestrator/assets.test.ts
+++ b/tests/unit/services/orchestrator/assets.test.ts
@@ -229,6 +229,47 @@ describe('AssetService Unit Tests', () => {
 
       await expect(assetService.getAll()).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
+
+    it('should translate SDK field names to API names in filter/orderby before delegating', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(
+        createMockTransformedAssetCollection(),
+      );
+
+      await assetService.getAll({
+        filter: "createdTime gt 2026-01-01",
+        orderby: 'lastModifiedTime desc',
+      });
+
+      // createdTime → creationTime, lastModifiedTime → lastModificationTime.
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          filter: 'creationTime gt 2026-01-01',
+          orderby: 'lastModificationTime desc',
+        }),
+      );
+    });
+  });
+
+  describe('OData field rewrite in getById', () => {
+    it('should rewrite renamed SDK field names in select before calling the API', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawAsset());
+
+      await assetService.getById(
+        ASSET_TEST_CONSTANTS.ASSET_ID,
+        TEST_CONSTANTS.FOLDER_ID,
+        { select: 'name,createdTime,lastModifiedTime' },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ASSET_ENDPOINTS.GET_BY_ID(ASSET_TEST_CONSTANTS.ASSET_ID),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'name,creationTime,lastModificationTime',
+          }),
+        }),
+      );
+    });
   });
 
   describe('getByName', () => {

--- a/tests/unit/services/orchestrator/attachments.test.ts
+++ b/tests/unit/services/orchestrator/attachments.test.ts
@@ -132,5 +132,25 @@ describe('AttachmentService Unit Tests', () => {
         }),
       );
     });
+
+    it('should rewrite both AttachmentsMap and BucketMap field names in OData strings', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawAttachment());
+
+      await attachmentService.getById(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_ID,
+        { select: 'name,createdTime,blobFileAccess/path,blobFileAccess/httpMethod' },
+      );
+
+      // AttachmentsMap: createdTime → creationTime.
+      // BucketMap (applied to nested blobFileAccess fields): path → fullPath, httpMethod → verb.
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ORCHESTRATOR_ATTACHMENT_ENDPOINTS.GET_BY_ID(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_ID),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'name,creationTime,blobFileAccess/fullPath,blobFileAccess/verb',
+          }),
+        }),
+      );
+    });
   });
 });

--- a/tests/unit/services/orchestrator/attachments.test.ts
+++ b/tests/unit/services/orchestrator/attachments.test.ts
@@ -113,5 +113,24 @@ describe('AttachmentService Unit Tests', () => {
         attachmentService.getById(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_ID)
       ).rejects.toThrow(ATTACHMENT_TEST_CONSTANTS.ERROR_ATTACHMENT_NOT_FOUND);
     });
+
+    it('should rewrite renamed SDK field names in select before calling the API', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawAttachment());
+
+      await attachmentService.getById(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_ID,
+        { select: 'name,createdTime,lastModifiedTime' },
+      );
+
+      // createdTime → creationTime, lastModifiedTime → lastModificationTime.
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ORCHESTRATOR_ATTACHMENT_ENDPOINTS.GET_BY_ID(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_ID),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'name,creationTime,lastModificationTime',
+          }),
+        }),
+      );
+    });
   });
 });

--- a/tests/unit/services/orchestrator/buckets.test.ts
+++ b/tests/unit/services/orchestrator/buckets.test.ts
@@ -1537,6 +1537,23 @@ describe('BucketService Unit Tests', () => {
         { folderId: TEST_CONSTANTS.FOLDER_ID },
       )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
+
+    it('should translate SDK field names to API names in filter before delegating', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [] } as any);
+
+      await bucketService.getFiles(BUCKET_TEST_CONSTANTS.BUCKET_ID, {
+        folderId: TEST_CONSTANTS.FOLDER_ID,
+        filter: "path eq '/folder/file.pdf' and httpMethod eq 'GET'",
+      });
+
+      // path → fullPath, httpMethod → verb (from BucketMap).
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          filter: "fullPath eq '/folder/file.pdf' and verb eq 'GET'",
+        }),
+      );
+    });
   });
 });
 

--- a/tests/unit/services/orchestrator/buckets.test.ts
+++ b/tests/unit/services/orchestrator/buckets.test.ts
@@ -613,6 +613,23 @@ describe('BucketService Unit Tests', () => {
         TEST_CONSTANTS.FOLDER_ID
       )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
+
+    it('should translate SDK field names to API names in filter before delegating', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 } as any);
+
+      await bucketService.getFileMetaData(BUCKET_TEST_CONSTANTS.BUCKET_ID, {
+        folderId: TEST_CONSTANTS.FOLDER_ID,
+        filter: "path eq '/data/file.pdf'",
+      });
+
+      // path → fullPath (from BucketMap reversed).
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          filter: "fullPath eq '/data/file.pdf'",
+        }),
+      );
+    });
   });
 
   describe('uploadFile', () => {
@@ -1205,6 +1222,26 @@ describe('BucketService Unit Tests', () => {
         folderId: TEST_CONSTANTS.FOLDER_ID,
         path: BUCKET_TEST_CONSTANTS.FILE_PATH
       })).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it('should rewrite renamed SDK field names in select before calling the API', async () => {
+      mockApiClient.get.mockResolvedValue(createMockReadUriApiResponse());
+
+      await bucketService.getReadUri(
+        BUCKET_TEST_CONSTANTS.BUCKET_ID,
+        BUCKET_TEST_CONSTANTS.FILE_PATH,
+        { folderId: TEST_CONSTANTS.FOLDER_ID, select: 'uri,httpMethod' },
+      );
+
+      // httpMethod → verb (from BucketMap reversed).
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        BUCKET_ENDPOINTS.GET_READ_URI(BUCKET_TEST_CONSTANTS.BUCKET_ID),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'uri,verb',
+          }),
+        }),
+      );
     });
   });
 

--- a/tests/unit/services/orchestrator/processes.test.ts
+++ b/tests/unit/services/orchestrator/processes.test.ts
@@ -506,6 +506,25 @@ describe('ProcessService Unit Tests', () => {
       );
     });
 
+    it('should rewrite renamed SDK field names in select before calling the API', async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
+
+      await service.getByName(PROCESS_TEST_CONSTANTS.PROCESS_NAME, {
+        folderId: TEST_CONSTANTS.FOLDER_ID,
+        select: 'name,processName,createdTime',
+      });
+
+      // processName → releaseName, createdTime → creationTime (from ProcessMap reversed).
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.GET_ALL,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'name,releaseName,creationTime',
+          }),
+        }),
+      );
+    });
+
     it('should route a numeric folderId to X-UIPATH-OrganizationUnitId', async () => {
       mockApiClient.get.mockResolvedValue({ value: [createMockRawOrchestratorProcess()] });
 

--- a/tests/unit/services/orchestrator/processes.test.ts
+++ b/tests/unit/services/orchestrator/processes.test.ts
@@ -151,11 +151,31 @@ describe('ProcessService Unit Tests', () => {
 
     it('should handle API errors', async () => {
       const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
-      
+
       // Mock PaginationHelpers.getAll to throw error
       vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
 
       await expect(service.getAll()).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it('should translate SDK field names to API names in filter/orderby before delegating', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(
+        createMockOrchestratorProcesses(),
+      );
+
+      await service.getAll({
+        filter: "processName eq 'InvoiceBot' and processKey eq 'abc'",
+        orderby: 'createdTime desc',
+      });
+
+      // processName → releaseName, processKey → releaseKey, createdTime → creationTime.
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          filter: "releaseName eq 'InvoiceBot' and releaseKey eq 'abc'",
+          orderby: 'creationTime desc',
+        }),
+      );
     });
 
   });
@@ -221,9 +241,28 @@ describe('ProcessService Unit Tests', () => {
       mockApiClient.get.mockRejectedValue(error);
 
       await expect(service.getById(
-        PROCESS_TEST_CONSTANTS.PROCESS_ID, 
+        PROCESS_TEST_CONSTANTS.PROCESS_ID,
         TEST_CONSTANTS.FOLDER_ID
       )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it('should rewrite renamed SDK field names in select before calling the API', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawOrchestratorProcess());
+
+      await service.getById(
+        PROCESS_TEST_CONSTANTS.PROCESS_ID,
+        TEST_CONSTANTS.FOLDER_ID,
+        { select: 'name,processName,createdTime' },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.GET_BY_ID(PROCESS_TEST_CONSTANTS.PROCESS_ID),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'name,releaseName,creationTime',
+          }),
+        }),
+      );
     });
   });
 

--- a/tests/unit/services/orchestrator/processes.test.ts
+++ b/tests/unit/services/orchestrator/processes.test.ts
@@ -470,6 +470,28 @@ describe('ProcessService Unit Tests', () => {
       await expect(service.start(request)).rejects.toBeInstanceOf(ValidationError);
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
+
+    it('should rewrite renamed SDK field names in query options before calling the API', async () => {
+      const mockResponse = createMockProcessStartApiResponse([createMockProcessStartResponse()]);
+      mockApiClient.post.mockResolvedValue(mockResponse);
+
+      const request = PROCESS_TEST_CONSTANTS.PROCESS_START_REQUEST as ProcessStartRequest;
+      await service.start(request, {
+        folderId: TEST_CONSTANTS.FOLDER_ID,
+        filter: "processName eq 'InvoiceBot'",
+      });
+
+      // processName → releaseName (ProcessMap reversed).
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        PROCESS_ENDPOINTS.START_PROCESS,
+        expect.any(Object),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$filter': "releaseName eq 'InvoiceBot'",
+          }),
+        }),
+      );
+    });
   });
 
   describe('getByName', () => {

--- a/tests/unit/services/orchestrator/queues.test.ts
+++ b/tests/unit/services/orchestrator/queues.test.ts
@@ -225,5 +225,48 @@ describe('QueueService Unit Tests', () => {
 
       await expect(queueService.getAll()).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
+
+    it('should translate SDK field names to API names in filter/orderby before delegating', async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(
+        createMockTransformedQueueCollection(),
+      );
+
+      await queueService.getAll({
+        filter: "folderName eq 'Finance' and folderId eq 7",
+        orderby: 'createdTime desc',
+      });
+
+      // Options arriving at PaginationHelpers should already be in API field space:
+      // folderName → organizationUnitFullyQualifiedName, folderId → organizationUnitId,
+      // createdTime → creationTime.
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          filter: "organizationUnitFullyQualifiedName eq 'Finance' and organizationUnitId eq 7",
+          orderby: 'creationTime desc',
+        }),
+      );
+    });
+  });
+
+  describe('OData field rewrite in getById', () => {
+    it('should rewrite renamed SDK field names in select before calling the API', async () => {
+      mockApiClient.get.mockResolvedValue(createMockRawQueue());
+
+      await queueService.getById(
+        QUEUE_TEST_CONSTANTS.QUEUE_ID,
+        TEST_CONSTANTS.FOLDER_ID,
+        { select: 'name,createdTime,folderId' },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        QUEUE_ENDPOINTS.GET_BY_ID(QUEUE_TEST_CONSTANTS.QUEUE_ID),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            '$select': 'name,creationTime,organizationUnitId',
+          }),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

Extends [PLT-102084](https://uipath.atlassian.net/browse/PLT-102084) — applied to Jobs in #536 — to the remaining services whose field maps rename API fields on responses: **Queues, Assets, Buckets, Processes, Attachments, Tasks**.

Without this, a consumer who reads a renamed field on a response (e.g. `processName`, `createdTime`, `folderId`) and turns around to filter / orderby / select / expand by that same name is silently rejected by the API, which only knows the original field names (`releaseName`, `creationTime`, `organizationUnitId`, …).

## Changes

Wire `transformOptions(options, EntityMap)` at every OData input edge that pairs with a response-side `transformData(…, EntityMap)`:

| Service | OData input edges wired |
|---------|--------------------------|
| Queues | `getAll`, `getById` |
| Assets | `getAll`, `getById`, `getByName` (via shared helper) |
| Buckets | `getFileMetaData`, `getFiles`, `getReadUri`, `_getWriteUri` |
| Processes | `getAll`, `getById`, `getByName`, `start` (query options) |
| Attachments | `getById` |
| Tasks (action-center) | `getAll`, `getById` |

`FolderScopedService.getByNameLookup` gains an optional `requestFieldMap` parameter so Assets/Processes can apply their respective maps inside the shared `getByName` flow before the OData `$filter=Name eq '…'` is built.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm run test:unit` — 1948 / 1948 passing (10 new tests)
- [x] `npm run build` — produces `dist/` output
- [x] Per-service unit tests mirror the Jobs pattern from #536: assert the post-transformation shape on the call to `PaginationHelpers.getAll` / `addPrefixToKeys`. Tasks' suite identity-mocks the transform module, so its two new tests assert the wiring (that `transformOptions` is invoked with the right map) rather than the rewritten string.

Refs: [PLT-106297](https://uipath.atlassian.net/browse/PLT-106297), [PLT-102084](https://uipath.atlassian.net/browse/PLT-102084)

[PLT-102084]: https://uipath.atlassian.net/browse/PLT-102084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLT-106297]: https://uipath.atlassian.net/browse/PLT-106297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ