### PR TITLE
chore: bump version to 1.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.5.3",
+            "version": "1.5.4",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
### Bug Fixes

- Fixed `Entities.create()` failing with `"Target entity is not provided in request"` when the schema includes `FILE` fields, the SDK now sends the correct payload so FILE fields are creatable end-to-end (#596)

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.5.3...1.5.4
