### PR TITLE
test(integration-service): add Integration Service integration tests

### DIFF
--- a/tests/.env.integration.example
+++ b/tests/.env.integration.example
@@ -74,3 +74,23 @@ TASKS_TEST_USER_GROUP_ID=
 # User ID (from tasks.getUsers()) used by the single-user task assignment tests.
 # The user must have task permissions in the folder identified by INTEGRATION_TEST_FOLDER_ID.
 TASKS_TEST_USER_ID=
+
+# ============================================
+# Integration Service test fixtures
+# ============================================
+
+# Connector key (elementKey) of a connector that exists on the tenant
+# (e.g. "uipath-slack", "uipath-uipath-airdk"). Used by Connectors + Elements tests.
+INTEGRATION_SERVICE_TEST_CONNECTOR_KEY=uipath-microsoft-outlook365
+
+# Connection GUID of an existing connection on the tenant for the connector above.
+# Used by Connections.getById/ping, Elements instance reads, and execute.
+INTEGRATION_SERVICE_TEST_CONNECTION_ID=
+
+# Event operation name supported by the connector (e.g. "INDEX_COMPLETED").
+# Required to exercise the Elements event endpoints; leave blank to skip those tests.
+INTEGRATION_SERVICE_TEST_EVENT_OPERATION=
+
+# Optional override for the object name used in Elements + execute tests.
+# When unset the tests pick the first object the connector exposes.
+INTEGRATION_SERVICE_TEST_OBJECT_NAME=

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -24,6 +24,10 @@ export interface IntegrationConfig {
   jobsTestFolderId?: string;
   tasksTestUserGroupId?: string;
   tasksTestUserId?: string;
+  isConnectorKey?: string;
+  isConnectionId?: string;
+  isEventOperation?: string;
+  isObjectName?: string;
 }
 
 function isValidUrl(value: string): boolean {
@@ -79,6 +83,10 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     jobsTestFolderId: typeof rawConfig.jobsTestFolderId === 'string' ? rawConfig.jobsTestFolderId : undefined,
     tasksTestUserGroupId: typeof rawConfig.tasksTestUserGroupId === 'string' ? rawConfig.tasksTestUserGroupId : undefined,
     tasksTestUserId: typeof rawConfig.tasksTestUserId === 'string' ? rawConfig.tasksTestUserId : undefined,
+    isConnectorKey: typeof rawConfig.isConnectorKey === 'string' ? rawConfig.isConnectorKey : undefined,
+    isConnectionId: typeof rawConfig.isConnectionId === 'string' ? rawConfig.isConnectionId : undefined,
+    isEventOperation: typeof rawConfig.isEventOperation === 'string' ? rawConfig.isEventOperation : undefined,
+    isObjectName: typeof rawConfig.isObjectName === 'string' ? rawConfig.isObjectName : undefined,
   };
 }
 
@@ -118,6 +126,10 @@ export function loadIntegrationConfig(): IntegrationConfig {
     jobsTestFolderId: process.env.JOBS_TEST_FOLDER_ID || undefined,
     tasksTestUserGroupId: process.env.TASKS_TEST_USER_GROUP_ID || undefined,
     tasksTestUserId: process.env.TASKS_TEST_USER_ID || undefined,
+    isConnectorKey: process.env.INTEGRATION_SERVICE_TEST_CONNECTOR_KEY || undefined,
+    isConnectionId: process.env.INTEGRATION_SERVICE_TEST_CONNECTION_ID || undefined,
+    isEventOperation: process.env.INTEGRATION_SERVICE_TEST_EVENT_OPERATION || undefined,
+    isObjectName: process.env.INTEGRATION_SERVICE_TEST_OBJECT_NAME || undefined,
   };
 
   cachedConfig = validateConfig(rawConfig);

--- a/tests/integration/config/unified-setup.ts
+++ b/tests/integration/config/unified-setup.ts
@@ -16,6 +16,9 @@ import { AgentMemory } from '../../../src/services/agents/memory';
 import { AgentTraces } from '../../../src/services/observability/traces/agent';
 import { Traces } from '../../../src/services/observability/traces';
 import { Governance } from '../../../src/services/governance';
+import { ConnectorsService } from '../../../src/services/integration-service/connectors/connectors';
+import { ConnectionsService } from '../../../src/services/integration-service/connections/connections';
+import { ElementsService } from '../../../src/services/integration-service/elements/elements';
 import { loadIntegrationConfig, IntegrationConfig } from './test-config';
 import { UiPath as LegacyUiPath } from '../../../src/uipath';
 import { afterAll, beforeAll } from 'vitest';
@@ -56,6 +59,9 @@ export interface TestServices {
   traces?: Traces;
   agents?: Agents;
   governance?: Governance;
+  isConnectors?: ConnectorsService;
+  isConnections?: ConnectionsService;
+  isElements?: ElementsService;
 }
 
 /**
@@ -141,6 +147,9 @@ function createV1Services(config: IntegrationConfig): TestServices {
     traces: new Traces(sdk),
     agents: new Agents(sdk),
     governance: new Governance(sdk),
+    isConnectors: new ConnectorsService(sdk),
+    isConnections: new ConnectionsService(sdk),
+    isElements: new ElementsService(sdk),
   };
 }
 

--- a/tests/integration/shared/integration-service/connections.integration.test.ts
+++ b/tests/integration/shared/integration-service/connections.integration.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { ConnectionsService } from '../../../../src/services/integration-service/connections/connections';
+import {
+  ConnectionState,
+} from '../../../../src/models/integration-service/connections.types';
+
+const modes: InitMode[] = ['v1'];
+
+describe.each(modes)('Integration Service — Connections [%s]', (mode) => {
+  setupUnifiedTests(mode);
+
+  let connections!: ConnectionsService;
+  let connectionId!: string;
+
+  beforeAll(() => {
+    const service = getServices().isConnections;
+    if (!service) {
+      throw new Error('Connections service is not registered for this init mode');
+    }
+    connections = service;
+
+    const config = getTestConfig();
+    if (!config.isConnectionId) {
+      throw new Error(
+        'INTEGRATION_SERVICE_TEST_CONNECTION_ID must be set in .env.integration to run Connections integration tests',
+      );
+    }
+    connectionId = config.isConnectionId;
+  });
+
+  describe('getAll', () => {
+    it('should return a plain array of connections with bound methods', async () => {
+      const result = await connections.getAll({ pageSize: 5 });
+
+      expect(Array.isArray(result)).toBe(true);
+      if (result.length === 0) {
+        throw new Error(
+          'Test tenant has no connections — create at least one connection to run Connections integration tests.',
+        );
+      }
+
+      const sample = result[0];
+      expect(typeof sample.id).toBe('string');
+      expect(typeof sample.name).toBe('string');
+      expect(typeof sample.ping).toBe('function');
+      expect(typeof sample.reauthenticate).toBe('function');
+    });
+
+    it('should respect mostRecentFirst sorting', async () => {
+      const result = await connections.getAll({ pageSize: 3, mostRecentFirst: true });
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('getById', () => {
+    it('should retrieve a connection by id with camelCase response fields', async () => {
+      const result = await connections.getById(connectionId);
+
+      expect(result.id).toBe(connectionId);
+      expect(typeof result.name).toBe('string');
+      expect(typeof result.state).toBe('string');
+      expect(typeof result.createTime).toBe('string');
+
+      // PascalCase API fields must be absent
+      const raw = result as unknown as Record<string, unknown>;
+      expect(raw.Id).toBeUndefined();
+      expect(raw.Name).toBeUndefined();
+      expect(raw.State).toBeUndefined();
+      expect(raw.CreateTime).toBeUndefined();
+    });
+
+    it('should error when the connection does not exist', async () => {
+      await expect(
+        connections.getById('00000000-0000-0000-0000-000000000000'),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('ping', () => {
+    it('should return a status for a known connection', async () => {
+      const result = await connections.ping(connectionId);
+
+      expect(typeof result.connector).toBe('string');
+      expect(Object.values(ConnectionState)).toContain(result.status);
+    });
+
+    it('should accept forceRefresh', async () => {
+      const result = await connections.ping(connectionId, { forceRefresh: true });
+      expect(Object.values(ConnectionState)).toContain(result.status);
+    });
+  });
+
+  describe('bound methods on Connection entity', () => {
+    it('connection.ping() should delegate to the service and resolve', async () => {
+      const conn = await connections.getById(connectionId);
+      const status = await conn.ping();
+      expect(Object.values(ConnectionState)).toContain(status.status);
+    });
+  });
+
+  // reauthenticate is a mutating OAuth-flow trigger that would invalidate the
+  // existing session in the test tenant — exercise it only as a smoke test that
+  // the SDK plumbing reaches the API. Live tests can verify shape (sessionId
+  // present, authUrl present). Skipping by default to avoid disturbing the
+  // shared test tenant. To exercise: remove `.skip` and set the env flag.
+  describe.skip('reauthenticate (manual run only)', () => {
+    it('should return an authUrl + sessionId payload', async () => {
+      const session = await connections.reauthenticate(connectionId);
+      expect(typeof session.sessionId).toBe('string');
+      expect(typeof session.authUrl).toBe('string');
+      expect(typeof session.expiresAt).toBe('number');
+    });
+  });
+});

--- a/tests/integration/shared/integration-service/connectors.integration.test.ts
+++ b/tests/integration/shared/integration-service/connectors.integration.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { ConnectorsService } from '../../../../src/services/integration-service/connectors/connectors';
+
+const modes: InitMode[] = ['v1'];
+
+describe.each(modes)('Integration Service — Connectors [%s]', (mode) => {
+  setupUnifiedTests(mode);
+
+  let connectors!: ConnectorsService;
+  let connectorKey!: string;
+
+  beforeAll(() => {
+    const service = getServices().isConnectors;
+    if (!service) {
+      throw new Error('Connectors service is not registered for this init mode');
+    }
+    connectors = service;
+
+    const config = getTestConfig();
+    if (!config.isConnectorKey) {
+      throw new Error(
+        'INTEGRATION_SERVICE_TEST_CONNECTOR_KEY must be set in .env.integration to run Connectors integration tests',
+      );
+    }
+    connectorKey = config.isConnectorKey;
+  });
+
+  describe('getAll', () => {
+    it.only('should return a non-empty list of connectors as a plain array', async () => {
+      const result = await connectors.getAll();
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+
+      const sample = result[0];
+      expect(typeof sample.id).toBe('number');
+      expect(typeof sample.key).toBe('string');
+      expect(typeof sample.name).toBe('string');
+      expect(typeof sample.isPrivate).toBe('boolean');
+    });
+
+    it('should accept hasHttpRequest filter without error', async () => {
+      const result = await connectors.getAll({ hasHttpRequest: true });
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('getById', () => {
+    it('should retrieve a connector by key with camelCase response fields', async () => {
+      const result = await connectors.getById(connectorKey);
+
+      expect(result).toBeDefined();
+      expect(result.key).toBe(connectorKey);
+      expect(typeof result.name).toBe('string');
+      expect(typeof result.id).toBe('number');
+
+      // PascalCase keys must not be present — this validates the SDK returns the API shape verbatim
+      // and exercises the assumption baked into the design (IS APIs return camelCase).
+      const raw = result as unknown as Record<string, unknown>;
+      expect(raw.Key).toBeUndefined();
+      expect(raw.Name).toBeUndefined();
+      expect(raw.Id).toBeUndefined();
+    });
+
+    it('should error when the connector does not exist', async () => {
+      await expect(
+        connectors.getById('this-connector-does-not-exist-xyz'),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getConnections', () => {
+    it('should list connections for a connector', async () => {
+      const result = await connectors.getConnections(connectorKey);
+
+      expect(Array.isArray(result)).toBe(true);
+      if (result.length === 0) {
+        throw new Error(
+          `Connector ${connectorKey} has no connections in the test tenant — set up at least one connection to run this test.`,
+        );
+      }
+
+      const sample = result[0];
+      expect(typeof sample.id).toBe('string');
+      expect(typeof sample.name).toBe('string');
+      // Bound methods must be attached
+      expect(typeof sample.ping).toBe('function');
+      expect(typeof sample.reauthenticate).toBe('function');
+    });
+
+    it('should respect pageSize', async () => {
+      const result = await connectors.getConnections(connectorKey, { pageSize: 1 });
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('getDefaultConnection', () => {
+    it('should return the default connection for a connector that has one', async () => {
+      const result = await connectors.getDefaultConnection(connectorKey);
+
+      expect(result).toBeDefined();
+      expect(typeof result.id).toBe('string');
+      expect(typeof result.isDefault).toBe('boolean');
+      expect(typeof result.ping).toBe('function');
+    });
+  });
+});

--- a/tests/integration/shared/integration-service/elements.integration.test.ts
+++ b/tests/integration/shared/integration-service/elements.integration.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { ElementsService } from '../../../../src/services/integration-service/elements/elements';
+
+const modes: InitMode[] = ['v1'];
+
+describe.each(modes)('Integration Service — Elements [%s]', (mode) => {
+  setupUnifiedTests(mode);
+
+  let elements!: ElementsService;
+  let elementKey!: string;
+  let connectionId!: string;
+  let objectName!: string;
+  let eventOperation: string | undefined;
+  let eventObjectName!: string;
+
+  beforeAll(async () => {
+    const service = getServices().isElements;
+    if (!service) {
+      throw new Error('Elements service is not registered for this init mode');
+    }
+    elements = service;
+
+    const config = getTestConfig();
+    if (!config.isConnectorKey) {
+      throw new Error('INTEGRATION_SERVICE_TEST_CONNECTOR_KEY must be set in .env.integration');
+    }
+    if (!config.isConnectionId) {
+      throw new Error('INTEGRATION_SERVICE_TEST_CONNECTION_ID must be set in .env.integration');
+    }
+    elementKey = config.isConnectorKey;
+    connectionId = config.isConnectionId;
+    eventOperation = config.isEventOperation;
+
+    // Resolve an objectName + eventObjectName from the connector itself so each
+    // test exercises a real API path. Fallback to the env override when supplied.
+    const objects = await elements.getObjects(elementKey);
+    if (objects.length === 0) {
+      throw new Error(`Connector ${elementKey} has no objects — cannot exercise Elements tests.`);
+    }
+    objectName = config.isObjectName ?? objects[0].name;
+
+    if (eventOperation) {
+      const eventObjects = await elements.getEventObjects(elementKey, eventOperation);
+      if (eventObjects.length === 0) {
+        throw new Error(
+          `Connector ${elementKey} has no event objects for operation ${eventOperation}.`,
+        );
+      }
+      eventObjectName = eventObjects[0].name;
+    }
+  });
+
+  describe('static (connection-independent)', () => {
+    it('getObjects should return a plain array of objects', async () => {
+      const result = await elements.getObjects(elementKey);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+
+      const sample = result[0];
+      expect(typeof sample.name).toBe('string');
+    });
+
+    it('getActivities should return a plain array', async () => {
+      const result = await elements.getActivities(elementKey);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('getObjectMetadata should return an object with name + fields', async () => {
+      const result = await elements.getObjectMetadata(elementKey, objectName);
+      expect(result).toBeDefined();
+      expect(result.name).toBe(objectName);
+    });
+  });
+
+  describe('instance (connection-scoped)', () => {
+    it('getInstanceObjects should return a plain array', async () => {
+      const result = await elements.getInstanceObjects(connectionId, elementKey);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('getInstanceObjectMetadata should return an object with name', async () => {
+      const result = await elements.getInstanceObjectMetadata(connectionId, elementKey, objectName);
+      expect(result).toBeDefined();
+      expect(result.name).toBe(objectName);
+    });
+  });
+
+  describe('events', () => {
+    it('getEventObjects should return a plain array', async () => {
+      if (!eventOperation) {
+        throw new Error(
+          'INTEGRATION_SERVICE_TEST_EVENT_OPERATION must be set to exercise event endpoints',
+        );
+      }
+      const result = await elements.getEventObjects(elementKey, eventOperation);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('getEventObjectMetadata should return an object with name + eventMode', async () => {
+      if (!eventOperation) {
+        throw new Error(
+          'INTEGRATION_SERVICE_TEST_EVENT_OPERATION must be set to exercise event endpoints',
+        );
+      }
+      const result = await elements.getEventObjectMetadata(elementKey, eventOperation, eventObjectName);
+      expect(result).toBeDefined();
+      expect(result.name).toBe(eventObjectName);
+    });
+
+    it('getInstanceEventObjects should return a plain array', async () => {
+      if (!eventOperation) {
+        throw new Error(
+          'INTEGRATION_SERVICE_TEST_EVENT_OPERATION must be set to exercise event endpoints',
+        );
+      }
+      const result = await elements.getInstanceEventObjects(connectionId, elementKey, eventOperation);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('getInstanceEventObjectMetadata should return an object', async () => {
+      if (!eventOperation) {
+        throw new Error(
+          'INTEGRATION_SERVICE_TEST_EVENT_OPERATION must be set to exercise event endpoints',
+        );
+      }
+      const result = await elements.getInstanceEventObjectMetadata(
+        connectionId,
+        elementKey,
+        eventOperation,
+        eventObjectName,
+      );
+      expect(result).toBeDefined();
+      expect(result.name).toBe(eventObjectName);
+    });
+  });
+});

--- a/tests/integration/shared/integration-service/execution.integration.test.ts
+++ b/tests/integration/shared/integration-service/execution.integration.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { execute } from '../../../../src/services/integration-service/execution/execution';
+import { ElementsService } from '../../../../src/services/integration-service/elements/elements';
+import type { UiPath } from '../../../../src/core/uipath';
+
+const modes: InitMode[] = ['v1'];
+
+describe.each(modes)('Integration Service — execute [%s]', (mode) => {
+  setupUnifiedTests(mode);
+
+  let sdk!: UiPath;
+  let elements!: ElementsService;
+  let connectionId!: string;
+  let elementKey!: string;
+  let objectName!: string;
+
+  beforeAll(async () => {
+    const services = getServices();
+    const elementsService = services.isElements;
+    if (!elementsService) {
+      throw new Error('Elements service is not registered for this init mode');
+    }
+    sdk = services.sdk;
+    elements = elementsService;
+
+    const config = getTestConfig();
+    if (!config.isConnectionId) {
+      throw new Error('INTEGRATION_SERVICE_TEST_CONNECTION_ID must be set in .env.integration');
+    }
+    if (!config.isConnectorKey) {
+      throw new Error('INTEGRATION_SERVICE_TEST_CONNECTOR_KEY must be set in .env.integration');
+    }
+    connectionId = config.isConnectionId;
+    elementKey = config.isConnectorKey;
+
+    // Resolve an object the test connection actually exposes so the passthrough GET
+    // has a target. Fallback to env override when supplied.
+    const objects = await elements.getInstanceObjects(connectionId, elementKey);
+    if (objects.length === 0) {
+      throw new Error(
+        `Connection ${connectionId} exposes no objects — cannot exercise execute.`,
+      );
+    }
+    objectName = config.isObjectName ?? objects[0].name;
+  });
+
+  describe('GET passthrough', () => {
+    it('should reach the connector and return an envelope', async () => {
+      const result = await execute(sdk, connectionId, objectName, 'GET');
+
+      expect(typeof result.ok).toBe('boolean');
+      expect(typeof result.status).toBe('number');
+      expect(typeof result.headers).toBe('object');
+      // ok=true or ok=false are both valid here — the API or downstream connector
+      // may legitimately reject the operation. Either way the envelope must arrive.
+    });
+
+    it('should preserve non-2xx responses without throwing', async () => {
+      // Calls a deliberately non-existent objectName so the API rejects the request;
+      // execute must surface the error envelope rather than throwing.
+      const result = await execute(sdk, connectionId, '__non_existent_object__', 'GET');
+      expect(result.ok).toBe(false);
+      expect(result.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
PR 5/5 — live-API integration tests for the **Integration Service** (Connectors, Connections, Elements, Execution), plus integration test wiring (`test-config.ts`, `unified-setup.ts`) and `.env.integration.example` fixtures.

## ⚠️ Draft — expected to fail until the feature PRs merge
This PR targets `main` but the four services it tests are not yet in `main`. CI will be **red** until the stack lands:

1. #554 Connections
2. #555 Connectors
3. #556 Elements
4. #557 Execution

**After all four merge into `main`, rebase this branch onto `main`** and the suite will compile and run green. Kept as a draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)