### PR TITLE
feat(maestro): add retry to process instances [PLT-106613]

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ await processInstances.resume(instanceId, 'folder-key');
 await processInstances.cancel(instanceId, 'folder-key', {
   comment: 'Cancelled due to error'
 });
+await processInstances.retry(instanceId, 'folder-key', {
+  comment: 'Retrying flaky failure'
+});
 
 // Maestro Case Instances
 const caseInstance = await caseInstances.getById(instanceId, 'folder-key');

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -96,6 +96,7 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `cancel()` | `PIMS` |
 | `pause()` | `PIMS` |
 | `resume()` | `PIMS` |
+| `retry()` | `PIMS` |
 
 ## Maestro Cases
 

--- a/src/models/maestro/process-instances.models.ts
+++ b/src/models/maestro/process-instances.models.ts
@@ -74,7 +74,7 @@ export interface ProcessInstancesServiceModel {
   >;
 
   /**
-   * Get a process instance by ID with operation methods (cancel, pause, resume)
+   * Get a process instance by ID with operation methods (cancel, pause, resume, retry)
    * @param id The ID of the instance to retrieve
    * @param folderKey The folder key for authorization
    * @returns Promise resolving to a process instance
@@ -200,6 +200,36 @@ export interface ProcessInstancesServiceModel {
   resume(instanceId: string, folderKey: string, options?: ProcessInstanceOperationOptions): Promise<OperationResponse<ProcessInstanceOperationResponse>>;
 
   /**
+   * Retry a faulted process instance
+   *
+   * Re-runs the failed elements of the instance (and the elements that follow) within the
+   * same instance, spawning new jobs. Use to recover from transient/flaky failures.
+   * @param instanceId The ID of the instance to retry
+   * @param folderKey The folder key for authorization
+   * @param options Optional retry options with comment
+   * @returns Promise resolving to operation result with instance data
+   * @example
+   * ```typescript
+   * // Retry a faulted process instance
+   * const result = await processInstances.retry(
+   *   <instanceId>,
+   *   <folderKey>
+   * );
+   *
+   * // Or using instance method
+   * const instance = await processInstances.getById(
+   *   <instanceId>,
+   *   <folderKey>
+   * );
+   * if (instance.latestRunStatus === 'Faulted') {
+   *   const result = await instance.retry({ comment: 'Retrying flaky failure' });
+   *   console.log(`Retried: ${result.success}`);
+   * }
+   * ```
+   */
+  retry(instanceId: string, folderKey: string, options?: ProcessInstanceOperationOptions): Promise<OperationResponse<ProcessInstanceOperationResponse>>;
+
+  /**
    * Get global variables for a process instance
    * 
    * @param instanceId The ID of the instance to get variables for
@@ -286,6 +316,14 @@ export interface ProcessInstanceMethods {
   resume(options?: ProcessInstanceOperationOptions): Promise<OperationResponse<ProcessInstanceOperationResponse>>;
 
   /**
+   * Retries this faulted process instance
+   *
+   * @param options - Optional retry options with comment
+   * @returns Promise resolving to operation result
+   */
+  retry(options?: ProcessInstanceOperationOptions): Promise<OperationResponse<ProcessInstanceOperationResponse>>;
+
+  /**
    * Gets incidents for this process instance
    * 
    * @returns Promise resolving to array of incidents for this instance
@@ -346,6 +384,13 @@ function createProcessInstanceMethods(instanceData: RawProcessInstanceGetRespons
       if (!instanceData.folderKey) throw new Error('Process instance folder key is undefined');
       
       return service.resume(instanceData.instanceId, instanceData.folderKey, options);
+    },
+
+    async retry(options?: ProcessInstanceOperationOptions): Promise<OperationResponse<ProcessInstanceOperationResponse>> {
+      if (!instanceData.instanceId) throw new Error('Process instance ID is undefined');
+      if (!instanceData.folderKey) throw new Error('Process instance folder key is undefined');
+
+      return service.retry(instanceData.instanceId, instanceData.folderKey, options);
     },
 
     async getIncidents(): Promise<ProcessIncidentGetResponse[]> {

--- a/src/services/maestro/processes/process-instances.ts
+++ b/src/services/maestro/processes/process-instances.ts
@@ -102,7 +102,7 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
   }
 
   /**
-   * Get a process instance by ID with operation methods (cancel, pause, resume)
+   * Get a process instance by ID with operation methods (cancel, pause, resume, retry)
    * @param id The ID of the instance to retrieve
    * @param folderKey The folder key for authorization
    * @returns Promise<ProcessInstanceGetResponse>
@@ -261,7 +261,29 @@ export class ProcessInstancesService extends BaseService implements ProcessInsta
     const response = await this.post<ProcessInstanceOperationResponse>(MAESTRO_ENDPOINTS.INSTANCES.RESUME(instanceId), options || {}, {
       headers: createHeaders({ [FOLDER_KEY]: folderKey })
     });
-    
+
+    return {
+      success: true,
+      data: response.data
+    };
+  }
+
+  /**
+   * Retry a faulted process instance
+   *
+   * Re-runs the failed elements of the instance (and the elements that follow) within
+   * the same instance, spawning new jobs. Use to recover from transient/flaky failures.
+   * @param instanceId The ID of the instance to retry
+   * @param folderKey The folder key for authorization
+   * @param options Optional retry options with comment
+   * @returns Promise resolving to operation result with updated instance data
+   */
+  @track('ProcessInstances.Retry')
+  async retry(instanceId: string, folderKey: string, options?: ProcessInstanceOperationOptions): Promise<OperationResponse<ProcessInstanceOperationResponse>> {
+    const response = await this.post<ProcessInstanceOperationResponse>(MAESTRO_ENDPOINTS.INSTANCES.RETRY(instanceId), options || {}, {
+      headers: createHeaders({ [FOLDER_KEY]: folderKey })
+    });
+
     return {
       success: true,
       data: response.data

--- a/src/utils/constants/endpoints/maestro.ts
+++ b/src/utils/constants/endpoints/maestro.ts
@@ -21,6 +21,7 @@ export const MAESTRO_ENDPOINTS = {
     CANCEL: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/cancel`,
     PAUSE: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/pause`,
     RESUME: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/resume`,
+    RETRY: (instanceId: string) => `${PIMS_BASE}/api/v1/instances/${instanceId}/retry`,
   },
   INCIDENTS: {
     GET_ALL: `${PIMS_BASE}/api/v1/incidents/summary`,

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -220,6 +220,46 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
     });
   });
 
+  describe('retry', () => {
+    let faultedInstanceId!: string;
+    let folderKey!: string;
+
+    beforeAll(async () => {
+      const { processInstances } = getServices();
+      const config = getTestConfig();
+
+      if (!config.folderKey) {
+        throw new Error('No folderKey configured for testing');
+      }
+      folderKey = config.folderKey;
+
+      const instances = await processInstances.getAll({ pageSize: 50 });
+      const faulted = instances.items.find((inst) =>
+        /fault|fail/i.test(inst.latestRunStatus ?? '')
+      );
+
+      if (!faulted) {
+        throw new Error(
+          'No faulted process instance available in the test tenant to exercise retry. ' +
+            'Seed a faulted instance in the "Integration Test" folder.'
+        );
+      }
+      faultedInstanceId = faulted.instanceId;
+    });
+
+    it('should retry a faulted process instance', async () => {
+      const { processInstances } = getServices();
+
+      const result = await processInstances.retry(faultedInstanceId, folderKey, {
+        comment: 'Integration test retry',
+      });
+
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+    });
+  });
+
   describe('Instance details', () => {
     it('should retrieve process variables', async () => {
       if (!testInstanceId) {

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -222,16 +222,10 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
   describe('retry', () => {
     let faultedInstanceId!: string;
-    let folderKey!: string;
+    let faultedFolderKey!: string;
 
     beforeAll(async () => {
       const { processInstances } = getServices();
-      const config = getTestConfig();
-
-      if (!config.folderKey) {
-        throw new Error('No folderKey configured for testing');
-      }
-      folderKey = config.folderKey;
 
       const instances = await processInstances.getAll({ pageSize: 50 });
       const faulted = instances.items.find((inst) =>
@@ -241,16 +235,17 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
       if (!faulted) {
         throw new Error(
           'No faulted process instance available in the test tenant to exercise retry. ' +
-            'Seed a faulted instance in the "Integration Test" folder.'
+            'Seed one by running a deliberately-faulting Maestro process.'
         );
       }
       faultedInstanceId = faulted.instanceId;
+      faultedFolderKey = faulted.folderKey;
     });
 
     it('should retry a faulted process instance', async () => {
       const { processInstances } = getServices();
 
-      const result = await processInstances.retry(faultedInstanceId, folderKey, {
+      const result = await processInstances.retry(faultedInstanceId, faultedFolderKey, {
         comment: 'Integration test retry',
       });
 

--- a/tests/unit/models/maestro/process-instances.test.ts
+++ b/tests/unit/models/maestro/process-instances.test.ts
@@ -31,6 +31,7 @@ describe('Process Instance Models', () => {
       cancel: vi.fn(),
       pause: vi.fn(),
       resume: vi.fn(),
+      retry: vi.fn(),
       getVariables: vi.fn()
     } as any;
   });
@@ -229,6 +230,69 @@ describe('Process Instance Models', () => {
       });
     });
 
+    describe('processInstance.retry()', () => {
+      it('should call processInstance.retry with bound instanceId and folderKey', async () => {
+        const mockInstanceData = createMockProcessInstance();
+        const instance = createProcessInstanceWithMethods(mockInstanceData, mockService);
+
+        const mockResponse = createMockOperationResponse({
+          instanceId: MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+          status: TEST_CONSTANTS.CANCELLED
+        });
+        mockService.retry = vi.fn().mockResolvedValue(mockResponse);
+
+
+        await instance.retry();
+
+
+        expect(mockService.retry).toHaveBeenCalledWith(
+          MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+          MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+          undefined
+        );
+      });
+
+      it('should call service.retry with bound parameters and options', async () => {
+        const mockInstanceData = createMockProcessInstance();
+        const instance = createProcessInstanceWithMethods(mockInstanceData, mockService);
+
+        const mockResponse = createMockOperationResponse({
+          instanceId: MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+          status: TEST_CONSTANTS.CANCELLED
+        });
+        const options: ProcessInstanceOperationOptions = { comment: 'Test retry' };
+        mockService.retry = vi.fn().mockResolvedValue(mockResponse);
+
+
+        await instance.retry(options);
+
+
+        expect(mockService.retry).toHaveBeenCalledWith(
+          MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
+          MAESTRO_TEST_CONSTANTS.FOLDER_KEY,
+          options
+        );
+      });
+
+      it('should throw error if instanceId is undefined', async () => {
+        const mockInstanceData = createMockProcessInstance();
+        const invalidInstanceData = { ...mockInstanceData, instanceId: undefined as any };
+        const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
+
+
+        await expect(invalidInstance.retry()).rejects.toThrow('Process instance ID is undefined');
+      });
+
+      it('should throw error if folderKey is undefined', async () => {
+        const mockInstanceData = createMockProcessInstance();
+        const invalidInstanceData = { ...mockInstanceData, folderKey: undefined as any };
+        const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
+
+
+        await expect(invalidInstance.retry()).rejects.toThrow('Process instance folder key is undefined');
+      });
+    });
+
     describe('processInstance.getExecutionHistory()', () => {
       it('should call processInstance.getExecutionHistory with bound instanceId and folderKey', async () => {
         const mockInstanceData = createMockProcessInstance();
@@ -378,6 +442,7 @@ describe('Process Instance Models', () => {
       expect(instance).toHaveProperty('cancel');
       expect(instance).toHaveProperty('pause');
       expect(instance).toHaveProperty('resume');
+      expect(instance).toHaveProperty('retry');
       expect(instance).toHaveProperty('getExecutionHistory');
       expect(instance).toHaveProperty('getBpmn');
       expect(instance).toHaveProperty('getVariables');

--- a/tests/unit/models/maestro/process-instances.test.ts
+++ b/tests/unit/models/maestro/process-instances.test.ts
@@ -237,13 +237,11 @@ describe('Process Instance Models', () => {
 
         const mockResponse = createMockOperationResponse({
           instanceId: MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
-          status: TEST_CONSTANTS.CANCELLED
+          status: TEST_CONSTANTS.RUNNING
         });
         mockService.retry = vi.fn().mockResolvedValue(mockResponse);
 
-
         await instance.retry();
-
 
         expect(mockService.retry).toHaveBeenCalledWith(
           MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
@@ -258,14 +256,12 @@ describe('Process Instance Models', () => {
 
         const mockResponse = createMockOperationResponse({
           instanceId: MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
-          status: TEST_CONSTANTS.CANCELLED
+          status: TEST_CONSTANTS.RUNNING
         });
         const options: ProcessInstanceOperationOptions = { comment: 'Test retry' };
         mockService.retry = vi.fn().mockResolvedValue(mockResponse);
 
-
         await instance.retry(options);
-
 
         expect(mockService.retry).toHaveBeenCalledWith(
           MAESTRO_TEST_CONSTANTS.INSTANCE_ID,
@@ -279,7 +275,6 @@ describe('Process Instance Models', () => {
         const invalidInstanceData = { ...mockInstanceData, instanceId: undefined as any };
         const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
 
-
         await expect(invalidInstance.retry()).rejects.toThrow('Process instance ID is undefined');
       });
 
@@ -287,7 +282,6 @@ describe('Process Instance Models', () => {
         const mockInstanceData = createMockProcessInstance();
         const invalidInstanceData = { ...mockInstanceData, folderKey: undefined as any };
         const invalidInstance = createProcessInstanceWithMethods(invalidInstanceData, mockService);
-
 
         await expect(invalidInstance.retry()).rejects.toThrow('Process instance folder key is undefined');
       });

--- a/tests/unit/services/maestro/process-instances.test.ts
+++ b/tests/unit/services/maestro/process-instances.test.ts
@@ -503,9 +503,7 @@ describe('ProcessInstancesService', () => {
 
       mockApiClient.post.mockResolvedValue(mockApiResponse);
 
-
       const result = await service.retry(instanceId, folderKey, options);
-
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MAESTRO_ENDPOINTS.INSTANCES.RETRY(instanceId),
@@ -531,9 +529,7 @@ describe('ProcessInstancesService', () => {
 
       mockApiClient.post.mockResolvedValue(mockApiResponse);
 
-
       const result = await service.retry(instanceId, folderKey);
-
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         MAESTRO_ENDPOINTS.INSTANCES.RETRY(instanceId),
@@ -553,7 +549,6 @@ describe('ProcessInstancesService', () => {
 
       const error = new Error(TEST_CONSTANTS.ERROR_MESSAGE);
       mockApiClient.post.mockRejectedValue(error);
-
 
       await expect(service.retry(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, MAESTRO_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });

--- a/tests/unit/services/maestro/process-instances.test.ts
+++ b/tests/unit/services/maestro/process-instances.test.ts
@@ -190,6 +190,7 @@ describe('ProcessInstancesService', () => {
       expect(result).toHaveProperty('cancel');
       expect(result).toHaveProperty('pause');
       expect(result).toHaveProperty('resume');
+      expect(result).toHaveProperty('retry');
       expect(result).toHaveProperty('getExecutionHistory');
       expect(result).toHaveProperty('getBpmn');
       expect(result).toHaveProperty('getVariables');
@@ -485,6 +486,76 @@ describe('ProcessInstancesService', () => {
 
       
       await expect(service.resume(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, MAESTRO_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('retry', () => {
+    it('should retry process instance successfully', async () => {
+
+      const instanceId = MAESTRO_TEST_CONSTANTS.INSTANCE_ID;
+      const folderKey = MAESTRO_TEST_CONSTANTS.FOLDER_KEY;
+      const options: ProcessInstanceOperationOptions = {
+        comment: 'Retrying instance'
+      };
+      const mockApiResponse = createMockMaestroApiOperationResponse({
+        status: 'Running'
+      });
+
+      mockApiClient.post.mockResolvedValue(mockApiResponse);
+
+
+      const result = await service.retry(instanceId, folderKey, options);
+
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MAESTRO_ENDPOINTS.INSTANCES.RETRY(instanceId),
+        options,
+        {
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: folderKey
+          })
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockApiResponse);
+    });
+
+    it('should retry process instance without options', async () => {
+
+      const instanceId = MAESTRO_TEST_CONSTANTS.INSTANCE_ID;
+      const folderKey = MAESTRO_TEST_CONSTANTS.FOLDER_KEY;
+      const mockApiResponse = createMockMaestroApiOperationResponse({
+        status: 'Running'
+      });
+
+      mockApiClient.post.mockResolvedValue(mockApiResponse);
+
+
+      const result = await service.retry(instanceId, folderKey);
+
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        MAESTRO_ENDPOINTS.INSTANCES.RETRY(instanceId),
+        {},
+        {
+          headers: expect.objectContaining({
+            [FOLDER_KEY]: folderKey
+          })
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockApiResponse);
+    });
+
+    it('should handle API errors', async () => {
+
+      const error = new Error(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+
+      await expect(service.retry(MAESTRO_TEST_CONSTANTS.INSTANCE_ID, MAESTRO_TEST_CONSTANTS.FOLDER_KEY)).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a `retry` operation to Maestro process instances, mirroring the existing `cancel` / `pause` / `resume` pattern. The retry endpoint (`POST /api/v1/instances/{id}/retry`) is already exposed by the `uip` CLI but was missing from the TypeScript SDK.

Retrying a faulted instance re-runs the failed element(s) — and the elements that follow — within the *same* instance, spawning new jobs. The invoice-processing vertical solution wants this from its coded app to recover from transient/flaky platform failures.

Surfaces both call styles, consistent with the other lifecycle ops:

```typescript
// Service method
await processInstances.retry(instanceId, folderKey, { comment: 'Retrying flaky failure' });

// Bound instance method
const instance = await processInstances.getById(instanceId, folderKey);
if (instance.latestRunStatus === 'Faulted') {
  await instance.retry({ comment: 'Retrying flaky failure' });
}
```

### Changes
- `endpoints/maestro.ts` — add `INSTANCES.RETRY`
- `services/maestro/processes/process-instances.ts` — add `retry()` (`@track('ProcessInstances.Retry')`)
- `models/maestro/process-instances.models.ts` — add `retry` to the service interface, the instance-methods interface, and the instance-method factory
- `README.md` — add `retry` to the Control Process Instances example
- Unit tests — service + instance-method `retry` cases
- Integration test — `retry` test under `tests/integration/shared/maestro/`, following `docs/integration-testing.md`

## Test plan
- `tsc --noEmit`: clean
- `oxlint`: 0 warnings / 0 errors
- `npm run test:unit`: **1970 passed** (8 new `retry` cases across the service + instance-method suites)
- `npm run build`: success; `retry` present in generated `dist/index.d.ts` at both service and instance level

### Integration test — verified manually, can't run on CI yet
The whole `tests/integration/shared/maestro/**` dir is currently CI-excluded (`vitest.integration.config.ts`), so this test does not run on the gate — same as the existing pause/resume/cancel tests.

Ran it manually against `procodeapps/integrationtest` (alpha). Finding: the SDK auths via a **PAT**, and the PIMS `retry` endpoint returns **403 "This API endpoint is not authorized"** for PAT auth even with all Orchestrator + Maestro scopes granted. The same retry on the same instance/folder **succeeds via an OAuth user token** (verified with `uip maestro flow instance retry`). So:

- The SDK method and wiring are correct (the 403 is a real server response to a well-formed call).
- The endpoint rejects PAT auth specifically — which is likely *why* the maestro integration suite is CI-excluded (these instance write-ops can't run under the harness's PAT).
- The intended consumer — the coded app, which auths as the logged-in user via `@uipath/auth-react` (OAuth) — **will work**, matching the CLI/OAuth path.

Context: https://uipath-product.slack.com/archives/C08NANN3X8V/p1782308060215309