### PR TITLE
test(notifications): make ApiClient mock constructable for vitest 4

### DIFF
--- a/tests/unit/services/notification/notifications.test.ts
+++ b/tests/unit/services/notification/notifications.test.ts
@@ -34,7 +34,7 @@ describe('NotificationService Unit Tests', () => {
   beforeEach(() => {
     const { instance } = createServiceTestDependencies();
     mockApiClient = createMockApiClient();
-    vi.mocked(ApiClient).mockImplementation(() => mockApiClient as unknown as ApiClient);
+    vi.mocked(ApiClient).mockImplementation(function () { return mockApiClient as unknown as ApiClient; });
     vi.mocked(PaginationHelpers.getAll).mockReset();
 
     notificationService = new NotificationService(instance);


### PR DESCRIPTION
## Why

The Notifications service test (`tests/unit/services/notification/notifications.test.ts`) merged **after** the vitest-4 mock migration, so it was never converted and still mocked `ApiClient` with an arrow function:

```ts
vi.mocked(ApiClient).mockImplementation(() => mockApiClient as unknown as ApiClient);
```

Vitest 4 constructs a mock's implementation through the underlying function's `[[Construct]]` slot when it's called with `new`. Arrow functions have no `[[Construct]]` slot, so `new ApiClient(...)` in the service constructor throws `() => ... is not a constructor`, and the suite fails to run.

## What

Converted the single occurrence to a constructable regular function, matching every other service test:

```ts
vi.mocked(ApiClient).mockImplementation(function () { return mockApiClient as unknown as ApiClient; });
```

Repo-wide sweep confirmed this was the **only** remaining arrow-function constructor mock on `main` — all other `() =>` mocks are method spies / function-call mocks (never `new`-ed).

## Verification (vitest 4.1.9 installed)

- ✅ `notifications.test.ts` — 6/6 pass (was failing to collect)
- ✅ Full unit suite — **1992/1992 pass**, 68 files
- ✅ `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)