### PR TITLE
docs: mark agent-memory as preview, restructure agents nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,7 @@ nav:
   - API Reference:
       - Services:
           - Agents:
+            - agents/index.md
             - Conversational Agent:
               - conversational-agent/index.md
               - Conversations:
@@ -189,8 +190,7 @@ nav:
               - Messages: api/interfaces/MessageServiceModel.md
               - User Settings: api/interfaces/UserSettingsServiceModel.md
             - Feedback: api/interfaces/FeedbackServiceModel.md
-            - Agents: api/interfaces/AgentServiceModel.md
-            - Agent Memory: api/interfaces/AgentMemoryServiceModel.md
+            - Memory Spaces: api/interfaces/AgentMemoryServiceModel.md
           - Attachments:
             - api/interfaces/attachments/index.md
           - Assets: api/interfaces/AssetServiceModel.md

--- a/scripts/docs-post-process.mjs
+++ b/scripts/docs-post-process.mjs
@@ -37,6 +37,11 @@ const sections = [
     removeSource: true,
   },
   {
+    source: 'api/interfaces/AgentServiceModel.md',
+    dest: 'agents/index.md',
+    header: '# Agents\n\n',
+  },
+  {
     source: 'api/interfaces/ConversationalAgentServiceModel.md',
     dest: 'conversational-agent/index.md',
     header: '# Conversational Agent\n\n',

--- a/src/models/agents/agents.models.ts
+++ b/src/models/agents/agents.models.ts
@@ -29,8 +29,26 @@ import type {
 /**
  * Service for retrieving runtime data for UiPath Agents.
  *
+ * UiPath Agents are AI-driven automations powered by large language models
+ * and machine learning that plan, make decisions, and execute tasks in
+ * dynamic environments.
+ *
  * See [About Agents](https://docs.uipath.com/agents/automation-cloud/latest/user-guide/about-agents)
  * for an overview of UiPath Agents.
+ *
+ * ### Usage
+ *
+ * Prerequisites: Initialize the SDK first - see [Getting Started](/uipath-typescript/getting-started/#import-initialize)
+ *
+ * ```typescript
+ * import { Agents } from '@uipath/uipath-typescript/agents';
+ *
+ * const agents = new Agents(sdk);
+ * const list = await agents.getAll(
+ *   new Date('2025-01-01T00:00:00Z'),
+ *   new Date('2025-02-01T00:00:00Z'),
+ * );
+ * ```
  */
 export interface AgentServiceModel {
   /**

--- a/src/models/agents/memory/memory.models.ts
+++ b/src/models/agents/memory/memory.models.ts
@@ -8,9 +8,16 @@ import {
 } from './memory.types';
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+ * Preview: This service is experimental and may change or be removed in future releases.
+ * ///
+ *
  * Service for managing UiPath Agent Memory.
  *
- * Agent Memory is a persistent store of information an agent 
+ * Agent Memory is a persistent store of information an agent
  * retains across runs to improve runtime reliability.
  *
  * @example
@@ -27,6 +34,13 @@ import {
  */
 export interface AgentMemoryServiceModel {
   /**
+   *
+   * @experimental
+   *
+   * /// warning
+   * Preview: This method is experimental and may change or be removed in future releases.
+   * ///
+   *
    * Gets agent memory state over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
@@ -58,6 +72,13 @@ export interface AgentMemoryServiceModel {
   getTimeline(options?: AgentMemoryGetTimelineOptions): Promise<AgentMemoryGetTimelineResponse[]>;
 
   /**
+   *
+   * @experimental
+   *
+   * /// warning
+   * Preview: This method is experimental and may change or be removed in future releases.
+   * ///
+   *
    * Gets the number of agent memory calls (accesses to the memory store) over time, with optional filters.
    *
    * @param options - Optional time window and scope filters
@@ -89,6 +110,13 @@ export interface AgentMemoryServiceModel {
   getCallsTimeline(options?: AgentMemoryGetCallsTimelineOptions): Promise<AgentMemoryGetCallsTimelineResponse[]>;
 
   /**
+   *
+   * @experimental
+   *
+   * /// warning
+   * Preview: This method is experimental and may change or be removed in future releases.
+   * ///
+   *
    * Gets the top memory spaces by memory count, with optional filters
    *
    * @param options - Optional limit, time window, and scope filters


### PR DESCRIPTION
1. Renamed the `Agent Memory` nav label to `Memory Spaces` (this is how it's shown in the platform)
2. Marked `Memory Spaces` services as preview
3. Restructured the Agents section so `AgentServiceModel` content is the landing page for the Agents dropdown (no separate entry)

<img width="1723" height="1002" alt="Screenshot 2026-07-07 at 3 37 52 AM" src="https://github.com/user-attachments/assets/a4ce8808-4ff9-4673-9150-07cf5e7e6dc4" />


<img width="1534" height="995" alt="Screenshot 2026-07-07 at 4 00 40 PM" src="https://github.com/user-attachments/assets/3fdc774c-50a1-4125-95d9-b1b9bc4df805" />

