### PR TITLE
fix(samples): drop fonts.css from validation station runtime assets

### DIFF
--- a/samples/document-validation-app/vite.config.ts
+++ b/samples/document-validation-app/vite.config.ts
@@ -13,7 +13,7 @@ const WC_ROOT = dirname(
 
 // Stylesheets the web component fetches (as raw CSS) at runtime to adopt into its
 // shadow root.
-const WC_RUNTIME_CSS = ['styles.css', 'fonts.css'];
+const WC_RUNTIME_CSS = ['styles.css'];
 
 // BUILD: place the web component's runtime files next to the emitted JS chunks, where
 // `import.meta.url` will resolve them.


### PR DESCRIPTION
## Summary

- The DU validation station WC (`@uipath/du-validation-station-wc`) no longer ships `fonts.css` — only `styles.css`
- The sample app's vite config still listed both, causing `ENOENT` on build
- Aligns with [uipath-ui-widgets vite.config.ts](https://github.com/UiPath/uipath-ui-widgets/blob/59682ebeb8225fa7ba51e2ca92a3960f90862b38/vite.config.ts#L15)