### PR TITLE
fix(data-fabric): stop requiring referenceEntityId/referenceFieldId for FILE fields

### DIFF
--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -304,9 +304,9 @@ export interface EntityCreateFieldOptions extends EntityFieldBase {
   type?: EntityFieldDataType;
   /** Choice set ID for choice-set fields */
   choiceSetId?: string;
-  /** UUID of the referenced entity (required when `type` is `RELATIONSHIP` or `FILE`) */
+  /** UUID of the referenced entity (required when `type` is `RELATIONSHIP`). Ignored for `FILE` — the server wires it to the system attachment entity. */
   referenceEntityId?: string;
-  /** UUID of the referenced field on the target entity (required when `type` is `RELATIONSHIP` or `FILE`) */
+  /** UUID of the referenced field on the target entity (required when `type` is `RELATIONSHIP`). Ignored for `FILE`. */
   referenceFieldId?: string;
   /**
    * Folder key of the reference target when it lives outside the source's folder. Pass `'00000000-0000-0000-0000-000000000000'` for tenant-level system targets.

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -304,9 +304,9 @@ export interface EntityCreateFieldOptions extends EntityFieldBase {
   type?: EntityFieldDataType;
   /** Choice set ID for choice-set fields */
   choiceSetId?: string;
-  /** UUID of the referenced entity (required when `type` is `RELATIONSHIP`). Ignored for `FILE` — the server wires it to the system attachment entity. */
+  /** UUID of the referenced entity (required when `type` is `RELATIONSHIP`; ignored for `FILE`). */
   referenceEntityId?: string;
-  /** UUID of the referenced field on the target entity (required when `type` is `RELATIONSHIP`). Ignored for `FILE`. */
+  /** UUID of the referenced field on the target entity (required when `type` is `RELATIONSHIP`; ignored for `FILE`). */
   referenceFieldId?: string;
   /**
    * Folder key of the reference target when it lives outside the source's folder. Pass `'00000000-0000-0000-0000-000000000000'` for tenant-level system targets.

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -1254,7 +1254,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
     this.validateFieldConstraints(fieldType, field, field.fieldName);
     const isRelationship = fieldType === EntityFieldDataType.RELATIONSHIP;
     const isFile = fieldType === EntityFieldDataType.FILE;
-    if ((isRelationship || isFile) && (!field.referenceEntityId || !field.referenceFieldId)) {
+    if (isRelationship && (!field.referenceEntityId || !field.referenceFieldId)) {
       throw new ValidationError({
         message: `Field '${field.fieldName}' of type ${fieldType} requires both referenceEntityId and referenceFieldId (UUIDs of the target entity and field).`,
       });
@@ -1264,6 +1264,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
     // server-side; fall back to a bare {id} when no meta was fetched.
     const referenceEntityBody = refMeta?.referenceEntity ?? (field.referenceEntityId === undefined ? undefined : { id: field.referenceEntityId });
     const referenceChoiceSetBody = refMeta?.referenceChoiceSet;
+    // FILE: server wires refs to EntityAttachment
     return {
       name: field.fieldName,
       displayName: field.displayName ?? field.fieldName,
@@ -1282,9 +1283,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
       ...(field.choiceSetId !== undefined && { choiceSetId: field.choiceSetId }),
       ...((isRelationship || isFile) && { isForeignKey: true }),
       ...(isRelationship && { referenceType: ReferenceType.ManyToOne }),
-      ...(referenceEntityBody !== undefined && { referenceEntity: referenceEntityBody }),
+      ...(!isFile && referenceEntityBody !== undefined && { referenceEntity: referenceEntityBody }),
       ...(referenceChoiceSetBody !== undefined && { referenceChoiceSet: referenceChoiceSetBody }),
-      ...(field.referenceFieldId !== undefined && { referenceField: { id: field.referenceFieldId } }),
+      ...(!isFile && field.referenceFieldId !== undefined && { referenceField: { id: field.referenceFieldId } }),
     };
   }
 

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -1264,7 +1264,6 @@ export class EntityService extends BaseService implements EntityServiceModel {
     // server-side; fall back to a bare {id} when no meta was fetched.
     const referenceEntityBody = refMeta?.referenceEntity ?? (field.referenceEntityId === undefined ? undefined : { id: field.referenceEntityId });
     const referenceChoiceSetBody = refMeta?.referenceChoiceSet;
-    // FILE: server wires refs to EntityAttachment
     return {
       name: field.fieldName,
       displayName: field.displayName ?? field.fieldName,
@@ -1283,6 +1282,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
       ...(field.choiceSetId !== undefined && { choiceSetId: field.choiceSetId }),
       ...((isRelationship || isFile) && { isForeignKey: true }),
       ...(isRelationship && { referenceType: ReferenceType.ManyToOne }),
+      // FILE: server auto-wires refs to the EntityAttachment system entity; caller-sent UUIDs would fail the server's relationship pre-check.
       ...(!isFile && referenceEntityBody !== undefined && { referenceEntity: referenceEntityBody }),
       ...(referenceChoiceSetBody !== undefined && { referenceChoiceSet: referenceChoiceSetBody }),
       ...(!isFile && field.referenceFieldId !== undefined && { referenceField: { id: field.referenceFieldId } }),

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -2294,7 +2294,19 @@ describe("EntityService Unit Tests", () => {
         expect(f?.referenceEntity).toEqual({ id: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID });
       });
 
-      it("should emit isForeignKey, referenceEntity, referenceField — but NOT referenceType — for FILE fields", async () => {
+      it("should emit isForeignKey but omit referenceEntity/referenceField/referenceType for FILE fields (server wires them)", async () => {
+        await entityService.create("my_entity", [{
+          fieldName: "file_field",
+          type: EntityFieldDataType.FILE,
+        }]);
+        const f = getCreatedFields().find((x) => x.name === "file_field");
+        expect(f?.isForeignKey).toBe(true);
+        expect(f?.referenceEntity).toBeUndefined();
+        expect(f?.referenceField).toBeUndefined();
+        expect(f?.referenceType).toBeUndefined();
+      });
+
+      it("should strip caller-provided referenceEntityId/referenceFieldId on FILE (server discards them anyway)", async () => {
         await entityService.create("my_entity", [{
           fieldName: "file_field",
           type: EntityFieldDataType.FILE,
@@ -2302,18 +2314,8 @@ describe("EntityService Unit Tests", () => {
           referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
         }]);
         const f = getCreatedFields().find((x) => x.name === "file_field");
-        expect(f?.referenceEntity).toEqual({ id: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID });
-        expect(f?.referenceField).toEqual({ id: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID });
-        expect(f?.isForeignKey).toBe(true);
-        expect(f?.referenceType).toBeUndefined();
-      });
-
-      it("should throw ValidationError when FILE field is missing reference IDs", async () => {
-        await expect(
-          entityService.create("my_entity", [
-            { fieldName: "file_field", type: EntityFieldDataType.FILE },
-          ]),
-        ).rejects.toThrow(/requires both referenceEntityId and referenceFieldId/);
+        expect(f?.referenceEntity).toBeUndefined();
+        expect(f?.referenceField).toBeUndefined();
       });
     });
   });
@@ -2551,7 +2553,7 @@ describe("EntityService Unit Tests", () => {
         mockApiClient.post.mockResolvedValue(undefined);
 
         const referenceIds =
-          type === EntityFieldDataType.RELATIONSHIP || type === EntityFieldDataType.FILE
+          type === EntityFieldDataType.RELATIONSHIP
             ? {
                 referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
                 referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2736,8 +2738,6 @@ describe("EntityService Unit Tests", () => {
           addFields: [{
             fieldName: "file_field",
             type: EntityFieldDataType.FILE,
-            referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
-            referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
           }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
@@ -2745,29 +2745,19 @@ describe("EntityService Unit Tests", () => {
         expect(f.sqlType).toEqual({ name: "UNIQUEIDENTIFIER", lengthLimit: 300 });
       });
 
-      it("should emit isForeignKey, referenceEntity, referenceField — but NOT referenceType — for FILE fields", async () => {
+      it("should emit isForeignKey but omit referenceEntity/referenceField/referenceType for FILE fields (server wires them)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           addFields: [{
             fieldName: "file_field",
             type: EntityFieldDataType.FILE,
-            referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
-            referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
           }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "file_field");
-        expect(f.referenceEntity).toEqual({ id: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID });
-        expect(f.referenceField).toEqual({ id: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID });
         expect(f.isForeignKey).toBe(true);
+        expect(f.referenceEntity).toBeUndefined();
+        expect(f.referenceField).toBeUndefined();
         expect(f.referenceType).toBeUndefined();
-      });
-
-      it("should throw ValidationError when FILE field is missing reference IDs", async () => {
-        await expect(
-          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "file_field", type: EntityFieldDataType.FILE }],
-          }),
-        ).rejects.toThrow(/requires both referenceEntityId and referenceFieldId/);
       });
 
       it("should set RELATIONSHIP lengthLimit to fixed value 300 (UNIQUEIDENTIFIER)", async () => {
@@ -2892,8 +2882,6 @@ describe("EntityService Unit Tests", () => {
             addFields: [{
               fieldName: "file_field",
               type: EntityFieldDataType.FILE,
-              referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
-              referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
               lengthLimit: 500,
             }],
           }),

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -2760,6 +2760,21 @@ describe("EntityService Unit Tests", () => {
         expect(f.referenceType).toBeUndefined();
       });
 
+      it("should strip caller-provided referenceEntityId/referenceFieldId on FILE (server discards them anyway)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{
+            fieldName: "file_field",
+            type: EntityFieldDataType.FILE,
+            referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
+            referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
+          }],
+        });
+        const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
+        const f = fields.find((x: FieldSchemaPayload) => x.name === "file_field");
+        expect(f.referenceEntity).toBeUndefined();
+        expect(f.referenceField).toBeUndefined();
+      });
+
       it("should set RELATIONSHIP lengthLimit to fixed value 300 (UNIQUEIDENTIFIER)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           addFields: [{


### PR DESCRIPTION
## Summary
- Server auto-wires FILE field refs to the system `EntityAttachment` entity and discards client-sent values. The prior SDK-side mandate on `referenceEntityId`/`referenceFieldId` was stricter than the backend and pushed callers to pass bogus/self-ref UUIDs, which tripped the relationship pre-check and broke attachment uploads (SQL 547 — relationship violation).
- Mandate now applies to `RELATIONSHIP` only; for `FILE`, refs are stripped from the outbound payload so caller-passed UUIDs can't derail server-side wiring.

## Changes
- `src/services/data-fabric/entities.ts` — condition narrowed to `isRelationship`; `!isFile` gate on `referenceEntity` / `referenceField` emission.
- `src/models/data-fabric/entities.types.ts` — JSDoc updated: refs required for `RELATIONSHIP` only.
- `tests/unit/services/data-fabric/entities.test.ts` — flipped both "FILE emits refs" cases → "FILE omits refs (server wires them)"; dropped both "throws when FILE missing refs".

Linked: DS-7849

## Test plan
- [x] `npm run typecheck` (pre-existing telemetry errors unrelated)
- [x] `npm run lint` — 0 warnings
- [x] `npm test tests/unit/services/data-fabric/entities.test.ts` — 189 passed
- [ ] Manual: create FILE field via SDK without refs, upload attachment end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)