### PR TITLE
fix(samples): update package-lock.json

### DIFF
--- a/samples/data-fabric-app/package-lock.json
+++ b/samples/data-fabric-app/package-lock.json
@@ -2617,7 +2617,7 @@
     },
     "node_modules/@uipath/ui-widgets-datatable": {
       "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@uipath/ui-widgets-datatable/1.0.1/aa2b1cb2eb43eab0c1f5de48c37cf72dde61a606",
+      "resolved": "https://registry.npmjs.org/@uipath/ui-widgets-datatable/-/ui-widgets-datatable-1.0.1.tgz",
       "integrity": "sha512-dHnfxZK61CSbsMUzOsQXs8UXVr/ytY3HOUQN3XP8dChYQlS0Nzr9lCRFSBReejm5vXmI7qsmNTPw3iMW6JTZxQ==",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
The PR is to point `ui-widgets-datatable` package to npm.