### PR TITLE
feat(integration-service): add Execution passthrough

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -34,6 +34,12 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `getInstanceEventObjects()` | `ConnectionService` or `ConnectionServiceUser` |
 | `getInstanceEventObjectMetadata()` | `ConnectionService` or `ConnectionServiceUser` |
 
+## Integration Service — Execution
+
+| Function | OAuth Scope |
+|----------|-------------|
+| `execute()` | `ConnectionService` or `ConnectionServiceUser` (plus any third-party scopes required by the underlying connection) |
+
 ## Assets
 
 | Method | OAuth Scope |

--- a/package.json
+++ b/package.json
@@ -245,6 +245,16 @@
                 "types": "./dist/is-connections/index.d.ts",
                 "default": "./dist/is-connections/index.cjs"
             }
+        },
+        "./is-execution": {
+            "import": {
+                "types": "./dist/is-execution/index.d.ts",
+                "default": "./dist/is-execution/index.mjs"
+            },
+            "require": {
+                "types": "./dist/is-execution/index.d.ts",
+                "default": "./dist/is-execution/index.cjs"
+            }
         }
     },
     "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -243,6 +243,11 @@ const serviceEntries = [
     name: 'is-connections',
     input: 'src/services/integration-service/connections/index.ts',
     output: 'is-connections/index'
+  },
+  {
+    name: 'is-execution',
+    input: 'src/services/integration-service/execution/index.ts',
+    output: 'is-execution/index'
   }
 ];
 

--- a/src/models/integration-service/execution.types.ts
+++ b/src/models/integration-service/execution.types.ts
@@ -1,0 +1,42 @@
+/**
+ * Integration Service — Execution passthrough types.
+ */
+
+/**
+ * HTTP method for an execute call.
+ */
+export type ExecuteMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * Result envelope returned by {@link execute}.
+ *
+ * Unlike most SDK methods this *does not* throw on non-2xx responses — the
+ * caller inspects `ok` / `status` and `body` to handle connector-specific
+ * errors. This is required because the underlying Integration Service API
+ * proxies arbitrary third-party HTTP calls, and the body carries vendor
+ * error details that callers need to surface.
+ */
+export interface ExecuteResult {
+  /** True for HTTP 2xx responses. */
+  ok: boolean;
+  /** HTTP status code from the underlying call. */
+  status: number;
+  /** HTTP status text from the underlying call. */
+  statusText: string;
+  /** Parsed JSON body when the response is JSON, raw text otherwise. */
+  body: unknown;
+  /** Response headers as a flat record. */
+  headers: Record<string, string>;
+}
+
+/**
+ * Options accepted by {@link execute}.
+ */
+export interface ExecuteOptions {
+  /** Body to send for POST/PUT/PATCH. Serialized as JSON. */
+  body?: unknown;
+  /** Query string parameters. */
+  queryParams?: Record<string, string>;
+  /** Folder key (GUID) to scope the call via `x-uipath-folderkey`. */
+  folderKey?: string;
+}

--- a/src/services/integration-service/execution/execution.ts
+++ b/src/services/integration-service/execution/execution.ts
@@ -1,0 +1,154 @@
+import { track } from '../../../core/telemetry';
+import { ValidationError } from '../../../core/errors';
+import { SDKInternalsRegistry } from '../../../core/internals';
+import { ELEMENT_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { FOLDER_KEY, CONTENT_TYPES } from '../../../utils/constants/headers';
+import type { IUiPath } from '../../../core/types';
+import {
+  ExecuteMethod,
+  ExecuteOptions,
+  ExecuteResult,
+} from '../../../models/integration-service/execution.types';
+
+/**
+ * Internal class so we can decorate `execute` with `@track`. Method decorators
+ * cannot be applied to free functions directly.
+ *
+ * @internal
+ */
+class Execution {
+  constructor(private readonly instance: IUiPath) {}
+
+  @track('Execution.Execute')
+  async execute(
+    connectionId: string,
+    objectName: string,
+    method: ExecuteMethod,
+    options: ExecuteOptions,
+  ): Promise<ExecuteResult> {
+    if (!connectionId) {
+      throw new ValidationError({ message: 'connectionId is required for execute' });
+    }
+    if (!objectName) {
+      throw new ValidationError({ message: 'objectName is required for execute' });
+    }
+
+    const { config, tokenManager } = SDKInternalsRegistry.get(this.instance);
+    const token = await tokenManager.getValidToken();
+
+    const relativePath = ELEMENT_ENDPOINTS.INSTANCE.EXECUTE(connectionId, objectName);
+    const baseSegment = `${config.orgName}/${config.tenantName}/`;
+    const url = new URL(baseSegment + relativePath, config.baseUrl).toString();
+
+    let fullUrl = url;
+    if (options.queryParams && Object.keys(options.queryParams).length > 0) {
+      const qs = new URLSearchParams(options.queryParams).toString();
+      const sep = url.includes('?') ? '&' : '?';
+      fullUrl = `${url}${sep}${qs}`;
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    };
+    if (options.folderKey) {
+      headers[FOLDER_KEY] = options.folderKey;
+    }
+
+    const hasBody = options.body !== undefined && ['POST', 'PUT', 'PATCH'].includes(method);
+    if (hasBody) {
+      headers['Content-Type'] = CONTENT_TYPES.JSON;
+    }
+
+    const response = await fetch(fullUrl, {
+      method,
+      headers,
+      body: hasBody ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    let parsed: unknown = text;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+    }
+
+    const flatHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      flatHeaders[key] = value;
+    });
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      body: parsed,
+      headers: flatHeaders,
+    };
+  }
+}
+
+/**
+ * Execute an arbitrary HTTP operation against a connection instance through
+ * the Integration Service passthrough endpoint.
+ *
+ * Targets `elements_/v3/element/instances/{connectionId}/{objectName}`.
+ * Use this when you need to call a connector's runtime API without going
+ * through a curated SDK method.
+ *
+ * Unlike standard SDK methods, **this does not throw on non-2xx responses**.
+ * The full HTTP envelope (`ok`, `status`, `body`, `headers`) is returned so
+ * callers can surface connector-specific error bodies.
+ *
+ * @param uipath - UiPath SDK instance providing authentication and configuration
+ * @param connectionId - Connection GUID
+ * @param objectName - Connector object name (e.g. `tickets`, `messages`)
+ * @param method - HTTP method (defaults to `GET`)
+ * @param options - Body, query params, and folder scoping
+ * @returns Promise resolving to an {@link ExecuteResult}
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { execute } from '@uipath/uipath-typescript/is-execution';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * // GET — list records
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'GET');
+ * if (result.ok) {
+ *   console.log(result.body);
+ * } else {
+ *   console.error(`Connector returned ${result.status}: ${JSON.stringify(result.body)}`);
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // POST — create a record
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'POST', {
+ *   body: { subject: 'New ticket', priority: 'high' },
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // GET with query params and folder scoping
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'GET', {
+ *   queryParams: { limit: '10', status: 'open' },
+ *   folderKey: '<folderKey>',
+ * });
+ * ```
+ */
+export async function execute(
+  uipath: IUiPath,
+  connectionId: string,
+  objectName: string,
+  method: ExecuteMethod = 'GET',
+  options: ExecuteOptions = {},
+): Promise<ExecuteResult> {
+  return new Execution(uipath).execute(connectionId, objectName, method, options);
+}

--- a/src/services/integration-service/execution/index.ts
+++ b/src/services/integration-service/execution/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Integration Service — Execution passthrough module.
+ *
+ * @example
+ * ```typescript
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { execute } from '@uipath/uipath-typescript/is-execution';
+ *
+ * const sdk = new UiPath(config);
+ * await sdk.initialize();
+ *
+ * const result = await execute(sdk, '<connectionId>', 'tickets', 'GET');
+ * ```
+ *
+ * @module
+ */
+
+export { execute } from './execution';
+export * from '../../../models/integration-service/execution.types';

--- a/tests/unit/services/integration-service/execution.test.ts
+++ b/tests/unit/services/integration-service/execution.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execute } from '../../../../src/services/integration-service/execution/execution';
+import { ValidationError } from '../../../../src/core/errors';
+import { createServiceTestDependencies } from '../../../utils/setup';
+import { IS_TEST_CONSTANTS } from '../../../utils/mocks';
+import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+
+const OBJECT_NAME = 'tickets';
+
+interface MockableTokenManager {
+  getValidToken?: () => Promise<string>;
+}
+
+function buildDeps() {
+  const deps = createServiceTestDependencies();
+  (deps.tokenManager as unknown as MockableTokenManager).getValidToken = vi
+    .fn()
+    .mockResolvedValue('mock-access-token');
+  return deps;
+}
+
+const buildResponse = (init: {
+  status?: number;
+  statusText?: string;
+  body?: string;
+  headers?: Record<string, string>;
+}) => {
+  const status = init.status ?? 200;
+  return new Response(init.body ?? '', {
+    status,
+    statusText: init.statusText ?? 'OK',
+    headers: init.headers ?? { 'content-type': 'application/json' },
+  });
+};
+
+describe('execute', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('executes a GET against the connection passthrough endpoint', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: JSON.stringify([{ id: 1 }]) }));
+
+    const result = await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toContain(`/elements_/v3/element/instances/${IS_TEST_CONSTANTS.CONNECTION_ID}/${OBJECT_NAME}`);
+    expect(init.method).toBe('GET');
+    expect(init.headers).toMatchObject({ Authorization: expect.stringMatching(/^Bearer /) });
+    expect(init.body).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual([{ id: 1 }]);
+  });
+
+  it('serializes JSON body for POST', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: JSON.stringify({ id: 42 }) }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'POST', {
+      body: { subject: 'New' },
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(init.body).toBe('{"subject":"New"}');
+  });
+
+  it('appends query params to the URL', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'GET', {
+      queryParams: { limit: '10', status: 'open' },
+    });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain('limit=10');
+    expect(url).toContain('status=open');
+  });
+
+  it('sends folder header when folderKey is provided', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'GET', {
+      folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers[FOLDER_KEY]).toBe(IS_TEST_CONSTANTS.FOLDER_KEY);
+  });
+
+  it('returns full envelope on non-2xx without throwing', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(
+      buildResponse({
+        status: 400,
+        statusText: 'Bad Request',
+        body: JSON.stringify({ error: 'invalid' }),
+      }),
+    );
+
+    const result = await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.statusText).toBe('Bad Request');
+    expect(result.body).toEqual({ error: 'invalid' });
+  });
+
+  it('returns raw text when response body is not JSON', async () => {
+    const { instance } = buildDeps();
+    fetchSpy.mockResolvedValue(
+      buildResponse({ body: 'plain text', headers: { 'content-type': 'text/plain' } }),
+    );
+
+    const result = await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    expect(result.body).toBe('plain text');
+  });
+
+  it('throws ValidationError when connectionId is missing', async () => {
+    const { instance } = buildDeps();
+    await expect(
+      execute(instance, '', OBJECT_NAME),
+    ).rejects.toThrow(ValidationError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws ValidationError when objectName is missing', async () => {
+    const { instance } = buildDeps();
+    await expect(
+      execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, ''),
+    ).rejects.toThrow(ValidationError);
+  });
+});


### PR DESCRIPTION
## Summary
PR 4/4 of the **Integration Service** stack. Adds the **Execution** passthrough.

- `execute()` via `@uipath/uipath-typescript/is-execution` — runs an arbitrary HTTP operation against a connection instance and returns the full response envelope without throwing on non-2xx
- Reuses `ELEMENT_ENDPOINTS.INSTANCE.EXECUTE`
- Unit tests, OAuth scope docs

## Stack
- Base: **`feat/is-elements`** — merge the lower PRs first; GitHub will retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)