### PR TITLE
feat(samples): runtime compliance dashboard sample (agentic governance insights)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Check out the [`/samples`](./samples) folder to see sample applications built us
 
 - **[process-app](./samples/process-app)**: A Maestro process management application demonstrating OAuth authentication and SDK usage
 - **[conversational-agent-app](./samples/conversational-agent-app)**: A Conversational Agent chat application with real-time streaming, conversation management, file attachments, tool call visualization, and feedback
+- **[dashboards/runtime-compliance](./samples/dashboards/runtime-compliance)**: A runtime compliance dashboard for AI agent fleets — compliance check results, enforcement outcomes, and flagged agents via the agentic governance insights APIs (requires the Agentic Governance private preview)
 
 <div align="right">
 

--- a/samples/dashboards/README.md
+++ b/samples/dashboards/README.md
@@ -1,0 +1,11 @@
+# Dashboard Samples
+
+A collection of UiPath **dashboard** samples — React + TypeScript Coded Apps that visualize live tenant data through the `@uipath/uipath-typescript` SDK: KPI cards with period-over-period deltas, drill-down charts, and record-grain tables.
+
+Pick the dashboard that matches what you want to observe, then open its folder and follow that README to set up and deploy.
+
+## Choose a sample
+
+| Sample | Use it when… | Demonstrates | OAuth scopes |
+|--------|--------------|--------------|--------------|
+| [`runtime-compliance`](./runtime-compliance) | You want runtime observability over **UiPath compliance checks** on your AI agent fleet — failures, enforcement outcomes, flagged agents, per-run reports. **Requires the Agentic Governance private preview.** | `AgentTraces.getGovernanceSummary` + cursor-paginated `getGovernanceDecisions` (SDK ≥ 1.5.1), client-side derivations, per-card time-range toggles | `Insights`, `Insights.RealTimeData`, `OR.Folders.Read` |

--- a/samples/dashboards/runtime-compliance/.gitignore
+++ b/samples/dashboards/runtime-compliance/.gitignore
@@ -1,0 +1,31 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Build outputs
+node_modules
+dist
+dist-ssr
+.uipath
+
+# The repo-root .gitignore has `lib/` to ignore build artifacts elsewhere
+# in the monorepo. Un-ignore our application source `src/lib/`.
+!src/lib/
+!src/lib/**
+
+# Local UiPath OAuth config (tenant-specific) — copy uipath.json.example
+# to uipath.json and fill in your values. The committed sample only ships
+# the .example template, not real tenant info.
+uipath.json
+
+# OS / editor
+.DS_Store
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/samples/dashboards/runtime-compliance/README.md
+++ b/samples/dashboards/runtime-compliance/README.md
@@ -1,0 +1,136 @@
+# Runtime Compliance Dashboard
+
+A sample React + TypeScript dashboard for **UiPath agentic runtime-governance insights**: compliance check results, enforcement outcomes, and flagged agents across your AI agent fleet, built with the UiPath TypeScript SDK. Deploys as a UiPath Coded App.
+
+> [!IMPORTANT]
+> **Agentic Governance private preview required.** This dashboard reads agentic runtime-governance insights — the results of **UiPath compliance checks** (recommended runtime safeguards evaluated during agent runs, distinct from admin-deployed policies). Data appears only when your organization is **enrolled in the Agentic Governance private preview** and your agents run with compliance checks enabled. Outside the preview, the dashboard deploys and signs in fine but every widget shows an empty state — deploy it once your org is opted in.
+
+> [!NOTE]
+> **Data access.** If the APIs return `403`, your account doesn't have access to governance data for the organization — ask your administrator.
+
+## What it shows
+
+| Widget | Description |
+| ------ | ----------- |
+| **Failed Compliance Checks** (KPI) | Deny verdicts in the window, with a change badge vs the prior equal-length period. Click → every failed check with agent, check, hook, mode, action, and full reason text. |
+| **Checks Failing** (KPI) | Distinct compliance checks with at least one failure. Click → evaluated-vs-failed per check. |
+| **Flagged Agents** (KPI) | Agents with at least one failed check. Click → evaluated-vs-failed per agent. |
+| **Enforcement Outcomes** (donut) | All evaluations split allowed / denied (enforced) / observed-only (audit mode). |
+| **Why Checks Failed** (donut) | Failures grouped by reason — run-specific numbers are stripped so similar reasons merge. |
+| **Agents by Failed Checks** (table) | Ranked highest first, with Top 5/10/20 toggle. |
+| **Agent Compliance by Run** (table) | One row per agent run, paginated. Click a run → its full report: checks passed vs failed per lifecycle hook, what was denied and why, and the complete decision log. |
+
+The KPI row shares one 24h / 7d / 30d toggle; each chart and the agents table carry their own.
+
+## SDK Usage
+
+### Importing the SDK
+
+```typescript
+// Core SDK for authentication
+import { UiPath, UiPathError } from '@uipath/uipath-typescript/core';
+
+// Agent traces service — carries the governance insights methods (SDK >= 1.5.1)
+import {
+  AgentTraces,
+  AgentGovernanceMode,
+  AgentGovernanceVerdict,
+} from '@uipath/uipath-typescript/traces';
+import type { AgentGovernanceDecisionGetResponse } from '@uipath/uipath-typescript/traces';
+```
+
+### Initializing the SDK
+
+```typescript
+// Create SDK instance — empty config is fine for Coded Apps;
+// the SDK reads from <meta name="uipath:*"> tags injected by the platform
+// (or by the @uipath/coded-apps-dev Vite plugin during local dev).
+const sdk = new UiPath();
+await sdk.initialize();
+
+const traces = new AgentTraces(sdk);
+
+// Aggregated posture for a window (+ the prior window for the change badge)
+const summary = await traces.getGovernanceSummary(start, { endTime: end, topN: 100 });
+console.log(`${summary.violations} failed of ${summary.total} checks`);
+
+// Every individual decision — one page per call, so loop the cursor
+let page = await traces.getGovernanceDecisions(start, { endTime: end, pageSize: 200 });
+const rows = [...page.items];
+while (page.hasNextPage && page.nextCursor) {
+  page = await traces.getGovernanceDecisions(start, { endTime: end, pageSize: 200, cursor: page.nextCursor });
+  rows.push(...page.items);
+}
+```
+
+### SDK methods exercised by this sample
+
+| Service | Method | Where it's used |
+| ------- | ------ | --------------- |
+| `AgentTraces` | `getGovernanceSummary` | KPI totals + prior-period change badge (`useKpis`) |
+| `AgentTraces` | `getGovernanceDecisions` (cursor-paginated) | Donuts, agents table, runs table, run reports, and every drill-down (`useDecisions`) |
+
+Everything else — outcome classification (audit mode = observed-only), reason normalization, per-run grouping by `traceId` — is derived client-side in [`src/lib/governance.ts`](./src/lib/governance.ts).
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- An **External Application** (non-confidential) in your UiPath org with:
+  - Scopes: `Insights Insights.RealTimeData OR.Folders.Read`
+  - Redirect URI: `http://localhost:5173`
+
+### Run locally
+
+```bash
+npm install
+cp uipath.json.example uipath.json   # fill in clientId, orgName, tenantName
+npm run dev
+```
+
+Open `http://localhost:5173` and sign in with your UiPath account.
+
+## Building for Production
+
+```bash
+npm run build
+```
+
+Built bundle lives in `dist/`. From there:
+
+```bash
+# One-time: install the codedapp tool plugin for the uip CLI.
+uip tools install codedapp
+
+# Sign in with the uip CLI (interactive — pick the org + tenant to deploy to).
+uip login --it
+
+uip codedapp pack ./dist --name runtime-compliance-dashboard --version 1.0.0
+uip codedapp publish
+uip codedapp deploy
+```
+
+See the [Coded Apps CLI reference](https://uipath.github.io/uipath-typescript/coded-apps/cli-reference/) for full options.
+
+## Troubleshooting
+
+1. **Every widget is empty** — your organization isn't enrolled in the Agentic Governance private preview, or your agents aren't running with UiPath compliance checks enabled. There is genuinely no data to show until both are true.
+
+2. **`403` / access errors** — your account doesn't have access to governance data for the organization. Ask your administrator.
+
+3. **Authentication fails / "Invalid redirect URI"** — verify the redirect URI on the External App matches `http://localhost:5173` for dev, and your deployed URL for production.
+
+4. **`getGovernanceDecisions is not a function`** — your installed SDK is older than `1.5.1`; run `npm install` to pick up the version pinned by this sample.
+
+### Getting help
+
+- [UiPath TypeScript SDK documentation](https://uipath.github.io/uipath-typescript/)
+
+## Technologies Used
+
+- **React 19** + **TypeScript** + **Vite**
+- **@uipath/uipath-typescript** — the SDK under test (`AgentTraces` governance insights, ≥ 1.5.1)
+- **@uipath/coded-apps-dev** — Vite plugin emitting `<meta name="uipath:*">` tags during local dev
+- **Recharts** for the donuts · **Tailwind CSS** · **lucide-react** icons
+- **OAuth 2.0** (handled by the SDK) for authentication

--- a/samples/dashboards/runtime-compliance/index.html
+++ b/samples/dashboards/runtime-compliance/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Runtime Compliance Violations</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.tsx"></script>
+  </body>
+</html>

--- a/samples/dashboards/runtime-compliance/package-lock.json
+++ b/samples/dashboards/runtime-compliance/package-lock.json
@@ -1,0 +1,2056 @@
+{
+  "name": "runtime-compliance-dashboard",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "runtime-compliance-dashboard",
+      "version": "1.0.0",
+      "dependencies": {
+        "@uipath/uipath-typescript": "^1.5.1",
+        "lucide-react": "^1.17.0",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+        "recharts": "^2.15.1"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.17",
+        "@types/node": "^25.9.1",
+        "@types/react": "^19.1.13",
+        "@types/react-dom": "^19.1.9",
+        "@uipath/coded-apps-dev": "^1.0.0-beta.1",
+        "@vitejs/plugin-react": "^6.0.3",
+        "postcss": "^8.5.15",
+        "tailwindcss": "^4.1.17",
+        "typescript": "~5.8.3",
+        "vite": "^8.1.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.204.0.tgz",
+      "integrity": "sha512-DqxY8yoAaiBPivoJD4UtgrMS8gEmzZ5lnaxzPojzLVHBGqPxgWm4zcuvcUHZiqQ6kRX2Klel2r9y8cA2HAtqpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.204.0.tgz",
+      "integrity": "sha512-y32iNNmpMUVFWSqbNrXE8xY/6EMge+HX3PXsMnCDV4cXT4SNT+W/3NgyMDf80KJL0fUK17/a0NmfXcrBhkFWrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.204.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.42.0.tgz",
+      "integrity": "sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
+      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
+      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-x64": "4.3.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
+      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
+      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
+      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
+      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
+      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
+      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
+      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
+      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
+      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
+      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
+      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
+      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
+      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.2",
+        "@tailwindcss/oxide": "4.3.2",
+        "postcss": "^8.5.15",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@uipath/coded-apps-dev": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://npm.pkg.github.com/download/@uipath/coded-apps-dev/1.0.0-beta.1/58f1c7d8d1629f4dfd21c70b6891decbef0cb3b8",
+      "integrity": "sha512-odwkDVNtt6yMjcvEuoRMo271o3mmpYDCQLecwFdHkmayr/G/yR6boJM3C1THdgRz3rjWJFSArW8OVB3C6O/TWg==",
+      "dev": true,
+      "dependencies": {
+        "unplugin": "^2.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@uipath/uipath-typescript": ">=1.0.0-0",
+        "esbuild": ">=0.17.0",
+        "rollup": ">=3.0.0",
+        "vite": ">=4.0.0",
+        "webpack": ">=5.0.0"
+      }
+    },
+    "node_modules/@uipath/core-telemetry": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://npm.pkg.github.com/download/@uipath/core-telemetry/1.0.0-beta.3/32d88184e5f8256cae61eaef80fe79e581a9b134",
+      "integrity": "sha512-e/IHHJ77tygw/LvFRSEQ/bxFlmTivrk0ApeRIsPqTpwxXNEryGxLzSjWCRflAKs3EYj+jiwEYRWINpodMjmrqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/sdk-logs": "^0.204.0"
+      }
+    },
+    "node_modules/@uipath/uipath-typescript": {
+      "version": "1.5.1",
+      "resolved": "https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.5.1/b09c9529168d651306ef05869965825417596161",
+      "integrity": "sha512-YJvxYJBL86E5ExuYselh3EO6cwdQM4qzGdr6BQw3nRTc9LlhiB11JbiekYq3fY6jX11so2FdXQPDU6JT1wqtUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@uipath/core-telemetry": "^1.0.0-beta.3",
+        "socket.io-client": "^4.8.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.2.1"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
+      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/samples/dashboards/runtime-compliance/package.json
+++ b/samples/dashboards/runtime-compliance/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "runtime-compliance-dashboard",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Sample React + TypeScript Coded App dashboard for UiPath agentic runtime-governance insights: compliance check results, enforcement outcomes, and flagged agents.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@uipath/uipath-typescript": "^1.5.1",
+    "lucide-react": "^1.17.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "recharts": "^2.15.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.17",
+    "@types/node": "^25.9.1",
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
+    "@uipath/coded-apps-dev": "^1.0.0-beta.1",
+    "@vitejs/plugin-react": "^6.0.3",
+    "postcss": "^8.5.15",
+    "tailwindcss": "^4.1.17",
+    "typescript": "~5.8.3",
+    "vite": "^8.1.0"
+  }
+}

--- a/samples/dashboards/runtime-compliance/postcss.config.js
+++ b/samples/dashboards/runtime-compliance/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}

--- a/samples/dashboards/runtime-compliance/src/App.tsx
+++ b/samples/dashboards/runtime-compliance/src/App.tsx
@@ -1,0 +1,24 @@
+import { AuthProvider, useAuth } from '@/context/AuthContext'
+import { Dashboard } from '@/components/Dashboard'
+import { LoginScreen } from '@/components/LoginScreen'
+
+function Gate() {
+  const { isAuthenticated, isLoading } = useAuth()
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-slate-200 border-t-(--brand)" />
+      </div>
+    )
+  }
+  return isAuthenticated ? <Dashboard /> : <LoginScreen />
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Gate />
+    </AuthProvider>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/AgentsTable.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/AgentsTable.tsx
@@ -1,0 +1,81 @@
+import { useMemo, useState } from 'react'
+import type { UiPath } from '@uipath/uipath-typescript/core'
+import { useDecisions } from '@/hooks/useGovernance'
+import { agentLabel, countBy, isFailed } from '@/lib/governance'
+import type { TimeWindow } from '@/lib/time'
+import { WINDOWS } from '@/lib/time'
+import { fmtInt } from '@/lib/format'
+import { CardShell, EmptyBlock, ErrorBlock, LoadingBlock } from './CardShell'
+import { Toggle } from './Toggle'
+
+const TOP_OPTIONS = ['5', '10', '20'] as const
+type TopN = (typeof TOP_OPTIONS)[number]
+
+/** Agents ranked by failed checks, highest first, with Top-N + time toggles. */
+export function AgentsTable({ sdk }: { sdk: UiPath }) {
+  const [window, setWindow] = useState<TimeWindow>('30d')
+  const [topN, setTopN] = useState<TopN>('20')
+  const decisions = useDecisions(sdk, window)
+
+  const ranked = useMemo(() => {
+    const failed = (decisions.data ?? []).filter(isFailed)
+    return countBy(failed, agentLabel).slice(0, Number(topN))
+  }, [decisions.data, topN])
+
+  const max = ranked[0]?.value ?? 0
+
+  return (
+    <CardShell
+      title="Agents by Failed Checks"
+      subtitle="Ranked, highest first"
+      controls={
+        <div className="flex flex-wrap items-center gap-2">
+          <Toggle
+            options={TOP_OPTIONS}
+            value={topN}
+            onChange={setTopN}
+            labels={{ '5': 'Top 5', '10': 'Top 10', '20': 'Top 20' }}
+            ariaLabel="Agents table size"
+          />
+          <Toggle options={WINDOWS} value={window} onChange={setWindow} ariaLabel="Agents table time range" />
+        </div>
+      }
+    >
+      {decisions.error ? (
+        <ErrorBlock message={decisions.error} />
+      ) : decisions.loading ? (
+        <LoadingBlock />
+      ) : ranked.length === 0 ? (
+        <EmptyBlock />
+      ) : (
+        <table className="w-full border-collapse text-left text-sm">
+          <thead>
+            <tr className="border-b border-slate-200 text-xs text-slate-500 uppercase">
+              <th className="w-56 py-2 pr-3 font-medium">Agent</th>
+              <th className="py-2 pr-3 font-medium" aria-hidden="true"></th>
+              <th className="w-28 py-2 text-right font-medium">Failed Checks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ranked.map((row) => (
+              <tr key={row.name} className="border-b border-slate-100">
+                <td className="max-w-0 truncate py-2.5 pr-3" title={row.name}>
+                  {row.name}
+                </td>
+                <td className="py-2.5 pr-3">
+                  <div className="h-2 w-full rounded-full bg-slate-100">
+                    <div
+                      className="h-2 rounded-full bg-(--brand)"
+                      style={{ width: `${max > 0 ? Math.max((row.value / max) * 100, 2) : 0}%` }}
+                    />
+                  </div>
+                </td>
+                <td className="py-2.5 text-right font-semibold tabular-nums">{fmtInt(row.value)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </CardShell>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/CardShell.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/CardShell.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react'
+import { ArrowUpRight } from 'lucide-react'
+
+interface CardShellProps {
+  title: string
+  subtitle?: string
+  /** Header controls (toggles). Wraps below the title when space is tight. */
+  controls?: ReactNode
+  onViewAll?: () => void
+  children: ReactNode
+}
+
+export function CardShell({ title, subtitle, controls, onViewAll, children }: CardShellProps) {
+  return (
+    <section className="flex min-w-0 flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      {/* flex-wrap keeps headers from cramping: controls drop below the title */}
+      <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <div className="min-w-0 flex-1 basis-48">
+          <div className="flex items-center gap-1.5">
+            <h3 className="truncate text-sm font-semibold" title={title}>
+              {title}
+            </h3>
+            {onViewAll && (
+              <button
+                type="button"
+                onClick={onViewAll}
+                className="inline-flex shrink-0 items-center gap-0.5 text-xs font-medium text-(--brand) hover:text-(--brand-dark)"
+              >
+                View all
+                <ArrowUpRight className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+          {subtitle && (
+            <p className="mt-0.5 truncate text-xs text-slate-500" title={subtitle}>
+              {subtitle}
+            </p>
+          )}
+        </div>
+        {controls}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export function LoadingBlock() {
+  return <div className="h-24 animate-pulse rounded-lg bg-slate-100" />
+}
+
+export function ErrorBlock({ message }: { message: string }) {
+  const accessDenied = /403|forbidden|authoriz/i.test(message)
+  return (
+    <div className="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+      {accessDenied
+        ? 'Your account does not have access to governance data for this organization — ask your administrator.'
+        : message}
+    </div>
+  )
+}
+
+export function EmptyBlock() {
+  return (
+    <p className="py-6 text-center text-sm text-slate-500">
+      No compliance checks in this window. Agents must run with UiPath compliance checks enabled
+      (Agentic Governance preview) for data to appear.
+    </p>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/Dashboard.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/Dashboard.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react'
+import { LogOut } from 'lucide-react'
+import { useAuth } from '@/context/AuthContext'
+import type { Decision, Slice } from '@/lib/governance'
+import { countBy, isFailed, normalizeReason, outcomeOf } from '@/lib/governance'
+import type { TimeWindow } from '@/lib/time'
+import { WINDOWS } from '@/lib/time'
+import { AgentsTable } from './AgentsTable'
+import { DonutCard } from './DonutCard'
+import { InfoTooltip } from './InfoTooltip'
+import { KpiSection } from './KpiSection'
+import { RunsTable } from './RunsTable'
+import { Toggle } from './Toggle'
+
+const OUTCOME_COLORS: Record<string, string> = {
+  Allowed: '#16a34a',
+  Denied: '#dc2626',
+  'Observed only': '#64748b',
+}
+
+/** Fixed-order outcome slices with stable semantic colors; zero slices drop out. */
+function outcomeSlices(rows: Decision[]): Slice[] {
+  const counts = new Map<string, number>()
+  for (const d of rows) {
+    const outcome = outcomeOf(d)
+    counts.set(outcome, (counts.get(outcome) ?? 0) + 1)
+  }
+  return (['Allowed', 'Denied', 'Observed only'] as const)
+    .map((name) => ({ name, value: counts.get(name) ?? 0, color: OUTCOME_COLORS[name] }))
+    .filter((slice) => slice.value > 0)
+}
+
+const MAX_REASON_SLICES = 6
+
+/** Failed checks grouped by normalized reason; long tails collapse into "Other". */
+function reasonSlices(rows: Decision[]): Slice[] {
+  const grouped = countBy(rows.filter(isFailed), (d) => normalizeReason(d.reason))
+  if (grouped.length <= MAX_REASON_SLICES) return grouped
+  const head = grouped.slice(0, MAX_REASON_SLICES - 1)
+  const otherTotal = grouped.slice(MAX_REASON_SLICES - 1).reduce((sum, s) => sum + s.value, 0)
+  return [...head, { name: 'Other', value: otherTotal }]
+}
+
+// Orange-led palette — UiPath orange is the primary chart color.
+const REASON_COLORS = ['#fa4616', '#fb923c', '#fdba74', '#7c3aed', '#0ea5e9', '#64748b']
+const OUTCOME_FALLBACK_COLORS = ['#fa4616', '#64748b', '#16a34a']
+
+export function Dashboard() {
+  const { sdk, logout } = useAuth()
+  const [kpiWindow, setKpiWindow] = useState<TimeWindow>('30d')
+
+  return (
+    <div className="mx-auto min-h-screen max-w-6xl px-4 py-8 lg:px-8">
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold">Runtime Compliance Violations</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            UiPath compliance check results, enforcement outcomes, and flagged agents across your
+            AI agent fleet.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={logout}
+          className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
+        >
+          <LogOut className="h-3.5 w-3.5" />
+          Sign out
+        </button>
+      </header>
+
+      {/* Overview row: section label + tooltip on the left, ONE shared window
+          toggle for all three KPI cards on the right. */}
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <h2 className="text-sm font-semibold text-slate-700">Overview</h2>
+          <InfoTooltip text="These metrics reflect UiPath compliance checks — recommended runtime safeguards evaluated during agent runs — not policies deployed by your administrators." />
+        </div>
+        <Toggle options={WINDOWS} value={kpiWindow} onChange={setKpiWindow} ariaLabel="Overview time range" />
+      </div>
+      <KpiSection sdk={sdk} window={kpiWindow} />
+
+      <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <DonutCard
+          sdk={sdk}
+          title="Enforcement Outcomes"
+          subtitle="Allowed / Denied / Observed-only"
+          slicesOf={outcomeSlices}
+          recordsOf={(rows) => rows}
+          headlineNoun="evaluations"
+          colors={OUTCOME_FALLBACK_COLORS}
+        />
+        <DonutCard
+          sdk={sdk}
+          title="Why Checks Failed"
+          subtitle="Failed checks grouped by reason"
+          slicesOf={reasonSlices}
+          recordsOf={(rows) => rows.filter(isFailed)}
+          headlineNoun="failed checks"
+          colors={REASON_COLORS}
+        />
+      </div>
+
+      <div className="mt-6">
+        <AgentsTable sdk={sdk} />
+      </div>
+
+      <div className="mt-6">
+        <RunsTable sdk={sdk} window="30d" />
+      </div>
+    </div>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/DecisionsTable.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/DecisionsTable.tsx
@@ -1,0 +1,53 @@
+import type { Decision } from '@/lib/governance'
+import { agentLabel, checkName } from '@/lib/governance'
+import { fmtTime } from '@/lib/format'
+
+/**
+ * Shared record-grain table: one row per compliance-check decision.
+ * Truncated cells always expose their full value via `title` (hover).
+ */
+export function DecisionsTable({ rows }: { rows: Decision[] }) {
+  if (rows.length === 0) {
+    return <p className="py-6 text-center text-sm text-slate-500">No records in this window.</p>
+  }
+  return (
+    <table className="w-full table-fixed border-collapse text-left text-sm">
+      <thead>
+        <tr className="border-b border-slate-200 text-xs text-slate-500 uppercase">
+          <th className="w-[16%] py-2 pr-3 font-medium">Agent</th>
+          <th className="w-[18%] py-2 pr-3 font-medium">Check</th>
+          <th className="w-[12%] py-2 pr-3 font-medium">Hook</th>
+          <th className="w-[9%] py-2 pr-3 font-medium">Mode</th>
+          <th className="w-[9%] py-2 pr-3 font-medium">Action</th>
+          <th className="w-[24%] py-2 pr-3 font-medium">Reason</th>
+          <th className="w-[12%] py-2 font-medium">Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((d, i) => (
+          <tr key={`${d.traceId}-${i}`} className="border-b border-slate-100 align-top">
+            <td className="truncate py-2 pr-3" title={agentLabel(d)}>
+              {agentLabel(d)}
+            </td>
+            <td className="truncate py-2 pr-3" title={checkName(d)}>
+              {checkName(d)}
+            </td>
+            <td className="truncate py-2 pr-3 text-slate-600" title={d.hook ?? ''}>
+              {d.hook ?? '—'}
+            </td>
+            <td className="py-2 pr-3 text-slate-600">{d.mode.toLowerCase()}</td>
+            <td className="truncate py-2 pr-3 text-slate-600" title={d.actionApplied ?? ''}>
+              {d.actionApplied?.toLowerCase() ?? '—'}
+            </td>
+            <td className="truncate py-2 pr-3 text-slate-600" title={d.reason ?? ''}>
+              {d.reason ?? '—'}
+            </td>
+            <td className="truncate py-2 text-slate-500" title={fmtTime(d.startTime)}>
+              {fmtTime(d.startTime)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/DonutCard.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/DonutCard.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from 'react'
+import type { UiPath } from '@uipath/uipath-typescript/core'
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
+import { useDecisions } from '@/hooks/useGovernance'
+import type { Decision, Slice } from '@/lib/governance'
+import type { TimeWindow } from '@/lib/time'
+import { WINDOWS, WINDOW_LABEL } from '@/lib/time'
+import { fmtInt, fmtPercent } from '@/lib/format'
+import { CardShell, EmptyBlock, ErrorBlock, LoadingBlock } from './CardShell'
+import { DecisionsTable } from './DecisionsTable'
+import { Modal } from './Modal'
+import { Toggle } from './Toggle'
+
+interface DonutCardProps {
+  sdk: UiPath
+  title: string
+  subtitle: string
+  /** Derive donut slices from the window's decisions. */
+  slicesOf: (rows: Decision[]) => Slice[]
+  /** Rows behind the donut, shown by "View all". */
+  recordsOf: (rows: Decision[]) => Decision[]
+  headlineNoun: string
+  colors: string[]
+}
+
+/**
+ * Donut over the window's compliance-check decisions, with its own time
+ * toggle. The legend always lists every slice with count + percentage, so the
+ * chart stays readable even when one slice dominates (e.g. 97% observed-only).
+ */
+export function DonutCard({
+  sdk,
+  title,
+  subtitle,
+  slicesOf,
+  recordsOf,
+  headlineNoun,
+  colors,
+}: DonutCardProps) {
+  const [window, setWindow] = useState<TimeWindow>('30d')
+  const [open, setOpen] = useState(false)
+  const decisions = useDecisions(sdk, window)
+
+  const slices = useMemo(() => slicesOf(decisions.data ?? []), [decisions.data, slicesOf])
+  const records = useMemo(() => recordsOf(decisions.data ?? []), [decisions.data, recordsOf])
+  const total = slices.reduce((sum, s) => sum + s.value, 0)
+
+  return (
+    <>
+      <CardShell
+        title={title}
+        subtitle={subtitle}
+        onViewAll={() => setOpen(true)}
+        controls={
+          <Toggle options={WINDOWS} value={window} onChange={setWindow} ariaLabel={`${title} time range`} />
+        }
+      >
+        {decisions.error ? (
+          <ErrorBlock message={decisions.error} />
+        ) : decisions.loading ? (
+          <LoadingBlock />
+        ) : total === 0 ? (
+          <EmptyBlock />
+        ) : (
+          <div className="flex items-center gap-6">
+            <div className="h-44 w-44 shrink-0">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={slices}
+                    dataKey="value"
+                    nameKey="name"
+                    innerRadius={52}
+                    outerRadius={80}
+                    paddingAngle={slices.length > 1 ? 2 : 0}
+                    strokeWidth={0}
+                  >
+                    {slices.map((slice, i) => (
+                      <Cell key={slice.name} fill={slice.color ?? colors[i % colors.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip formatter={(value) => fmtInt(Number(value))} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="mb-2 text-sm font-semibold">
+                {fmtInt(total)} {headlineNoun}
+              </p>
+              <ul className="space-y-1.5">
+                {slices.map((slice, i) => (
+                  <li key={slice.name} className="flex items-center gap-2 text-sm">
+                    <span
+                      className="h-2.5 w-2.5 shrink-0 rounded-sm"
+                      style={{ backgroundColor: slice.color ?? colors[i % colors.length] }}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-slate-700" title={slice.name}>
+                      {slice.name}
+                    </span>
+                    <span className="shrink-0 text-slate-500 tabular-nums">
+                      {fmtInt(slice.value)} ({fmtPercent(slice.value, total)})
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+      </CardShell>
+
+      {open && (
+        <Modal
+          title={title}
+          subtitle={`Individual records in the ${WINDOW_LABEL[window]}`}
+          onClose={() => setOpen(false)}
+        >
+          {records.length === 0 ? <EmptyBlock /> : <DecisionsTable rows={records} />}
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/InfoTooltip.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/InfoTooltip.tsx
@@ -1,0 +1,22 @@
+import { Info } from 'lucide-react'
+
+/** Small ⓘ affordance with a hover/focus tooltip — not a banner. */
+export function InfoTooltip({ text }: { text: string }) {
+  return (
+    <span className="group relative inline-flex">
+      <button
+        type="button"
+        aria-label="More information"
+        className="inline-flex text-slate-400 hover:text-slate-600 focus:outline-none"
+      >
+        <Info className="h-3.5 w-3.5" />
+      </button>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute top-full left-1/2 z-20 mt-1.5 w-72 -translate-x-1/2 rounded-md bg-slate-900 px-3 py-2 text-xs leading-relaxed text-slate-100 opacity-0 shadow-lg transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
+      >
+        {text}
+      </span>
+    </span>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/KpiSection.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/KpiSection.tsx
@@ -1,0 +1,199 @@
+import { useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { UiPath } from '@uipath/uipath-typescript/core'
+import { TrendingDown, TrendingUp } from 'lucide-react'
+import { useDecisions, useKpis } from '@/hooks/useGovernance'
+import type { Decision } from '@/lib/governance'
+import { agentLabel, checkName, isFailed } from '@/lib/governance'
+import type { TimeWindow } from '@/lib/time'
+import { WINDOW_LABEL } from '@/lib/time'
+import { fmtInt } from '@/lib/format'
+import { CardShell, EmptyBlock, ErrorBlock, LoadingBlock } from './CardShell'
+import { DecisionsTable } from './DecisionsTable'
+import { Modal } from './Modal'
+
+type KpiModal = 'failed' | 'checks' | 'agents' | null
+
+interface KpiSectionProps {
+  sdk: UiPath
+  window: TimeWindow
+}
+
+/** Grouped evaluated-vs-failed table used by the Checks Failing / Flagged Agents drill-downs. */
+function GroupedTable({
+  rows,
+  keyOf,
+  keyHeader,
+}: {
+  rows: Decision[]
+  keyOf: (d: Decision) => string
+  keyHeader: string
+}) {
+  const grouped = useMemo(() => {
+    const acc = new Map<string, { evaluated: number; failed: number }>()
+    for (const d of rows) {
+      const k = keyOf(d)
+      const entry = acc.get(k) ?? { evaluated: 0, failed: 0 }
+      entry.evaluated += 1
+      if (isFailed(d)) entry.failed += 1
+      acc.set(k, entry)
+    }
+    return [...acc.entries()]
+      .filter(([, v]) => v.failed > 0)
+      .sort((a, b) => b[1].failed - a[1].failed)
+  }, [rows, keyOf])
+
+  if (grouped.length === 0) {
+    return <p className="py-6 text-center text-sm text-slate-500">Nothing failing in this window.</p>
+  }
+  return (
+    <table className="w-full border-collapse text-left text-sm">
+      <thead>
+        <tr className="border-b border-slate-200 text-xs text-slate-500 uppercase">
+          <th className="py-2 pr-3 font-medium">{keyHeader}</th>
+          <th className="w-28 py-2 pr-3 text-right font-medium">Evaluated</th>
+          <th className="w-28 py-2 text-right font-medium">Failed</th>
+        </tr>
+      </thead>
+      <tbody>
+        {grouped.map(([name, v]) => (
+          <tr key={name} className="border-b border-slate-100">
+            <td className="max-w-0 truncate py-2 pr-3" title={name}>
+              {name}
+            </td>
+            <td className="py-2 pr-3 text-right tabular-nums">{fmtInt(v.evaluated)}</td>
+            <td className="py-2 text-right font-semibold tabular-nums">{fmtInt(v.failed)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export function KpiSection({ sdk, window }: KpiSectionProps) {
+  const kpis = useKpis(sdk, window)
+  const decisions = useDecisions(sdk, window)
+  const [open, setOpen] = useState<KpiModal>(null)
+
+  const failedRows = useMemo(
+    () => (decisions.data ?? []).filter(isFailed),
+    [decisions.data],
+  )
+
+  const delta = (kpis.data?.failedChecks ?? 0) - (kpis.data?.priorFailedChecks ?? 0)
+
+  const cards: Array<{
+    key: Exclude<KpiModal, null>
+    title: string
+    description: string
+    value: number | undefined
+    badge?: ReactNode
+  }> = [
+    {
+      key: 'failed',
+      title: 'Failed Compliance Checks',
+      description: 'Deny verdicts from UiPath compliance checks',
+      value: kpis.data?.failedChecks,
+      badge:
+        kpis.data && delta !== 0 ? (
+          <span
+            className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-semibold ${
+              delta > 0 ? 'bg-red-50 text-red-600' : 'bg-emerald-50 text-emerald-600'
+            }`}
+            title={`${fmtInt(Math.abs(delta))} ${delta > 0 ? 'more' : 'fewer'} than the prior period`}
+          >
+            {delta > 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+            {delta > 0 ? '+' : '−'}
+            {fmtInt(Math.abs(delta))}
+          </span>
+        ) : undefined,
+    },
+    {
+      key: 'checks',
+      title: 'Checks Failing',
+      description: 'Distinct compliance checks breached',
+      value: kpis.data?.checksFailing,
+    },
+    {
+      key: 'agents',
+      title: 'Flagged Agents',
+      description: 'Agents with at least one failed check',
+      value: kpis.data?.flaggedAgents,
+    },
+  ]
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((card) => (
+          <CardShell
+            key={card.key}
+            title={card.title}
+            onViewAll={() => setOpen(card.key)}
+          >
+            {kpis.error ? (
+              <ErrorBlock message={kpis.error} />
+            ) : kpis.loading ? (
+              <LoadingBlock />
+            ) : (
+              <div>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-3xl font-bold tabular-nums">
+                    {fmtInt(card.value ?? 0)}
+                  </span>
+                  {card.badge}
+                </div>
+                <p className="mt-1 text-xs text-slate-500">{card.description}</p>
+                {card.key === 'failed' && (
+                  <p className="mt-0.5 text-xs text-slate-400">vs prior period</p>
+                )}
+              </div>
+            )}
+          </CardShell>
+        ))}
+      </div>
+
+      {open === 'failed' && (
+        <Modal
+          title="Failed Compliance Checks"
+          subtitle={`Every deny verdict in the ${WINDOW_LABEL[window]}`}
+          onClose={() => setOpen(null)}
+        >
+          {decisions.loading ? (
+            <LoadingBlock />
+          ) : failedRows.length === 0 ? (
+            <EmptyBlock />
+          ) : (
+            <DecisionsTable rows={failedRows} />
+          )}
+        </Modal>
+      )}
+      {open === 'checks' && (
+        <Modal
+          title="Checks Failing"
+          subtitle={`Compliance checks with at least one failure in the ${WINDOW_LABEL[window]}`}
+          onClose={() => setOpen(null)}
+        >
+          {decisions.loading ? (
+            <LoadingBlock />
+          ) : (
+            <GroupedTable rows={decisions.data ?? []} keyOf={checkName} keyHeader="Check" />
+          )}
+        </Modal>
+      )}
+      {open === 'agents' && (
+        <Modal
+          title="Flagged Agents"
+          subtitle={`Agents with at least one failed check in the ${WINDOW_LABEL[window]}`}
+          onClose={() => setOpen(null)}
+        >
+          {decisions.loading ? (
+            <LoadingBlock />
+          ) : (
+            <GroupedTable rows={decisions.data ?? []} keyOf={agentLabel} keyHeader="Agent" />
+          )}
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/LoginScreen.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/LoginScreen.tsx
@@ -1,0 +1,27 @@
+import { ShieldCheck } from 'lucide-react'
+import { useAuth } from '@/context/AuthContext'
+
+export function LoginScreen() {
+  const { login, isLoading, error } = useAuth()
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm">
+        <ShieldCheck className="mx-auto h-10 w-10 text-(--brand)" />
+        <h1 className="mt-4 text-lg font-bold">Runtime Compliance Violations</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Sign in with your UiPath account to load compliance check results for your agent fleet.
+        </p>
+        <button
+          type="button"
+          onClick={login}
+          disabled={isLoading}
+          className="mt-6 w-full rounded-lg bg-(--brand) px-4 py-2 text-sm font-semibold text-white hover:bg-(--brand-dark) disabled:opacity-50"
+        >
+          {isLoading ? 'Signing in…' : 'Sign in with UiPath'}
+        </button>
+        {error && <p className="mt-3 text-xs text-red-600">{error}</p>}
+      </div>
+    </div>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/Modal.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/Modal.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+import type { ReactNode } from 'react'
+import { X } from 'lucide-react'
+
+interface ModalProps {
+  title: string
+  subtitle?: string
+  onClose: () => void
+  children: ReactNode
+}
+
+export function Modal({ title, subtitle, onClose, children }: ModalProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="flex max-h-[85vh] w-full max-w-4xl flex-col rounded-xl bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-slate-100 px-5 py-4">
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-semibold" title={title}>
+              {title}
+            </h2>
+            {subtitle && <p className="mt-0.5 text-xs text-slate-500">{subtitle}</p>}
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="overflow-auto px-5 py-4">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/RunReportModal.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/RunReportModal.tsx
@@ -1,0 +1,63 @@
+import { CheckCircle2, XCircle } from 'lucide-react'
+import type { RunReport } from '@/lib/governance'
+import { checkName } from '@/lib/governance'
+import { fmtInt } from '@/lib/format'
+import { DecisionsTable } from './DecisionsTable'
+import { Modal } from './Modal'
+
+interface RunReportModalProps {
+  report: RunReport
+  agentName: string
+  onClose: () => void
+}
+
+/**
+ * Full compliance report for one agent run: checks passed vs failed at each
+ * lifecycle hook, what was denied and why, and the complete decision log.
+ */
+export function RunReportModal({ report, agentName, onClose }: RunReportModalProps) {
+  return (
+    <Modal title={`Compliance report — ${agentName}`} onClose={onClose}>
+      <h4 className="mb-2 text-xs font-semibold text-slate-500 uppercase">Checks by lifecycle hook</h4>
+      <div className="mb-5 flex flex-wrap gap-2">
+        {report.byHook.map((h) => (
+          <span
+            key={h.hook}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs"
+          >
+            <span className="font-medium">{h.hook}</span>
+            <span className="inline-flex items-center gap-0.5 text-emerald-600">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              {fmtInt(h.passed)}
+            </span>
+            <span
+              className={`inline-flex items-center gap-0.5 ${h.failed > 0 ? 'text-red-600' : 'text-slate-400'}`}
+            >
+              <XCircle className="h-3.5 w-3.5" />
+              {fmtInt(h.failed)}
+            </span>
+          </span>
+        ))}
+      </div>
+
+      {report.denied.length > 0 && (
+        <>
+          <h4 className="mb-2 text-xs font-semibold text-slate-500 uppercase">Denied — and why</h4>
+          <ul className="mb-5 space-y-2">
+            {report.denied.map((d, i) => (
+              <li key={i} className="rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-sm">
+                <span className="font-medium">{checkName(d)}</span>
+                <span className="text-slate-500"> · {d.hook ?? '—'} · </span>
+                <span className="text-slate-600">{d.actionApplied?.toLowerCase() ?? 'denied'}</span>
+                {d.reason && <p className="mt-1 text-xs text-slate-600">{d.reason}</p>}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      <h4 className="mb-2 text-xs font-semibold text-slate-500 uppercase">Complete decision log</h4>
+      <DecisionsTable rows={report.rows} />
+    </Modal>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/RunsTable.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/RunsTable.tsx
@@ -1,0 +1,123 @@
+import { useMemo, useState } from 'react'
+import type { UiPath } from '@uipath/uipath-typescript/core'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useDecisions } from '@/hooks/useGovernance'
+import { buildRunReport, deriveRuns } from '@/lib/governance'
+import type { TimeWindow } from '@/lib/time'
+import { fmtInt, fmtTime } from '@/lib/format'
+import { CardShell, EmptyBlock, ErrorBlock, LoadingBlock } from './CardShell'
+import { RunReportModal } from './RunReportModal'
+
+const PAGE_SIZE = 25
+
+/**
+ * One row per agent run, newest first, paginated. Clicking a run opens its
+ * full compliance report.
+ */
+export function RunsTable({ sdk, window }: { sdk: UiPath; window: TimeWindow }) {
+  const decisions = useDecisions(sdk, window)
+  const [page, setPage] = useState(0)
+  const [openRun, setOpenRun] = useState<string | null>(null)
+
+  const runs = useMemo(() => deriveRuns(decisions.data ?? []), [decisions.data])
+  const pageCount = Math.max(1, Math.ceil(runs.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount - 1)
+  const visible = runs.slice(clampedPage * PAGE_SIZE, (clampedPage + 1) * PAGE_SIZE)
+
+  const report = useMemo(
+    () => (openRun ? buildRunReport(decisions.data ?? [], openRun) : null),
+    [decisions.data, openRun],
+  )
+
+  return (
+    <>
+      <CardShell title="Agent Compliance by Run" subtitle="One row per agent run — click a run for its full report">
+        {decisions.error ? (
+          <ErrorBlock message={decisions.error} />
+        ) : decisions.loading ? (
+          <LoadingBlock />
+        ) : runs.length === 0 ? (
+          <EmptyBlock />
+        ) : (
+          <>
+            <table className="w-full border-collapse text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-xs text-slate-500 uppercase">
+                  <th className="py-2 pr-3 font-medium">Agent</th>
+                  <th className="w-44 py-2 pr-3 font-medium">Started</th>
+                  <th className="w-24 py-2 pr-3 text-right font-medium">Evaluated</th>
+                  <th className="w-24 py-2 pr-3 text-right font-medium">Failed</th>
+                  <th className="w-28 py-2 font-medium">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((run) => (
+                  <tr
+                    key={run.runKey}
+                    className="cursor-pointer border-b border-slate-100 hover:bg-slate-50"
+                    onClick={() => setOpenRun(run.runKey)}
+                  >
+                    <td className="max-w-0 truncate py-2.5 pr-3 font-medium" title={run.agentName}>
+                      {run.agentName}
+                    </td>
+                    <td className="truncate py-2.5 pr-3 text-slate-600" title={fmtTime(run.startTime)}>
+                      {fmtTime(run.startTime)}
+                    </td>
+                    <td className="py-2.5 pr-3 text-right tabular-nums">{fmtInt(run.evaluated)}</td>
+                    <td
+                      className={`py-2.5 pr-3 text-right font-semibold tabular-nums ${
+                        run.failed > 0 ? 'text-red-600' : 'text-slate-400'
+                      }`}
+                    >
+                      {fmtInt(run.failed)}
+                    </td>
+                    <td className="truncate py-2.5 text-slate-600" title={run.action}>
+                      {run.action}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-3 flex items-center justify-between text-xs text-slate-500">
+              <span>
+                Showing {fmtInt(clampedPage * PAGE_SIZE + 1)}–
+                {fmtInt(Math.min((clampedPage + 1) * PAGE_SIZE, runs.length))} of {fmtInt(runs.length)} runs
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <button
+                  type="button"
+                  aria-label="Previous page"
+                  disabled={clampedPage === 0}
+                  onClick={() => setPage(clampedPage - 1)}
+                  className="rounded-md border border-slate-200 p-1 disabled:opacity-40"
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </button>
+                <span className="px-1 tabular-nums">
+                  {fmtInt(clampedPage + 1)} / {fmtInt(pageCount)}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Next page"
+                  disabled={clampedPage >= pageCount - 1}
+                  onClick={() => setPage(clampedPage + 1)}
+                  className="rounded-md border border-slate-200 p-1 disabled:opacity-40"
+                >
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </button>
+              </span>
+            </div>
+          </>
+        )}
+      </CardShell>
+
+      {openRun && report && (
+        <RunReportModal
+          report={report}
+          agentName={runs.find((r) => r.runKey === openRun)?.agentName ?? 'Agent run'}
+          onClose={() => setOpenRun(null)}
+        />
+      )}
+    </>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/components/Toggle.tsx
+++ b/samples/dashboards/runtime-compliance/src/components/Toggle.tsx
@@ -1,0 +1,40 @@
+interface ToggleProps<T extends string> {
+  options: readonly T[]
+  value: T
+  onChange: (value: T) => void
+  labels?: Partial<Record<T, string>>
+  ariaLabel: string
+}
+
+/**
+ * Segmented toggle — the active option renders as a filled UiPath-orange pill
+ * with white text; inactive options stay plain.
+ */
+export function Toggle<T extends string>({ options, value, onChange, labels, ariaLabel }: ToggleProps<T>) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="inline-flex shrink-0 items-center gap-0.5 rounded-lg border border-slate-200 bg-white p-0.5"
+    >
+      {options.map((option) => {
+        const active = option === value
+        return (
+          <button
+            key={option}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(option)}
+            className={
+              active
+                ? 'rounded-md bg-(--brand) px-2.5 py-1 text-xs font-semibold text-white'
+                : 'rounded-md px-2.5 py-1 text-xs font-medium text-slate-500 hover:text-slate-800'
+            }
+          >
+            {labels?.[option] ?? option}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/samples/dashboards/runtime-compliance/src/context/AuthContext.tsx
+++ b/samples/dashboards/runtime-compliance/src/context/AuthContext.tsx
@@ -1,0 +1,91 @@
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { UiPath, UiPathError } from '@uipath/uipath-typescript/core'
+
+interface AuthContextType {
+  isAuthenticated: boolean
+  isLoading: boolean
+  sdk: UiPath
+  login: () => Promise<void>
+  logout: () => void
+  error: string | null
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+/**
+ * Provides the authenticated UiPath SDK instance to the app.
+ *
+ * Coded App pattern: `new UiPath()` (no config) picks up `clientId`,
+ * `orgName`, `tenantName`, `baseUrl`, `scope`, and `redirectUri` from the
+ * `<meta name="uipath:*">` tags injected by `@uipath/coded-apps-dev`
+ * (locally, from `uipath.json`) or by the UiPath platform (in production).
+ */
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [sdk] = useState<UiPath>(() => new UiPath())
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Guard against React StrictMode's double-invocation in dev — the OAuth
+  // `code` is single-use, so calling completeOAuth() twice fails the second
+  // time with "Authentication failed".
+  const didInit = useRef(false)
+
+  useEffect(() => {
+    if (didInit.current) return
+    didInit.current = true
+
+    const init = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        if (sdk.isInOAuthCallback()) {
+          // SDK strips ?code & ?state from the URL after a successful exchange.
+          await sdk.completeOAuth()
+        }
+        setIsAuthenticated(sdk.isAuthenticated())
+      } catch (err) {
+        console.error('Auth init failed:', err)
+        setError(err instanceof UiPathError ? err.message : 'Authentication failed')
+        setIsAuthenticated(false)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    init()
+  }, [sdk])
+
+  const login = async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      await sdk.initialize()
+      setIsAuthenticated(sdk.isAuthenticated())
+    } catch (err) {
+      console.error('Login failed:', err)
+      setError(err instanceof UiPathError ? err.message : 'Login failed')
+      setIsAuthenticated(false)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const logout = () => {
+    sdk.logout()
+    setIsAuthenticated(false)
+    setError(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, isLoading, sdk, login, logout, error }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>')
+  return ctx
+}

--- a/samples/dashboards/runtime-compliance/src/hooks/useGovernance.ts
+++ b/samples/dashboards/runtime-compliance/src/hooks/useGovernance.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react'
+import type { UiPath } from '@uipath/uipath-typescript/core'
+import type { Decision, KpiTotals } from '@/lib/governance'
+import { fetchDecisions, fetchKpis } from '@/lib/governance'
+import type { TimeWindow } from '@/lib/time'
+import { rangeFor } from '@/lib/time'
+
+interface Result<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+}
+
+// Session-scoped caches so toggling a card between windows it has already
+// shown is instant, and cards sharing a window share one network call.
+const decisionsCache = new Map<TimeWindow, Promise<Decision[]>>()
+const kpisCache = new Map<TimeWindow, Promise<KpiTotals>>()
+
+function useCached<T>(
+  sdk: UiPath,
+  window: TimeWindow,
+  cache: Map<TimeWindow, Promise<T>>,
+  fetcher: (sdk: UiPath, range: ReturnType<typeof rangeFor>) => Promise<T>,
+): Result<T> {
+  const [state, setState] = useState<Result<T>>({ data: null, loading: true, error: null })
+
+  useEffect(() => {
+    let cancelled = false
+    setState((s) => ({ ...s, loading: true, error: null }))
+    let promise = cache.get(window)
+    if (!promise) {
+      promise = fetcher(sdk, rangeFor(window))
+      cache.set(window, promise)
+    }
+    promise
+      .then((data) => {
+        if (!cancelled) setState({ data, loading: false, error: null })
+      })
+      .catch((err: unknown) => {
+        cache.delete(window) // don't cache failures
+        if (!cancelled) {
+          setState({
+            data: null,
+            loading: false,
+            error: err instanceof Error ? err.message : 'Request failed',
+          })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sdk, window])
+
+  return state
+}
+
+/** All compliance-check decisions for the window (cursor-looped, cached). */
+export function useDecisions(sdk: UiPath, window: TimeWindow): Result<Decision[]> {
+  return useCached(sdk, window, decisionsCache, fetchDecisions)
+}
+
+/** KPI totals (current + prior window) from the aggregated summary. */
+export function useKpis(sdk: UiPath, window: TimeWindow): Result<KpiTotals> {
+  return useCached(sdk, window, kpisCache, fetchKpis)
+}

--- a/samples/dashboards/runtime-compliance/src/index.css
+++ b/samples/dashboards/runtime-compliance/src/index.css
@@ -1,0 +1,19 @@
+@import 'tailwindcss';
+
+:root {
+  /* UiPath orange — primary chart + accent color */
+  --brand: #fa4616;
+  --brand-dark: #d63a10;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}

--- a/samples/dashboards/runtime-compliance/src/lib/format.ts
+++ b/samples/dashboards/runtime-compliance/src/lib/format.ts
@@ -1,0 +1,15 @@
+/** Whole numbers render as whole numbers — never "3.0". */
+export function fmtInt(n: number): string {
+  return Math.round(n).toLocaleString('en-US', { maximumFractionDigits: 0 })
+}
+
+export function fmtPercent(part: number, total: number): string {
+  if (total <= 0) return '0%'
+  return `${Math.round((part / total) * 100)}%`
+}
+
+export function fmtTime(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString()
+}

--- a/samples/dashboards/runtime-compliance/src/lib/governance.ts
+++ b/samples/dashboards/runtime-compliance/src/lib/governance.ts
@@ -1,0 +1,193 @@
+import type { UiPath } from '@uipath/uipath-typescript/core'
+import {
+  AgentTraces,
+  AgentGovernanceMode,
+  AgentGovernanceVerdict,
+} from '@uipath/uipath-typescript/traces'
+import type { AgentGovernanceDecisionGetResponse } from '@uipath/uipath-typescript/traces'
+import type { Range } from './time'
+import { priorRange } from './time'
+
+/** One compliance-check decision, as returned by the SDK. */
+export type Decision = AgentGovernanceDecisionGetResponse
+
+const PAGE_SIZE = 200
+// Safety valve for pathological windows; 50 pages × 200 rows is far beyond
+// anything a dashboard should render anyway.
+const MAX_PAGES = 50
+
+/**
+ * Every compliance-check decision in the window, newest data included —
+ * cursor-looped because each call returns ONE page.
+ */
+export async function fetchDecisions(sdk: UiPath, range: Range): Promise<Decision[]> {
+  const traces = new AgentTraces(sdk)
+  const rows: Decision[] = []
+  let page = await traces.getGovernanceDecisions(range.start, {
+    endTime: range.end,
+    pageSize: PAGE_SIZE,
+  })
+  rows.push(...page.items)
+  let pages = 1
+  while (page.hasNextPage && page.nextCursor && pages < MAX_PAGES) {
+    page = await traces.getGovernanceDecisions(range.start, {
+      endTime: range.end,
+      pageSize: PAGE_SIZE,
+      cursor: page.nextCursor,
+    })
+    rows.push(...page.items)
+    pages += 1
+  }
+  return rows
+}
+
+export interface KpiTotals {
+  /** Deny verdicts in the window. */
+  failedChecks: number
+  /** Deny verdicts in the equal-length prior window (for the change badge). */
+  priorFailedChecks: number
+  /** Distinct checks with at least one failure. */
+  checksFailing: number
+  /** Agents with at least one failed check. */
+  flaggedAgents: number
+}
+
+/** KPI totals from the aggregated summary — current window + prior window in one round trip each. */
+export async function fetchKpis(sdk: UiPath, range: Range): Promise<KpiTotals> {
+  const traces = new AgentTraces(sdk)
+  const prior = priorRange(range)
+  const [current, previous] = await Promise.all([
+    traces.getGovernanceSummary(range.start, { endTime: range.end, topN: 100 }),
+    traces.getGovernanceSummary(prior.start, { endTime: prior.end }),
+  ])
+  return {
+    failedChecks: current.violations,
+    priorFailedChecks: previous.violations,
+    checksFailing: current.byPolicy.filter((p) => p.violationCount > 0).length,
+    flaggedAgents: current.byAgent.filter((a) => a.violationCount > 0).length,
+  }
+}
+
+// ── Derivations over decision rows ─────────────────────────────────────────────
+
+export function isFailed(d: Decision): boolean {
+  return d.evaluatorResult === AgentGovernanceVerdict.Deny
+}
+
+export type Outcome = 'Allowed' | 'Denied' | 'Observed only'
+
+/**
+ * Enforcement outcome of one evaluation. Checks running in audit mode are
+ * observed-only — logged, never enforced — regardless of verdict.
+ */
+export function outcomeOf(d: Decision): Outcome {
+  if (d.mode !== AgentGovernanceMode.Enforce) return 'Observed only'
+  return isFailed(d) ? 'Denied' : 'Allowed'
+}
+
+export function checkName(d: Decision): string {
+  return d.policyName ?? d.policyId ?? 'Unknown check'
+}
+
+export function agentLabel(d: Decision): string {
+  return d.agentName ?? d.agentId ?? 'Unknown agent'
+}
+
+export interface Slice {
+  name: string
+  value: number
+  /** Optional fixed color — lets semantic slices keep their color when zero-value slices are filtered out. */
+  color?: string
+}
+
+export function countBy<T>(rows: T[], key: (row: T) => string): Slice[] {
+  const acc = new Map<string, number>()
+  for (const row of rows) {
+    const k = key(row)
+    acc.set(k, (acc.get(k) ?? 0) + 1)
+  }
+  return [...acc.entries()]
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value)
+}
+
+/**
+ * Group similar failure reasons: reason strings often embed run-specific
+ * numbers ("…detected with a probability of 0.97"), which would make every
+ * failure its own donut slice. Strip numbers so variants merge.
+ */
+export function normalizeReason(reason: string | null): string {
+  if (!reason) return 'No reason provided'
+  const normalized = reason
+    .replace(/\d+(?:\.\d+)?%?/g, 'N')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return normalized.length > 0 ? normalized : 'No reason provided'
+}
+
+// ── Runs ───────────────────────────────────────────────────────────────────────
+
+export interface RunRow {
+  /** The run's trace id — one agent run produces one trace. */
+  runKey: string
+  agentName: string
+  startTime: string
+  evaluated: number
+  failed: number
+  action: string
+}
+
+/** One row per agent run: group decisions by their trace. */
+export function deriveRuns(rows: Decision[]): RunRow[] {
+  const byRun = new Map<string, RunRow>()
+  for (const d of rows) {
+    if (!d.traceId) continue
+    const run = byRun.get(d.traceId) ?? {
+      runKey: d.traceId,
+      agentName: agentLabel(d),
+      startTime: d.startTime,
+      evaluated: 0,
+      failed: 0,
+      action: 'allowed',
+    }
+    run.evaluated += 1
+    if (d.startTime < run.startTime) run.startTime = d.startTime
+    if (isFailed(d)) {
+      run.failed += 1
+      run.action =
+        d.mode === AgentGovernanceMode.Enforce ? (d.actionApplied ?? 'denied') : 'observed'
+    }
+    byRun.set(d.traceId, run)
+  }
+  return [...byRun.values()].sort((a, b) => b.startTime.localeCompare(a.startTime))
+}
+
+export interface HookStat {
+  hook: string
+  passed: number
+  failed: number
+}
+
+export interface RunReport {
+  rows: Decision[]
+  byHook: HookStat[]
+  denied: Decision[]
+}
+
+/** Full report for one run: per-hook pass/fail plus the complete decision log. */
+export function buildRunReport(rows: Decision[], runKey: string): RunReport {
+  const runRows = rows
+    .filter((d) => d.traceId === runKey)
+    .slice()
+    .sort((a, b) => a.startTime.localeCompare(b.startTime))
+  const hooks = [...new Set(runRows.map((d) => d.hook ?? 'UNKNOWN'))]
+  return {
+    rows: runRows,
+    byHook: hooks.map((hook) => ({
+      hook,
+      passed: runRows.filter((d) => (d.hook ?? 'UNKNOWN') === hook && !isFailed(d)).length,
+      failed: runRows.filter((d) => (d.hook ?? 'UNKNOWN') === hook && isFailed(d)).length,
+    })),
+    denied: runRows.filter(isFailed),
+  }
+}

--- a/samples/dashboards/runtime-compliance/src/lib/time.ts
+++ b/samples/dashboards/runtime-compliance/src/lib/time.ts
@@ -1,0 +1,31 @@
+export type TimeWindow = '24h' | '7d' | '30d'
+
+export const WINDOWS: TimeWindow[] = ['24h', '7d', '30d']
+
+const WINDOW_MS: Record<TimeWindow, number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+}
+
+export interface Range {
+  start: Date
+  end: Date
+}
+
+export function rangeFor(window: TimeWindow): Range {
+  const end = new Date()
+  return { start: new Date(end.getTime() - WINDOW_MS[window]), end }
+}
+
+/** The equal-length period immediately before `range` — used for change badges. */
+export function priorRange(range: Range): Range {
+  const length = range.end.getTime() - range.start.getTime()
+  return { start: new Date(range.start.getTime() - length), end: range.start }
+}
+
+export const WINDOW_LABEL: Record<TimeWindow, string> = {
+  '24h': 'last 24 hours',
+  '7d': 'last 7 days',
+  '30d': 'last 30 days',
+}

--- a/samples/dashboards/runtime-compliance/src/main.tsx
+++ b/samples/dashboards/runtime-compliance/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/samples/dashboards/runtime-compliance/src/vite-env.d.ts
+++ b/samples/dashboards/runtime-compliance/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/samples/dashboards/runtime-compliance/tsconfig.app.json
+++ b/samples/dashboards/runtime-compliance/tsconfig.app.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/samples/dashboards/runtime-compliance/tsconfig.json
+++ b/samples/dashboards/runtime-compliance/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/samples/dashboards/runtime-compliance/tsconfig.node.json
+++ b/samples/dashboards/runtime-compliance/tsconfig.node.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/samples/dashboards/runtime-compliance/uipath.json.example
+++ b/samples/dashboards/runtime-compliance/uipath.json.example
@@ -1,0 +1,8 @@
+{
+  "clientId": "<your-oauth-external-app-client-id>",
+  "scope": "Insights Insights.RealTimeData OR.Folders.Read",
+  "orgName": "<your-org-name>",
+  "tenantName": "<your-tenant-name>",
+  "baseUrl": "https://api.uipath.com",
+  "redirectUri": "http://localhost:5173"
+}

--- a/samples/dashboards/runtime-compliance/vite.config.ts
+++ b/samples/dashboards/runtime-compliance/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { uipathCodedApps } from '@uipath/coded-apps-dev/vite'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// https://vite.dev/config/
+export default defineConfig({
+  // Coded App requirement: assets must use relative paths so they resolve
+  // correctly under the <base href="/your-app-name/"> the platform injects
+  // at deploy time.
+  base: './',
+  plugins: [
+    react(),
+    // Reads uipath.json and injects <meta name="uipath:*"> tags into
+    // index.html during local dev. At deploy time the platform injects
+    // production values, so the same SDK init code works in both places.
+    uipathCodedApps(),
+  ],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  optimizeDeps: {
+    include: ['@uipath/uipath-typescript'],
+  },
+})


### PR DESCRIPTION
## What

Adds a **Runtime Compliance Dashboard** sample under a new `samples/dashboards/` group — a React + TypeScript Coded App visualizing UiPath compliance-check results across an AI agent fleet, and the first sample exercising the **SDK 1.5.1 agentic governance insights APIs** (`AgentTraces.getGovernanceSummary` / `getGovernanceDecisions`, #560).

**Widgets:** Failed Compliance Checks KPI (prior-period change badge), Checks Failing + Flagged Agents KPIs, Enforcement Outcomes donut (allowed / denied / observed-only), Why Checks Failed donut (reason-normalized grouping), ranked Agents-by-Failed-Checks table (Top 5/10/20), and a paginated Agent-Compliance-by-Run table whose rows open a full per-run report (per-hook pass/fail + complete decision log). Per-card 24h/7d/30d toggles compute query windows at runtime — a deliberate demonstration of the positional-`startTime` calling convention and cursor-loop pagination.

## Conventions followed

- Mirrors `data-fabric-app`: `new UiPath()` + `sdk.initialize()` meta-tag auth, `@uipath/coded-apps-dev` Vite plugin, tenant-neutral `uipath.json.example` (real config gitignored), tsconfig trio, `tsc -b && vite build`
- Mirrors `coded-action-apps`: `samples/dashboards/` is an umbrella group with a "Choose a sample" README table, anticipating future dashboard samples (agent health / ops are natural siblings)
- Root README §Samples gains an entry
- README prominently calls out that **data requires the Agentic Governance private preview** (compliance checks enabled on agents), and uses access-neutral 403 wording for permissions
- No changes outside `samples/` + the root README

## Validation

`npm install && npm run build` green (strict tsc + vite). Sign-in flow and data rendering follow the `data-fabric-app` auth pattern verbatim; widgets render empty states when the org has no governance data.

Generated with Claude Code

https://claude.ai/code/session_019BrysPytXxf9LtC3xQDYSC