### PR TITLE
test(data-fabric): make ApiClient mocks constructable for vitest 4

### DIFF
--- a/tests/unit/services/data-fabric/directory.test.ts
+++ b/tests/unit/services/data-fabric/directory.test.ts
@@ -22,7 +22,7 @@ describe('DataFabricDirectoryService Unit Tests', () => {
   beforeEach(() => {
     const { instance } = createServiceTestDependencies();
     mockApiClient = createMockApiClient();
-    vi.mocked(ApiClient).mockImplementation(() => mockApiClient as unknown as ApiClient);
+    vi.mocked(ApiClient).mockImplementation(function () { return mockApiClient as unknown as ApiClient; });
     directoryService = new DataFabricDirectoryService(instance);
   });
 

--- a/tests/unit/services/data-fabric/roles.test.ts
+++ b/tests/unit/services/data-fabric/roles.test.ts
@@ -18,7 +18,7 @@ describe('DataFabricRoleService Unit Tests', () => {
   beforeEach(() => {
     const { instance } = createServiceTestDependencies();
     mockApiClient = createMockApiClient();
-    vi.mocked(ApiClient).mockImplementation(() => mockApiClient as unknown as ApiClient);
+    vi.mocked(ApiClient).mockImplementation(function () { return mockApiClient as unknown as ApiClient; });
     rolesService = new DataFabricRoleService(instance);
   });
 


### PR DESCRIPTION
## Why

The DataFabric **directory** and **roles** service tests merged **after** the vitest-4 mock migration, so they were never converted and still mocked `ApiClient` with an arrow function:

```ts
vi.mocked(ApiClient).mockImplementation(() => mockApiClient as unknown as ApiClient);
```

Vitest 4 constructs a mock's implementation through the underlying function's `[[Construct]]` slot when it's called with `new`. Arrow functions have no `[[Construct]]` slot, so `new ApiClient(...)` in the service constructor throws `() => ... is not a constructor`, and both suites fail to run.

## What

Converted the `ApiClient` mock in both files to a constructable regular function, matching every other service test:

```ts
vi.mocked(ApiClient).mockImplementation(function () { return mockApiClient as unknown as ApiClient; });
```

- `tests/unit/services/data-fabric/directory.test.ts:25`
- `tests/unit/services/data-fabric/roles.test.ts:21`

Repo-wide sweep confirmed these were the only remaining arrow-function constructor mocks on `main` (the notifications one landed in #570).

## Verification (vitest 4.1.9 installed)

- ✅ directory + roles tests — 29/29 pass (were failing to collect)
- ✅ Full unit suite — **2021/2021 pass**, 70 files
- ✅ `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)