### PR TITLE
feat(integration-service): add Connectors service

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -2,6 +2,15 @@
 
 This page lists the specific OAuth scopes required in external app for each SDK method.
 
+## Integration Service — Connectors
+
+| Method | OAuth Scope |
+|--------|-------------|
+| `getAll()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getById()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getDefaultConnection()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getConnections()` | `ConnectionService` or `ConnectionServiceUser` |
+
 ## Integration Service — Connections
 
 | Method | OAuth Scope |

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -20,6 +20,26 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `ping()` | `ConnectionService` or `ConnectionServiceUser` |
 | `reauthenticate()` | `ConnectionService` |
 
+## Integration Service — Elements
+
+| Method | OAuth Scope |
+|--------|-------------|
+| `getObjects()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getActivities()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getObjectMetadata()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getEventObjects()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getEventObjectMetadata()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getInstanceObjects()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getInstanceObjectMetadata()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getInstanceEventObjects()` | `ConnectionService` or `ConnectionServiceUser` |
+| `getInstanceEventObjectMetadata()` | `ConnectionService` or `ConnectionServiceUser` |
+
+## Integration Service — Execution
+
+| Function | OAuth Scope |
+|----------|-------------|
+| `execute()` | `ConnectionService` or `ConnectionServiceUser` (plus any third-party scopes required by the underlying connection) |
+
 ## Assets
 
 | Method | OAuth Scope |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,6 +202,7 @@ nav:
           - Integration Service:
             - Connectors: api/interfaces/ConnectorsServiceModel.md
             - Connections: api/interfaces/ConnectionsServiceModel.md
+            - Elements: api/interfaces/ElementsServiceModel.md
           - Maestro:
             - Processes: api/interfaces/MaestroProcessesServiceModel.md
             - Process Instances: api/interfaces/ProcessInstancesServiceModel.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,6 +200,7 @@ nav:
             - Choice Sets: api/interfaces/ChoiceSetServiceModel.md
           - Governance: api/interfaces/GovernanceServiceModel.md
           - Integration Service:
+            - Connectors: api/interfaces/ConnectorsServiceModel.md
             - Connections: api/interfaces/ConnectionsServiceModel.md
           - Maestro:
             - Processes: api/interfaces/MaestroProcessesServiceModel.md

--- a/package.json
+++ b/package.json
@@ -226,6 +226,16 @@
                 "default": "./dist/is-connectors/index.cjs"
             }
         },
+        "./is-elements": {
+            "import": {
+                "types": "./dist/is-elements/index.d.ts",
+                "default": "./dist/is-elements/index.mjs"
+            },
+            "require": {
+                "types": "./dist/is-elements/index.d.ts",
+                "default": "./dist/is-elements/index.cjs"
+            }
+        },
         "./is-connections": {
             "import": {
                 "types": "./dist/is-connections/index.d.ts",
@@ -234,6 +244,16 @@
             "require": {
                 "types": "./dist/is-connections/index.d.ts",
                 "default": "./dist/is-connections/index.cjs"
+            }
+        },
+        "./is-execution": {
+            "import": {
+                "types": "./dist/is-execution/index.d.ts",
+                "default": "./dist/is-execution/index.mjs"
+            },
+            "require": {
+                "types": "./dist/is-execution/index.d.ts",
+                "default": "./dist/is-execution/index.cjs"
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -216,6 +216,16 @@
                 "default": "./dist/governance/index.cjs"
             }
         },
+        "./is-connectors": {
+            "import": {
+                "types": "./dist/is-connectors/index.d.ts",
+                "default": "./dist/is-connectors/index.mjs"
+            },
+            "require": {
+                "types": "./dist/is-connectors/index.d.ts",
+                "default": "./dist/is-connectors/index.cjs"
+            }
+        },
         "./is-connections": {
             "import": {
                 "types": "./dist/is-connections/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -230,6 +230,11 @@ const serviceEntries = [
     output: 'governance/index'
   },
   {
+    name: 'is-connectors',
+    input: 'src/services/integration-service/connectors/index.ts',
+    output: 'is-connectors/index'
+  },
+  {
     name: 'is-connections',
     input: 'src/services/integration-service/connections/index.ts',
     output: 'is-connections/index'

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -235,9 +235,19 @@ const serviceEntries = [
     output: 'is-connectors/index'
   },
   {
+    name: 'is-elements',
+    input: 'src/services/integration-service/elements/index.ts',
+    output: 'is-elements/index'
+  },
+  {
     name: 'is-connections',
     input: 'src/services/integration-service/connections/index.ts',
     output: 'is-connections/index'
+  },
+  {
+    name: 'is-execution',
+    input: 'src/services/integration-service/execution/index.ts',
+    output: 'is-execution/index'
   }
 ];
 

--- a/src/models/integration-service/connectors.models.ts
+++ b/src/models/integration-service/connectors.models.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration Service — Connector models
+ *
+ * Connectors are read-only catalog entries — no bound entity methods are
+ * attached (no `update`, `cancel`, etc. operate on a connector).
+ */
+
+import {
+  RawConnectorGetResponse,
+  ConnectorGetAllOptions,
+  ConnectorGetDefaultConnectionOptions,
+  ConnectorGetConnectionsOptions,
+} from './connectors.types';
+import { ConnectionGetResponse } from './connections.models';
+
+/**
+ * A connector catalog entry from the Integration Service.
+ */
+export type ConnectorGetResponse = RawConnectorGetResponse;
+
+/**
+ * Service for inspecting UiPath Integration Service connectors.
+ *
+ * Connectors are the catalog of integrations available on a tenant (Slack,
+ * Microsoft 365, Salesforce, custom connectors, ...). Use this service to
+ * discover connectors, fetch their metadata, and list / locate the connection
+ * instances built on top of them.
+ *
+ * ### Usage
+ *
+ * Prerequisites: Initialize the SDK first - see [Getting Started](/uipath-typescript/getting-started/#import-initialize)
+ *
+ * ```typescript
+ * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+ *
+ * const connectors = new Connectors(sdk);
+ * const allConnectors = await connectors.getAll();
+ * ```
+ */
+export interface ConnectorsServiceModel {
+  /**
+   * List all connectors available on this tenant.
+   *
+   * Returns a plain array — the Integration Service does not paginate this endpoint.
+   *
+   * @param options - Optional filter (e.g. limit to connectors exposing HTTP Request activities)
+   * @returns Promise resolving to an array of {@link ConnectorGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * const all = await connectors.getAll();
+   * for (const connector of all) {
+   *   console.log(`${connector.key} — ${connector.name} (${connector.lifeCycleStage})`);
+   * }
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Only connectors that expose an HTTP Request activity
+   * const httpEnabled = await connectors.getAll({ hasHttpRequest: true });
+   * ```
+   */
+  getAll(options?: ConnectorGetAllOptions): Promise<ConnectorGetResponse[]>;
+
+  /**
+   * Get a single connector by key or numeric ID.
+   *
+   * @param keyOrId - Connector key (e.g. `uipath-slack`) or numeric ID as a string
+   * @returns Promise resolving to a {@link ConnectorGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * const slack = await connectors.getById('uipath-slack');
+   * console.log(slack.name, slack.authentication?.type);
+   * ```
+   */
+  getById(keyOrId: string): Promise<ConnectorGetResponse>;
+
+  /**
+   * Get the default connection for a connector in the current folder.
+   *
+   * Each connector may have a single connection marked as default per folder;
+   * use this to resolve "which connection should I use for Slack?" without
+   * paging through the full list.
+   *
+   * @param keyOrId - Connector key or numeric ID as a string
+   * @param options - Folder scoping options
+   * @returns Promise resolving to a {@link ConnectionGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * const defaultSlack = await connectors.getDefaultConnection('uipath-slack', {
+   *   folderKey: '<folderKey>',
+   * });
+   *
+   * // Use bound methods directly on the entity
+   * const status = await defaultSlack.ping();
+   * console.log(status.status);
+   * ```
+   */
+  getDefaultConnection(
+    keyOrId: string,
+    options?: ConnectorGetDefaultConnectionOptions,
+  ): Promise<ConnectionGetResponse>;
+
+  /**
+   * List all connections for a connector.
+   *
+   * Returns a plain array — the Integration Service uses page-indexed
+   * pagination (no continuation cursor). Increment `pageIndex` to walk pages.
+   *
+   * @param keyOrId - Connector key or numeric ID as a string
+   * @param options - Folder scoping, paging, and sorting options
+   * @returns Promise resolving to an array of {@link ConnectionGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * // First page of Slack connections in a folder
+   * const slackConnections = await connectors.getConnections('uipath-slack', {
+   *   folderKey: '<folderKey>',
+   *   pageSize: 25,
+   * });
+   *
+   * for (const conn of slackConnections) {
+   *   const status = await conn.ping();
+   *   console.log(`${conn.name}: ${status.status}`);
+   * }
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Walk subsequent pages
+   * const page2 = await connectors.getConnections('uipath-slack', {
+   *   folderKey: '<folderKey>',
+   *   pageSize: 25,
+   *   pageIndex: 2,
+   * });
+   * ```
+   */
+  getConnections(
+    keyOrId: string,
+    options?: ConnectorGetConnectionsOptions,
+  ): Promise<ConnectionGetResponse[]>;
+}

--- a/src/models/integration-service/connectors.types.ts
+++ b/src/models/integration-service/connectors.types.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration Service — Connector types
+ *
+ * Types for the Connectors API (`connections_/api/v1/Connectors`).
+ */
+
+/**
+ * Authentication scheme descriptor on a connector (`oauth2`, `basic`, `apiKey`, ...).
+ * Shape is connector-dependent; exposed as a record so the SDK doesn't impose
+ * a closed schema on third-party connectors.
+ */
+export interface ConnectorAuthentication {
+  /** Auth type identifier (e.g. `oauth2`, `basic`, `apiKey`). */
+  type?: string;
+  /** Free-form fields specific to the auth scheme. */
+  [key: string]: unknown;
+}
+
+/**
+ * Template metadata describing how the connector should be configured at runtime.
+ * Shape is connector-dependent; preserved as-is from the API.
+ */
+export interface ConnectorTemplateProperties {
+  [key: string]: unknown;
+}
+
+/**
+ * Raw connector response from the Integration Service API.
+ */
+export interface RawConnectorGetResponse {
+  /** Numeric connector ID. */
+  id: number;
+  /** Stable connector key (used as `elementKey` for Elements API calls). */
+  key: string;
+  /** Display name (e.g. "Slack", "Microsoft OneDrive"). */
+  name: string;
+  /** Free-form description. */
+  description?: string;
+  /** URL to the connector's logo image. */
+  image?: string;
+  /** Whether the connector is private (custom or org-scoped). */
+  isPrivate: boolean;
+  /** Whether the connector publishes events / triggers. */
+  hasEvents?: boolean;
+  /** Event types the connector emits. */
+  eventTypes?: string[];
+  /** Lifecycle stage (e.g. `GA`, `BETA`, `CUSTOM`). */
+  lifeCycleStage?: string;
+  /** Tag string (comma-separated). */
+  tags?: string;
+  /** Connector classification (e.g. `application`, `database`). */
+  type?: string;
+  /** Tier (e.g. `1`, `2`). */
+  tier?: string;
+  /** Boolean feature flags exposed by the connector. */
+  flags?: Record<string, boolean>;
+  /** Template properties describing how to configure the connector. */
+  templateProperties?: ConnectorTemplateProperties;
+  /** Authentication scheme(s) supported by the connector. */
+  authentication?: ConnectorAuthentication;
+  /** Categories the connector belongs to (e.g. `CRM`, `Communication`). */
+  categories?: string[];
+  /** Number of connection instances for this connector. */
+  connectionCount?: number;
+  /** ID of the parent custom connector (when this connector is a fork). */
+  customConnectorId?: number;
+  /** Whether the connector is enabled on this tenant. */
+  enabled?: boolean;
+  /** Whether the caller owns the connector. */
+  isOwner?: boolean;
+  /** Vendor / publisher name. */
+  vendorName?: string;
+}
+
+/**
+ * Options for {@link ConnectorsServiceModel.getAll}.
+ */
+export interface ConnectorGetAllOptions {
+  /** Limit results to connectors that expose an HTTP Request activity. */
+  hasHttpRequest?: boolean;
+}
+
+// getById takes no body/query options — keyOrId is positional.
+
+/**
+ * Options for {@link ConnectorsServiceModel.getDefaultConnection}.
+ */
+export interface ConnectorGetDefaultConnectionOptions {
+  /** Folder key (GUID) to scope the lookup. */
+  folderKey?: string;
+  /** Search across folders the caller has access to. */
+  allFolders?: boolean;
+}
+
+/**
+ * Options for {@link ConnectorsServiceModel.getConnections}.
+ *
+ * The API returns a plain array — pagination is page-indexed via `pageIndex`/`pageSize`.
+ * There is no continuation cursor; callers paginate by incrementing `pageIndex`.
+ */
+export interface ConnectorGetConnectionsOptions {
+  /** Folder key (GUID) to scope the query to a specific folder. */
+  folderKey?: string;
+  /** Include connections from all folders the caller has access to. */
+  allFolders?: boolean;
+  /** Include only default connections. */
+  folderDefaults?: boolean;
+  /** 1-indexed page number. */
+  pageIndex?: number;
+  /** Page size (number of items per page). */
+  pageSize?: number;
+  /** Sort newest-first. */
+  mostRecentFirst?: boolean;
+  /** Force a connector refresh, skipping cache. */
+  fetchLatest?: boolean;
+}

--- a/src/models/integration-service/elements.models.ts
+++ b/src/models/integration-service/elements.models.ts
@@ -1,0 +1,241 @@
+/**
+ * Integration Service — Elements models
+ *
+ * Read-only catalog/metadata APIs — no entity binding.
+ */
+
+import {
+  ElementObject,
+  ElementActivity,
+  ElementObjectMetadataResponse,
+  ElementEventObject,
+  ElementEventObjectMetadataResponse,
+  ElementObjectsGetOptions,
+  ElementActivitiesGetOptions,
+  ElementObjectMetadataGetOptions,
+  ElementEventObjectsGetOptions,
+  ElementEventObjectMetadataGetOptions,
+} from './elements.types';
+
+/**
+ * Service for inspecting connector elements (objects, activities, trigger events,
+ * field schemas) on UiPath Integration Service.
+ *
+ * The Elements API powers design-time tooling — every connector exposes a
+ * catalog of *objects* (resources like `contacts`, `messages`), *activities*
+ * (curated operations like `Send Email`), and *event objects* (trigger sources
+ * like `New Message`). Each can be inspected statically (connector-only) or
+ * scoped to a connection instance (which enriches the response with custom
+ * fields discovered from the live system).
+ *
+ * ### Usage
+ *
+ * Prerequisites: Initialize the SDK first - see [Getting Started](/uipath-typescript/getting-started/#import-initialize)
+ *
+ * ```typescript
+ * import { Elements } from '@uipath/uipath-typescript/is-elements';
+ *
+ * const elements = new Elements(sdk);
+ * const objects = await elements.getObjects('uipath-slack');
+ * ```
+ */
+export interface ElementsServiceModel {
+  /**
+   * List objects (resources) exposed by a connector.
+   *
+   * @param elementKey - Connector key (e.g. `uipath-slack`)
+   * @param options - Filtering options (type, subtype, hasEvents, hasBulk)
+   * @returns Promise resolving to an array of {@link ElementObject}
+   * @example
+   * ```typescript
+   * import { Elements } from '@uipath/uipath-typescript/is-elements';
+   *
+   * const elements = new Elements(sdk);
+   *
+   * const objects = await elements.getObjects('uipath-slack');
+   * for (const obj of objects) {
+   *   console.log(`${obj.name} — ${obj.displayName}`);
+   * }
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Only objects that support events
+   * const eventCapable = await elements.getObjects('uipath-slack', { hasEvents: true });
+   * ```
+   */
+  getObjects(elementKey: string, options?: ElementObjectsGetOptions): Promise<ElementObject[]>;
+
+  /**
+   * List curated activities exposed by a connector.
+   *
+   * @param elementKey - Connector key
+   * @param options - Optional `version` to pin to a specific connector schema
+   * @returns Promise resolving to an array of {@link ElementActivity}
+   * @example
+   * ```typescript
+   * const activities = await elements.getActivities('uipath-slack');
+   * for (const activity of activities) {
+   *   console.log(`${activity.name}: ${activity.operation} on ${activity.objectName}`);
+   * }
+   * ```
+   */
+  getActivities(elementKey: string, options?: ElementActivitiesGetOptions): Promise<ElementActivity[]>;
+
+  /**
+   * Get metadata for a single connector object (field schema, supported methods,
+   * parameters). Connection-independent — returns the standard schema only.
+   *
+   * @param elementKey - Connector key
+   * @param objectName - Object name (e.g. `messages`)
+   * @param options - Optional `version`, `hydrateParameters`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getObjectMetadata('uipath-slack', 'messages');
+   * console.log(`Fields: ${Object.keys(meta.fields ?? {}).length}`);
+   * ```
+   */
+  getObjectMetadata(
+    elementKey: string,
+    objectName: string,
+    options?: ElementObjectMetadataGetOptions,
+  ): Promise<ElementObjectMetadataResponse>;
+
+  /**
+   * List event objects (trigger sources) for a connector's event operation.
+   *
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name (e.g. `INDEX_COMPLETED`)
+   * @param options - Optional `version`
+   * @returns Promise resolving to an array of {@link ElementEventObject}
+   * @example
+   * ```typescript
+   * const events = await elements.getEventObjects('uipath-slack', 'NEW_MESSAGE');
+   * ```
+   */
+  getEventObjects(
+    elementKey: string,
+    operationName: string,
+    options?: ElementEventObjectsGetOptions,
+  ): Promise<ElementEventObject[]>;
+
+  /**
+   * Get metadata for a single event object.
+   *
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name
+   * @param objectName - Event object name
+   * @param options - Optional `version`, `allFields`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementEventObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getEventObjectMetadata(
+   *   'uipath-slack',
+   *   'NEW_MESSAGE',
+   *   'channels',
+   * );
+   * ```
+   */
+  getEventObjectMetadata(
+    elementKey: string,
+    operationName: string,
+    objectName: string,
+    options?: ElementEventObjectMetadataGetOptions,
+  ): Promise<ElementEventObjectMetadataResponse>;
+
+  /**
+   * List objects exposed by a connection instance (includes connector custom
+   * fields discovered from the live system).
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param options - Filtering options
+   * @returns Promise resolving to an array of {@link ElementObject}
+   * @example
+   * ```typescript
+   * const objects = await elements.getInstanceObjects('<connectionId>', 'uipath-slack');
+   * ```
+   */
+  getInstanceObjects(
+    connectionId: string,
+    elementKey: string,
+    options?: ElementObjectsGetOptions,
+  ): Promise<ElementObject[]>;
+
+  /**
+   * Get instance-scoped metadata for a single object — includes connector
+   * custom fields discovered from the live system.
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param objectName - Object name
+   * @param options - Optional `version`, `hydrateParameters`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getInstanceObjectMetadata(
+   *   '<connectionId>',
+   *   'uipath-salesforce',
+   *   'Account',
+   * );
+   * ```
+   */
+  getInstanceObjectMetadata(
+    connectionId: string,
+    elementKey: string,
+    objectName: string,
+    options?: ElementObjectMetadataGetOptions,
+  ): Promise<ElementObjectMetadataResponse>;
+
+  /**
+   * List event objects for a connection instance.
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name
+   * @param options - Optional `version`
+   * @returns Promise resolving to an array of {@link ElementEventObject}
+   * @example
+   * ```typescript
+   * const events = await elements.getInstanceEventObjects(
+   *   '<connectionId>',
+   *   'uipath-slack',
+   *   'NEW_MESSAGE',
+   * );
+   * ```
+   */
+  getInstanceEventObjects(
+    connectionId: string,
+    elementKey: string,
+    operationName: string,
+    options?: ElementEventObjectsGetOptions,
+  ): Promise<ElementEventObject[]>;
+
+  /**
+   * Get instance-scoped metadata for a single event object.
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name
+   * @param objectName - Event object name
+   * @param options - Optional `version`, `allFields`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementEventObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getInstanceEventObjectMetadata(
+   *   '<connectionId>',
+   *   'uipath-slack',
+   *   'NEW_MESSAGE',
+   *   'channels',
+   * );
+   * ```
+   */
+  getInstanceEventObjectMetadata(
+    connectionId: string,
+    elementKey: string,
+    operationName: string,
+    objectName: string,
+    options?: ElementEventObjectMetadataGetOptions,
+  ): Promise<ElementEventObjectMetadataResponse>;
+}

--- a/src/models/integration-service/elements.types.ts
+++ b/src/models/integration-service/elements.types.ts
@@ -1,0 +1,296 @@
+/**
+ * Integration Service — Elements (connector metadata) types.
+ *
+ * The Elements API returns deeply nested, connector-dependent shapes. We type
+ * the well-known fields explicitly and leave the open extension points loose
+ * (`Record<string, unknown>`) so the SDK doesn't force a false-positive failure
+ * when a connector ships a new metadata field.
+ */
+
+/**
+ * A parameter declared on a connector method (path, query, body, header, value).
+ */
+export interface ElementMethodParameter {
+  /** Parameter name (e.g. `folderKey`, `limit`). */
+  name: string;
+  /** Where the parameter is sent. */
+  type: string;
+  /** Parameter primitive type (`string`, `integer`, ...). */
+  dataType?: string;
+  /** Whether the parameter is required. */
+  required?: boolean;
+  /** Caller-facing display name. */
+  displayName?: string;
+  /** Default value if any. */
+  defaultValue?: unknown;
+  /** Free-form description. */
+  description?: string;
+  /** Whether this parameter participates in curated UX. */
+  curated?: boolean;
+  /** Cross-object reference (lookup hints). */
+  reference?: Record<string, unknown>;
+  /** Design-time UX hints. */
+  design?: Record<string, unknown>;
+  /** Sort order in UX panels. */
+  sortOrder?: number;
+  /** Open-ended additional fields the API may ship per connector. */
+  [key: string]: unknown;
+}
+
+/**
+ * Describes a single HTTP method invocation on a connector object.
+ */
+export interface ElementMethodDefinition {
+  /** Logical operation name (e.g. `Create`, `List`). */
+  operation?: string;
+  /** HTTP method. */
+  method: string;
+  /** API path template. */
+  path?: string;
+  /** Parameters consumed by the method. */
+  parameters?: ElementMethodParameter[];
+  /** OpenAPI operation ID. */
+  operationId?: string;
+  /** Curated activity descriptor. */
+  curated?: Record<string, unknown>;
+  /** Friendly response label. */
+  responseDisplayName?: string;
+  /** Design-time UX hints. */
+  design?: Record<string, unknown>;
+  /** Open-ended additional fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * Connector object metadata block. The `method` map is keyed by HTTP verb.
+ */
+export interface ElementObjectMetadata {
+  /** Whether the object exposes connector-specific custom fields. */
+  hasCustomFieldDiscovery?: boolean;
+  /** HTTP-verb-keyed map of methods supported on this object. */
+  method?: Record<string, ElementMethodDefinition>;
+  /** Whether the object exposes search-friendly fields. */
+  hasSearchables?: boolean;
+  /** Open-ended additional fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * A connector object (resource).
+ */
+export interface ElementObject {
+  /** Object name (e.g. `contacts`). */
+  name: string;
+  /** API path template. */
+  path?: string;
+  /** Object type (e.g. `standard`, `custom`). */
+  type?: string;
+  /** Object subtype. */
+  subType?: string;
+  /** Owning connector key. */
+  elementKey?: string;
+  /** Display name. */
+  displayName?: string;
+  /** Connector custom-ness marker. */
+  custom?: string;
+  /** Object metadata block. */
+  metadata?: ElementObjectMetadata;
+  /** Whether the object is featured as a priority. */
+  isPriority?: boolean;
+  /** Whether the object is hidden from UX. */
+  isHidden?: boolean;
+}
+
+/**
+ * A curated activity exposed by a connector.
+ */
+export interface ElementActivity {
+  /** Activity name. */
+  name: string;
+  /** Display name. */
+  displayName?: string;
+  /** Description. */
+  description?: string;
+  /** Object the activity operates on. */
+  objectName?: string;
+  /** HTTP method name. */
+  methodName?: string;
+  /** Event operation (for triggers). */
+  eventOperation?: string;
+  /** Logical operation (e.g. `List`, `Create`). */
+  operation?: string;
+  /** Event delivery mode (e.g. `polling`, `webhooks`). */
+  eventMode?: string;
+  /** Lifecycle stage (`GA`, `BETA`, ...). */
+  lifecycleStage?: string;
+  /** Project types this activity is compatible with. */
+  compatibleProjectTypes?: string[];
+  /** Tag list. */
+  tags?: string[];
+  /** Subtype. */
+  subType?: string;
+  /** Whether this activity is a trigger. */
+  trigger?: boolean;
+  /** Whether this activity is a curated UX element. */
+  curated?: boolean;
+  /** Trigger marker (legacy). */
+  isTrigger?: boolean;
+  /** Open-ended additional fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * Field descriptor on a metadata response — the value in the `fields` map,
+ * keyed by field name/path (e.g. `channel`, `attachment.image_url`).
+ *
+ * Shape is connector-dependent and very open-ended (type, sample value, HTTP
+ * method usage, lookup references, UI hints). We keep it as a free-form record.
+ */
+export type ElementField = Record<string, unknown>;
+
+/**
+ * Object metadata response (returned by `getObjectMetadata` and `getInstanceObjectMetadata`).
+ */
+export interface ElementObjectMetadataResponse {
+  /** Object name. */
+  name: string;
+  /** Path template. */
+  path?: string;
+  /** Object type. */
+  type?: string;
+  /** Object subtype. */
+  subType?: string;
+  /** Owning connector key. */
+  elementKey?: string;
+  /** Display name. */
+  displayName?: string;
+  /** Connector custom-ness marker. */
+  custom?: string;
+  /** Connector object metadata. */
+  metadata?: ElementObjectMetadata;
+  /** Field schema, keyed by field name/path. */
+  fields?: Record<string, ElementField>;
+  /** Whether the object is hidden from UX. */
+  isHidden?: boolean;
+  /** Whether the object is featured as a priority. */
+  isPriority?: boolean;
+}
+
+/**
+ * An event-source object (trigger root).
+ */
+export interface ElementEventObject {
+  /** Event object name. */
+  name: string;
+  /** Event delivery mode (`polling`, `webhooks`). */
+  eventMode?: string;
+  /** Whether the event ID field is hidden in UX. */
+  hideEventIDField?: boolean;
+  /** Whether the event is debug-disabled. */
+  debugDisabled?: boolean;
+  /** Friendly display name. */
+  displayName?: string;
+  /** Whether the webhook URL is shown in the UX. */
+  isWebhookUrlVisible?: boolean;
+  /** Whether the event uses Bring-Your-Own-Auth. */
+  byoaConnection?: boolean;
+  /** Whether the left-operand filter builder is static. */
+  hasStaticLeftOperandFilterBuilder?: boolean;
+  /** Whether the event is hidden from UX. */
+  isHidden?: boolean;
+  /** Auth types this event supports. */
+  supportedAuths?: string[];
+  /** Event-source parameters. */
+  parameters?: ElementMethodParameter[];
+  /** Logical operation. */
+  operation?: string;
+  /** Bound object name (for events that resolve dynamically). */
+  objectName?: string;
+  /** Whether the object name is dynamic. */
+  isDynamicObjectName?: boolean;
+  /** Description. */
+  description?: string;
+  /** Open-ended additional fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * Event-object metadata response.
+ */
+export interface ElementEventObjectMetadataResponse {
+  /** Event object name. */
+  name: string;
+  /** Path template. */
+  path?: string;
+  /** Object type. */
+  type?: string;
+  /** Object subtype. */
+  subType?: string;
+  /** Owning connector key. */
+  elementKey?: string;
+  /** Display name. */
+  displayName?: string;
+  /** Connector custom-ness marker. */
+  custom?: string;
+  /** Event delivery mode. */
+  eventMode?: string;
+  /** Field schema, keyed by field name/path. */
+  fields?: Record<string, ElementField>;
+}
+
+/**
+ * Options for {@link ElementsServiceModel.getObjects}.
+ */
+export interface ElementObjectsGetOptions {
+  /** Filter by object type (e.g. `standard`, `custom`). */
+  type?: string;
+  /** Filter by object subtype. */
+  subType?: string;
+  /** Limit to objects that support events. */
+  hasEvents?: boolean;
+  /** Limit to objects that support bulk operations. */
+  hasBulk?: boolean;
+}
+
+/**
+ * Options for {@link ElementsServiceModel.getActivities}.
+ */
+export interface ElementActivitiesGetOptions {
+  /** Connector schema version (defaults to the latest published). */
+  version?: string;
+}
+
+/**
+ * Options for {@link ElementsServiceModel.getObjectMetadata}
+ * and {@link ElementsServiceModel.getInstanceObjectMetadata}.
+ */
+export interface ElementObjectMetadataGetOptions {
+  /** Connector schema version (defaults to the latest published). */
+  version?: string;
+  /** Hydrate parameters with values discovered from the connection. */
+  hydrateParameters?: boolean;
+  /** Include parent-array references in nested objects. */
+  includeParentArray?: boolean;
+}
+
+/**
+ * Options for {@link ElementsServiceModel.getEventObjects}
+ * and {@link ElementsServiceModel.getInstanceEventObjects}.
+ */
+export interface ElementEventObjectsGetOptions {
+  /** Connector schema version (defaults to the latest published). */
+  version?: string;
+}
+
+/**
+ * Options for {@link ElementsServiceModel.getEventObjectMetadata}
+ * and {@link ElementsServiceModel.getInstanceEventObjectMetadata}.
+ */
+export interface ElementEventObjectMetadataGetOptions {
+  /** Connector schema version (defaults to the latest published). */
+  version?: string;
+  /** Include all fields, not just curated. */
+  allFields?: boolean;
+  /** Include parent-array references in nested objects. */
+  includeParentArray?: boolean;
+}

--- a/src/models/integration-service/execution.types.ts
+++ b/src/models/integration-service/execution.types.ts
@@ -1,0 +1,42 @@
+/**
+ * Integration Service — Execution passthrough types.
+ */
+
+/**
+ * HTTP method for an execute call.
+ */
+export type ExecuteMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * Result envelope returned by {@link execute}.
+ *
+ * Unlike most SDK methods this *does not* throw on non-2xx responses — the
+ * caller inspects `ok` / `status` and `body` to handle connector-specific
+ * errors. This is required because the underlying Integration Service API
+ * proxies arbitrary third-party HTTP calls, and the body carries vendor
+ * error details that callers need to surface.
+ */
+export interface ExecuteResult {
+  /** True for HTTP 2xx responses. */
+  ok: boolean;
+  /** HTTP status code from the underlying call. */
+  status: number;
+  /** HTTP status text from the underlying call. */
+  statusText: string;
+  /** Parsed JSON body when the response is JSON, raw text otherwise. */
+  body: unknown;
+  /** Response headers as a flat record. */
+  headers: Record<string, string>;
+}
+
+/**
+ * Options accepted by {@link execute}.
+ */
+export interface ExecuteOptions {
+  /** Body to send for POST/PUT/PATCH. Serialized as JSON. */
+  body?: unknown;
+  /** Query string parameters. */
+  queryParams?: Record<string, string>;
+  /** Folder key (GUID) to scope the call via `x-uipath-folderkey`. */
+  folderKey?: string;
+}

--- a/src/models/integration-service/index.ts
+++ b/src/models/integration-service/index.ts
@@ -4,5 +4,7 @@
  * Internal-types files are intentionally not re-exported.
  */
 
+export * from './connectors.types';
+export * from './connectors.models';
 export * from './connections.types';
 export * from './connections.models';

--- a/src/models/integration-service/index.ts
+++ b/src/models/integration-service/index.ts
@@ -8,3 +8,5 @@ export * from './connectors.types';
 export * from './connectors.models';
 export * from './connections.types';
 export * from './connections.models';
+export * from './elements.types';
+export * from './elements.models';

--- a/src/services/integration-service/connectors/connectors.ts
+++ b/src/services/integration-service/connectors/connectors.ts
@@ -1,0 +1,215 @@
+import { BaseService } from '../../base';
+import { track } from '../../../core/telemetry';
+import { ValidationError } from '../../../core/errors';
+import { createHeaders } from '../../../utils/http/headers';
+import { FOLDER_KEY } from '../../../utils/constants/headers';
+import { CONNECTOR_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { QueryParams } from '../../../models/common/request-spec';
+import {
+  RawConnectorGetResponse,
+  ConnectorGetAllOptions,
+  ConnectorGetDefaultConnectionOptions,
+  ConnectorGetConnectionsOptions,
+} from '../../../models/integration-service/connectors.types';
+import {
+  ConnectorGetResponse,
+  ConnectorsServiceModel,
+} from '../../../models/integration-service/connectors.models';
+import {
+  ConnectionGetResponse,
+  ConnectionsServiceModel,
+  createConnectionWithMethods,
+} from '../../../models/integration-service/connections.models';
+import { RawConnectionGetResponse } from '../../../models/integration-service/connections.types';
+import { ConnectionsService } from '../connections/connections';
+import type { IUiPath } from '../../../core/types';
+
+/**
+ * Service for inspecting UiPath Integration Service connectors.
+ *
+ * Connectors are the catalog of integrations available on a tenant (Slack,
+ * Microsoft 365, Salesforce, custom connectors, ...). Use this service to
+ * discover connectors, fetch their metadata, and list / locate the connection
+ * instances built on top of them.
+ *
+ * ### Usage
+ *
+ * Prerequisites: Initialize the SDK first - see [Getting Started](/uipath-typescript/getting-started/#import-initialize)
+ *
+ * ```typescript
+ * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+ *
+ * const connectors = new Connectors(sdk);
+ * const allConnectors = await connectors.getAll();
+ * ```
+ */
+export class ConnectorsService extends BaseService implements ConnectorsServiceModel {
+  private connectionsService: ConnectionsServiceModel;
+
+  /**
+   * Creates an instance of the Connectors service.
+   *
+   * @param instance - UiPath SDK instance providing authentication and configuration
+   */
+  constructor(instance: IUiPath) {
+    super(instance);
+    this.connectionsService = new ConnectionsService(instance);
+  }
+
+  /**
+   * List all connectors available on this tenant.
+   *
+   * Returns a plain array — the Integration Service does not paginate this endpoint.
+   *
+   * @param options - Optional filter (e.g. limit to connectors exposing HTTP Request activities)
+   * @returns Promise resolving to an array of {@link ConnectorGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * const all = await connectors.getAll();
+   * for (const connector of all) {
+   *   console.log(`${connector.key} — ${connector.name} (${connector.lifeCycleStage})`);
+   * }
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Only connectors that expose an HTTP Request activity
+   * const httpEnabled = await connectors.getAll({ hasHttpRequest: true });
+   * ```
+   */
+  @track('Connectors.GetAll')
+  async getAll(options?: ConnectorGetAllOptions): Promise<ConnectorGetResponse[]> {
+    const response = await this.get<RawConnectorGetResponse[]>(CONNECTOR_ENDPOINTS.GET_ALL, {
+      params: options as QueryParams | undefined,
+    });
+    return response.data ?? [];
+  }
+
+  /**
+   * Get a single connector by key or numeric ID.
+   *
+   * @param keyOrId - Connector key (e.g. `uipath-slack`) or numeric ID as a string
+   * @returns Promise resolving to a {@link ConnectorGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * const slack = await connectors.getById('uipath-slack');
+   * console.log(slack.name, slack.authentication?.type);
+   * ```
+   */
+  @track('Connectors.GetById')
+  async getById(keyOrId: string): Promise<ConnectorGetResponse> {
+    if (!keyOrId) {
+      throw new ValidationError({ message: 'keyOrId is required for getById' });
+    }
+    const response = await this.get<RawConnectorGetResponse>(CONNECTOR_ENDPOINTS.GET_BY_ID(keyOrId));
+    return response.data;
+  }
+
+  /**
+   * Get the default connection for a connector in the current folder.
+   *
+   * Each connector may have a single connection marked as default per folder;
+   * use this to resolve "which connection should I use for Slack?" without
+   * paging through the full list.
+   *
+   * @param keyOrId - Connector key or numeric ID as a string
+   * @param options - Folder scoping options
+   * @returns Promise resolving to a {@link ConnectionGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * const defaultSlack = await connectors.getDefaultConnection('uipath-slack', {
+   *   folderKey: '<folderKey>',
+   * });
+   *
+   * // Use bound methods directly on the entity
+   * const status = await defaultSlack.ping();
+   * console.log(status.status);
+   * ```
+   */
+  @track('Connectors.GetDefaultConnection')
+  async getDefaultConnection(
+    keyOrId: string,
+    options?: ConnectorGetDefaultConnectionOptions,
+  ): Promise<ConnectionGetResponse> {
+    if (!keyOrId) {
+      throw new ValidationError({ message: 'keyOrId is required for getDefaultConnection' });
+    }
+    const { folderKey, ...queryOptions } = options ?? {};
+    const response = await this.get<RawConnectionGetResponse>(
+      CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(keyOrId),
+      {
+        headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+        params: queryOptions as QueryParams,
+      },
+    );
+    return createConnectionWithMethods(response.data, this.connectionsService);
+  }
+
+  /**
+   * List all connections for a connector.
+   *
+   * Returns a plain array — the Integration Service uses page-indexed
+   * pagination (no continuation cursor). Increment `pageIndex` to walk pages.
+   *
+   * @param keyOrId - Connector key or numeric ID as a string
+   * @param options - Folder scoping, paging, and sorting options
+   * @returns Promise resolving to an array of {@link ConnectionGetResponse}
+   * @example
+   * ```typescript
+   * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+   *
+   * const connectors = new Connectors(sdk);
+   *
+   * // First page of Slack connections in a folder
+   * const slackConnections = await connectors.getConnections('uipath-slack', {
+   *   folderKey: '<folderKey>',
+   *   pageSize: 25,
+   * });
+   *
+   * for (const conn of slackConnections) {
+   *   const status = await conn.ping();
+   *   console.log(`${conn.name}: ${status.status}`);
+   * }
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Walk subsequent pages
+   * const page2 = await connectors.getConnections('uipath-slack', {
+   *   folderKey: '<folderKey>',
+   *   pageSize: 25,
+   *   pageIndex: 2,
+   * });
+   * ```
+   */
+  @track('Connectors.GetConnections')
+  async getConnections(
+    keyOrId: string,
+    options?: ConnectorGetConnectionsOptions,
+  ): Promise<ConnectionGetResponse[]> {
+    if (!keyOrId) {
+      throw new ValidationError({ message: 'keyOrId is required for getConnections' });
+    }
+    const { folderKey, ...queryOptions } = options ?? {};
+    const response = await this.get<RawConnectionGetResponse[]>(
+      CONNECTOR_ENDPOINTS.GET_CONNECTIONS(keyOrId),
+      {
+        headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+        params: queryOptions as QueryParams,
+      },
+    );
+    return (response.data ?? []).map((conn) => createConnectionWithMethods(conn, this.connectionsService));
+  }
+}

--- a/src/services/integration-service/connectors/index.ts
+++ b/src/services/integration-service/connectors/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Integration Service — Connectors module.
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { Connectors } from '@uipath/uipath-typescript/is-connectors';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * const connectors = new Connectors(sdk);
+ * const all = await connectors.getAll();
+ * ```
+ *
+ * @module
+ */
+
+export { ConnectorsService as Connectors, ConnectorsService } from './connectors';
+
+export * from '../../../models/integration-service/connectors.types';
+export * from '../../../models/integration-service/connectors.models';
+
+// Re-exported because Connector methods return Connection entities.
+export * from '../../../models/integration-service/connections.types';
+export * from '../../../models/integration-service/connections.models';

--- a/src/services/integration-service/elements/elements.ts
+++ b/src/services/integration-service/elements/elements.ts
@@ -1,0 +1,329 @@
+import { BaseService } from '../../base';
+import { track } from '../../../core/telemetry';
+import { ValidationError } from '../../../core/errors';
+import { ELEMENT_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { QueryParams } from '../../../models/common/request-spec';
+import {
+  ElementObject,
+  ElementActivity,
+  ElementObjectMetadataResponse,
+  ElementEventObject,
+  ElementEventObjectMetadataResponse,
+  ElementObjectsGetOptions,
+  ElementActivitiesGetOptions,
+  ElementObjectMetadataGetOptions,
+  ElementEventObjectsGetOptions,
+  ElementEventObjectMetadataGetOptions,
+} from '../../../models/integration-service/elements.types';
+import { ElementsServiceModel } from '../../../models/integration-service/elements.models';
+
+function requireArg(value: string, name: string, method: string): void {
+  if (!value) {
+    throw new ValidationError({ message: `${name} is required for ${method}` });
+  }
+}
+
+/**
+ * Service for inspecting connector elements (objects, activities, trigger events,
+ * field schemas) on UiPath Integration Service.
+ *
+ * The Elements API powers design-time tooling — every connector exposes a
+ * catalog of *objects* (resources like `contacts`, `messages`), *activities*
+ * (curated operations like `Send Email`), and *event objects* (trigger sources
+ * like `New Message`). Each can be inspected statically (connector-only) or
+ * scoped to a connection instance (which enriches the response with custom
+ * fields discovered from the live system).
+ *
+ * ### Usage
+ *
+ * Prerequisites: Initialize the SDK first - see [Getting Started](/uipath-typescript/getting-started/#import-initialize)
+ *
+ * ```typescript
+ * import { Elements } from '@uipath/uipath-typescript/is-elements';
+ *
+ * const elements = new Elements(sdk);
+ * const objects = await elements.getObjects('uipath-slack');
+ * ```
+ */
+export class ElementsService extends BaseService implements ElementsServiceModel {
+  /**
+   * List objects (resources) exposed by a connector.
+   *
+   * @param elementKey - Connector key (e.g. `uipath-slack`)
+   * @param options - Filtering options (type, subtype, hasEvents, hasBulk)
+   * @returns Promise resolving to an array of {@link ElementObject}
+   * @example
+   * ```typescript
+   * import { Elements } from '@uipath/uipath-typescript/is-elements';
+   *
+   * const elements = new Elements(sdk);
+   *
+   * const objects = await elements.getObjects('uipath-slack');
+   * for (const obj of objects) {
+   *   console.log(`${obj.name} — ${obj.displayName}`);
+   * }
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Only objects that support events
+   * const eventCapable = await elements.getObjects('uipath-slack', { hasEvents: true });
+   * ```
+   */
+  @track('Elements.GetObjects')
+  async getObjects(elementKey: string, options?: ElementObjectsGetOptions): Promise<ElementObject[]> {
+    requireArg(elementKey, 'elementKey', 'getObjects');
+    const response = await this.get<ElementObject[]>(ELEMENT_ENDPOINTS.OBJECTS.LIST(elementKey), {
+      params: options as QueryParams | undefined,
+    });
+    return response.data ?? [];
+  }
+
+  /**
+   * List curated activities exposed by a connector.
+   *
+   * @param elementKey - Connector key
+   * @param options - Optional `version` to pin to a specific connector schema
+   * @returns Promise resolving to an array of {@link ElementActivity}
+   * @example
+   * ```typescript
+   * const activities = await elements.getActivities('uipath-slack');
+   * for (const activity of activities) {
+   *   console.log(`${activity.name}: ${activity.operation} on ${activity.objectName}`);
+   * }
+   * ```
+   */
+  @track('Elements.GetActivities')
+  async getActivities(elementKey: string, options?: ElementActivitiesGetOptions): Promise<ElementActivity[]> {
+    requireArg(elementKey, 'elementKey', 'getActivities');
+    const response = await this.get<ElementActivity[]>(ELEMENT_ENDPOINTS.ACTIVITIES.LIST(elementKey), {
+      params: options as QueryParams | undefined,
+    });
+    return response.data ?? [];
+  }
+
+  /**
+   * Get metadata for a single connector object (field schema, supported methods,
+   * parameters). Connection-independent — returns the standard schema only.
+   *
+   * @param elementKey - Connector key
+   * @param objectName - Object name (e.g. `messages`)
+   * @param options - Optional `version`, `hydrateParameters`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getObjectMetadata('uipath-slack', 'messages');
+   * console.log(`Fields: ${Object.keys(meta.fields ?? {}).length}`);
+   * ```
+   */
+  @track('Elements.GetObjectMetadata')
+  async getObjectMetadata(
+    elementKey: string,
+    objectName: string,
+    options?: ElementObjectMetadataGetOptions,
+  ): Promise<ElementObjectMetadataResponse> {
+    requireArg(elementKey, 'elementKey', 'getObjectMetadata');
+    requireArg(objectName, 'objectName', 'getObjectMetadata');
+    const response = await this.get<ElementObjectMetadataResponse>(
+      ELEMENT_ENDPOINTS.OBJECTS.METADATA(elementKey, objectName),
+      { params: options as QueryParams | undefined },
+    );
+    return response.data;
+  }
+
+  /**
+   * List event objects (trigger sources) for a connector's event operation.
+   *
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name (e.g. `INDEX_COMPLETED`)
+   * @param options - Optional `version`
+   * @returns Promise resolving to an array of {@link ElementEventObject}
+   * @example
+   * ```typescript
+   * const events = await elements.getEventObjects('uipath-slack', 'NEW_MESSAGE');
+   * ```
+   */
+  @track('Elements.GetEventObjects')
+  async getEventObjects(
+    elementKey: string,
+    operationName: string,
+    options?: ElementEventObjectsGetOptions,
+  ): Promise<ElementEventObject[]> {
+    requireArg(elementKey, 'elementKey', 'getEventObjects');
+    requireArg(operationName, 'operationName', 'getEventObjects');
+    const response = await this.get<ElementEventObject[]>(
+      ELEMENT_ENDPOINTS.EVENTS.OBJECTS(elementKey, operationName),
+      { params: options as QueryParams | undefined },
+    );
+    return response.data ?? [];
+  }
+
+  /**
+   * Get metadata for a single event object.
+   *
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name
+   * @param objectName - Event object name
+   * @param options - Optional `version`, `allFields`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementEventObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getEventObjectMetadata(
+   *   'uipath-slack',
+   *   'NEW_MESSAGE',
+   *   'channels',
+   * );
+   * ```
+   */
+  @track('Elements.GetEventObjectMetadata')
+  async getEventObjectMetadata(
+    elementKey: string,
+    operationName: string,
+    objectName: string,
+    options?: ElementEventObjectMetadataGetOptions,
+  ): Promise<ElementEventObjectMetadataResponse> {
+    requireArg(elementKey, 'elementKey', 'getEventObjectMetadata');
+    requireArg(operationName, 'operationName', 'getEventObjectMetadata');
+    requireArg(objectName, 'objectName', 'getEventObjectMetadata');
+    const response = await this.get<ElementEventObjectMetadataResponse>(
+      ELEMENT_ENDPOINTS.EVENTS.METADATA(elementKey, operationName, objectName),
+      { params: options as QueryParams | undefined },
+    );
+    return response.data;
+  }
+
+  /**
+   * List objects exposed by a connection instance (includes connector custom
+   * fields discovered from the live system).
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param options - Filtering options
+   * @returns Promise resolving to an array of {@link ElementObject}
+   * @example
+   * ```typescript
+   * const objects = await elements.getInstanceObjects('<connectionId>', 'uipath-slack');
+   * ```
+   */
+  @track('Elements.GetInstanceObjects')
+  async getInstanceObjects(
+    connectionId: string,
+    elementKey: string,
+    options?: ElementObjectsGetOptions,
+  ): Promise<ElementObject[]> {
+    requireArg(connectionId, 'connectionId', 'getInstanceObjects');
+    requireArg(elementKey, 'elementKey', 'getInstanceObjects');
+    const response = await this.get<ElementObject[]>(
+      ELEMENT_ENDPOINTS.INSTANCE.OBJECTS.LIST(connectionId, elementKey),
+      { params: options as QueryParams | undefined },
+    );
+    return response.data ?? [];
+  }
+
+  /**
+   * Get instance-scoped metadata for a single object — includes connector
+   * custom fields discovered from the live system.
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param objectName - Object name
+   * @param options - Optional `version`, `hydrateParameters`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getInstanceObjectMetadata(
+   *   '<connectionId>',
+   *   'uipath-salesforce',
+   *   'Account',
+   * );
+   * ```
+   */
+  @track('Elements.GetInstanceObjectMetadata')
+  async getInstanceObjectMetadata(
+    connectionId: string,
+    elementKey: string,
+    objectName: string,
+    options?: ElementObjectMetadataGetOptions,
+  ): Promise<ElementObjectMetadataResponse> {
+    requireArg(connectionId, 'connectionId', 'getInstanceObjectMetadata');
+    requireArg(elementKey, 'elementKey', 'getInstanceObjectMetadata');
+    requireArg(objectName, 'objectName', 'getInstanceObjectMetadata');
+    const response = await this.get<ElementObjectMetadataResponse>(
+      ELEMENT_ENDPOINTS.INSTANCE.OBJECTS.METADATA(connectionId, elementKey, objectName),
+      { params: options as QueryParams | undefined },
+    );
+    return response.data;
+  }
+
+  /**
+   * List event objects for a connection instance.
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name
+   * @param options - Optional `version`
+   * @returns Promise resolving to an array of {@link ElementEventObject}
+   * @example
+   * ```typescript
+   * const events = await elements.getInstanceEventObjects(
+   *   '<connectionId>',
+   *   'uipath-slack',
+   *   'NEW_MESSAGE',
+   * );
+   * ```
+   */
+  @track('Elements.GetInstanceEventObjects')
+  async getInstanceEventObjects(
+    connectionId: string,
+    elementKey: string,
+    operationName: string,
+    options?: ElementEventObjectsGetOptions,
+  ): Promise<ElementEventObject[]> {
+    requireArg(connectionId, 'connectionId', 'getInstanceEventObjects');
+    requireArg(elementKey, 'elementKey', 'getInstanceEventObjects');
+    requireArg(operationName, 'operationName', 'getInstanceEventObjects');
+    const response = await this.get<ElementEventObject[]>(
+      ELEMENT_ENDPOINTS.INSTANCE.EVENTS.OBJECTS(connectionId, elementKey, operationName),
+      { params: options as QueryParams | undefined },
+    );
+    return response.data ?? [];
+  }
+
+  /**
+   * Get instance-scoped metadata for a single event object.
+   *
+   * @param connectionId - Connection GUID
+   * @param elementKey - Connector key
+   * @param operationName - Event operation name
+   * @param objectName - Event object name
+   * @param options - Optional `version`, `allFields`, `includeParentArray`
+   * @returns Promise resolving to an {@link ElementEventObjectMetadataResponse}
+   * @example
+   * ```typescript
+   * const meta = await elements.getInstanceEventObjectMetadata(
+   *   '<connectionId>',
+   *   'uipath-slack',
+   *   'NEW_MESSAGE',
+   *   'channels',
+   * );
+   * ```
+   */
+  @track('Elements.GetInstanceEventObjectMetadata')
+  async getInstanceEventObjectMetadata(
+    connectionId: string,
+    elementKey: string,
+    operationName: string,
+    objectName: string,
+    options?: ElementEventObjectMetadataGetOptions,
+  ): Promise<ElementEventObjectMetadataResponse> {
+    requireArg(connectionId, 'connectionId', 'getInstanceEventObjectMetadata');
+    requireArg(elementKey, 'elementKey', 'getInstanceEventObjectMetadata');
+    requireArg(operationName, 'operationName', 'getInstanceEventObjectMetadata');
+    requireArg(objectName, 'objectName', 'getInstanceEventObjectMetadata');
+    const response = await this.get<ElementEventObjectMetadataResponse>(
+      ELEMENT_ENDPOINTS.INSTANCE.EVENTS.METADATA(connectionId, elementKey, operationName, objectName),
+      { params: options as QueryParams | undefined },
+    );
+    return response.data;
+  }
+}

--- a/src/services/integration-service/elements/index.ts
+++ b/src/services/integration-service/elements/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Integration Service — Elements module.
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { Elements } from '@uipath/uipath-typescript/is-elements';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * const elements = new Elements(sdk);
+ * const objects = await elements.getObjects('uipath-slack');
+ * ```
+ *
+ * @module
+ */
+
+export { ElementsService as Elements, ElementsService } from './elements';
+
+export * from '../../../models/integration-service/elements.types';
+export * from '../../../models/integration-service/elements.models';

--- a/src/services/integration-service/execution/execution.ts
+++ b/src/services/integration-service/execution/execution.ts
@@ -1,0 +1,154 @@
+import { track } from '../../../core/telemetry';
+import { ValidationError } from '../../../core/errors';
+import { SDKInternalsRegistry } from '../../../core/internals';
+import { ELEMENT_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { FOLDER_KEY, CONTENT_TYPES } from '../../../utils/constants/headers';
+import type { IUiPath } from '../../../core/types';
+import {
+  ExecuteMethod,
+  ExecuteOptions,
+  ExecuteResult,
+} from '../../../models/integration-service/execution.types';
+
+/**
+ * Internal class so we can decorate `execute` with `@track`. Method decorators
+ * cannot be applied to free functions directly.
+ *
+ * @internal
+ */
+class Execution {
+  constructor(private readonly instance: IUiPath) {}
+
+  @track('Execution.Execute')
+  async execute(
+    connectionId: string,
+    objectName: string,
+    method: ExecuteMethod,
+    options: ExecuteOptions,
+  ): Promise<ExecuteResult> {
+    if (!connectionId) {
+      throw new ValidationError({ message: 'connectionId is required for execute' });
+    }
+    if (!objectName) {
+      throw new ValidationError({ message: 'objectName is required for execute' });
+    }
+
+    const { config, tokenManager } = SDKInternalsRegistry.get(this.instance);
+    const token = await tokenManager.getValidToken();
+
+    const relativePath = ELEMENT_ENDPOINTS.INSTANCE.EXECUTE(connectionId, objectName);
+    const baseSegment = `${config.orgName}/${config.tenantName}/`;
+    const url = new URL(baseSegment + relativePath, config.baseUrl).toString();
+
+    let fullUrl = url;
+    if (options.queryParams && Object.keys(options.queryParams).length > 0) {
+      const qs = new URLSearchParams(options.queryParams).toString();
+      const sep = url.includes('?') ? '&' : '?';
+      fullUrl = `${url}${sep}${qs}`;
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    };
+    if (options.folderKey) {
+      headers[FOLDER_KEY] = options.folderKey;
+    }
+
+    const hasBody = options.body !== undefined && ['POST', 'PUT', 'PATCH'].includes(method);
+    if (hasBody) {
+      headers['Content-Type'] = CONTENT_TYPES.JSON;
+    }
+
+    const response = await fetch(fullUrl, {
+      method,
+      headers,
+      body: hasBody ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    let parsed: unknown = text;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+    }
+
+    const flatHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      flatHeaders[key] = value;
+    });
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      body: parsed,
+      headers: flatHeaders,
+    };
+  }
+}
+
+/**
+ * Execute an arbitrary HTTP operation against a connection instance through
+ * the Integration Service passthrough endpoint.
+ *
+ * Targets `elements_/v3/element/instances/{connectionId}/{objectName}`.
+ * Use this when you need to call a connector's runtime API without going
+ * through a curated SDK method.
+ *
+ * Unlike standard SDK methods, **this does not throw on non-2xx responses**.
+ * The full HTTP envelope (`ok`, `status`, `body`, `headers`) is returned so
+ * callers can surface connector-specific error bodies.
+ *
+ * @param uipath - UiPath SDK instance providing authentication and configuration
+ * @param connectionId - Connection GUID
+ * @param objectName - Connector object name (e.g. `tickets`, `messages`)
+ * @param method - HTTP method (defaults to `GET`)
+ * @param options - Body, query params, and folder scoping
+ * @returns Promise resolving to an {@link ExecuteResult}
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { execute } from '@uipath/uipath-typescript/is-execution';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * // GET — list records
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'GET');
+ * if (result.ok) {
+ *   console.log(result.body);
+ * } else {
+ *   console.error(`Connector returned ${result.status}: ${JSON.stringify(result.body)}`);
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // POST — create a record
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'POST', {
+ *   body: { subject: 'New ticket', priority: 'high' },
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // GET with query params and folder scoping
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'GET', {
+ *   queryParams: { limit: '10', status: 'open' },
+ *   folderKey: '<folderKey>',
+ * });
+ * ```
+ */
+export async function execute(
+  uipath: IUiPath,
+  connectionId: string,
+  objectName: string,
+  method: ExecuteMethod = 'GET',
+  options: ExecuteOptions = {},
+): Promise<ExecuteResult> {
+  return new Execution(uipath).execute(connectionId, objectName, method, options);
+}

--- a/src/services/integration-service/execution/index.ts
+++ b/src/services/integration-service/execution/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Integration Service — Execution passthrough module.
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { execute } from '@uipath/uipath-typescript/is-execution';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'GET');
+ * ```
+ *
+ * @module
+ */
+
+export { execute } from './execution';
+export * from '../../../models/integration-service/execution.types';

--- a/src/utils/constants/endpoints/base.ts
+++ b/src/utils/constants/endpoints/base.ts
@@ -10,3 +10,4 @@ export const AUTOPILOT_BASE = 'autopilotforeveryone_';
 export const LLMOPS_BASE = 'llmopstenant_';
 export const INSIGHTS_RTM_BASE = 'insightsrtm_';
 export const CONNECTIONS_BASE = 'connections_';
+export const ELEMENTS_BASE = 'elements_/v3/element';

--- a/src/utils/constants/endpoints/integration-service.ts
+++ b/src/utils/constants/endpoints/integration-service.ts
@@ -6,6 +6,13 @@
 
 import { CONNECTIONS_BASE } from './base';
 
+export const CONNECTOR_ENDPOINTS = {
+  GET_ALL: `${CONNECTIONS_BASE}/api/v1/Connectors`,
+  GET_BY_ID: (keyOrId: string) => `${CONNECTIONS_BASE}/api/v1/Connectors/${encodeURIComponent(keyOrId)}`,
+  GET_DEFAULT_CONNECTION: (keyOrId: string) => `${CONNECTIONS_BASE}/api/v1/Connectors/${encodeURIComponent(keyOrId)}/connection`,
+  GET_CONNECTIONS: (keyOrId: string) => `${CONNECTIONS_BASE}/api/v1/Connectors/${encodeURIComponent(keyOrId)}/connections`,
+} as const;
+
 export const CONNECTION_ENDPOINTS = {
   GET_ALL: `${CONNECTIONS_BASE}/api/v1/Connections`,
   GET_BY_ID: (connectionId: string) => `${CONNECTIONS_BASE}/api/v1/Connections/${encodeURIComponent(connectionId)}`,

--- a/src/utils/constants/endpoints/integration-service.ts
+++ b/src/utils/constants/endpoints/integration-service.ts
@@ -1,10 +1,12 @@
 /**
  * Integration Service Endpoints
  *
- * `connections_` domain — connectors and connections (CONNECTOR_ENDPOINTS, CONNECTION_ENDPOINTS).
+ * Two service domains:
+ * - `connections_` — connectors and connections (CONNECTOR_ENDPOINTS, CONNECTION_ENDPOINTS)
+ * - `elements_/v3/element` — connector elements and metadata (ELEMENT_ENDPOINTS)
  */
 
-import { CONNECTIONS_BASE } from './base';
+import { CONNECTIONS_BASE, ELEMENTS_BASE } from './base';
 
 export const CONNECTOR_ENDPOINTS = {
   GET_ALL: `${CONNECTIONS_BASE}/api/v1/Connectors`,
@@ -18,4 +20,47 @@ export const CONNECTION_ENDPOINTS = {
   GET_BY_ID: (connectionId: string) => `${CONNECTIONS_BASE}/api/v1/Connections/${encodeURIComponent(connectionId)}`,
   PING: (connectionId: string) => `${CONNECTIONS_BASE}/api/v1/Connections/${encodeURIComponent(connectionId)}/ping`,
   REAUTHENTICATE: (connectionId: string) => `${CONNECTIONS_BASE}/api/v1/Connections/${encodeURIComponent(connectionId)}/auth`,
+} as const;
+
+export const ELEMENT_ENDPOINTS = {
+  OBJECTS: {
+    /** List objects (resources) exposed by a connector. */
+    LIST: (elementKey: string) => `${ELEMENTS_BASE}/elements/${encodeURIComponent(elementKey)}/objects`,
+    /** Get metadata for a single object. */
+    METADATA: (elementKey: string, objectName: string) =>
+      `${ELEMENTS_BASE}/elements/${encodeURIComponent(elementKey)}/objects/${encodeURIComponent(objectName)}/metadata`,
+  },
+  ACTIVITIES: {
+    /** List curated activities exposed by a connector. */
+    LIST: (elementKey: string) => `${ELEMENTS_BASE}/elements/${encodeURIComponent(elementKey)}/activities`,
+  },
+  EVENTS: {
+    /** List event objects for a connector's event operation (trigger). */
+    OBJECTS: (elementKey: string, operationName: string) =>
+      `${ELEMENTS_BASE}/elements/${encodeURIComponent(elementKey)}/events/operations/${encodeURIComponent(operationName)}/objects`,
+    /** Get metadata for a single event object. */
+    METADATA: (elementKey: string, operationName: string, objectName: string) =>
+      `${ELEMENTS_BASE}/elements/${encodeURIComponent(elementKey)}/events/operations/${encodeURIComponent(operationName)}/objects/${encodeURIComponent(objectName)}/metadata`,
+  },
+  INSTANCE: {
+    OBJECTS: {
+      /** List objects for a connection instance (includes custom fields). */
+      LIST: (connectionId: string, elementKey: string) =>
+        `${ELEMENTS_BASE}/instances/${encodeURIComponent(connectionId)}/elements/${encodeURIComponent(elementKey)}/objects`,
+      /** Get instance-scoped metadata for a single object. */
+      METADATA: (connectionId: string, elementKey: string, objectName: string) =>
+        `${ELEMENTS_BASE}/instances/${encodeURIComponent(connectionId)}/elements/${encodeURIComponent(elementKey)}/objects/${encodeURIComponent(objectName)}/metadata`,
+    },
+    EVENTS: {
+      /** List event objects for a connection instance. */
+      OBJECTS: (connectionId: string, elementKey: string, operationName: string) =>
+        `${ELEMENTS_BASE}/instances/${encodeURIComponent(connectionId)}/elements/${encodeURIComponent(elementKey)}/events/operations/${encodeURIComponent(operationName)}/objects`,
+      /** Get instance-scoped metadata for a single event object. */
+      METADATA: (connectionId: string, elementKey: string, operationName: string, objectName: string) =>
+        `${ELEMENTS_BASE}/instances/${encodeURIComponent(connectionId)}/elements/${encodeURIComponent(elementKey)}/events/operations/${encodeURIComponent(operationName)}/objects/${encodeURIComponent(objectName)}/metadata`,
+    },
+    /** Generic HTTP passthrough endpoint for executing a request against a connection instance. */
+    EXECUTE: (connectionId: string, objectName: string) =>
+      `${ELEMENTS_BASE}/instances/${encodeURIComponent(connectionId)}/${encodeURIComponent(objectName)}`,
+  },
 } as const;

--- a/tests/unit/services/integration-service/connectors.test.ts
+++ b/tests/unit/services/integration-service/connectors.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ConnectorsService } from '../../../../src/services/integration-service/connectors/connectors';
+import { CONNECTOR_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import { ApiClient } from '../../../../src/core/http/api-client';
+import { ValidationError } from '../../../../src/core/errors';
+import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
+import {
+  IS_TEST_CONSTANTS,
+  createMockConnector,
+  createMockConnection,
+  createMockError,
+  TEST_CONSTANTS,
+} from '../../../utils/mocks';
+
+vi.mock('../../../../src/core/http/api-client');
+
+describe('ConnectorsService', () => {
+  let service: ConnectorsService;
+  let mockApiClient: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    const { instance } = createServiceTestDependencies();
+    mockApiClient = createMockApiClient();
+    vi.mocked(ApiClient).mockImplementation(() => mockApiClient as unknown as ApiClient);
+    service = new ConnectorsService(instance);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAll', () => {
+    it('should return all connectors as a plain array', async () => {
+      const mock = [createMockConnector(), createMockConnector({ key: 'uipath-slack', name: 'Slack' })];
+      mockApiClient.get.mockResolvedValue(mock);
+
+      const result = await service.getAll();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTOR_ENDPOINTS.GET_ALL, {
+        params: undefined,
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].key).toBe(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+      expect(result[1].key).toBe('uipath-slack');
+    });
+
+    it('should forward hasHttpRequest option as a query param', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      await service.getAll({ hasHttpRequest: true });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTOR_ENDPOINTS.GET_ALL, {
+        params: { hasHttpRequest: true },
+      });
+    });
+
+    it('should handle an empty response', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      const result = await service.getAll();
+      expect(result).toEqual([]);
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.get.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+      await expect(service.getAll()).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('getById', () => {
+    it('should return a single connector by key', async () => {
+      const mock = createMockConnector();
+      mockApiClient.get.mockResolvedValue(mock);
+
+      const result = await service.getById(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_BY_ID(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        {},
+      );
+      expect(result.id).toBe(IS_TEST_CONSTANTS.CONNECTOR_ID);
+    });
+
+    it('should throw ValidationError when keyOrId is empty', async () => {
+      await expect(service.getById('')).rejects.toThrow(ValidationError);
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should propagate API errors', async () => {
+      mockApiClient.get.mockRejectedValue(createMockError(IS_TEST_CONSTANTS.ERROR_CONNECTOR_NOT_FOUND));
+      await expect(service.getById(IS_TEST_CONSTANTS.CONNECTOR_KEY)).rejects.toThrow(
+        IS_TEST_CONSTANTS.ERROR_CONNECTOR_NOT_FOUND,
+      );
+    });
+  });
+
+  describe('getDefaultConnection', () => {
+    it('should return the default connection with bound methods', async () => {
+      const mock = createMockConnection();
+      mockApiClient.get.mockResolvedValue(mock);
+
+      const result = await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        {
+          headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY },
+          params: {},
+        },
+      );
+      expect(result.id).toBe(IS_TEST_CONSTANTS.CONNECTION_ID);
+      // Bound methods attached:
+      expect(typeof result.ping).toBe('function');
+      expect(typeof result.reauthenticate).toBe('function');
+    });
+
+    it('should send no folder header when folderKey is omitted', async () => {
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: {}, params: {} },
+      );
+    });
+
+    it('should pass allFolders as a query param', async () => {
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY, { allFolders: true });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: {}, params: { allFolders: true } },
+      );
+    });
+
+    it('should throw ValidationError when keyOrId is empty', async () => {
+      await expect(service.getDefaultConnection('')).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('getConnections', () => {
+    it('should return connections with bound methods on each entity', async () => {
+      mockApiClient.get.mockResolvedValue([
+        createMockConnection(),
+        createMockConnection({ id: IS_TEST_CONSTANTS.CONNECTION_ID_2, name: 'second' }),
+      ]);
+
+      const result = await service.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+        pageSize: 25,
+        pageIndex: 1,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_CONNECTIONS(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        {
+          headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY },
+          params: { pageSize: 25, pageIndex: 1 },
+        },
+      );
+      expect(result).toHaveLength(2);
+      for (const conn of result) {
+        expect(typeof conn.ping).toBe('function');
+        expect(typeof conn.reauthenticate).toBe('function');
+      }
+    });
+
+    it('should default to empty array when API returns null', async () => {
+      mockApiClient.get.mockResolvedValue(null);
+      const result = await service.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+      expect(result).toEqual([]);
+    });
+
+    it('should throw ValidationError when keyOrId is empty', async () => {
+      await expect(service.getConnections('')).rejects.toThrow(ValidationError);
+    });
+  });
+});

--- a/tests/unit/services/integration-service/elements.test.ts
+++ b/tests/unit/services/integration-service/elements.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ElementsService } from '../../../../src/services/integration-service/elements/elements';
+import { ELEMENT_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import { ApiClient } from '../../../../src/core/http/api-client';
+import { ValidationError } from '../../../../src/core/errors';
+import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
+import { IS_TEST_CONSTANTS, createMockError, TEST_CONSTANTS } from '../../../utils/mocks';
+
+vi.mock('../../../../src/core/http/api-client');
+
+const EVENT_OPERATION = 'INDEX_COMPLETED';
+const OBJECT_NAME = 'indexes';
+
+describe('ElementsService', () => {
+  let service: ElementsService;
+  let mockApiClient: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    const { instance } = createServiceTestDependencies();
+    mockApiClient = createMockApiClient();
+    vi.mocked(ApiClient).mockImplementation(() => mockApiClient as unknown as ApiClient);
+    service = new ElementsService(instance);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('static (connection-independent)', () => {
+    it('getObjects returns array and forwards options', async () => {
+      mockApiClient.get.mockResolvedValue([{ name: 'foo' }]);
+      const result = await service.getObjects(IS_TEST_CONSTANTS.CONNECTOR_KEY, { hasEvents: true });
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.OBJECTS.LIST(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { params: { hasEvents: true } },
+      );
+      expect(result).toEqual([{ name: 'foo' }]);
+    });
+
+    it('getActivities returns array', async () => {
+      mockApiClient.get.mockResolvedValue([{ name: 'send' }]);
+      const result = await service.getActivities(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.ACTIVITIES.LIST(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { params: undefined },
+      );
+      expect(result).toEqual([{ name: 'send' }]);
+    });
+
+    it('getObjectMetadata returns single metadata object', async () => {
+      const mockMeta = { name: OBJECT_NAME, fields: { id: { name: 'id' } } };
+      mockApiClient.get.mockResolvedValue(mockMeta);
+      const result = await service.getObjectMetadata(IS_TEST_CONSTANTS.CONNECTOR_KEY, OBJECT_NAME, {
+        version: '1.0',
+        includeParentArray: true,
+      });
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.OBJECTS.METADATA(IS_TEST_CONSTANTS.CONNECTOR_KEY, OBJECT_NAME),
+        { params: { version: '1.0', includeParentArray: true } },
+      );
+      expect(result).toBe(mockMeta);
+    });
+
+    it('getEventObjects returns array', async () => {
+      mockApiClient.get.mockResolvedValue([{ name: OBJECT_NAME }]);
+      await service.getEventObjects(IS_TEST_CONSTANTS.CONNECTOR_KEY, EVENT_OPERATION);
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.EVENTS.OBJECTS(IS_TEST_CONSTANTS.CONNECTOR_KEY, EVENT_OPERATION),
+        { params: undefined },
+      );
+    });
+
+    it('getEventObjectMetadata returns single object', async () => {
+      const mockMeta = { name: OBJECT_NAME };
+      mockApiClient.get.mockResolvedValue(mockMeta);
+      await service.getEventObjectMetadata(
+        IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        EVENT_OPERATION,
+        OBJECT_NAME,
+        { allFields: true },
+      );
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.EVENTS.METADATA(IS_TEST_CONSTANTS.CONNECTOR_KEY, EVENT_OPERATION, OBJECT_NAME),
+        { params: { allFields: true } },
+      );
+    });
+  });
+
+  describe('instance (connection-scoped)', () => {
+    it('getInstanceObjects returns array', async () => {
+      mockApiClient.get.mockResolvedValue([{ name: 'foo' }]);
+      await service.getInstanceObjects(IS_TEST_CONSTANTS.CONNECTION_ID, IS_TEST_CONSTANTS.CONNECTOR_KEY);
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.INSTANCE.OBJECTS.LIST(
+          IS_TEST_CONSTANTS.CONNECTION_ID,
+          IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        ),
+        { params: undefined },
+      );
+    });
+
+    it('getInstanceObjectMetadata returns metadata', async () => {
+      mockApiClient.get.mockResolvedValue({ name: OBJECT_NAME });
+      await service.getInstanceObjectMetadata(
+        IS_TEST_CONSTANTS.CONNECTION_ID,
+        IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        OBJECT_NAME,
+      );
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.INSTANCE.OBJECTS.METADATA(
+          IS_TEST_CONSTANTS.CONNECTION_ID,
+          IS_TEST_CONSTANTS.CONNECTOR_KEY,
+          OBJECT_NAME,
+        ),
+        { params: undefined },
+      );
+    });
+
+    it('getInstanceEventObjects returns array', async () => {
+      mockApiClient.get.mockResolvedValue([{ name: OBJECT_NAME }]);
+      await service.getInstanceEventObjects(
+        IS_TEST_CONSTANTS.CONNECTION_ID,
+        IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        EVENT_OPERATION,
+      );
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.INSTANCE.EVENTS.OBJECTS(
+          IS_TEST_CONSTANTS.CONNECTION_ID,
+          IS_TEST_CONSTANTS.CONNECTOR_KEY,
+          EVENT_OPERATION,
+        ),
+        { params: undefined },
+      );
+    });
+
+    it('getInstanceEventObjectMetadata returns metadata', async () => {
+      mockApiClient.get.mockResolvedValue({ name: OBJECT_NAME });
+      await service.getInstanceEventObjectMetadata(
+        IS_TEST_CONSTANTS.CONNECTION_ID,
+        IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        EVENT_OPERATION,
+        OBJECT_NAME,
+      );
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        ELEMENT_ENDPOINTS.INSTANCE.EVENTS.METADATA(
+          IS_TEST_CONSTANTS.CONNECTION_ID,
+          IS_TEST_CONSTANTS.CONNECTOR_KEY,
+          EVENT_OPERATION,
+          OBJECT_NAME,
+        ),
+        { params: undefined },
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('throws ValidationError when elementKey is missing', async () => {
+      await expect(service.getObjects('')).rejects.toThrow(ValidationError);
+      await expect(service.getActivities('')).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when objectName is missing', async () => {
+      await expect(
+        service.getObjectMetadata(IS_TEST_CONSTANTS.CONNECTOR_KEY, ''),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when connectionId is missing on instance reads', async () => {
+      await expect(
+        service.getInstanceObjects('', IS_TEST_CONSTANTS.CONNECTOR_KEY),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when operationName is missing on event reads', async () => {
+      await expect(
+        service.getEventObjects(IS_TEST_CONSTANTS.CONNECTOR_KEY, ''),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates API errors from getObjects', async () => {
+      mockApiClient.get.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+      await expect(service.getObjects(IS_TEST_CONSTANTS.CONNECTOR_KEY)).rejects.toThrow(
+        TEST_CONSTANTS.ERROR_MESSAGE,
+      );
+    });
+  });
+});

--- a/tests/unit/services/integration-service/execution.test.ts
+++ b/tests/unit/services/integration-service/execution.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execute } from '../../../../src/services/integration-service/execution/execution';
+import { ValidationError } from '../../../../src/core/errors';
+import { createServiceTestDependencies } from '../../../utils/setup';
+import { IS_TEST_CONSTANTS } from '../../../utils/mocks';
+import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+
+const OBJECT_NAME = 'tickets';
+
+interface MockableTokenManager {
+  getValidToken?: () => Promise<string>;
+}
+
+function buildDeps() {
+  const deps = createServiceTestDependencies();
+  (deps.tokenManager as unknown as MockableTokenManager).getValidToken = vi
+    .fn()
+    .mockResolvedValue('mock-access-token');
+  return deps;
+}
+
+const buildResponse = (init: {
+  status?: number;
+  statusText?: string;
+  body?: string;
+  headers?: Record<string, string>;
+}) => {
+  const status = init.status ?? 200;
+  return new Response(init.body ?? '', {
+    status,
+    statusText: init.statusText ?? 'OK',
+    headers: init.headers ?? { 'content-type': 'application/json' },
+  });
+};
+
+describe('execute', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('executes a GET against the connection passthrough endpoint', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: JSON.stringify([{ id: 1 }]) }));
+
+    const result = await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toContain(`/elements_/v3/element/instances/${IS_TEST_CONSTANTS.CONNECTION_ID}/${OBJECT_NAME}`);
+    expect(init.method).toBe('GET');
+    expect(init.headers).toMatchObject({ Authorization: expect.stringMatching(/^Bearer /) });
+    expect(init.body).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual([{ id: 1 }]);
+  });
+
+  it('serializes JSON body for POST', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: JSON.stringify({ id: 42 }) }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'POST', {
+      body: { subject: 'New' },
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(init.body).toBe('{"subject":"New"}');
+  });
+
+  it('appends query params to the URL', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'GET', {
+      queryParams: { limit: '10', status: 'open' },
+    });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain('limit=10');
+    expect(url).toContain('status=open');
+  });
+
+  it('sends folder header when folderKey is provided', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'GET', {
+      folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers[FOLDER_KEY]).toBe(IS_TEST_CONSTANTS.FOLDER_KEY);
+  });
+
+  it('returns full envelope on non-2xx without throwing', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(
+      buildResponse({
+        status: 400,
+        statusText: 'Bad Request',
+        body: JSON.stringify({ error: 'invalid' }),
+      }),
+    );
+
+    const result = await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.statusText).toBe('Bad Request');
+    expect(result.body).toEqual({ error: 'invalid' });
+  });
+
+  it('returns raw text when response body is not JSON', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(
+      buildResponse({ body: 'plain text', headers: { 'content-type': 'text/plain' } }),
+    );
+
+    const result = await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    expect(result.body).toBe('plain text');
+  });
+
+  it('throws ValidationError when connectionId is missing', async () => {
+    const { instance } = buildDeps();
+    await expect(
+      execute(instance, '', OBJECT_NAME),
+    ).rejects.toThrow(ValidationError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws ValidationError when objectName is missing', async () => {
+    const { instance } = buildDeps();
+    await expect(
+      execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, ''),
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/tests/utils/mocks/integration-service.ts
+++ b/tests/utils/mocks/integration-service.ts
@@ -8,7 +8,40 @@
 import { IS_TEST_CONSTANTS } from '../constants/integration-service';
 import { createMockBaseResponse } from './core';
 import { ConnectionState } from '../../../src/models/integration-service/connections.types';
+import type { RawConnectorGetResponse } from '../../../src/models/integration-service/connectors.types';
 import type { RawConnectionGetResponse } from '../../../src/models/integration-service/connections.types';
+
+/**
+ * Creates a mock raw Connector response.
+ */
+export const createMockConnector = (
+  overrides: Partial<RawConnectorGetResponse> = {},
+): RawConnectorGetResponse => {
+  return createMockBaseResponse<RawConnectorGetResponse>(
+    {
+      id: IS_TEST_CONSTANTS.CONNECTOR_ID,
+      key: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+      name: IS_TEST_CONSTANTS.CONNECTOR_NAME,
+      description: 'Mock connector for tests',
+      image: 'https://example.invalid/icon.png',
+      isPrivate: false,
+      hasEvents: true,
+      eventTypes: ['INDEX_COMPLETED'],
+      lifeCycleStage: IS_TEST_CONSTANTS.CONNECTOR_LIFECYCLE_GA,
+      tags: 'genai',
+      type: 'application',
+      tier: IS_TEST_CONSTANTS.CONNECTOR_TIER,
+      flags: {},
+      authentication: { type: 'oauth2' },
+      categories: ['AI'],
+      connectionCount: 1,
+      enabled: true,
+      isOwner: false,
+      vendorName: 'UiPath',
+    },
+    overrides,
+  );
+};
 
 /**
  * Creates a mock raw Connection response.


### PR DESCRIPTION
## Summary
PR 2/4 of the **Integration Service** stack. Adds the **Connectors** service.

- New service via `@uipath/uipath-typescript/is-connectors`: `getAll`, `getById`, `getDefaultConnection`, `getConnections`
- `CONNECTOR_ENDPOINTS` constants; delegates connection lookups to the Connections service
- Unit tests, `createMockConnector` fixture, OAuth scope docs, mkdocs nav

## Stack
- Base: **`feat/is-connections`** (PR #554) — merge that first; GitHub will retarget this to `main`.
- Depends on Connections (`connectors.ts` imports `ConnectionsService`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)