### PR TITLE
fix(docs): fill JSDoc gaps flagged by validation gate

### DIFF
--- a/src/core/errors/authentication.ts
+++ b/src/core/errors/authentication.ts
@@ -10,6 +10,7 @@ import { ErrorParams } from './types';
  * - Missing authentication
  */
 export class AuthenticationError extends UiPathError {
+  /** @internal */
   constructor(params: Partial<ErrorParams> = {}) {
     super(ErrorType.AUTHENTICATION, {
       message: params.message || ErrorMessages.AUTHENTICATION_FAILED,

--- a/src/core/errors/authorization.ts
+++ b/src/core/errors/authorization.ts
@@ -10,6 +10,7 @@ import { ErrorParams } from './types';
  * - Invalid scope
  */
 export class AuthorizationError extends UiPathError {
+  /** @internal */
   constructor(params: Partial<ErrorParams> = {}) {
     super(ErrorType.AUTHORIZATION, {
       message: params.message || ErrorMessages.ACCESS_DENIED,

--- a/src/core/errors/guards.ts
+++ b/src/core/errors/guards.ts
@@ -9,6 +9,9 @@ import { NetworkError } from './network';
 
 /**
  * Type guard to check if an error is a UiPathError
+ *
+ * @param error - The value to check
+ * @returns True if the value is a UiPathError
  */
 export function isUiPathError(error: unknown): error is UiPathError {
   return error instanceof UiPathError;
@@ -16,6 +19,9 @@ export function isUiPathError(error: unknown): error is UiPathError {
 
 /**
  * Type guard to check if an error is an AuthenticationError
+ *
+ * @param error - The value to check
+ * @returns True if the value is an AuthenticationError
  */
 export function isAuthenticationError(error: unknown): error is AuthenticationError {
   return error instanceof AuthenticationError;
@@ -23,6 +29,9 @@ export function isAuthenticationError(error: unknown): error is AuthenticationEr
 
 /**
  * Type guard to check if an error is an AuthorizationError
+ *
+ * @param error - The value to check
+ * @returns True if the value is an AuthorizationError
  */
 export function isAuthorizationError(error: unknown): error is AuthorizationError {
   return error instanceof AuthorizationError;
@@ -30,6 +39,9 @@ export function isAuthorizationError(error: unknown): error is AuthorizationErro
 
 /**
  * Type guard to check if an error is a ValidationError
+ *
+ * @param error - The value to check
+ * @returns True if the value is a ValidationError
  */
 export function isValidationError(error: unknown): error is ValidationError {
   return error instanceof ValidationError;
@@ -37,6 +49,9 @@ export function isValidationError(error: unknown): error is ValidationError {
 
 /**
  * Type guard to check if an error is a NotFoundError
+ *
+ * @param error - The value to check
+ * @returns True if the value is a NotFoundError
  */
 export function isNotFoundError(error: unknown): error is NotFoundError {
   return error instanceof NotFoundError;
@@ -44,6 +59,9 @@ export function isNotFoundError(error: unknown): error is NotFoundError {
 
 /**
  * Type guard to check if an error is a RateLimitError
+ *
+ * @param error - The value to check
+ * @returns True if the value is a RateLimitError
  */
 export function isRateLimitError(error: unknown): error is RateLimitError {
   return error instanceof RateLimitError;
@@ -51,6 +69,9 @@ export function isRateLimitError(error: unknown): error is RateLimitError {
 
 /**
  * Type guard to check if an error is a ServerError
+ *
+ * @param error - The value to check
+ * @returns True if the value is a ServerError
  */
 export function isServerError(error: unknown): error is ServerError {
   return error instanceof ServerError;
@@ -58,6 +79,9 @@ export function isServerError(error: unknown): error is ServerError {
 
 /**
  * Type guard to check if an error is a NetworkError
+ *
+ * @param error - The value to check
+ * @returns True if the value is a NetworkError
  */
 export function isNetworkError(error: unknown): error is NetworkError {
   return error instanceof NetworkError;
@@ -65,6 +89,9 @@ export function isNetworkError(error: unknown): error is NetworkError {
 
 /**
  * Helper to get error details in a safe way
+ *
+ * @param error - The error to extract details from
+ * @returns The error message and, when available, the HTTP status code
  */
 export function getErrorDetails(error: unknown): { message: string; statusCode?: number } {
   if (isUiPathError(error)) {

--- a/src/core/errors/network.ts
+++ b/src/core/errors/network.ts
@@ -11,6 +11,7 @@ import { ErrorParams } from './types';
  * - Request aborted
  */
 export class NetworkError extends UiPathError {
+  /** @internal */
   constructor(params: Partial<ErrorParams> = {}) {
     super(ErrorType.NETWORK, {
       message: params.message || ErrorMessages.NETWORK_ERROR,

--- a/src/core/errors/not-found.ts
+++ b/src/core/errors/not-found.ts
@@ -10,6 +10,7 @@ import { ErrorParams } from './types';
  * - Resource deleted
  */
 export class NotFoundError extends UiPathError {
+  /** @internal */
   constructor(params: Partial<ErrorParams> = {}) {
     super(ErrorType.NOT_FOUND, {
       message: params.message || ErrorMessages.RESOURCE_NOT_FOUND,

--- a/src/core/errors/rate-limit.ts
+++ b/src/core/errors/rate-limit.ts
@@ -9,6 +9,7 @@ import { ErrorParams } from './types';
  * - API throttling
  */
 export class RateLimitError extends UiPathError {
+  /** @internal */
   constructor(params: Partial<ErrorParams> = {}) {
     super(ErrorType.RATE_LIMIT, {
       message: params.message || ErrorMessages.RATE_LIMIT_EXCEEDED,

--- a/src/core/errors/server.ts
+++ b/src/core/errors/server.ts
@@ -10,6 +10,7 @@ import { ErrorParams } from './types';
  * - Gateway timeout
  */
 export class ServerError extends UiPathError {
+  /** @internal */
   constructor(params: Partial<ErrorParams> = {}) {
     super(ErrorType.SERVER, {
       message: params.message || ErrorMessages.INTERNAL_SERVER_ERROR,

--- a/src/core/errors/validation.ts
+++ b/src/core/errors/validation.ts
@@ -10,6 +10,7 @@ import { ErrorParams } from './types';
  * - Invalid data format
  */
 export class ValidationError extends UiPathError {
+  /** @internal */
   constructor(params: Partial<ErrorParams> = {}) {
     super(ErrorType.VALIDATION, {
       message: params.message || ErrorMessages.VALIDATION_FAILED,

--- a/src/core/telemetry/index.ts
+++ b/src/core/telemetry/index.ts
@@ -28,9 +28,12 @@ import {
 // across every subpath bundle (`assets`, `feedback`, `tasks`, …).
 const sdkClient = getOrCreateClient(CLOUD_ROLE_NAME);
 
+/** @internal */
 export const track = createTrack(sdkClient);
+/** @internal */
 export const trackEvent = createTrackEvent(sdkClient);
 
+/** @internal */
 export const telemetryClient = {
     initialize(context?: TelemetryContext): void {
         sdkClient.initialize({

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -64,6 +64,11 @@ export class UiPath implements IUiPath {
   /** Read-only config for user convenience */
   public readonly config!: Readonly<BaseConfig>;
 
+  /**
+   * Creates a UiPath SDK instance.
+   *
+   * @param config - Optional SDK configuration; when omitted, configuration is loaded from meta tags
+   */
   constructor(config?: PartialUiPathConfig) {
     // Load configuration from meta tags
     const configFromMetaTags = loadFromMetaTags();

--- a/src/models/conversational-agent/agents/agents.models.ts
+++ b/src/models/conversational-agent/agents/agents.models.ts
@@ -91,6 +91,13 @@ function createAgentMethods(
   };
 }
 
+/**
+ * Combines raw agent data with bound methods.
+ *
+ * @param agentData - The raw agent data from API
+ * @param conversationService - The conversation service instance
+ * @returns An agent object with added methods
+ */
 export function createAgentWithMethods<T extends RawAgentGetResponse>(
   agentData: T,
   conversationService: ConversationServiceModel

--- a/src/models/conversational-agent/conversations/conversations.models.ts
+++ b/src/models/conversational-agent/conversations/conversations.models.ts
@@ -31,16 +31,23 @@ import type { SessionStream } from './types/events/session.types';
 export interface ConversationSessionMethods {
   /**
    * Starts a real-time chat session for a conversation
+   *
+   * @param conversationId - The conversation ID
+   * @param options - Optional session options
    */
   startSession(conversationId: string, options?: ConversationSessionOptions): SessionStream;
 
   /**
    * Gets an active session for a conversation
+   *
+   * @param conversationId - The conversation ID
    */
   getSession(conversationId: string): SessionStream | undefined;
 
   /**
    * Ends an active session for a conversation
+   *
+   * @param conversationId - The conversation ID
    */
   endSession(conversationId: string): void;
 }

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -1172,7 +1172,7 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
 /**
  * Creates an actionable entity by combining entity metadata with data and management methods
  *
- * @param entityMetadata - Entity metadata
+ * @param entityData - The raw entity data from API
  * @param service - The entity service instance
  * @returns Entity metadata with added methods
  */

--- a/src/models/orchestrator/queues.models.ts
+++ b/src/models/orchestrator/queues.models.ts
@@ -20,8 +20,7 @@ import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '.
 export interface QueueServiceModel {
   /**
    * Gets all queues across folders with optional filtering and folder scoping
-   * 
-   * @signature getAll(options?) → Promise&lt;QueueGetResponse[]&gt;
+   *
    * @param options Query options including optional folderId and pagination options
    * @returns Promise resolving to either an array of queues NonPaginatedResponse<QueueGetResponse> or a PaginatedResponse<QueueGetResponse> when pagination options are used.
    * {@link QueueGetResponse}
@@ -66,6 +65,7 @@ export interface QueueServiceModel {
    * 
    * @param id - Queue ID
    * @param folderId - Required folder ID
+   * @param options - Optional query options
    * @returns Promise resolving to a queue definition
    * @example
    * ```typescript

--- a/src/services/orchestrator/queues/queues.ts
+++ b/src/services/orchestrator/queues/queues.ts
@@ -104,8 +104,9 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
    * 
    * @param id - Queue ID
    * @param folderId - Required folder ID
+   * @param options - Optional query options
    * @returns Promise resolving to a queue definition
-   * 
+   *
    * @example
    * ```typescript
    * import { Queues } from '@uipath/uipath-typescript/queues';


### PR DESCRIPTION
## What

Documents every public API gap surfaced by the JSDoc validation gate (#592), so `npm run docs:validate` exits 0 and the `jsdoc-validation` CI check goes green.

## Fixes

**Missing docs (documented):**
- Error type guards (`isUiPathError`, `isAuthenticationError`, … `getErrorDetails`) — added `@param`/`@returns`
- `createAgentWithMethods` — added the JSDoc block its 8 sibling factories already have
- `QueueServiceModel.getById` / `QueueService.getById` — documented the `options` param
- `ConversationSessionMethods` (`startSession`/`getSession`/`endSession`) — documented params
- `UiPath` constructor — documented `config`

**Doc bugs:**
- `createEntityWithMethods` — `@param entityMetadata` renamed to the actual param `entityData`
- `QueueServiceModel.getAll` — removed the unknown `@signature` block tag

**Internal (excluded from public docs via `@internal`):**
- Telemetry exports (`track`, `trackEvent`, `telemetryClient`) — internal infra
- Error-class constructors — users catch errors, never construct them

## Notes

- Stacked on #592 (the validation gate). Diff collapses to just these doc changes once #592 merges.
- Two cosmetic `metaData has multiple declarations with a comment` warnings remain — a TypeDoc comment-merge quirk, not a `notDocumented` finding; exit code stays 0.
- `typecheck` + `lint` clean.

Generated with Claude Code
