### PR TITLE
docs: add Template Gallery + docs PR preview workflow

### DIFF
--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -77,6 +77,23 @@ jobs:
           source docs-env/bin/activate
           mkdocs build
 
+      - name: Point Template Gallery assets at the PR commit
+        # An open PR's new samples aren't on `main` yet, so the gallery's default
+        # `"ref": "main"` would 404 their GIFs and source links in the preview.
+        # Rewrite that single ref in the built page to this PR's head commit, where
+        # the assets exist. Same-repo PRs only (forks get no published preview, and
+        # their head SHA isn't served from this repo's raw host). HEAD_SHA is passed
+        # via env (never interpolated into the script body) and is a 40-char hex SHA.
+        if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          page="site/samples/index.html"
+          if [ -f "$page" ]; then
+            sed -i "s/\"ref\": \"main\"/\"ref\": \"${HEAD_SHA}\"/" "$page"
+            echo "Rewrote Template Gallery ref -> ${HEAD_SHA}"
+          fi
+
       - name: Deploy / update / remove PR preview
         # Same-repo PRs only — fork PRs get a read-only token and can't publish.
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -44,7 +44,7 @@ jobs:
         if: github.event.action != 'closed'
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Setup Python
         if: github.event.action != 'closed'

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -1,0 +1,89 @@
+# Builds the docs site for every PR that touches docs, and (for same-repo PRs)
+# publishes a live preview at:  https://<org>.github.io/<repo>/pr-preview/pr-<N>/
+#
+# The build step doubles as a CI gate: if `mkdocs build` fails, the check fails,
+# so a broken docs change can't merge. The preview is torn down when the PR closes.
+#
+# Security notes:
+#   - Uses `pull_request` (NOT `pull_request_target`): fork PRs run with a
+#     read-only GITHUB_TOKEN and no secrets, so building untrusted PR code is safe.
+#   - The write-scoped preview deploy is gated to same-repo PRs only (fork PRs
+#     still get the build gate, just no preview — GitHub gives them a read-only
+#     token regardless).
+#   - No untrusted event data (PR title/body/branch) is interpolated into any
+#     `run:` step, so there's no command-injection surface.
+#   - The one third-party action (rossjrw, an individual account) is pinned to a
+#     full commit SHA.
+name: Docs PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "docs/requirements.txt"
+      - ".github/workflows/docs-pr-preview.yml"
+
+permissions:
+  contents: write        # publish the preview to the gh-pages branch
+  pull-requests: write   # post/update the preview link comment
+
+concurrency:
+  group: docs-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Setup Python
+        if: github.event.action != 'closed'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Node dependencies
+        if: github.event.action != 'closed'
+        run: npm ci
+
+      - name: Install Coded Action Apps dependencies
+        if: github.event.action != 'closed'
+        working-directory: packages/coded-action-app
+        run: npm ci
+
+      - name: Install docs requirements
+        if: github.event.action != 'closed'
+        run: |
+          python3 -m venv docs-env
+          source docs-env/bin/activate
+          pip install -r docs/requirements.txt
+
+      - name: Generate API documentation
+        if: github.event.action != 'closed'
+        run: npm run docs:api
+
+      - name: Build MkDocs site (CI gate)
+        if: github.event.action != 'closed'
+        run: |
+          source docs-env/bin/activate
+          mkdocs build
+
+      - name: Deploy / update / remove PR preview
+        # Same-repo PRs only — fork PRs get a read-only token and can't publish.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.6.1
+        with:
+          source-dir: site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -37,17 +37,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
         if: github.event.action != 'closed'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
       - name: Setup Python
         if: github.event.action != 'closed'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Deploy / update / remove PR preview
         # Same-repo PRs only — fork PRs get a read-only token and can't publish.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.6.1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         with:
           source-dir: site
           preview-branch: gh-pages

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -22,7 +22,6 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
-      - "docs/requirements.txt"
       - ".github/workflows/docs-pr-preview.yml"
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -50,6 +50,15 @@ jobs:
           mkdocs build
 
       - name: Deploy to GitHub Pages
-        run: |
-          source docs-env/bin/activate
-          mkdocs gh-deploy --force
+        # Deploy the pre-built site/ (from the "Build MkDocs Documentation" step)
+        # instead of `mkdocs gh-deploy --force`, which force-replaces the whole
+        # gh-pages branch and would delete the PR-preview umbrella dir.
+        # clean-exclude keeps `pr-preview/` intact while still removing stale
+        # docs pages; force: false rebases instead of clobbering concurrent
+        # preview deployments.
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+        with:
+          branch: gh-pages
+          folder: site
+          clean-exclude: pr-preview/
+          force: false

--- a/Agents.md
+++ b/Agents.md
@@ -21,6 +21,17 @@ npm run docs:api         # typedoc + post-process
 
 - Version bumps go in a **separate PR** — never include a version bump in a feature or fix PR. Other in-flight changes may need to ship in the same version, so the bump is always a dedicated step.
 
+## Samples & Template Gallery
+
+- Every app under `samples/` must ship a **preview GIF** at `samples/<app>/screenshots/` (e.g. `preview.gif`) showing the app in use. The app README and the docs Template Gallery both render it — a missing GIF leaves an empty poster tile in the gallery.
+- The **Template Gallery** (`docs/samples/index.md`) is the browsable, filterable index of `samples/` published on the docs site. When you **add, rename, remove, or re-scope a sample, update the gallery in the same PR** so the site stays in sync. Edit the inline app list (the `#tg-data` JSON block) — add or adjust an entry:
+
+  ```json
+  { "id": "<folder>", "title": "...", "description": "...", "category": "<existing category id>", "framework": "React | Angular", "tags": ["..."], "path": "samples/<...>", "preview": "samples/<...>/screenshots/preview.gif" }
+  ```
+
+  `path` is the repo-relative sample folder; `preview` is the repo-relative GIF path (or `null` to show a generated poster). Reuse an existing `category` id and `tags` where possible — they drive the gallery filters.
+
 @agent_docs/architecture.md
 @agent_docs/conventions.md
 @agent_docs/rules.md

--- a/Agents.md
+++ b/Agents.md
@@ -21,17 +21,6 @@ npm run docs:api         # typedoc + post-process
 
 - Version bumps go in a **separate PR** — never include a version bump in a feature or fix PR. Other in-flight changes may need to ship in the same version, so the bump is always a dedicated step.
 
-## Samples & Template Gallery
-
-- Every app under `samples/` must ship a **preview GIF** at `samples/<app>/screenshots/` (e.g. `preview.gif`) showing the app in use. The app README and the docs Template Gallery both render it — a missing GIF leaves an empty poster tile in the gallery.
-- The **Template Gallery** (`docs/samples/index.md`) is the browsable, filterable index of `samples/` published on the docs site. When you **add, rename, remove, or re-scope a sample, update the gallery in the same PR** so the site stays in sync. Edit the inline app list (the `#tg-data` JSON block) — add or adjust an entry:
-
-  ```json
-  { "id": "<folder>", "title": "...", "description": "...", "category": "<existing category id>", "framework": "React | Angular", "tags": ["..."], "path": "samples/<...>", "preview": "samples/<...>/screenshots/preview.gif" }
-  ```
-
-  `path` is the repo-relative sample folder; `preview` is the repo-relative GIF path (or `null` to show a generated poster). Reuse an existing `category` id and `tags` where possible — they drive the gallery filters.
-
 @agent_docs/architecture.md
 @agent_docs/conventions.md
 @agent_docs/rules.md

--- a/agent_docs/rules.md
+++ b/agent_docs/rules.md
@@ -74,6 +74,17 @@ JSDoc comments in `src/models/{domain}/*.models.ts` are the **source of truth fo
 - **Do not duplicate backend validation SDK-side** — when an API parameter has backend-enforced constraints (e.g., character limits, allowed formats), document the constraint in JSDoc (`@param search - Search string (1–100 chars)`) rather than adding matching SDK-side validation. SDK-side checks risk drifting out of sync with backend rules as the API evolves, producing confusing double-error scenarios.
 - **NEVER** expose internal implementation details in user-facing JSDoc — remove references to `OData`, internal API protocols, or internal endpoint names (e.g., "via the OData GetFiles endpoint", "with OData query options"). End users don't need to know which protocol or internal API mechanism the SDK uses; such details belong in code comments or internal docs, not in generated API documentation.
 
+### Samples & Template Gallery
+
+- Every app under `samples/` must ship a **preview GIF** at `samples/<app>/screenshots/` (e.g. `preview.gif`) showing the app in use. The app README and the docs Template Gallery both render it — a missing GIF leaves an empty poster tile in the gallery.
+- The **Template Gallery** (`docs/samples/index.md`) is the browsable, searchable index of `samples/` published on the docs site. When you **add, rename, remove, or re-scope a sample, update the gallery in the same PR** so the site stays in sync. Edit the inline app list (the `#tg-data` JSON block) — add or adjust an entry:
+
+  ```json
+  { "id": "<folder>", "title": "...", "description": "...", "category": "<existing category id>", "framework": "React | Angular", "tags": ["..."], "path": "samples/<...>", "preview": "samples/<...>/screenshots/preview.gif" }
+  ```
+
+  `path` is the repo-relative sample folder; `preview` is the repo-relative GIF path (or `null` to show a generated poster). Reuse an existing `category` id — it drives the category tabs; `framework` drives the framework filter; `tags` are matched by the search box.
+
 ## Post-implementation verification checklist
 
 Run after every implementation, before committing.

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -1,10 +1,10 @@
 ---
-title: Template Gallery
+title: Sample Apps Gallery
 hide:
   - toc
 ---
 
-# Template Gallery
+# Sample Apps Gallery
 
 Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. Each card links to the source and copies a ready-to-run `degit` command.
 

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -78,7 +78,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 .md-typeset .tg-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); }
 .md-typeset .tg-card { display: flex; flex-direction: column; background: var(--tg-surface); border: 1px solid var(--tg-hair); border-radius: 12px; overflow: hidden; transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease; }
 .md-typeset .tg-card:hover { transform: translateY(-3px); box-shadow: 0 12px 30px rgba(0,0,0,.12); border-color: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent); }
-.md-typeset .tg-thumblink { display: block; position: relative; }
+.md-typeset .tg-thumblink { position: absolute; inset: 0; z-index: 1; }
 .md-typeset .tg-thumb { position: relative; aspect-ratio: 16 / 10; overflow: hidden; background: var(--tg-poster, linear-gradient(135deg,#888,#555)); display: grid; place-items: center; }
 .md-typeset .tg-thumb img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; display: block; opacity: 0; transition: opacity .4s ease; margin: 0; max-width: none; }
 .md-typeset .tg-thumb img.tg-loaded { opacity: 1; }
@@ -86,7 +86,8 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 .md-typeset .tg-glyph .g { font-size: 1.8rem; display: block; letter-spacing: -0.02em; }
 .md-typeset .tg-glyph .s { font-size: 0.66rem; letter-spacing: 0.14em; opacity: 0.85; text-transform: uppercase; margin-top: 0.35rem; }
 .md-typeset .tg-badge-fw { position: absolute; top: 0.6rem; right: 0.6rem; z-index: 2; font-family: var(--tg-mono); font-size: 0.62rem; font-weight: 600; padding: 0.24rem 0.5rem; border-radius: 999px; color: #fff; background: rgba(20,20,22,.55); border: 1px solid rgba(255,255,255,.18); }
-.md-typeset .tg-badge-live { position: absolute; top: 0.6rem; left: 0.6rem; z-index: 2; font-family: var(--tg-mono); font-size: 0.58rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; padding: 0.22rem 0.45rem; border-radius: 999px; color: #fff; background: rgba(20,20,22,.5); display: flex; align-items: center; gap: 0.3rem; }
+.md-typeset .tg-badge-live { position: absolute; top: 0.6rem; left: 0.6rem; z-index: 2; font-family: var(--tg-mono); font-size: 0.58rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; padding: 0.22rem 0.45rem; border-radius: 999px; color: #fff; background: rgba(20,20,22,.5); display: flex; align-items: center; gap: 0.3rem; text-decoration: none; cursor: pointer; }
+.md-typeset .tg-badge-live:hover { background: rgba(20,20,22,.75); }
 .md-typeset .tg-badge-live .blip { width: 6px; height: 6px; border-radius: 50%; background: #57e08a; }
 .md-typeset .tg-body { padding: 0.9rem 1rem 1rem; display: flex; flex-direction: column; gap: 0.5rem; flex: 1; }
 .md-typeset .tg-catline { font-family: var(--tg-mono); font-size: 0.64rem; letter-spacing: 0.1em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.4rem; font-weight: 700; color: var(--tg-muted); }
@@ -226,12 +227,13 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     var el = document.createElement("article");
     el.className = "tg-card";
     el.style.setProperty("--tg-poster", poster(app));
-    var h = '<a class="tg-thumblink" href="' + esc(folder) + '" target="_blank" rel="noopener" aria-label="Open ' + esc(app.title) + ' on GitHub"><div class="tg-thumb">';
+    var h = '<div class="tg-thumb">';
     h += '<span class="tg-badge-fw">' + esc(app.framework) + "</span>";
-    if (app.preview) h += '<span class="tg-badge-live"><span class="blip"></span>Live preview</span>';
+    if (app.preview) h += '<a class="tg-badge-live" href="' + esc(DATA.repo + "/blob/main/" + app.preview) + '" target="_blank" rel="noopener" title="View the preview GIF"><span class="blip"></span>Live preview</a>';
     h += '<div class="tg-glyph"><span class="g">' + esc(monogram(app)) + '</span><span class="s">' + esc(c.label) + "</span></div>";
     if (app.preview) h += '<img alt="' + esc(app.title) + ' preview" loading="lazy" src="' + esc((DATA.assetsBaseUrl || "") + app.preview) + '" />';
-    h += "</div></a>";
+    h += '<a class="tg-thumblink" href="' + esc(folder) + '" target="_blank" rel="noopener" aria-label="Open ' + esc(app.title) + ' on GitHub"></a>';
+    h += "</div>";
     h += '<div class="tg-body">';
     h += '<span class="tg-catline"><span class="sw" style="background:' + esc(c.accent[0]) + '"></span>' + esc(c.label) + "</span>";
     h += '<h3 class="tg-title"><a class="tg-titlelink" href="' + esc(folder) + '" target="_blank" rel="noopener">' + esc(app.title) + "</a></h3>";

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -24,7 +24,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     </div>
   </div>
   <div class="tg-meta">
-    <span class="tg-count"><b id="tg-count-n">0</b> <span id="tg-count-w">apps</span></span>
+    <span class="tg-count" aria-live="polite"><b id="tg-count-n">0</b> <span id="tg-count-w">apps</span></span>
     <button type="button" class="tg-clear" id="tg-clear" hidden>Clear filters</button>
   </div>
   <div class="tg-grid" id="tg-grid"></div>
@@ -175,22 +175,38 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   }
   function countIn(cat) { return DATA.apps.filter(function (a) { return cat === "all" || a.category === cat; }).length; }
 
+  // Controls are built once and then only their aria-pressed state is updated on
+  // re-render, so activating a pill via keyboard doesn't rebuild the DOM and lose focus.
   function renderTabs() {
-    var cats = [{ id: "all", label: "All" }].concat(DATA.categories);
-    $("tg-tabs").innerHTML = cats.map(function (c) {
-      var on = state.cat === c.id;
-      return '<button type="button" class="tg-pill" aria-pressed="' + on + '" data-cat="' + c.id + '">' + esc(c.label) + ' <span class="tg-cnt">' + countIn(c.id) + "</span></button>";
-    }).join("");
-    $("tg-tabs").querySelectorAll("[data-cat]").forEach(function (b) { b.addEventListener("click", function () { state.cat = b.dataset.cat; render(); }); });
+    var wrap = $("tg-tabs");
+    if (!wrap.children.length) {
+      var cats = [{ id: "all", label: "All" }].concat(DATA.categories);
+      wrap.innerHTML = cats.map(function (c) {
+        return '<button type="button" class="tg-pill" aria-pressed="' + (state.cat === c.id) + '" data-cat="' + c.id + '">' + esc(c.label) + ' <span class="tg-cnt">' + countIn(c.id) + "</span></button>";
+      }).join("");
+      wrap.querySelectorAll("[data-cat]").forEach(function (b) { b.addEventListener("click", function () { state.cat = b.dataset.cat; render(); }); });
+    } else {
+      wrap.querySelectorAll("[data-cat]").forEach(function (b) { b.setAttribute("aria-pressed", String(state.cat === b.dataset.cat)); });
+    }
   }
   function renderFilters() {
-    var fws = Array.from(new Set(DATA.apps.map(function (a) { return a.framework; }))).sort();
-    $("tg-fw").innerHTML = fws.map(function (f) { return '<button type="button" class="tg-pill tg-pill-sm" aria-pressed="' + state.fws.has(f) + '" data-fw="' + esc(f) + '">' + esc(f) + "</button>"; }).join("");
-    $("tg-fw").querySelectorAll("[data-fw]").forEach(function (b) { b.addEventListener("click", function () { var f = b.dataset.fw; state.fws.has(f) ? state.fws.delete(f) : state.fws.add(f); render(); }); });
-    var counts = {}; DATA.apps.forEach(function (a) { (a.tags || []).forEach(function (t) { counts[t] = (counts[t] || 0) + 1; }); });
-    var tags = Object.keys(counts).sort(function (a, b) { return counts[b] - counts[a] || a.localeCompare(b); });
-    $("tg-tags").innerHTML = tags.map(function (t) { return '<button type="button" class="tg-pill tg-pill-sm" aria-pressed="' + state.tags.has(t) + '" data-tag="' + esc(t) + '">' + esc(t) + "</button>"; }).join("");
-    $("tg-tags").querySelectorAll("[data-tag]").forEach(function (b) { b.addEventListener("click", function () { var t = b.dataset.tag; state.tags.has(t) ? state.tags.delete(t) : state.tags.add(t); render(); }); });
+    var fwWrap = $("tg-fw");
+    if (!fwWrap.children.length) {
+      var fws = Array.from(new Set(DATA.apps.map(function (a) { return a.framework; }))).sort();
+      fwWrap.innerHTML = fws.map(function (f) { return '<button type="button" class="tg-pill tg-pill-sm" aria-pressed="' + state.fws.has(f) + '" data-fw="' + esc(f) + '">' + esc(f) + "</button>"; }).join("");
+      fwWrap.querySelectorAll("[data-fw]").forEach(function (b) { b.addEventListener("click", function () { var f = b.dataset.fw; state.fws.has(f) ? state.fws.delete(f) : state.fws.add(f); render(); }); });
+    } else {
+      fwWrap.querySelectorAll("[data-fw]").forEach(function (b) { b.setAttribute("aria-pressed", String(state.fws.has(b.dataset.fw))); });
+    }
+    var tagWrap = $("tg-tags");
+    if (!tagWrap.children.length) {
+      var counts = {}; DATA.apps.forEach(function (a) { (a.tags || []).forEach(function (t) { counts[t] = (counts[t] || 0) + 1; }); });
+      var tags = Object.keys(counts).sort(function (a, b) { return counts[b] - counts[a] || a.localeCompare(b); });
+      tagWrap.innerHTML = tags.map(function (t) { return '<button type="button" class="tg-pill tg-pill-sm" aria-pressed="' + state.tags.has(t) + '" data-tag="' + esc(t) + '">' + esc(t) + "</button>"; }).join("");
+      tagWrap.querySelectorAll("[data-tag]").forEach(function (b) { b.addEventListener("click", function () { var t = b.dataset.tag; state.tags.has(t) ? state.tags.delete(t) : state.tags.add(t); render(); }); });
+    } else {
+      tagWrap.querySelectorAll("[data-tag]").forEach(function (b) { b.setAttribute("aria-pressed", String(state.tags.has(b.dataset.tag))); });
+    }
   }
   var COPY = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
   var CODEICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 6 2 12 8 18"/><polyline points="16 6 22 12 16 18"/></svg>';
@@ -209,7 +225,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     if (app.preview) h += '<img alt="' + esc(app.title) + ' preview" loading="lazy" src="' + esc((DATA.assetsBaseUrl || "") + app.preview) + '" />';
     h += "</div></a>";
     h += '<div class="tg-body">';
-    h += '<span class="tg-catline"><span class="sw" style="background:' + c.accent[0] + '"></span>' + esc(c.label) + "</span>";
+    h += '<span class="tg-catline"><span class="sw" style="background:' + esc(c.accent[0]) + '"></span>' + esc(c.label) + "</span>";
     h += '<a class="tg-titlelink" href="' + esc(folder) + '" target="_blank" rel="noopener"><span class="tg-title">' + esc(app.title) + "</span></a>";
     h += '<p class="tg-desc">' + esc(app.description) + "</p>";
     h += '<div class="tg-foot">';

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -25,6 +25,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   <div class="tg-meta">
     <span class="tg-count" aria-live="polite"><b id="tg-count-n">0</b> <span id="tg-count-w">apps</span></span>
     <button type="button" class="tg-clear" id="tg-clear" hidden>Clear filters</button>
+    <a class="tg-ghlink" id="tg-browse" target="_blank" rel="noopener">Browse all on GitHub ↗</a>
   </div>
   <div class="tg-grid" id="tg-grid"></div>
   <div class="tg-empty" id="tg-empty" hidden>No apps match these filters.</div>
@@ -72,6 +73,8 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 .md-typeset .tg-count b { color: var(--tg-ink); }
 .md-typeset .tg-clear { background: none; border: 0; color: var(--tg-accent); cursor: pointer; font: inherit; font-size: 0.8rem; font-weight: 600; padding: 0; }
 .md-typeset .tg-clear:hover { text-decoration: underline; }
+.md-typeset .tg-ghlink { margin-left: auto; color: var(--tg-accent); font-size: 0.8rem; font-weight: 600; text-decoration: none; white-space: nowrap; }
+.md-typeset .tg-ghlink:hover { text-decoration: underline; }
 
 /* grid + cards */
 .md-typeset .tg-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); }
@@ -273,6 +276,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   function render() { renderTabs(); renderFilters(); renderGrid(); }
   $("tg-search").addEventListener("input", function (e) { state.q = e.target.value.trim().toLowerCase(); renderGrid(); });
   $("tg-clear").addEventListener("click", function () { state.cat = "all"; state.fws.clear(); state.q = ""; $("tg-search").value = ""; render(); $("tg-search").focus(); });
+  $("tg-browse").href = TREE_BASE + "samples";
   render();
 })();
 </script>

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -180,7 +180,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     return fallback();
   }
   var toastT;
-  function toast(cmd) { var t = $("tg-toast"); t.innerHTML = "Copied <span class=\"mono\">" + esc(cmd) + "</span>"; t.classList.add("show"); clearTimeout(toastT); toastT = setTimeout(function () { t.classList.remove("show"); }, 2600); }
+  function toast(label, mono) { var t = $("tg-toast"); t.innerHTML = esc(label) + (mono ? ' <span class="mono">' + esc(mono) + "</span>" : ""); t.classList.add("show"); clearTimeout(toastT); toastT = setTimeout(function () { t.classList.remove("show"); }, 2600); }
 
   function matches(app) {
     if (state.cat !== "all" && app.category !== state.cat) return false;
@@ -258,10 +258,10 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     el.querySelectorAll(".tg-copybtn").forEach(function (btn) {
       btn.addEventListener("click", function () {
         copyText(btn.getAttribute("data-copy")).then(function (ok) {
-          if (!ok) { toast("Copy failed — select and copy manually: " + btn.getAttribute("data-copy")); return; }
+          if (!ok) { toast("Copy failed — copy manually:", btn.getAttribute("data-copy")); return; }
           btn.classList.add("copied");
           var l = btn.querySelector(".lbl"); var prev = l.textContent; l.textContent = "Copied!";
-          toast(btn.getAttribute("data-copy"));
+          toast("Copied", btn.getAttribute("data-copy"));
           setTimeout(function () { btn.classList.remove("copied"); l.textContent = prev; }, 1600);
         });
       });

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -11,7 +11,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 <div class="tg" id="tg">
   <div class="tg-controls">
     <div class="tg-toprow">
-      <div class="tg-row" id="tg-tabs" role="tablist" aria-label="Categories"></div>
+      <div class="tg-row" id="tg-tabs" role="group" aria-label="Filter by category"></div>
       <label class="tg-search">
         <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="9" cy="9" r="6"/><path d="M14 14l4 4" stroke-linecap="round"/></svg>
         <input id="tg-search" type="search" placeholder="Search apps…" aria-label="Search apps" />
@@ -61,7 +61,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   display: inline-flex; align-items: center; gap: 0.35rem;
 }
 .md-typeset .tg-pill:hover { border-color: var(--tg-accent); }
-.md-typeset .tg-pill[aria-pressed="true"], .md-typeset .tg-pill[aria-selected="true"] { background: var(--tg-accent); border-color: var(--tg-accent); color: var(--tg-on-accent); }
+.md-typeset .tg-pill[aria-pressed="true"] { background: var(--tg-accent); border-color: var(--tg-accent); color: var(--tg-on-accent); }
 .md-typeset .tg-pill .tg-cnt { font-family: var(--tg-mono); font-size: 0.7rem; opacity: 0.7; }
 .md-typeset .tg-pill-sm { font-size: 0.74rem; padding: 0.32rem 0.65rem; }
 .md-typeset .tg-search { display: flex; align-items: center; gap: 0.45rem; flex: 0 0 auto; background: var(--tg-surface); border: 1px solid var(--tg-hair); border-radius: 999px; padding: 0.38rem 0.85rem; min-width: 240px; }
@@ -179,7 +179,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     var cats = [{ id: "all", label: "All" }].concat(DATA.categories);
     $("tg-tabs").innerHTML = cats.map(function (c) {
       var on = state.cat === c.id;
-      return '<button type="button" class="tg-pill" role="tab" aria-selected="' + on + '" data-cat="' + c.id + '">' + esc(c.label) + ' <span class="tg-cnt">' + countIn(c.id) + "</span></button>";
+      return '<button type="button" class="tg-pill" aria-pressed="' + on + '" data-cat="' + c.id + '">' + esc(c.label) + ' <span class="tg-cnt">' + countIn(c.id) + "</span></button>";
     }).join("");
     $("tg-tabs").querySelectorAll("[data-cat]").forEach(function (b) { b.addEventListener("click", function () { state.cat = b.dataset.cat; render(); }); });
   }

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -20,7 +20,6 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     <div class="tg-row" id="tg-filters">
       <span class="tg-flabel">Filter</span>
       <span id="tg-fw"></span>
-      <span id="tg-tags"></span>
     </div>
   </div>
   <div class="tg-meta">
@@ -115,7 +114,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 <script type="application/json" id="tg-data">
 {
   "repo": "https://github.com/UiPath/uipath-typescript",
-  "assetsBaseUrl": "https://raw.githubusercontent.com/UiPath/uipath-typescript/main/",
+  "ref": "main",
   "categories": [
     { "id": "action-apps", "label": "Action Apps", "accent": ["#FA4616", "#FF8A4C"] },
     { "id": "agents", "label": "Agents", "accent": ["#7C5CFC", "#A78BFA"] },
@@ -148,7 +147,14 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   if (!root || root.dataset.mounted) return;
   root.dataset.mounted = "1";
   var DATA = JSON.parse(document.getElementById("tg-data").textContent);
-  var state = { cat: "all", fws: new Set(), tags: new Set(), q: "" };
+  // All sample assets/links resolve against a single git ref. Defaults to "main";
+  // the docs PR-preview build rewrites it to the PR's head commit so a new sample's
+  // assets (not yet on main) resolve in the preview. See .github/workflows/docs-pr-preview.yml.
+  var REF = DATA.ref || "main";
+  var RAW_BASE = DATA.repo.replace("https://github.com/", "https://raw.githubusercontent.com/") + "/" + REF + "/";
+  var TREE_BASE = DATA.repo + "/tree/" + REF + "/";
+  var BLOB_BASE = DATA.repo + "/blob/" + REF + "/";
+  var state = { cat: "all", fws: new Set(), q: "" };
   var $ = function (id) { return document.getElementById(id); };
   function esc(s) { return String(s).replace(/[&<>"]/g, function (m) { return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[m]; }); }
   function catById(id) { return (DATA.categories || []).find(function (c) { return c.id === id; }); }
@@ -181,7 +187,6 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   function matches(app) {
     if (state.cat !== "all" && app.category !== state.cat) return false;
     if (state.fws.size && !state.fws.has(app.framework)) return false;
-    if (state.tags.size) { for (var t of state.tags) if ((app.tags || []).indexOf(t) === -1) return false; }
     if (state.q) { var hay = (app.title + " " + app.description + " " + (app.tags || []).join(" ") + " " + app.framework).toLowerCase(); if (hay.indexOf(state.q) === -1) return false; }
     return true;
   }
@@ -210,28 +215,19 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     } else {
       fwWrap.querySelectorAll("[data-fw]").forEach(function (b) { b.setAttribute("aria-pressed", String(state.fws.has(b.dataset.fw))); });
     }
-    var tagWrap = $("tg-tags");
-    if (!tagWrap.children.length) {
-      var counts = {}; DATA.apps.forEach(function (a) { (a.tags || []).forEach(function (t) { counts[t] = (counts[t] || 0) + 1; }); });
-      var tags = Object.keys(counts).sort(function (a, b) { return counts[b] - counts[a] || a.localeCompare(b); });
-      tagWrap.innerHTML = tags.map(function (t) { return '<button type="button" class="tg-pill tg-pill-sm" aria-pressed="' + state.tags.has(t) + '" data-tag="' + esc(t) + '">' + esc(t) + "</button>"; }).join("");
-      tagWrap.querySelectorAll("[data-tag]").forEach(function (b) { b.addEventListener("click", function () { var t = b.dataset.tag; state.tags.has(t) ? state.tags.delete(t) : state.tags.add(t); render(); }); });
-    } else {
-      tagWrap.querySelectorAll("[data-tag]").forEach(function (b) { b.setAttribute("aria-pressed", String(state.tags.has(b.dataset.tag))); });
-    }
   }
   var COPY = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
   function card(app) {
     var c = catById(app.category) || { label: app.category, accent: ["#888", "#555"] };
-    var folder = app.path ? (DATA.repo + "/tree/main/" + app.path) : DATA.repo;
+    var folder = app.path ? (TREE_BASE + app.path) : DATA.repo;
     var el = document.createElement("article");
     el.className = "tg-card";
     el.style.setProperty("--tg-poster", poster(app));
     var h = '<div class="tg-thumb">';
     h += '<span class="tg-badge-fw">' + esc(app.framework) + "</span>";
-    if (app.preview) h += '<a class="tg-badge-live" href="' + esc(DATA.repo + "/blob/main/" + app.preview) + '" target="_blank" rel="noopener" title="View the preview GIF"><span class="blip"></span>Live preview</a>';
+    if (app.preview) h += '<a class="tg-badge-live" href="' + esc(BLOB_BASE + app.preview) + '" target="_blank" rel="noopener" title="View the preview GIF"><span class="blip"></span>Live preview</a>';
     h += '<div class="tg-glyph"><span class="g">' + esc(monogram(app)) + '</span><span class="s">' + esc(c.label) + "</span></div>";
-    if (app.preview) h += '<img alt="' + esc(app.title) + ' preview" loading="lazy" src="' + esc((DATA.assetsBaseUrl || "") + app.preview) + '" />';
+    if (app.preview) h += '<img alt="' + esc(app.title) + ' preview" loading="lazy" src="' + esc(RAW_BASE + app.preview) + '" />';
     h += '<a class="tg-thumblink" href="' + esc(folder) + '" target="_blank" rel="noopener" aria-label="Open ' + esc(app.title) + ' on GitHub"></a>';
     h += "</div>";
     h += '<div class="tg-body">';
@@ -272,11 +268,11 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     $("tg-count-n").textContent = list.length;
     $("tg-count-w").textContent = list.length === 1 ? "app" : "apps";
     $("tg-empty").hidden = list.length !== 0;
-    $("tg-clear").hidden = !(state.cat !== "all" || state.fws.size || state.tags.size || state.q);
+    $("tg-clear").hidden = !(state.cat !== "all" || state.fws.size || state.q);
   }
   function render() { renderTabs(); renderFilters(); renderGrid(); }
   $("tg-search").addEventListener("input", function (e) { state.q = e.target.value.trim().toLowerCase(); renderGrid(); });
-  $("tg-clear").addEventListener("click", function () { state.cat = "all"; state.fws.clear(); state.tags.clear(); state.q = ""; $("tg-search").value = ""; render(); $("tg-search").focus(); });
+  $("tg-clear").addEventListener("click", function () { state.cat = "all"; state.fws.clear(); state.q = ""; $("tg-search").value = ""; render(); $("tg-search").focus(); });
   render();
 })();
 </script>

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -159,9 +159,25 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   function poster(app) { var c = catById(app.category) || { accent: ["#888", "#555"] }; return "linear-gradient(135deg," + c.accent[0] + "," + c.accent[1] + ")"; }
   function monogram(app) { var c = catById(app.category); return (c ? c.label : app.title).split(/[\s/]+/).filter(Boolean).slice(0, 2).map(function (w) { return w[0]; }).join("").toUpperCase(); }
   function slug() { return (DATA.repo || "").replace(/^https?:\/\/github\.com\//, "").replace(/\/+$/, ""); }
+  // Resolves to true if the text was copied. Falls back to execCommand when the
+  // Clipboard API is missing OR rejects (e.g. document not focused / denied), so
+  // it never leaves an unhandled rejection.
   function copyText(t) {
-    if (navigator.clipboard && navigator.clipboard.writeText) return navigator.clipboard.writeText(t);
-    return new Promise(function (res) { var ta = document.createElement("textarea"); ta.value = t; ta.style.position = "fixed"; ta.style.opacity = "0"; document.body.appendChild(ta); ta.select(); try { document.execCommand("copy"); } catch (e) {} document.body.removeChild(ta); res(); });
+    var fallback = function () {
+      var ok = false;
+      try {
+        var ta = document.createElement("textarea");
+        ta.value = t; ta.style.position = "fixed"; ta.style.opacity = "0";
+        document.body.appendChild(ta); ta.focus(); ta.select();
+        ok = document.execCommand("copy");
+        document.body.removeChild(ta);
+      } catch (e) { ok = false; }
+      return Promise.resolve(ok);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(t).then(function () { return true; }, fallback);
+    }
+    return fallback();
   }
   var toastT;
   function toast(cmd) { var t = $("tg-toast"); t.innerHTML = "Copied <span class=\"mono\">" + esc(cmd) + "</span>"; t.classList.add("show"); clearTimeout(toastT); toastT = setTimeout(function () { t.classList.remove("show"); }, 2600); }
@@ -241,7 +257,8 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     }
     el.querySelectorAll(".tg-copybtn").forEach(function (btn) {
       btn.addEventListener("click", function () {
-        copyText(btn.getAttribute("data-copy")).then(function () {
+        copyText(btn.getAttribute("data-copy")).then(function (ok) {
+          if (!ok) { toast("Copy failed — select and copy manually: " + btn.getAttribute("data-copy")); return; }
           btn.classList.add("copied");
           var l = btn.querySelector(".lbl"); var prev = l.textContent; l.textContent = "Copied!";
           toast(btn.getAttribute("data-copy"));

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -43,7 +43,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   --tg-surface: color-mix(in srgb, var(--md-default-fg-color) 3%, var(--md-default-bg-color));
   --tg-surface-2: color-mix(in srgb, var(--md-default-fg-color) 6%, var(--md-default-bg-color));
   --tg-accent-soft: color-mix(in srgb, var(--md-primary-fg-color) 12%, transparent);
-  --tg-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+  --tg-mono: var(--md-code-font-family, ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace);
   margin-top: 1.2rem;
 }
 
@@ -94,7 +94,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 .md-typeset .tg-titlelink { text-decoration: none; }
 .md-typeset .tg-title { font-size: 1.02rem; font-weight: 700; margin: 0; line-height: 1.25; color: var(--tg-ink); letter-spacing: -0.01em; }
 .md-typeset .tg-titlelink:hover .tg-title { color: var(--tg-accent); }
-.md-typeset .tg-desc { font-size: 0.83rem; color: var(--tg-muted); margin: 0; flex: 1; line-height: 1.5; }
+.md-typeset .tg-desc { font-size: 0.8rem; color: var(--tg-muted); margin: 0; flex: 1; line-height: 1.5; }
 .md-typeset .tg-foot { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; margin-top: 0.3rem; padding-top: 0.7rem; border-top: 1px solid var(--tg-hair); }
 .md-typeset .tg-clone { font: inherit; cursor: pointer; text-align: left; flex: none; display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.7rem; border-radius: 9px; border: 1px solid var(--tg-hair); background: var(--tg-surface-2); color: var(--tg-ink); }
 .md-typeset .tg-clone:hover { border-color: var(--tg-accent); }

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -101,11 +101,6 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 .md-typeset .tg-clone svg { flex: none; width: 15px; height: 15px; color: var(--tg-accent); }
 .md-typeset .tg-clone .lbl { font-size: 0.76rem; font-weight: 700; }
 .md-typeset .tg-clone.copied { border-color: var(--tg-accent); background: var(--tg-accent-soft); }
-.md-typeset .tg-vscode { font: inherit; cursor: pointer; display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.6rem; border: 0; background: none; color: var(--tg-muted); border-radius: 8px; }
-.md-typeset .tg-vscode:hover { color: var(--tg-accent); background: var(--tg-surface-2); }
-.md-typeset .tg-vscode svg { width: 15px; height: 15px; flex: none; }
-.md-typeset .tg-vscode .lbl { font-size: 0.76rem; font-weight: 600; }
-.md-typeset .tg-vscode.copied { color: var(--tg-accent); }
 /* suppress Material's auto external-link icon inside the gallery (we style our own) */
 .md-typeset .tg a::after { display: none !important; }
 .md-typeset .tg-empty { text-align: center; padding: 3rem 1rem; color: var(--tg-muted); }
@@ -225,7 +220,6 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     }
   }
   var COPY = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
-  var CODEICON = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 6 2 12 8 18"/><polyline points="16 6 22 12 16 18"/></svg>';
   function card(app) {
     var c = catById(app.category) || { label: app.category, accent: ["#888", "#555"] };
     var folder = app.path ? (DATA.repo + "/tree/main/" + app.path) : DATA.repo;
@@ -244,10 +238,8 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     h += '<p class="tg-desc">' + esc(app.description) + "</p>";
     if (app.path) {
       var cloneCmd = "npx degit " + slug() + "/" + app.path + " " + app.id;
-      var vscodeCmd = cloneCmd + " && code " + app.id;
       h += '<div class="tg-foot">';
       h += '<button type="button" class="tg-clone tg-copybtn" data-copy="' + esc(cloneCmd) + '" title="Copy clone command: ' + esc(cloneCmd) + '">' + COPY + '<span class="lbl">Clone</span></button>';
-      h += '<button type="button" class="tg-vscode tg-copybtn" data-copy="' + esc(vscodeCmd) + '" title="Copy: ' + esc(vscodeCmd) + '">' + CODEICON + '<span class="lbl">Open in VS Code</span></button>';
       h += "</div>"; // .tg-foot
     }
     h += "</div>"; // .tg-body

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -219,7 +219,10 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     h += "</div>"; // .tg-body
     el.innerHTML = h;
     var img = el.querySelector("img");
-    if (img) img.addEventListener("load", function () { img.classList.add("tg-loaded"); });
+    if (img) {
+      img.addEventListener("load", function () { img.classList.add("tg-loaded"); });
+      if (img.complete) img.classList.add("tg-loaded"); // already-cached images fire load before this listener attaches
+    }
     el.querySelectorAll(".tg-copybtn").forEach(function (btn) {
       btn.addEventListener("click", function () {
         copyText(btn.getAttribute("data-copy")).then(function () {

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -1,0 +1,249 @@
+---
+title: Template Gallery
+hide:
+  - toc
+---
+
+# Template Gallery
+
+Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. Each card links to the source and copies a ready-to-run `degit` command.
+
+<div class="tg" id="tg">
+  <div class="tg-controls">
+    <div class="tg-toprow">
+      <div class="tg-row" id="tg-tabs" role="tablist" aria-label="Categories"></div>
+      <label class="tg-search">
+        <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="9" cy="9" r="6"/><path d="M14 14l4 4" stroke-linecap="round"/></svg>
+        <input id="tg-search" type="search" placeholder="Search apps…" aria-label="Search apps" />
+      </label>
+    </div>
+    <div class="tg-row" id="tg-filters">
+      <span class="tg-flabel">Filter</span>
+      <span id="tg-fw"></span>
+      <span id="tg-tags"></span>
+    </div>
+  </div>
+  <div class="tg-meta">
+    <span class="tg-count"><b id="tg-count-n">0</b> <span id="tg-count-w">apps</span></span>
+    <button type="button" class="tg-clear" id="tg-clear" hidden>Clear filters</button>
+  </div>
+  <div class="tg-grid" id="tg-grid"></div>
+  <div class="tg-empty" id="tg-empty" hidden>No apps match these filters.</div>
+</div>
+<div class="tg-toast" id="tg-toast" role="status" aria-live="polite"></div>
+
+<style>
+.tg, .tg *, .tg *::before, .tg *::after { box-sizing: border-box; }
+.md-typeset .tg {
+  --tg-accent: var(--md-primary-fg-color);
+  --tg-on-accent: var(--md-primary-bg-color);
+  --tg-ink: var(--md-default-fg-color);
+  --tg-muted: var(--md-default-fg-color--light);
+  --tg-hair: var(--md-default-fg-color--lightest);
+  --tg-surface: color-mix(in srgb, var(--md-default-fg-color) 3%, var(--md-default-bg-color));
+  --tg-surface-2: color-mix(in srgb, var(--md-default-fg-color) 6%, var(--md-default-bg-color));
+  --tg-accent-soft: color-mix(in srgb, var(--md-primary-fg-color) 12%, transparent);
+  --tg-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+  margin-top: 1.2rem;
+}
+
+/* controls */
+.md-typeset .tg-controls { display: flex; flex-direction: column; gap: 0.7rem; padding-bottom: 1rem; border-bottom: 1px solid var(--tg-hair); }
+.md-typeset .tg-toprow { display: grid; grid-template-columns: 1fr auto; align-items: start; gap: 0.7rem 1rem; }
+.md-typeset #tg-tabs { min-width: 0; }
+@media (max-width: 640px) { .md-typeset .tg-toprow { grid-template-columns: 1fr; } .md-typeset .tg-search { min-width: 0; } }
+.md-typeset .tg-row { display: flex; flex-wrap: wrap; gap: 0.45rem; align-items: center; }
+.md-typeset .tg-flabel { font-family: var(--tg-mono); font-size: 0.62rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--tg-muted); margin-right: 0.1rem; }
+.md-typeset .tg-pill {
+  font-size: 0.8rem; font-weight: 600; cursor: pointer; line-height: 1;
+  padding: 0.42rem 0.8rem; border-radius: 999px; border: 1px solid var(--tg-hair);
+  background: var(--tg-surface); color: var(--tg-ink); transition: all .14s ease;
+  display: inline-flex; align-items: center; gap: 0.35rem;
+}
+.md-typeset .tg-pill:hover { border-color: var(--tg-accent); }
+.md-typeset .tg-pill[aria-pressed="true"] { background: var(--tg-accent); border-color: var(--tg-accent); color: var(--tg-on-accent); }
+.md-typeset .tg-pill .tg-cnt { font-family: var(--tg-mono); font-size: 0.7rem; opacity: 0.7; }
+.md-typeset .tg-pill-sm { font-size: 0.74rem; padding: 0.32rem 0.65rem; }
+.md-typeset .tg-search { display: flex; align-items: center; gap: 0.45rem; flex: 0 0 auto; background: var(--tg-surface); border: 1px solid var(--tg-hair); border-radius: 999px; padding: 0.38rem 0.85rem; min-width: 240px; }
+.md-typeset .tg-search:focus-within { border-color: var(--tg-accent); }
+.md-typeset .tg-search svg { width: 15px; height: 15px; color: var(--tg-muted); flex: none; }
+.md-typeset .tg-search input { border: 0; background: transparent; color: var(--tg-ink); font: inherit; font-size: 0.85rem; width: 100%; outline: none; }
+
+.md-typeset .tg-meta { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin: 1rem 0 1.2rem; color: var(--tg-muted); font-size: 0.82rem; }
+.md-typeset .tg-count b { color: var(--tg-ink); }
+.md-typeset .tg-clear { background: none; border: 0; color: var(--tg-accent); cursor: pointer; font: inherit; font-size: 0.8rem; font-weight: 600; padding: 0; }
+.md-typeset .tg-clear:hover { text-decoration: underline; }
+
+/* grid + cards */
+.md-typeset .tg-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); }
+.md-typeset .tg-card { display: flex; flex-direction: column; background: var(--tg-surface); border: 1px solid var(--tg-hair); border-radius: 12px; overflow: hidden; transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease; }
+.md-typeset .tg-card:hover { transform: translateY(-3px); box-shadow: 0 12px 30px rgba(0,0,0,.12); border-color: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent); }
+.md-typeset .tg-thumblink { display: block; position: relative; }
+.md-typeset .tg-thumb { position: relative; aspect-ratio: 16 / 10; overflow: hidden; background: var(--tg-poster, linear-gradient(135deg,#888,#555)); display: grid; place-items: center; }
+.md-typeset .tg-thumb img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; display: block; opacity: 0; transition: opacity .4s ease; margin: 0; max-width: none; }
+.md-typeset .tg-thumb img.tg-loaded { opacity: 1; }
+.md-typeset .tg-glyph { font-family: var(--tg-mono); font-weight: 700; color: #fff; text-align: center; text-shadow: 0 2px 12px rgba(0,0,0,.25); padding: 1rem; }
+.md-typeset .tg-glyph .g { font-size: 1.8rem; display: block; letter-spacing: -0.02em; }
+.md-typeset .tg-glyph .s { font-size: 0.66rem; letter-spacing: 0.14em; opacity: 0.85; text-transform: uppercase; margin-top: 0.35rem; }
+.md-typeset .tg-badge-fw { position: absolute; top: 0.6rem; right: 0.6rem; z-index: 2; font-family: var(--tg-mono); font-size: 0.62rem; font-weight: 600; padding: 0.24rem 0.5rem; border-radius: 999px; color: #fff; background: rgba(20,20,22,.55); border: 1px solid rgba(255,255,255,.18); }
+.md-typeset .tg-badge-live { position: absolute; top: 0.6rem; left: 0.6rem; z-index: 2; font-family: var(--tg-mono); font-size: 0.58rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; padding: 0.22rem 0.45rem; border-radius: 999px; color: #fff; background: rgba(20,20,22,.5); display: flex; align-items: center; gap: 0.3rem; }
+.md-typeset .tg-badge-live .blip { width: 6px; height: 6px; border-radius: 50%; background: #57e08a; }
+.md-typeset .tg-body { padding: 0.9rem 1rem 1rem; display: flex; flex-direction: column; gap: 0.5rem; flex: 1; }
+.md-typeset .tg-catline { font-family: var(--tg-mono); font-size: 0.64rem; letter-spacing: 0.1em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.4rem; font-weight: 700; color: var(--tg-muted); }
+.md-typeset .tg-catline .sw { width: 9px; height: 9px; border-radius: 2px; }
+.md-typeset .tg-titlelink { text-decoration: none; }
+.md-typeset .tg-title { font-size: 1.02rem; font-weight: 700; margin: 0; line-height: 1.25; color: var(--tg-ink); letter-spacing: -0.01em; }
+.md-typeset .tg-titlelink:hover .tg-title { color: var(--tg-accent); }
+.md-typeset .tg-desc { font-size: 0.83rem; color: var(--tg-muted); margin: 0; flex: 1; line-height: 1.5; }
+.md-typeset .tg-foot { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; margin-top: 0.3rem; padding-top: 0.7rem; border-top: 1px solid var(--tg-hair); }
+.md-typeset .tg-clone { font: inherit; cursor: pointer; text-align: left; flex: none; display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.7rem; border-radius: 9px; border: 1px solid var(--tg-hair); background: var(--tg-surface-2); color: var(--tg-ink); }
+.md-typeset .tg-clone:hover { border-color: var(--tg-accent); }
+.md-typeset .tg-clone svg { flex: none; width: 15px; height: 15px; color: var(--tg-accent); }
+.md-typeset .tg-clone .lbl { font-size: 0.76rem; font-weight: 700; }
+.md-typeset .tg-clone.copied { border-color: var(--tg-accent); background: var(--tg-accent-soft); }
+.md-typeset .tg-vscode { font: inherit; cursor: pointer; display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.6rem; border: 0; background: none; color: var(--tg-muted); border-radius: 8px; }
+.md-typeset .tg-vscode:hover { color: var(--tg-accent); background: var(--tg-surface-2); }
+.md-typeset .tg-vscode svg { width: 15px; height: 15px; flex: none; }
+.md-typeset .tg-vscode .lbl { font-size: 0.76rem; font-weight: 600; }
+.md-typeset .tg-vscode.copied { color: var(--tg-accent); }
+/* suppress Material's auto external-link icon inside the gallery (we style our own) */
+.md-typeset .tg a::after { display: none !important; }
+.md-typeset .tg-empty { text-align: center; padding: 3rem 1rem; color: var(--tg-muted); }
+
+.tg-toast { position: fixed; left: 50%; bottom: 1.3rem; z-index: 100; transform: translateX(-50%) translateY(18px); background: var(--md-default-fg-color); color: var(--md-default-bg-color); font-size: 0.83rem; font-weight: 600; padding: 0.6rem 1rem; border-radius: 999px; box-shadow: 0 12px 30px rgba(0,0,0,.3); opacity: 0; pointer-events: none; transition: opacity .22s ease, transform .22s ease; max-width: 90vw; display: flex; gap: 0.5rem; align-items: center; }
+.tg-toast .mono { font-family: var(--tg-mono); font-size: 0.76rem; opacity: 0.85; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tg-toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+@media (prefers-reduced-motion: reduce) { .md-typeset .tg-card, .tg-toast { transition: none; } }
+</style>
+
+<script type="application/json" id="tg-data">
+{
+  "repo": "https://github.com/UiPath/uipath-typescript",
+  "assetsBaseUrl": "https://raw.githubusercontent.com/UiPath/uipath-typescript/main/",
+  "categories": [
+    { "id": "action-apps", "label": "Action Apps", "accent": ["#FA4616", "#FF8A4C"] },
+    { "id": "agents", "label": "Agents", "accent": ["#7C5CFC", "#A78BFA"] },
+    { "id": "dashboards", "label": "Dashboards", "accent": ["#0EA5A4", "#2DD4C4"] },
+    { "id": "data-fabric", "label": "Data Fabric", "accent": ["#2563EB", "#5B8DEF"] },
+    { "id": "document", "label": "Document / HITL", "accent": ["#0F9D6B", "#34D399"] },
+    { "id": "process", "label": "Process Orchestration", "accent": ["#DB2777", "#F472B6"] }
+  ],
+  "apps": [
+    { "id": "conversational-agent-app", "title": "Conversational Agent App", "description": "Interact with UiPath Conversational Agents — real-time streaming responses over WebSocket, conversation management, file attachments, tool-call visualization, and feedback.", "category": "agents", "framework": "React", "tags": ["Agents","Conversational","WebSocket","Streaming"], "path": "samples/conversational-agent-app", "preview": "samples/conversational-agent-app/screenshots/preview.gif" },
+    { "id": "agent-runtime-compliance", "title": "Agent Runtime Compliance Dashboard", "description": "Dashboard showing how AI agents perform against UiPath runtime compliance checks — enforcement outcomes, failure reasons, agents ranked by failed checks, and per-run decision logs via the Agent Traces governance APIs.", "category": "dashboards", "framework": "React", "tags": ["Governance","Agent Traces","Analytics","Preview"], "path": "samples/dashboards/agent-runtime-compliance", "preview": "samples/dashboards/agent-runtime-compliance/screenshots/agent-runtime-compliance-dashboard.gif" },
+    { "id": "data-fabric-app", "title": "Data Fabric Explorer", "description": "Browse and manage UiPath Data Fabric entities, records, and choice sets via the SDK. Deploys as a UiPath Coded App.", "category": "data-fabric", "framework": "React", "tags": ["Data Fabric","CRUD","Coded App"], "path": "samples/data-fabric-app", "preview": "samples/data-fabric-app/screenshots/preview.gif" },
+    { "id": "data-fabric-app-angular", "title": "Data Fabric Explorer (Angular)", "description": "The Angular counterpart of the React Data Fabric sample. Renders its own records grid and calls the SDK's record CRUD methods directly, exercising a wider slice of the Entities service.", "category": "data-fabric", "framework": "Angular", "tags": ["Data Fabric","CRUD","Angular","Coded App"], "path": "samples/data-fabric-app-angular", "preview": "samples/data-fabric-app-angular/screenshots/preview.gif" },
+    { "id": "document-validation-app", "title": "Document Validation Inbox", "description": "A human-in-the-loop document validation inbox on top of UiPath Action Center. Lists validation tasks grouped into Pending / Unassigned / Completed, renders the validation station, and lets a reviewer save, submit, or report an exception.", "category": "document", "framework": "React", "tags": ["Document Understanding","Action Center","HITL","OAuth / PKCE"], "path": "samples/document-validation-app", "preview": "samples/document-validation-app/screenshots/preview.gif" },
+    { "id": "process-app-v0", "title": "Maestro Process Management", "description": "Manage UiPath Maestro processes and process instances with OAuth authentication. Uses the single-package import pattern.", "category": "process", "framework": "React", "tags": ["Maestro","Process Orchestration","OAuth"], "path": "samples/process-app-v0", "preview": "samples/process-app-v0/screenshots/preview.gif" },
+    { "id": "process-app-v1", "title": "Maestro Process Management (Modular)", "description": "Manage Maestro processes and drill into a process instance's execution detail. Uses the recommended modular import pattern for smaller bundles and better performance.", "category": "process", "framework": "React", "tags": ["Maestro","Process Orchestration","Modular Import"], "path": "samples/process-app-v1", "preview": "samples/process-app-v1/screenshots/preview.gif" },
+    { "id": "action-app-with-data-fabric-entity", "title": "Action App — Data Fabric Entity", "description": "Coded Action App for loan-application review backed by a Data Fabric entity. Fetch an applicant record by name, review details, view the bundled document, and write the decision back to the entity.", "category": "action-apps", "framework": "React", "tags": ["Action Center","Coded Action App","Data Fabric","File Attachments"], "path": "samples/coded-action-apps/action-app-with-data-fabric-entity", "preview": null },
+    { "id": "action-app-with-document", "title": "Action App — Bundled Document", "description": "Coded Action App for loan-application review. Reviewers assess applicant details, view a bundled sample PDF, and complete the task with an Approve or Reject decision.", "category": "action-apps", "framework": "React", "tags": ["Action Center","Coded Action App","Documents"], "path": "samples/coded-action-apps/action-app-with-document", "preview": null },
+    { "id": "action-app-with-file-attachment-document", "title": "Action App — File Attachment", "description": "Coded Action App for loan-application review with direct file attachments. Preview and download a directly attached PDF, as opposed to referencing files from Storage Buckets.", "category": "action-apps", "framework": "React", "tags": ["Action Center","Coded Action App","File Attachments","Documents"], "path": "samples/coded-action-apps/action-app-with-file-attachment-document", "preview": null },
+    { "id": "action-app-with-image", "title": "Action App — Image", "description": "Coded Action App for loan-application review. Reviewers assess applicant details, view a bundled loan-application image, and complete the task with an Approve or Reject decision.", "category": "action-apps", "framework": "React", "tags": ["Action Center","Coded Action App","Images"], "path": "samples/coded-action-apps/action-app-with-image", "preview": null },
+    { "id": "action-app-with-storage-bucket-document", "title": "Action App — Storage Bucket Document", "description": "Coded Action App for loan-application review that loads its document from a Storage Bucket by bucket name and file path, as opposed to receiving a direct file attachment.", "category": "action-apps", "framework": "React", "tags": ["Action Center","Coded Action App","Storage Buckets","Documents"], "path": "samples/coded-action-apps/action-app-with-storage-bucket-document", "preview": null }
+  ]
+}
+</script>
+
+<script>
+(function () {
+  "use strict";
+  var root = document.getElementById("tg");
+  if (!root || root.dataset.mounted) return;
+  root.dataset.mounted = "1";
+  var DATA = JSON.parse(document.getElementById("tg-data").textContent);
+  var state = { cat: "all", fws: new Set(), tags: new Set(), q: "" };
+  var $ = function (id) { return document.getElementById(id); };
+  function esc(s) { return String(s).replace(/[&<>"]/g, function (m) { return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[m]; }); }
+  function catById(id) { return (DATA.categories || []).find(function (c) { return c.id === id; }); }
+  function poster(app) { var c = catById(app.category) || { accent: ["#888", "#555"] }; return "linear-gradient(135deg," + c.accent[0] + "," + c.accent[1] + ")"; }
+  function monogram(app) { var c = catById(app.category); return (c ? c.label : app.title).split(/[\s/]+/).filter(Boolean).slice(0, 2).map(function (w) { return w[0]; }).join("").toUpperCase(); }
+  function slug() { return (DATA.repo || "").replace(/^https?:\/\/github\.com\//, "").replace(/\/+$/, ""); }
+  function copyText(t) {
+    if (navigator.clipboard && navigator.clipboard.writeText) return navigator.clipboard.writeText(t);
+    return new Promise(function (res) { var ta = document.createElement("textarea"); ta.value = t; ta.style.position = "fixed"; ta.style.opacity = "0"; document.body.appendChild(ta); ta.select(); try { document.execCommand("copy"); } catch (e) {} document.body.removeChild(ta); res(); });
+  }
+  var toastT;
+  function toast(cmd) { var t = $("tg-toast"); t.innerHTML = "Copied <span class=\"mono\">" + esc(cmd) + "</span>"; t.classList.add("show"); clearTimeout(toastT); toastT = setTimeout(function () { t.classList.remove("show"); }, 2600); }
+
+  function matches(app) {
+    if (state.cat !== "all" && app.category !== state.cat) return false;
+    if (state.fws.size && !state.fws.has(app.framework)) return false;
+    if (state.tags.size) { for (var t of state.tags) if ((app.tags || []).indexOf(t) === -1) return false; }
+    if (state.q) { var hay = (app.title + " " + app.description + " " + (app.tags || []).join(" ") + " " + app.framework).toLowerCase(); if (hay.indexOf(state.q) === -1) return false; }
+    return true;
+  }
+  function countIn(cat) { return DATA.apps.filter(function (a) { return cat === "all" || a.category === cat; }).length; }
+
+  function renderTabs() {
+    var cats = [{ id: "all", label: "All" }].concat(DATA.categories);
+    $("tg-tabs").innerHTML = cats.map(function (c) {
+      var on = state.cat === c.id;
+      return '<button type="button" class="tg-pill" role="tab" aria-pressed="' + on + '" data-cat="' + c.id + '">' + esc(c.label) + ' <span class="tg-cnt">' + countIn(c.id) + "</span></button>";
+    }).join("");
+    $("tg-tabs").querySelectorAll("[data-cat]").forEach(function (b) { b.addEventListener("click", function () { state.cat = b.dataset.cat; render(); }); });
+  }
+  function renderFilters() {
+    var fws = Array.from(new Set(DATA.apps.map(function (a) { return a.framework; }))).sort();
+    $("tg-fw").innerHTML = fws.map(function (f) { return '<button type="button" class="tg-pill tg-pill-sm" aria-pressed="' + state.fws.has(f) + '" data-fw="' + esc(f) + '">' + esc(f) + "</button>"; }).join("");
+    $("tg-fw").querySelectorAll("[data-fw]").forEach(function (b) { b.addEventListener("click", function () { var f = b.dataset.fw; state.fws.has(f) ? state.fws.delete(f) : state.fws.add(f); render(); }); });
+    var counts = {}; DATA.apps.forEach(function (a) { (a.tags || []).forEach(function (t) { counts[t] = (counts[t] || 0) + 1; }); });
+    var tags = Object.keys(counts).sort(function (a, b) { return counts[b] - counts[a] || a.localeCompare(b); });
+    $("tg-tags").innerHTML = tags.map(function (t) { return '<button type="button" class="tg-pill tg-pill-sm" aria-pressed="' + state.tags.has(t) + '" data-tag="' + esc(t) + '">' + esc(t) + "</button>"; }).join("");
+    $("tg-tags").querySelectorAll("[data-tag]").forEach(function (b) { b.addEventListener("click", function () { var t = b.dataset.tag; state.tags.has(t) ? state.tags.delete(t) : state.tags.add(t); render(); }); });
+  }
+  var COPY = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
+  var CODEICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 6 2 12 8 18"/><polyline points="16 6 22 12 16 18"/></svg>';
+  function card(app) {
+    var c = catById(app.category) || { label: app.category, accent: ["#888", "#555"] };
+    var folder = app.path ? (DATA.repo + "/tree/main/" + app.path) : DATA.repo;
+    var cloneCmd = "npx degit " + slug() + "/" + app.path + " " + app.id;
+    var vscodeCmd = cloneCmd + " && code " + app.id;
+    var el = document.createElement("article");
+    el.className = "tg-card";
+    el.style.setProperty("--tg-poster", poster(app));
+    var h = '<a class="tg-thumblink" href="' + esc(folder) + '" target="_blank" rel="noopener" aria-label="Open ' + esc(app.title) + ' on GitHub"><div class="tg-thumb">';
+    h += '<span class="tg-badge-fw">' + esc(app.framework) + "</span>";
+    if (app.preview) h += '<span class="tg-badge-live"><span class="blip"></span>Live preview</span>';
+    h += '<div class="tg-glyph"><span class="g">' + esc(monogram(app)) + '</span><span class="s">' + esc(c.label) + "</span></div>";
+    if (app.preview) h += '<img alt="' + esc(app.title) + ' preview" loading="lazy" src="' + esc((DATA.assetsBaseUrl || "") + app.preview) + '" />';
+    h += "</div></a>";
+    h += '<div class="tg-body">';
+    h += '<span class="tg-catline"><span class="sw" style="background:' + c.accent[0] + '"></span>' + esc(c.label) + "</span>";
+    h += '<a class="tg-titlelink" href="' + esc(folder) + '" target="_blank" rel="noopener"><span class="tg-title">' + esc(app.title) + "</span></a>";
+    h += '<p class="tg-desc">' + esc(app.description) + "</p>";
+    h += '<div class="tg-foot">';
+    h += '<button type="button" class="tg-clone tg-copybtn" data-copy="' + esc(cloneCmd) + '" title="Copy clone command: ' + esc(cloneCmd) + '">' + COPY + '<span class="lbl">Clone</span></button>';
+    h += '<button type="button" class="tg-vscode tg-copybtn" data-copy="' + esc(vscodeCmd) + '" title="Copy: ' + esc(vscodeCmd) + '">' + CODEICON + '<span class="lbl">Open in VS Code</span></button>';
+    h += "</div>"; // .tg-foot
+    h += "</div>"; // .tg-body
+    el.innerHTML = h;
+    var img = el.querySelector("img");
+    if (img) img.addEventListener("load", function () { img.classList.add("tg-loaded"); });
+    el.querySelectorAll(".tg-copybtn").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        copyText(btn.getAttribute("data-copy")).then(function () {
+          btn.classList.add("copied");
+          var l = btn.querySelector(".lbl"); var prev = l.textContent; l.textContent = "Copied!";
+          toast(btn.getAttribute("data-copy"));
+          setTimeout(function () { btn.classList.remove("copied"); l.textContent = prev; }, 1600);
+        });
+      });
+    });
+    return el;
+  }
+  function renderGrid() {
+    var list = DATA.apps.filter(matches);
+    var g = $("tg-grid"); g.innerHTML = "";
+    list.forEach(function (a) { g.appendChild(card(a)); });
+    $("tg-count-n").textContent = list.length;
+    $("tg-count-w").textContent = list.length === 1 ? "app" : "apps";
+    $("tg-empty").hidden = list.length !== 0;
+    $("tg-clear").hidden = !(state.cat !== "all" || state.fws.size || state.tags.size || state.q);
+  }
+  function render() { renderTabs(); renderFilters(); renderGrid(); }
+  $("tg-search").addEventListener("input", function (e) { state.q = e.target.value.trim().toLowerCase(); renderGrid(); });
+  $("tg-clear").addEventListener("click", function () { state.cat = "all"; state.fws.clear(); state.tags.clear(); state.q = ""; $("tg-search").value = ""; render(); });
+  render();
+})();
+</script>

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -61,7 +61,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   display: inline-flex; align-items: center; gap: 0.35rem;
 }
 .md-typeset .tg-pill:hover { border-color: var(--tg-accent); }
-.md-typeset .tg-pill[aria-pressed="true"] { background: var(--tg-accent); border-color: var(--tg-accent); color: var(--tg-on-accent); }
+.md-typeset .tg-pill[aria-pressed="true"], .md-typeset .tg-pill[aria-selected="true"] { background: var(--tg-accent); border-color: var(--tg-accent); color: var(--tg-on-accent); }
 .md-typeset .tg-pill .tg-cnt { font-family: var(--tg-mono); font-size: 0.7rem; opacity: 0.7; }
 .md-typeset .tg-pill-sm { font-size: 0.74rem; padding: 0.32rem 0.65rem; }
 .md-typeset .tg-search { display: flex; align-items: center; gap: 0.45rem; flex: 0 0 auto; background: var(--tg-surface); border: 1px solid var(--tg-hair); border-radius: 999px; padding: 0.38rem 0.85rem; min-width: 240px; }
@@ -179,7 +179,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     var cats = [{ id: "all", label: "All" }].concat(DATA.categories);
     $("tg-tabs").innerHTML = cats.map(function (c) {
       var on = state.cat === c.id;
-      return '<button type="button" class="tg-pill" role="tab" aria-pressed="' + on + '" data-cat="' + c.id + '">' + esc(c.label) + ' <span class="tg-cnt">' + countIn(c.id) + "</span></button>";
+      return '<button type="button" class="tg-pill" role="tab" aria-selected="' + on + '" data-cat="' + c.id + '">' + esc(c.label) + ' <span class="tg-cnt">' + countIn(c.id) + "</span></button>";
     }).join("");
     $("tg-tabs").querySelectorAll("[data-cat]").forEach(function (b) { b.addEventListener("click", function () { state.cat = b.dataset.cat; render(); }); });
   }

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -30,7 +30,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   <div class="tg-grid" id="tg-grid"></div>
   <div class="tg-empty" id="tg-empty" hidden>No apps match these filters.</div>
 </div>
-<div class="tg-toast" id="tg-toast" role="status" aria-live="polite"></div>
+<div class="tg-toast" id="tg-toast" role="status"></div>
 
 <style>
 .tg, .tg *, .tg *::before, .tg *::after { box-sizing: border-box; }
@@ -91,9 +91,9 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
 .md-typeset .tg-body { padding: 0.9rem 1rem 1rem; display: flex; flex-direction: column; gap: 0.5rem; flex: 1; }
 .md-typeset .tg-catline { font-family: var(--tg-mono); font-size: 0.64rem; letter-spacing: 0.1em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.4rem; font-weight: 700; color: var(--tg-muted); }
 .md-typeset .tg-catline .sw { width: 9px; height: 9px; border-radius: 2px; }
-.md-typeset .tg-titlelink { text-decoration: none; }
+.md-typeset .tg-titlelink { text-decoration: none; color: inherit; }
 .md-typeset .tg-title { font-size: 1.02rem; font-weight: 700; margin: 0; line-height: 1.25; color: var(--tg-ink); letter-spacing: -0.01em; }
-.md-typeset .tg-titlelink:hover .tg-title { color: var(--tg-accent); }
+.md-typeset .tg-titlelink:hover { color: var(--tg-accent); }
 .md-typeset .tg-desc { font-size: 0.8rem; color: var(--tg-muted); margin: 0; flex: 1; line-height: 1.5; }
 .md-typeset .tg-foot { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; margin-top: 0.3rem; padding-top: 0.7rem; border-top: 1px solid var(--tg-hair); }
 .md-typeset .tg-clone { font: inherit; cursor: pointer; text-align: left; flex: none; display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.7rem; border-radius: 9px; border: 1px solid var(--tg-hair); background: var(--tg-surface-2); color: var(--tg-ink); }
@@ -224,13 +224,11 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
       tagWrap.querySelectorAll("[data-tag]").forEach(function (b) { b.setAttribute("aria-pressed", String(state.tags.has(b.dataset.tag))); });
     }
   }
-  var COPY = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
-  var CODEICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 6 2 12 8 18"/><polyline points="16 6 22 12 16 18"/></svg>';
+  var COPY = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
+  var CODEICON = '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 6 2 12 8 18"/><polyline points="16 6 22 12 16 18"/></svg>';
   function card(app) {
     var c = catById(app.category) || { label: app.category, accent: ["#888", "#555"] };
     var folder = app.path ? (DATA.repo + "/tree/main/" + app.path) : DATA.repo;
-    var cloneCmd = "npx degit " + slug() + "/" + app.path + " " + app.id;
-    var vscodeCmd = cloneCmd + " && code " + app.id;
     var el = document.createElement("article");
     el.className = "tg-card";
     el.style.setProperty("--tg-poster", poster(app));
@@ -242,12 +240,16 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     h += "</div></a>";
     h += '<div class="tg-body">';
     h += '<span class="tg-catline"><span class="sw" style="background:' + esc(c.accent[0]) + '"></span>' + esc(c.label) + "</span>";
-    h += '<a class="tg-titlelink" href="' + esc(folder) + '" target="_blank" rel="noopener"><span class="tg-title">' + esc(app.title) + "</span></a>";
+    h += '<h3 class="tg-title"><a class="tg-titlelink" href="' + esc(folder) + '" target="_blank" rel="noopener">' + esc(app.title) + "</a></h3>";
     h += '<p class="tg-desc">' + esc(app.description) + "</p>";
-    h += '<div class="tg-foot">';
-    h += '<button type="button" class="tg-clone tg-copybtn" data-copy="' + esc(cloneCmd) + '" title="Copy clone command: ' + esc(cloneCmd) + '">' + COPY + '<span class="lbl">Clone</span></button>';
-    h += '<button type="button" class="tg-vscode tg-copybtn" data-copy="' + esc(vscodeCmd) + '" title="Copy: ' + esc(vscodeCmd) + '">' + CODEICON + '<span class="lbl">Open in VS Code</span></button>';
-    h += "</div>"; // .tg-foot
+    if (app.path) {
+      var cloneCmd = "npx degit " + slug() + "/" + app.path + " " + app.id;
+      var vscodeCmd = cloneCmd + " && code " + app.id;
+      h += '<div class="tg-foot">';
+      h += '<button type="button" class="tg-clone tg-copybtn" data-copy="' + esc(cloneCmd) + '" title="Copy clone command: ' + esc(cloneCmd) + '">' + COPY + '<span class="lbl">Clone</span></button>';
+      h += '<button type="button" class="tg-vscode tg-copybtn" data-copy="' + esc(vscodeCmd) + '" title="Copy: ' + esc(vscodeCmd) + '">' + CODEICON + '<span class="lbl">Open in VS Code</span></button>';
+      h += "</div>"; // .tg-foot
+    }
     h += "</div>"; // .tg-body
     el.innerHTML = h;
     var img = el.querySelector("img");
@@ -257,6 +259,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     }
     el.querySelectorAll(".tg-copybtn").forEach(function (btn) {
       btn.addEventListener("click", function () {
+        if (btn.classList.contains("copied")) return; // ignore repeat clicks during the "Copied!" window
         copyText(btn.getAttribute("data-copy")).then(function (ok) {
           if (!ok) { toast("Copy failed — copy manually:", btn.getAttribute("data-copy")); return; }
           btn.classList.add("copied");
@@ -279,7 +282,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
   }
   function render() { renderTabs(); renderFilters(); renderGrid(); }
   $("tg-search").addEventListener("input", function (e) { state.q = e.target.value.trim().toLowerCase(); renderGrid(); });
-  $("tg-clear").addEventListener("click", function () { state.cat = "all"; state.fws.clear(); state.tags.clear(); state.q = ""; $("tg-search").value = ""; render(); });
+  $("tg-clear").addEventListener("click", function () { state.cat = "all"; state.fws.clear(); state.tags.clear(); state.q = ""; $("tg-search").value = ""; render(); $("tg-search").focus(); });
   render();
 })();
 </script>

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -19,7 +19,7 @@ Browse, filter, and clone the official `@uipath/uipath-typescript` sample apps. 
     </div>
     <div class="tg-row" id="tg-filters">
       <span class="tg-flabel">Filter</span>
-      <span id="tg-fw"></span>
+      <span id="tg-fw" role="group" aria-label="Filter by framework"></span>
     </div>
   </div>
   <div class="tg-meta">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
   - Plugins:
       - Codex: plugins/codex.md
   - Sample Application: https://github.com/UiPath/uipath-typescript/tree/main/samples
+  - Template Gallery: samples/index.md
   - FAQ: FAQ.md
   - How To Contribute: CONTRIBUTING.md
   - Integration Testing: integration-testing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,8 +224,7 @@ nav:
         - SDK Reference: coded-action-app-sdk/interfaces/CodedActionAppServiceModel.md
   - Plugins:
       - Codex: plugins/codex.md
-  - Sample Application: https://github.com/UiPath/uipath-typescript/tree/main/samples
-  - Template Gallery: samples/index.md
+  - Sample Apps Gallery: samples/index.md
   - FAQ: FAQ.md
   - How To Contribute: CONTRIBUTING.md
   - Integration Testing: integration-testing.md


### PR DESCRIPTION
## What

Adds a **Template Gallery** to the documentation site, plus the CI to build and preview docs on PRs. Two commits:

1. **`docs:`** — the Template Gallery page + nav entry + a contributor convention.
2. **`ci:`** — a Docs PR Preview workflow (build gate + per-PR preview).

## 1. Template Gallery (`docs/samples/index.md`, `mkdocs.yml`, `Agents.md`)

A config-driven, browsable index of everything under [`samples/`](https://github.com/UiPath/uipath-typescript/tree/main/samples) — category tabs, framework + tag filters, search, and each sample's demo GIF. New nav entry sits after **Sample Application**.

- **Native Material page — no iframe.** Scoped under a `.tg` root and mapped to Material's theme variables, so it follows the docs light/dark toggle and brand color.
- **Per-card actions:** **Clone** (copies `npx degit UiPath/uipath-typescript/samples/<path> <name>` — verified for top-level and nested samples) and **Open in VS Code** (same `degit` chained with `&& code <name>`).
- Self-contained: inline config/CSS/JS, **no new build dependencies**.
- `Agents.md` gains a convention: adding a sample requires a preview GIF in its `screenshots/` folder **and** a matching Template Gallery entry, so the site stays in sync.

## 2. Docs PR Preview workflow (`.github/workflows/docs-pr-preview.yml`)

Closes a gap: `docs.yml` only builds/deploys on a schedule + manual dispatch, so nothing validated or previewed docs on a PR.

- **Builds the docs on every PR** touching `docs/**` or `mkdocs.yml` — the build is a **CI gate**, so a broken docs change fails a check instead of shipping.
- **Publishes a per-PR preview** at `…/pr-preview/pr-<N>/` for same-repo PRs, torn down on close.
- **Security:** `pull_request` (not `pull_request_target`); write-scoped deploy gated to same-repo PRs; no untrusted event data in `run:` steps; third-party action pinned to a commit SHA.
- **One-time after merge:** Settings → Actions → Workflow permissions → **Read and write** (so previews can publish to `gh-pages`).

## Preview

Isolated full-site build of this branch (temporary, personal Pages repo):
**https://rajivml.github.io/uipath-typescript/samples/**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
