### PR TITLE
poc: runtime resource override resolution for getByName

### DIFF
--- a/src/services/folder-scoped.ts
+++ b/src/services/folder-scoped.ts
@@ -7,6 +7,7 @@ import { addPrefixToKeys, transformOptions, FieldMapping } from '../utils/transf
 import { NotFoundError } from '../core/errors';
 import { validateName } from '../utils/validation/name-validator';
 import { resolveFolderHeaders } from '../utils/folder/folder-headers';
+import { resolveOverride, type ResourceOverride } from '../utils/overrides/resolve-override';
 
 /**
  * Matches single-quote characters in OData string literals — escaped to `''`
@@ -96,10 +97,22 @@ export class FolderScopedService extends BaseService {
     const validatedName = validateName(resourceType, name);
     const { folderId, folderKey, folderPath, ...queryOptions } = options;
 
+    // --- Override resolution (POC) ---
+    // The compiled code passes the DEFAULT name (e.g. "CustomerConfig").
+    // At runtime, check if an admin override exists for this resource.
+    // If so, use the overridden name and folderPath for the API call.
+    const override: ResourceOverride | null = resolveOverride(
+      resourceType.toLowerCase(),
+      validatedName,
+      folderPath ?? '.'
+    );
+    const resolvedName = override?.name ?? validatedName;
+    const resolvedFolderPath = override?.folderPath ?? folderPath;
+
     const headers = resolveFolderHeaders({
       folderId,
       folderKey,
-      folderPath,
+      folderPath: resolvedFolderPath,
       resourceType: `${resourceType}.getByName`,
       fallbackFolderKey: this.config.folderKey,
     });
@@ -110,7 +123,7 @@ export class FolderScopedService extends BaseService {
 
     const apiOptions = {
       ...addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions)),
-      '$filter': `Name eq '${validatedName.replace(SINGLE_QUOTE_RE, "''")}'`,
+      '$filter': `Name eq '${resolvedName.replace(SINGLE_QUOTE_RE, "''")}'`,
       '$top': '1',
     };
 
@@ -121,9 +134,9 @@ export class FolderScopedService extends BaseService {
 
     const items = response.data?.value;
     if (!items?.length) {
-      const folderHint = describeFolderForError(folderId, folderKey, folderPath);
+      const folderHint = describeFolderForError(folderId, folderKey, resolvedFolderPath);
       throw new NotFoundError({
-        message: `${resourceType} '${validatedName}' not found${folderHint}.`,
+        message: `${resourceType} '${resolvedName}' not found${folderHint}.`,
       });
     }
 

--- a/src/services/folder-scoped.ts
+++ b/src/services/folder-scoped.ts
@@ -97,7 +97,6 @@ export class FolderScopedService extends BaseService {
     const validatedName = validateName(resourceType, name);
     const { folderId, folderKey, folderPath, ...queryOptions } = options;
 
-    // --- Override resolution (POC) ---
     // The compiled code passes the DEFAULT name (e.g. "CustomerConfig").
     // At runtime, check if an admin override exists for this resource.
     // If so, use the overridden name and folderPath for the API call.

--- a/src/utils/overrides/resolve-override.ts
+++ b/src/utils/overrides/resolve-override.ts
@@ -1,0 +1,66 @@
+/**
+ * POC: Runtime resource override resolution.
+ *
+ * Reads the override dict from <script type="application/json" id="uipath-overrides">
+ * injected into index.html at deploy time (by syncResourceOverwritesToCdn).
+ *
+ * The override dict maps binding keys to new resource names/folders:
+ *   { "asset.CustomerConfig.Shared/PublicApps": { "name": "ProdConfig", "folderPath": "Production/Live" } }
+ *
+ * The DEFAULT name from bindings.gen.ts (compiled into the bundle) acts as
+ * a LOOKUP KEY. This function resolves it to the overridden value at runtime.
+ */
+
+export interface ResourceOverride {
+  name: string;
+  folderPath: string;
+}
+
+type OverrideDict = Record<string, ResourceOverride>;
+
+let cachedOverrides: OverrideDict | null = null;
+let loaded = false;
+
+function loadOverrides(): OverrideDict {
+  if (loaded) return cachedOverrides ?? {};
+
+  loaded = true;
+
+  if (typeof document === 'undefined') return {};
+
+  const el = document.getElementById('uipath-overrides');
+  if (!el) return {};
+
+  try {
+    cachedOverrides = JSON.parse(el.textContent ?? '{}');
+    console.log('[UiPath SDK] Loaded overrides:', cachedOverrides);
+    return cachedOverrides ?? {};
+  } catch {
+    console.warn('[UiPath SDK] Failed to parse uipath-overrides script tag');
+    return {};
+  }
+}
+
+/**
+ * Resolves a resource override at runtime.
+ *
+ * @param resourceType - e.g. "asset", "entity", "bucket"
+ * @param name - the DEFAULT resource name from compiled bindings (e.g. "CustomerConfig")
+ * @param folderPath - the DEFAULT folder path (e.g. "Shared/PublicApps")
+ * @returns the override if found, or null if no override exists
+ */
+export function resolveOverride(
+  resourceType: string,
+  name: string,
+  folderPath: string,
+): ResourceOverride | null {
+  const overrides = loadOverrides();
+  const key = `${resourceType}.${name}.${folderPath}`;
+  const override = overrides[key] ?? null;
+
+  if (override) {
+    console.log(`[UiPath SDK] Override resolved: "${name}" → "${override.name}" (folder: "${override.folderPath}")`);
+  }
+
+  return override;
+}

--- a/src/utils/overrides/resolve-override.ts
+++ b/src/utils/overrides/resolve-override.ts
@@ -1,5 +1,5 @@
 /**
- * POC: Runtime resource override resolution.
+ * Runtime resource override resolution.
  *
  * Reads the override dict from <script type="application/json" id="uipath-overrides">
  * injected into index.html at deploy time (by syncResourceOverwritesToCdn).


### PR DESCRIPTION
## Summary

POC for runtime resource override resolution in the SDK. Proves that admin-time overrides (injected into `index.html` at deploy time) can modify resource names used in API calls — even though the original names are hardcoded in the compiled JS bundle.

## What this does

- Adds `resolveOverride()` utility that reads `<script id="uipath-overrides">` from the DOM at runtime
- Integrates into `FolderScopedService.getByNameLookup()` — the shared method used by `assets.getByName()`, `buckets.getByName()`, `processes.getByName()`
- The compiled code passes `"CustomerConfig"` → SDK looks up override → API call uses `"ProdConfig"` instead

## How overrides flow

1. Developer writes: `assets.getByName(bindings.taggedAsset.name)` → compiled to `assets.getByName("CustomerConfig")`
2. At deploy time: `syncResourceOverwritesToCdn` injects `<script id="uipath-overrides">` into `index.html`
3. At runtime: SDK's `getByNameLookup` calls `resolveOverride("asset", "CustomerConfig", "Shared/PublicApps")`
4. Override found → `$filter=Name eq 'ProdConfig'` sent to API (NOT "CustomerConfig")

## POC validation

Tested with a Vite React app (`npm run build` → `npm run preview`):
- Verified `"CustomerConfig"` is hardcoded in the compiled JS bundle (`grep` confirms)
- Verified override resolution reads from DOM at runtime and substitutes the name
- Verified with real SDK calls against `alpha.uipath.com` / `appsdev` / `appsdevDefault`

## Context

This is part of the **Resource Access Policy (RAP)** design for public coded apps. RAP needs to know the actual resource names sent in API calls to validate them at the Cloudflare Worker edge. The override resolution ensures the policy uses the same names the SDK sends.

- Design doc: [Resource Access Policy — Public Coded Apps](https://uipath.atlassian.net/wiki/spaces/~712020419454ffa5454d1b8728787ac8ebeca7/pages/90874216800)
- Related: [Coded App Resource Overrides](https://uipath.atlassian.net/wiki/spaces/CLD/pages/90842595342)
- Related PR: business-apps-jamjam#17570 (server-side override sync)

## Not production-ready — needs:

- [ ] Cache invalidation when overrides change mid-session
- [ ] Support for entity/bucket services beyond folder-scoped
- [ ] Unit tests
- [ ] Integration with the overrides team's delivery mechanism
- [ ] Remove console.log statements

Generated with Claude Code