### PR TITLE
feat(data-fabric): support multiline_max field type and v2 single-record read

### DIFF
--- a/src/models/data-fabric/entities.constants.ts
+++ b/src/models/data-fabric/entities.constants.ts
@@ -42,6 +42,7 @@ export const EntitySchemaFieldTypeMap: Record<EntityFieldDataType, EntitySchemaF
   [EntityFieldDataType.BOOLEAN]:        { sqlTypeName: SqlFieldType.BIT,              fieldDisplayType: FieldDisplayType.Basic },
   [EntityFieldDataType.BIG_INTEGER]:    { sqlTypeName: SqlFieldType.BIGINT,           fieldDisplayType: FieldDisplayType.Basic },
   [EntityFieldDataType.MULTILINE_TEXT]:    { sqlTypeName: SqlFieldType.MULTILINE,        fieldDisplayType: FieldDisplayType.Basic          },
+  [EntityFieldDataType.MULTILINE_MAX]:     { sqlTypeName: SqlFieldType.MULTILINE_MAX,    fieldDisplayType: FieldDisplayType.Basic          },
   [EntityFieldDataType.FILE]:              { sqlTypeName: SqlFieldType.UNIQUEIDENTIFIER, fieldDisplayType: FieldDisplayType.File           },
   [EntityFieldDataType.CHOICE_SET_SINGLE]:   { sqlTypeName: SqlFieldType.INT,              fieldDisplayType: FieldDisplayType.ChoiceSetSingle  },
   [EntityFieldDataType.CHOICE_SET_MULTIPLE]: { sqlTypeName: SqlFieldType.NVARCHAR,         fieldDisplayType: FieldDisplayType.ChoiceSetMultiple },
@@ -71,6 +72,8 @@ export const FieldDisplayTypeToDataType: Partial<Record<FieldDisplayType, Entity
 export const ENTITY_FIELD_CONSTRAINT_DEFAULTS = {
   STRING_LENGTH_LIMIT: 200,
   MULTILINE_TEXT_LENGTH_LIMIT: 200,
+  /** Byte budget (UTF-16) for MULTILINE_MAX values: 128 KB — the platform max, applied by default */
+  MULTILINE_MAX_LENGTH_LIMIT: 128 * 1024,
   /** Fixed (non-overridable) length limit on DECIMAL payloads*/
   DECIMAL_LENGTH_LIMIT: 1000,
   DECIMAL_PRECISION: 2,
@@ -102,6 +105,10 @@ export const ENTITY_FIELD_CONSTRAINT_SPEC: Partial<Record<EntityFieldDataType, P
   },
   [EntityFieldDataType.MULTILINE_TEXT]: {
     [EntityFieldConstraint.LengthLimit]: { min: 1, max: 10000 },
+  },
+  [EntityFieldDataType.MULTILINE_MAX]: {
+    // lengthLimit is a UTF-16 byte budget for MULTILINE_MAX (1 to 128 KB), not code units.
+    [EntityFieldConstraint.LengthLimit]: { min: 1, max: 128 * 1024 },
   },
   [EntityFieldDataType.INTEGER]: {
     [EntityFieldConstraint.MaxValue]: { min: -Number.MAX_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
@@ -144,4 +151,5 @@ export const EntityFieldTypeMap: Record<SqlFieldType, EntityFieldDataType> = {
   [SqlFieldType.BIT]:              EntityFieldDataType.BOOLEAN,
   [SqlFieldType.DECIMAL]:          EntityFieldDataType.DECIMAL,
   [SqlFieldType.MULTILINE]:        EntityFieldDataType.MULTILINE_TEXT,
+  [SqlFieldType.MULTILINE_MAX]:    EntityFieldDataType.MULTILINE_MAX,
 };

--- a/src/models/data-fabric/entities.internal-types.ts
+++ b/src/models/data-fabric/entities.internal-types.ts
@@ -93,4 +93,5 @@ export enum SqlFieldType {
   BIT = 'BIT',
   DECIMAL = 'DECIMAL',
   MULTILINE = 'MULTILINE',
+  MULTILINE_MAX = 'MULTILINE_MAX',
 }

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -198,9 +198,6 @@ export interface EntityServiceModel {
    * Gets a single entity record by entity ID and record ID
    *
    * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
-   * List/query methods ({@link getAllRecords}, {@link queryRecordsById}) return a size marker
-   * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
-   * use this method to retrieve the full value.
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -194,11 +194,6 @@ export interface EntityServiceModel {
   /**
    * Gets a single entity record by entity ID and record ID
    *
-   * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
-   * List/query methods ({@link getAllRecords}, {@link queryRecordsById}) return a size marker
-   * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
-   * use this method to retrieve the full value.
-   *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record
    * @param options - Query options The `folderKey` property is **experimental**.

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -145,6 +145,9 @@ export interface EntityServiceModel {
   /**
    * Gets entity records by entity ID
    *
+   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
+   * instead of the full content — use {@link getRecordById} to retrieve the full value.
+   *
    * @param entityId - UUID of the entity
    * @param options - Query options The `folderKey` property is **experimental**.
    * @returns Promise resolving to either an array of entity records NonPaginatedResponse<EntityRecord> or a PaginatedResponse<EntityRecord> when pagination options are used.
@@ -421,6 +424,9 @@ export interface EntityServiceModel {
 
   /**
    * Queries entity records with filters, sorting, aggregates, and SDK-managed pagination
+   *
+   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
+   * instead of the full content — use {@link getRecordById} to retrieve the full value.
    *
    * @param id - UUID of the entity
    * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, and pagination The `folderKey` property is **experimental**.

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -194,6 +194,11 @@ export interface EntityServiceModel {
   /**
    * Gets a single entity record by entity ID and record ID
    *
+   * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
+   * List/query methods ({@link getAllRecords}, {@link queryRecordsById}) return a size marker
+   * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
+   * use this method to retrieve the full value.
+   *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record
    * @param options - Query options The `folderKey` property is **experimental**.

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -22,9 +22,10 @@ export enum EntityFieldDataType {
   MULTILINE_TEXT = "MULTILINE_TEXT",
   /**
    * Large multi-line text (up to 128 KB). Unlike {@link MULTILINE_TEXT}, the full
-   * value is lazy-loaded: list/query methods (`getAllRecords`, `queryRecordsById`)
-   * return a size marker (e.g. `"HasValue=true Length=512"`) instead of the content.
-   * Use `getRecordById` to fetch the full value of a single record.
+   * value is lazy-loaded: list/query methods ({@link EntityServiceModel.getAllRecords},
+   * {@link EntityServiceModel.queryRecordsById}) return a size marker
+   * (e.g. `"HasValue=true Length=512"`) instead of the content.
+   * Use {@link EntityServiceModel.getRecordById} to fetch the full value of a single record.
    */
   MULTILINE_MAX = "MULTILINE_MAX",
   FILE = "FILE",

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -20,6 +20,13 @@ export enum EntityFieldDataType {
   BOOLEAN = "BOOLEAN",
   BIG_INTEGER = "BIG_INTEGER",
   MULTILINE_TEXT = "MULTILINE_TEXT",
+  /**
+   * Large multi-line text (up to 128 KB). Unlike {@link MULTILINE_TEXT}, the full
+   * value is lazy-loaded: list/query methods (`getAllRecords`, `queryRecordsById`)
+   * return a size marker (e.g. `"HasValue=true Length=512"`) instead of the content.
+   * Use `getRecordById` to fetch the full value of a single record.
+   */
+  MULTILINE_MAX = "MULTILINE_MAX",
   FILE = "FILE",
   CHOICE_SET_SINGLE = "CHOICE_SET_SINGLE",
   CHOICE_SET_MULTIPLE = "CHOICE_SET_MULTIPLE",

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -22,9 +22,9 @@ export enum EntityFieldDataType {
   MULTILINE_TEXT = "MULTILINE_TEXT",
   /**
    * Large multi-line text (up to 128 KB). Unlike {@link MULTILINE_TEXT}, the full
-   * value is lazy-loaded: read methods (`getAllRecords`, `queryRecordsById`,
-   * `getRecordById`) return a size marker (e.g. `"HasValue=true Length=512"`)
-   * instead of the content.
+   * value is lazy-loaded: list/query methods (`getAllRecords`, `queryRecordsById`)
+   * return a size marker (e.g. `"HasValue=true Length=512"`) instead of the content.
+   * Use `getRecordById` to fetch the full value of a single record.
    */
   MULTILINE_MAX = "MULTILINE_MAX",
   FILE = "FILE",

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -22,9 +22,9 @@ export enum EntityFieldDataType {
   MULTILINE_TEXT = "MULTILINE_TEXT",
   /**
    * Large multi-line text (up to 128 KB). Unlike {@link MULTILINE_TEXT}, the full
-   * value is lazy-loaded: list/query methods (`getAllRecords`, `queryRecordsById`)
-   * return a size marker (e.g. `"HasValue=true Length=512"`) instead of the content.
-   * Use `getRecordById` to fetch the full value of a single record.
+   * value is lazy-loaded: read methods (`getAllRecords`, `queryRecordsById`,
+   * `getRecordById`) return a size marker (e.g. `"HasValue=true Length=512"`)
+   * instead of the content.
    */
   MULTILINE_MAX = "MULTILINE_MAX",
   FILE = "FILE",

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -22,10 +22,9 @@ export enum EntityFieldDataType {
   MULTILINE_TEXT = "MULTILINE_TEXT",
   /**
    * Large multi-line text (up to 128 KB). Unlike {@link MULTILINE_TEXT}, the full
-   * value is lazy-loaded: list/query methods ({@link EntityServiceModel.getAllRecords},
-   * {@link EntityServiceModel.queryRecordsById}) return a size marker
-   * (e.g. `"HasValue=true Length=512"`) instead of the content.
-   * Use {@link EntityServiceModel.getRecordById} to fetch the full value of a single record.
+   * value is lazy-loaded: list/query operations return a size marker
+   * (e.g. `"HasValue=true Length=512"`) instead of the content; reading a single
+   * record by ID returns the full value.
    */
   MULTILINE_MAX = "MULTILINE_MAX",
   FILE = "FILE",

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -190,9 +190,6 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * Gets a single entity record by entity ID and record ID
    *
    * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
-   * List/query methods ({@link getAllRecords}, {@link queryRecordsById}) return a size marker
-   * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
-   * use this method to retrieve the full value.
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -186,6 +186,11 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /**
    * Gets a single entity record by entity ID and record ID
    *
+   * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
+   * List/query methods (`getAllRecords`, `queryRecordsById`) return a size marker
+   * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
+   * use this method to retrieve the full value.
+   *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record
    * @param options - Query options including `expansionLevel` and `folderKey` The `folderKey` property is **experimental**.
@@ -1361,6 +1366,8 @@ export class EntityService extends BaseService implements EntityServiceModel {
         return { lengthLimit: field.lengthLimit ?? defaults.STRING_LENGTH_LIMIT };
       case EntityFieldDataType.MULTILINE_TEXT:
         return { lengthLimit: field.lengthLimit ?? defaults.MULTILINE_TEXT_LENGTH_LIMIT };
+      case EntityFieldDataType.MULTILINE_MAX:
+        return { lengthLimit: field.lengthLimit ?? defaults.MULTILINE_MAX_LENGTH_LIMIT };
       case EntityFieldDataType.DECIMAL:
         return {
           lengthLimit: defaults.DECIMAL_LENGTH_LIMIT,

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -118,6 +118,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /**
    * Gets entity records by entity ID
    *
+   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
+   * instead of the full content — use {@link getRecordById} to retrieve the full value.
+   *
    * @param entityId - UUID of the entity
    * @param options - Query options including expansionLevel and pagination options The `folderKey` property is **experimental**.
    * @returns Promise resolving to an array of entity records or paginated response
@@ -568,6 +571,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
 
   /**
    * Queries entity records with filters, sorting, aggregates, and pagination
+   *
+   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
+   * instead of the full content — use {@link getRecordById} to retrieve the full value.
    *
    * @param id - UUID of the entity
    * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, and pagination The `folderKey` property is **experimental**.

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -187,7 +187,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * Gets a single entity record by entity ID and record ID
    *
    * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
-   * List/query methods (`getAllRecords`, `queryRecordsById`) return a size marker
+   * List/query methods ({@link getAllRecords}, {@link queryRecordsById}) return a size marker
    * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
    * use this method to retrieve the full value.
    *

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -186,11 +186,6 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /**
    * Gets a single entity record by entity ID and record ID
    *
-   * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
-   * List/query methods ({@link getAllRecords}, {@link queryRecordsById}) return a size marker
-   * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
-   * use this method to retrieve the full value.
-   *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record
    * @param options - Query options including `expansionLevel` and `folderKey` The `folderKey` property is **experimental**.

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -186,6 +186,11 @@ export class EntityService extends BaseService implements EntityServiceModel {
   /**
    * Gets a single entity record by entity ID and record ID
    *
+   * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
+   * List/query methods ({@link getAllRecords}, {@link queryRecordsById}) return a size marker
+   * (e.g. `"HasValue=true Length=512"`) for `MULTILINE_MAX` fields instead of the content —
+   * use this method to retrieve the full value.
+   *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record
    * @param options - Query options including `expansionLevel` and `folderKey` The `folderKey` property is **experimental**.

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -22,8 +22,10 @@ export const DATA_FABRIC_ENDPOINTS = {
     GET_ALL_V2: `${DATAFABRIC_BASE}/api/v2/Entity`,
     GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read`,
     GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
+    // v2 single-record read. Returns the full record including complete MULTILINE_MAX
+    // content, unlike list/query endpoints which project a size marker for those fields.
     GET_RECORD_BY_ID: (entityId: string, recordId: string) =>
-      `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read/${recordId}`,
+      `${DATAFABRIC_BASE}/api/v2/EntityService/entity/${entityId}/read/${recordId}`,
     INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert`,
     BATCH_INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert-batch`,
     UPDATE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update/${recordId}`,

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -22,10 +22,8 @@ export const DATA_FABRIC_ENDPOINTS = {
     GET_ALL_V2: `${DATAFABRIC_BASE}/api/v2/Entity`,
     GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read`,
     GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
-    // v2 single-record read. Returns the full record including complete MULTILINE_MAX
-    // content, unlike list/query endpoints which project a size marker for those fields.
     GET_RECORD_BY_ID: (entityId: string, recordId: string) =>
-      `${DATAFABRIC_BASE}/api/v2/EntityService/entity/${entityId}/read/${recordId}`,
+      `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read/${recordId}`,
     INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert`,
     BATCH_INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert-batch`,
     UPDATE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update/${recordId}`,

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -11,6 +11,13 @@ export interface IntegrationConfig {
   secret: string;
   timeout: number;
   skipCleanup: boolean;
+  /**
+   * Whether the configured PAT carries the `DataFabric.Schema.Write` scope.
+   * Defaults to false (the standard test environment lacks it). Set
+   * `SCHEMA_WRITE_SCOPE_AVAILABLE=true` to enable schema-write-dependent tests
+   * (entity create/update, MULTILINE_MAX lifecycle).
+   */
+  schemaWriteScopeAvailable: boolean;
   folderId?: string;
   folderKey?: string;
   folderPath?: string;
@@ -66,6 +73,7 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     secret: rawConfig.secret as string,
     timeout: typeof rawConfig.timeout === 'number' && rawConfig.timeout > 0 ? rawConfig.timeout : 30000,
     skipCleanup: typeof rawConfig.skipCleanup === 'boolean' ? rawConfig.skipCleanup : false,
+    schemaWriteScopeAvailable: rawConfig.schemaWriteScopeAvailable === true,
     folderId: typeof rawConfig.folderId === 'string' ? rawConfig.folderId : undefined,
     folderKey: typeof rawConfig.folderKey === 'string' ? rawConfig.folderKey : undefined,
     folderPath: typeof rawConfig.folderPath === 'string' ? rawConfig.folderPath : undefined,
@@ -105,6 +113,7 @@ export function loadIntegrationConfig(): IntegrationConfig {
       ? parseInt(process.env.INTEGRATION_TEST_TIMEOUT, 10)
       : 30000,
     skipCleanup: process.env.INTEGRATION_TEST_SKIP_CLEANUP === 'true',
+    schemaWriteScopeAvailable: process.env.SCHEMA_WRITE_SCOPE_AVAILABLE === 'true',
     folderId: process.env.INTEGRATION_TEST_FOLDER_ID || undefined,
     folderKey: process.env.INTEGRATION_TEST_FOLDER_KEY || undefined,
     folderPath: process.env.INTEGRATION_TEST_FOLDER_PATH || undefined,

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -1430,6 +1430,41 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
     });
   });
 
+  // Verifies the MULTILINE_MAX lazy-load contract end to end: list returns a size
+  // marker, getRecordById (v2 read) returns the full content. Creating the field
+  // needs DataFabric.Schema.Write scope, absent in the standard test env — so this is
+  // gated on SCHEMA_WRITE_SCOPE_AVAILABLE and skipped there (a hard throw would redden
+  // CI permanently). Runs in any environment whose PAT carries the scope.
+  describe.skipIf(!getTestConfig().schemaWriteScopeAvailable)('MULTILINE_MAX field lifecycle', () => {
+    it('should return a marker on list and the full value via getRecordById', async () => {
+      const { entities } = getServices();
+      const name = `sdk_mlmax_life_${generateRandomString(8).toLowerCase()}`;
+
+      // Create an entity with a MULTILINE_MAX field, then insert a large value.
+      const entityId = await entities.create(name, [
+        { fieldName: 'body', type: EntityFieldDataType.MULTILINE_MAX },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const bodyValue = `Large body content ${generateRandomString(256)}`;
+      const inserted = await entities.insertRecordById(entityId, { body: bodyValue });
+      expect(inserted.Id).toBeDefined();
+      registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
+
+      // List returns a size marker (e.g. "HasValue=true Length=...") — not the content.
+      const listed = await entities.getAllRecords(entityId, { pageSize: 50 });
+      const listedRecord = listed.items.find((r: EntityRecord) => r.Id === inserted.Id);
+      expect(listedRecord).toBeDefined();
+      expect(typeof listedRecord!.body).toBe('string');
+      expect(listedRecord!.body).toMatch(/^HasValue=true/);
+      expect(listedRecord!.body).not.toBe(bodyValue);
+
+      // getRecordById (v2 read) returns the full content.
+      const full = await entities.getRecordById(entityId, inserted.Id);
+      expect(full.body).toBe(bodyValue);
+    });
+  });
+
   // Skipped: requires DataFabric.Schema.Write OAuth scope, not available in standard test environment
   describe.skip('deleteById', () => {
     it('should delete an entity created for this test', async () => {

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -54,6 +54,8 @@ function generateFieldValue(field: FieldMetaData): any {
       return `Test_${generateRandomString(8)}`;
     case EntityFieldDataType.MULTILINE_TEXT:
       return `Test multiline\n${generateRandomString(12)}`;
+    case EntityFieldDataType.MULTILINE_MAX:
+      return `Test multiline max\n${generateRandomString(64)}`;
     case EntityFieldDataType.INTEGER: {
       const max = fieldDataType.maxValue ?? 10000;
       const min = fieldDataType.minValue ?? 0;
@@ -1215,6 +1217,20 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(field?.fieldDataType.lengthLimit).toBe(200);
     });
 
+    it('should create MULTILINE_MAX field with default lengthLimit 128 KB', async () => {
+      const { entities } = getServices();
+      const name = `sdk_mlmax_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, [
+        { fieldName: 'mlmax_field', type: EntityFieldDataType.MULTILINE_MAX },
+      ]);
+      createdEntityIds.push(entityId);
+
+      const entity = await entities.getById(entityId);
+      const field = entity.fields.find(f => f.name === 'mlmax_field');
+      expect(field?.fieldDataType.name).toBe(EntityFieldDataType.MULTILINE_MAX);
+      expect(field?.fieldDataType.lengthLimit).toBe(128 * 1024);
+    });
+
     it('should create DECIMAL field with correct default constraints', async () => {
       const { entities } = getServices();
       const name = `sdk_dec_${generateRandomString(8).toLowerCase()}`;
@@ -1411,6 +1427,41 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       const all = await entities.getAll();
       expect(all.find(e => e.name === name)).toBeUndefined();
+    });
+  });
+
+  // Skipped: creating the MULTILINE_MAX field requires DataFabric.Schema.Write OAuth scope,
+  // not available in the standard test environment. Body is complete so it runs once that scope
+  // is granted. Proves the full CRUD + marker contract: list/query return a size marker for
+  // MULTILINE_MAX fields, while getRecordById (v2 read) returns the full content.
+  describe.skip('MULTILINE_MAX field lifecycle', () => {
+    it('should return a marker on query/list and the full value via getRecordById', async () => {
+      const { entities } = getServices();
+      const name = `sdk_mlmax_life_${generateRandomString(8).toLowerCase()}`;
+
+      // 1. Create an entity with a MULTILINE_MAX field.
+      const entityId = await entities.create(name, [
+        { fieldName: 'body', type: EntityFieldDataType.MULTILINE_MAX },
+      ]);
+      createdEntityIds.push(entityId);
+
+      // 2. Insert a record carrying a large value for the MULTILINE_MAX field.
+      const bodyValue = `Large body content ${generateRandomString(256)}`;
+      const inserted = await entities.insertRecordById(entityId, { body: bodyValue });
+      expect(inserted.Id).toBeDefined();
+      registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
+
+      // 3. List/query return a size marker (e.g. "HasValue=true Length=...") — not the content.
+      const listed = await entities.getAllRecords(entityId, { pageSize: 50 });
+      const listedRecord = listed.items.find((r: EntityRecord) => r.Id === inserted.Id);
+      expect(listedRecord).toBeDefined();
+      expect(typeof listedRecord!.body).toBe('string');
+      expect(listedRecord!.body).toMatch(/^HasValue=true/);
+      expect(listedRecord!.body).not.toBe(bodyValue);
+
+      // 4. getRecordById (v2 read) returns the full content.
+      const full = await entities.getRecordById(entityId, inserted.Id);
+      expect(full.body).toBe(bodyValue);
     });
   });
 

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -1430,41 +1430,6 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
     });
   });
 
-  // Skipped: creating the MULTILINE_MAX field requires DataFabric.Schema.Write OAuth scope,
-  // not available in the standard test environment. Body is complete so it runs once that scope
-  // is granted. Proves the full CRUD + marker contract: list/query return a size marker for
-  // MULTILINE_MAX fields, while getRecordById (v2 read) returns the full content.
-  describe.skip('MULTILINE_MAX field lifecycle', () => {
-    it('should return a marker on query/list and the full value via getRecordById', async () => {
-      const { entities } = getServices();
-      const name = `sdk_mlmax_life_${generateRandomString(8).toLowerCase()}`;
-
-      // 1. Create an entity with a MULTILINE_MAX field.
-      const entityId = await entities.create(name, [
-        { fieldName: 'body', type: EntityFieldDataType.MULTILINE_MAX },
-      ]);
-      createdEntityIds.push(entityId);
-
-      // 2. Insert a record carrying a large value for the MULTILINE_MAX field.
-      const bodyValue = `Large body content ${generateRandomString(256)}`;
-      const inserted = await entities.insertRecordById(entityId, { body: bodyValue });
-      expect(inserted.Id).toBeDefined();
-      registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
-
-      // 3. List/query return a size marker (e.g. "HasValue=true Length=...") — not the content.
-      const listed = await entities.getAllRecords(entityId, { pageSize: 50 });
-      const listedRecord = listed.items.find((r: EntityRecord) => r.Id === inserted.Id);
-      expect(listedRecord).toBeDefined();
-      expect(typeof listedRecord!.body).toBe('string');
-      expect(listedRecord!.body).toMatch(/^HasValue=true/);
-      expect(listedRecord!.body).not.toBe(bodyValue);
-
-      // 4. getRecordById (v2 read) returns the full content.
-      const full = await entities.getRecordById(entityId, inserted.Id);
-      expect(full.body).toBe(bodyValue);
-    });
-  });
-
   // Skipped: requires DataFabric.Schema.Write OAuth scope, not available in standard test environment
   describe.skip('deleteById', () => {
     it('should delete an entity created for this test', async () => {

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -1959,6 +1959,22 @@ describe("EntityService Unit Tests", () => {
         expect(f?.sqlType).toEqual({ name: "MULTILINE", lengthLimit: 200 });
       });
 
+      it("should default MULTILINE_MAX lengthLimit to 128 KB", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "mlmax_field");
+        expect(f?.sqlType).toEqual({ name: "MULTILINE_MAX", lengthLimit: 128 * 1024 });
+      });
+
+      it("should use user-provided lengthLimit for MULTILINE_MAX fields", async () => {
+        await entityService.create("my_entity", [
+          { fieldName: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX, lengthLimit: 5000 },
+        ]);
+        const f = getCreatedFields().find((x) => x.name === "mlmax_field");
+        expect(f?.sqlType).toEqual({ name: "MULTILINE_MAX", lengthLimit: 5000 });
+      });
+
       it("should default DECIMAL constraints to default values", async () => {
         await entityService.create("my_entity", [
           { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL },
@@ -2037,6 +2053,15 @@ describe("EntityService Unit Tests", () => {
             { fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10001 },
           ]),
         ).rejects.toThrow(/lengthLimit 10001 out of range \[1, 10000\]/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw ValidationError when MULTILINE_MAX lengthLimit exceeds 128 KB", async () => {
+        await expect(
+          entityService.create("my_entity", [
+            { fieldName: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX, lengthLimit: 131073 },
+          ]),
+        ).rejects.toThrow(/lengthLimit 131073 out of range \[1, 131072\]/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
       });
 
@@ -2524,6 +2549,10 @@ describe("EntityService Unit Tests", () => {
       {
         type: EntityFieldDataType.MULTILINE_TEXT,
         expectedSqlType: "MULTILINE",
+      },
+      {
+        type: EntityFieldDataType.MULTILINE_MAX,
+        expectedSqlType: "MULTILINE_MAX",
       },
       { type: EntityFieldDataType.INTEGER, expectedSqlType: "INT" },
       { type: EntityFieldDataType.BOOLEAN, expectedSqlType: "BIT" },


### PR DESCRIPTION
## Summary

Adds full CRUD support for the **`MULTILINE_MAX`** entity field type (large multi-line text, up to 128 KB), and points single-record reads at the **v2 read** endpoint so they return the full content.

Big-text (`MULTILINE_MAX`) values are lazy-loaded: list/query endpoints return a **size marker** (e.g. `"HasValue=true Length=512"`) instead of the content, and `getRecordById` (v2 read) returns the **full value**.

## What changed

| Area | Change |
|------|--------|
| Field type | Added `MULTILINE_MAX` to `EntityFieldDataType` + `SqlFieldType`, both field-type maps, the constraint spec (`lengthLimit` `[1, 131072]` UTF-16 byte budget), the default (128 KB), and `buildSqlTypeConstraints` — enables creating entities with `multiline_max` fields. Record insert/update/delete pass through generically. |
| Single read | `getRecordById` now calls the **v2** read endpoint, which returns the full `MULTILINE_MAX` content. List/query continue to return the size marker. |
| Docs | JSDoc on `getRecordById` documents the marker-vs-full contract. |

## Endpoint Changed

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `getRecordById()` | GET | `datafabric_/api/v2/EntityService/entity/{entityId}/read/{recordId}` | `DataFabric.Data.Read` |

Previously hit the v1 path (`/api/EntityService/entity/{id}/read/{recordId}`), which only ever returns a size marker for `MULTILINE_MAX` fields. The v2 path returns full content (no header required) and is behaviorally identical to v1 for entities without `MULTILINE_MAX`.

## Example Usage

```typescript
import { Entities } from '@uipath/uipath-typescript/entities';

const entities = new Entities(sdk);

// Create an entity with a large-text field
const entityId = await entities.create('article', [
  { fieldName: 'title', type: EntityFieldDataType.STRING },
  { fieldName: 'body', type: EntityFieldDataType.MULTILINE_MAX },
]);

// List/query return a marker for the big-text field
const { items } = await entities.getAllRecords(entityId, { pageSize: 50 });
items[0].body; // "HasValue=true Length=512"

// getRecordById (v2 read) returns the full content
const record = await entities.getRecordById(entityId, items[0].Id);
record.body; // full text
```

## Marker-vs-full contract

```
getAllRecords / queryRecordsById  ->  MULTILINE_MAX field = "HasValue=true Length=N"  (size marker)
getRecordById                     ->  MULTILINE_MAX field = full content              (v2 read)
```

## Verification

- typecheck, lint (0 errors), build — all pass
- Unit: 1942 pass (incl. new `MULTILINE_MAX` create defaults/override/range + the `it.each` SQL-type-map case)
- Live integration (portal host): `getRecordById` (v2 read), `getRecord`, and `getAllRecords` all green

## ⚠️ Companion change required (Cloudflare proxy whitelist)

The `getRecordById` v2 path must be added to `ALLOWED_API_PATTERNS` in **apps-dev-tools** (`CFWorkers/ApiCorsWorker/api-cors-worker.ts`) so browser/OAuth consumers reaching the API via `*.api.uipath.com` don't get a 403. v1 read and v2 query are already whitelisted; this new v2 read path is not.

Pattern to add (under the Data Fabric / Entity group):
```ts
new RegExp(`^\\/${DATAFABRIC_BASE}\\/api\\/v2\\/EntityService\\/entity\\/[^\\/]+\\/read\\/[^\\/]+$`)
```
The whitelist PR should land with or before this SDK release so there's no 403 window for browser consumers. (Backend/secret-mode and portal-host consumers are unaffected — they don't go through the proxy.)

## Files

| Area | Files |
|------|-------|
| Endpoint | `src/utils/constants/endpoints/data-fabric.ts` |
| Types | `src/models/data-fabric/entities.types.ts`, `src/models/data-fabric/entities.internal-types.ts` |
| Constants | `src/models/data-fabric/entities.constants.ts` |
| Models (JSDoc) | `src/models/data-fabric/entities.models.ts` |
| Service | `src/services/data-fabric/entities.ts` |
| Unit tests | `tests/unit/services/data-fabric/entities.test.ts` (+3 `MULTILINE_MAX` cases, +1 map row) |
| Integration tests | `tests/integration/shared/data-fabric/entities.integration.test.ts` (field generator, schema-create, marker-vs-full lifecycle) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
