### PR TITLE
feat: add daily CLI smoke test pipeline

### DIFF
--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -72,7 +72,6 @@ jobs:
         run: |
           uip codedapp deploy \
             --name "$APP_NAME" \
-            --path-name "$APP_NAME" \
             --folder-key "${{ env.FOLDER_KEY }}"
 
       - name: Health check
@@ -146,7 +145,6 @@ jobs:
         run: |
           uip codedapp deploy \
             --name "$APP_NAME" \
-            --path-name "$APP_NAME" \
             --folder-key "${{ env.FOLDER_KEY }}"
 
       - name: Health check

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -5,8 +5,6 @@ on:
     # 3:30 UTC = 9:00 AM IST, daily
     - cron: '30 3 * * *'
   workflow_dispatch: {} # manual trigger for testing
-  push:
-    branches: [feat/cli-smoke-test] # temporary: remove before merging to main
 
 permissions: {}
 
@@ -186,5 +184,5 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: "C0BEDPVQ1LK"
+            channel: "C0AMP09RXH7"
             text: "${{ steps.msg.outputs.text }}"

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -1,0 +1,184 @@
+name: CLI Smoke Test
+
+on:
+  schedule:
+    # 3:30 UTC = 9:00 AM IST, daily
+    - cron: '30 3 * * *'
+  workflow_dispatch: {} # manual trigger for testing
+
+permissions: {}
+
+env:
+  ALPHA_AUTHORITY: https://alpha.uipath.com
+  ORG: popoc
+  TENANT: adetenant
+  FOLDER_KEY: 8645d674-92d8-4281-9aef-43f3e3608ded
+
+jobs:
+  stable-cli:
+    name: Stable CLI (npm @latest)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      APP_NAME: cli-smoke-stable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install CLI (npm @latest)
+        run: |
+          npm i -g @uipath/cli@latest
+          uip tools update
+          echo "CLI version: $(uip --version)"
+          uip tools list
+
+      - name: Login
+        run: |
+          uip login \
+            --client-id "${{ secrets.UIPATH_CLIENT_ID }}" \
+            --client-secret "${{ secrets.UIPATH_CLIENT_SECRET }}" \
+            --authority "${{ env.ALPHA_AUTHORITY }}" \
+            --tenant "${{ env.TENANT }}"
+
+      - name: Pack
+        run: |
+          VERSION="0.0.$(date +%Y%m%d)"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          uip codedapp pack \
+            --name "$APP_NAME" \
+            --version "$VERSION" \
+            fixtures/smoke-test-app
+
+      - name: Publish
+        run: |
+          uip codedapp publish \
+            --name "$APP_NAME" \
+            --version "$VERSION"
+
+      - name: Deploy
+        run: |
+          uip codedapp deploy \
+            --name "$APP_NAME" \
+            --folder-key "${{ env.FOLDER_KEY }}"
+
+      - name: Health check
+        run: |
+          APP_URL="https://${{ env.ORG }}.uipath.host/${APP_NAME}"
+          echo "Checking $APP_URL"
+          for i in 1 2 3; do
+            if curl -sf --max-time 10 "$APP_URL" > /dev/null; then
+              echo "Health check passed on attempt $i"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "Health check failed after 3 attempts"
+          exit 1
+
+  alpha-cli:
+    name: Alpha CLI (GH Packages)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      APP_NAME: cli-smoke-alpha
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install CLI (GH Packages)
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> ~/.npmrc
+          echo "@uipath:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          npm i -g @uipath/cli
+          uip tools update
+          echo "CLI version: $(uip --version)"
+          uip tools list
+
+      - name: Login
+        run: |
+          uip login \
+            --client-id "${{ secrets.UIPATH_CLIENT_ID }}" \
+            --client-secret "${{ secrets.UIPATH_CLIENT_SECRET }}" \
+            --authority "${{ env.ALPHA_AUTHORITY }}" \
+            --tenant "${{ env.TENANT }}"
+
+      - name: Pack
+        run: |
+          VERSION="0.0.$(date +%Y%m%d)"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          uip codedapp pack \
+            --name "$APP_NAME" \
+            --version "$VERSION" \
+            fixtures/smoke-test-app
+
+      - name: Publish
+        run: |
+          uip codedapp publish \
+            --name "$APP_NAME" \
+            --version "$VERSION"
+
+      - name: Deploy
+        run: |
+          uip codedapp deploy \
+            --name "$APP_NAME" \
+            --folder-key "${{ env.FOLDER_KEY }}"
+
+      - name: Health check
+        run: |
+          APP_URL="https://${{ env.ORG }}.uipath.host/${APP_NAME}"
+          echo "Checking $APP_URL"
+          for i in 1 2 3; do
+            if curl -sf --max-time 10 "$APP_URL" > /dev/null; then
+              echo "Health check passed on attempt $i"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "Health check failed after 3 attempts"
+          exit 1
+
+  notify:
+    name: Slack Alert on Failure
+    runs-on: ubuntu-latest
+    needs: [stable-cli, alpha-cli]
+    if: failure()
+    permissions: {}
+    steps:
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::warning::SLACK_WEBHOOK_URL not set — skipping notification"
+            exit 0
+          fi
+
+          FAILED_JOBS=""
+          if [ "${{ needs.stable-cli.result }}" = "failure" ]; then
+            FAILED_JOBS="stable-cli (npm @latest)"
+          fi
+          if [ "${{ needs.alpha-cli.result }}" = "failure" ]; then
+            [ -n "$FAILED_JOBS" ] && FAILED_JOBS="$FAILED_JOBS, "
+            FAILED_JOBS="${FAILED_JOBS}alpha-cli (GH Packages)"
+          fi
+
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            -d "{\"text\":\":red_circle: *CLI Smoke Test Failed*\nJobs: ${FAILED_JOBS}\nRun: ${RUN_URL}\"}"

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -5,6 +5,8 @@ on:
     # 3:30 UTC = 9:00 AM IST, daily
     - cron: '30 3 * * *'
   workflow_dispatch: {} # manual trigger for testing
+  push:
+    branches: [feat/cli-smoke-test] # temporary: remove before merging to main
 
 permissions: {}
 

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -161,17 +161,17 @@ jobs:
     name: Slack Alert on Failure
     runs-on: ubuntu-latest
     needs: [stable-cli, alpha-cli]
-    if: failure()
+    if: failure() || contains(needs.*.result, 'cancelled')
     permissions: {}
     steps:
       - name: Build failure message
         id: msg
         run: |
           FAILED_JOBS=""
-          if [ "${{ needs.stable-cli.result }}" = "failure" ]; then
+          if [ "${{ needs.stable-cli.result }}" = "failure" ] || [ "${{ needs.stable-cli.result }}" = "cancelled" ]; then
             FAILED_JOBS="stable-cli (npm @latest)"
           fi
-          if [ "${{ needs.alpha-cli.result }}" = "failure" ]; then
+          if [ "${{ needs.alpha-cli.result }}" = "failure" ] || [ "${{ needs.alpha-cli.result }}" = "cancelled" ]; then
             [ -n "$FAILED_JOBS" ] && FAILED_JOBS="$FAILED_JOBS, "
             FAILED_JOBS="${FAILED_JOBS}alpha-cli (GH Packages)"
           fi

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install CLI (GH Packages)
         run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
           echo "@uipath:registry=https://npm.pkg.github.com" >> ~/.npmrc
           npm i -g @uipath/cli
           uip tools install codedapp

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -163,18 +163,12 @@ jobs:
     name: Slack Alert on Failure
     runs-on: ubuntu-latest
     needs: [stable-cli, alpha-cli]
-    if: failure()
+    if: always() # temporary: revert to failure() after testing Slack
     permissions: {}
     steps:
-      - name: Post to Slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Build failure message
+        id: msg
         run: |
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "::warning::SLACK_WEBHOOK_URL not set — skipping notification"
-            exit 0
-          fi
-
           FAILED_JOBS=""
           if [ "${{ needs.stable-cli.result }}" = "failure" ]; then
             FAILED_JOBS="stable-cli (npm @latest)"
@@ -183,9 +177,14 @@ jobs:
             [ -n "$FAILED_JOBS" ] && FAILED_JOBS="$FAILED_JOBS, "
             FAILED_JOBS="${FAILED_JOBS}alpha-cli (GH Packages)"
           fi
-
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "text=:red_circle: *CLI Smoke Test Failed*\nJobs: ${FAILED_JOBS}\nRun: ${RUN_URL}" >> "$GITHUB_OUTPUT"
 
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-type: application/json' \
-            -d "{\"text\":\":red_circle: *CLI Smoke Test Failed*\nJobs: ${FAILED_JOBS}\nRun: ${RUN_URL}\"}"
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "C0BEDPVQ1LK"
+            text: "${{ steps.msg.outputs.text }}"

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -11,10 +11,12 @@ on:
 permissions: {}
 
 env:
+  NODE_VERSION: "20"
   ALPHA_AUTHORITY: https://alpha.uipath.com
   ORG: popoc
   TENANT: adetenant
   FOLDER_KEY: 8645d674-92d8-4281-9aef-43f3e3608ded
+  LOGIN_SCOPE: "Apps OR.Folders.Read OR.Execution"
 
 jobs:
   stable-cli:
@@ -31,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install CLI (npm @latest)
         run: |
@@ -41,32 +43,36 @@ jobs:
           uip tools list
 
       - name: Login
+        env:
+          UIPATH_CLIENT_ID: ${{ secrets.UIPATH_CLIENT_ID }}
+          UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
         run: |
           uip login \
-            --client-id "${{ secrets.UIPATH_CLIENT_ID }}" \
-            --client-secret "${{ secrets.UIPATH_CLIENT_SECRET }}" \
             --authority "${{ env.ALPHA_AUTHORITY }}" \
-            --tenant "${{ env.TENANT }}"
+            --organization "${{ env.ORG }}" \
+            --tenant "${{ env.TENANT }}" \
+            --client-id "$UIPATH_CLIENT_ID" \
+            --client-secret "$UIPATH_CLIENT_SECRET" \
+            --scope "${{ env.LOGIN_SCOPE }}"
 
       - name: Pack
         run: |
           VERSION="0.0.$(date +%Y%m%d)"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           uip codedapp pack \
+            fixtures/smoke-test-app \
             --name "$APP_NAME" \
-            --version "$VERSION" \
-            fixtures/smoke-test-app
+            --version "$VERSION"
 
       - name: Publish
         run: |
-          uip codedapp publish \
-            --name "$APP_NAME" \
-            --version "$VERSION"
+          uip codedapp publish --name "$APP_NAME"
 
       - name: Deploy
         run: |
           uip codedapp deploy \
             --name "$APP_NAME" \
+            --path-name "$APP_NAME" \
             --folder-key "${{ env.FOLDER_KEY }}"
 
       - name: Health check
@@ -99,7 +105,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install CLI (GH Packages)
         run: |
@@ -111,32 +117,36 @@ jobs:
           uip tools list
 
       - name: Login
+        env:
+          UIPATH_CLIENT_ID: ${{ secrets.UIPATH_CLIENT_ID }}
+          UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
         run: |
           uip login \
-            --client-id "${{ secrets.UIPATH_CLIENT_ID }}" \
-            --client-secret "${{ secrets.UIPATH_CLIENT_SECRET }}" \
             --authority "${{ env.ALPHA_AUTHORITY }}" \
-            --tenant "${{ env.TENANT }}"
+            --organization "${{ env.ORG }}" \
+            --tenant "${{ env.TENANT }}" \
+            --client-id "$UIPATH_CLIENT_ID" \
+            --client-secret "$UIPATH_CLIENT_SECRET" \
+            --scope "${{ env.LOGIN_SCOPE }}"
 
       - name: Pack
         run: |
           VERSION="0.0.$(date +%Y%m%d)"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           uip codedapp pack \
+            fixtures/smoke-test-app \
             --name "$APP_NAME" \
-            --version "$VERSION" \
-            fixtures/smoke-test-app
+            --version "$VERSION"
 
       - name: Publish
         run: |
-          uip codedapp publish \
-            --name "$APP_NAME" \
-            --version "$VERSION"
+          uip codedapp publish --name "$APP_NAME"
 
       - name: Deploy
         run: |
           uip codedapp deploy \
             --name "$APP_NAME" \
+            --path-name "$APP_NAME" \
             --folder-key "${{ env.FOLDER_KEY }}"
 
       - name: Health check

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install CLI (npm @latest)
         run: |
           npm i -g @uipath/cli@latest
-          uip tools update
+          uip tools install codedapp
           echo "CLI version: $(uip --version)"
           uip tools list
 
@@ -106,7 +106,7 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> ~/.npmrc
           echo "@uipath:registry=https://npm.pkg.github.com" >> ~/.npmrc
           npm i -g @uipath/cli
-          uip tools update
+          uip tools install codedapp
           echo "CLI version: $(uip --version)"
           uip tools list
 

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -25,7 +25,8 @@ jobs:
     permissions:
       contents: read
     env:
-      APP_NAME: cli-smoke-stable
+      # Unique per run — always a fresh publish + deploy, no collisions
+      APP_NAME: smoke-s-${{ github.run_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,12 +58,10 @@ jobs:
 
       - name: Pack
         run: |
-          VERSION="0.0.$(date +%Y%m%d)"
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           uip codedapp pack \
             fixtures/smoke-test-app \
             --name "$APP_NAME" \
-            --version "$VERSION"
+            --version "1.0.0"
 
       - name: Publish
         run: |
@@ -96,7 +95,7 @@ jobs:
       contents: read
       packages: read
     env:
-      APP_NAME: cli-smoke-alpha
+      APP_NAME: smoke-a-${{ github.run_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -130,12 +129,10 @@ jobs:
 
       - name: Pack
         run: |
-          VERSION="0.0.$(date +%Y%m%d)"
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           uip codedapp pack \
             fixtures/smoke-test-app \
             --name "$APP_NAME" \
-            --version "$VERSION"
+            --version "1.0.0"
 
       - name: Publish
         run: |

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -163,7 +163,7 @@ jobs:
     name: Slack Alert on Failure
     runs-on: ubuntu-latest
     needs: [stable-cli, alpha-cli]
-    if: always() # temporary: revert to failure() after testing Slack
+    if: failure()
     permissions: {}
     steps:
       - name: Build failure message

--- a/fixtures/smoke-test-app/index.html
+++ b/fixtures/smoke-test-app/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>CLI Smoke Test</title></head>
+<body><h1>cli-smoke-test</h1></body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a scheduled GitHub Actions workflow that runs the full coded app lifecycle (`pack → publish → deploy → health check`) daily at 9 AM IST
- Two parallel jobs: **stable CLI** (npm `@latest`) and **alpha CLI** (GH Packages) — both deploy coded app against alpha env
- Posts to `#coded-apps-alerts` Slack channel on failure only