### PR TITLE
feat(traces): route governance endpoints via llmops base [PLT-106297]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -269,5 +269,5 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getUnitConsumption()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getSpansByTraceId()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getSpansByReference()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getGovernanceDecisions()` | `Traces.Api OR.Folders.Read` |
-| `getGovernanceSummary()` | `Traces.Api OR.Folders.Read` |
+| `getGovernanceDecisions()` | `Traces.Api Insights.RealTimeData Insights OR.Folders.Read` |
+| `getGovernanceSummary()` | `Traces.Api Insights.RealTimeData Insights OR.Folders.Read` |

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -269,5 +269,5 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getUnitConsumption()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getSpansByTraceId()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getSpansByReference()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getGovernanceDecisions()` | `Insights.RealTimeData Insights OR.Folders.Read` |
-| `getGovernanceSummary()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getGovernanceDecisions()` | `Traces.Api OR.Folders.Read` |
+| `getGovernanceSummary()` | `Traces.Api OR.Folders.Read` |

--- a/src/utils/constants/endpoints/agent-traces.ts
+++ b/src/utils/constants/endpoints/agent-traces.ts
@@ -1,4 +1,4 @@
-import { INSIGHTS_RTM_BASE } from './base';
+import { INSIGHTS_RTM_BASE, LLMOPS_BASE } from './base';
 
 /**
  * Agent Traces Service Endpoints
@@ -15,7 +15,7 @@ export const AGENT_TRACES_ENDPOINTS = {
   /** Paginated spans whose reference hierarchy contains the given reference id. */
   GET_SPANS_BY_REFERENCE: (referenceId: string) => `${INSIGHTS_RTM_BASE}/Traceview/spans/reference/${referenceId}`,
   /** Paginated raw governance decision rows. */
-  GET_GOVERNANCE_DECISIONS: `${INSIGHTS_RTM_BASE}/Governance/agentic/traces`,
+  GET_GOVERNANCE_DECISIONS: `${LLMOPS_BASE}/api/Governance/agentic/traces`,
   /** Aggregated governance posture (totals + top-N breakdowns). */
-  GET_GOVERNANCE_SUMMARY: `${INSIGHTS_RTM_BASE}/Governance/agentic/summary`,
+  GET_GOVERNANCE_SUMMARY: `${LLMOPS_BASE}/api/Governance/agentic/summary`,
 } as const;

--- a/tests/integration/shared/observability/traces/agent.integration.test.ts
+++ b/tests/integration/shared/observability/traces/agent.integration.test.ts
@@ -10,7 +10,8 @@ import {
 import { AGENT_TEST_CONSTANTS } from '../../../../utils/constants';
 
 /**
- * Integration tests for Agent Traces (`/insightsrtm_/Traceview/*`).
+ * Integration tests for Agent Traces — Traceview on `/insightsrtm_/Traceview/*`
+ * and governance on `/llmopstenant_/api/Governance/agentic/*`.
  *
  * Run with:
  *   npx vitest run tests/integration/shared/observability/traces/agent.integration.test.ts --config vitest.integration.config.ts
@@ -18,8 +19,11 @@ import { AGENT_TEST_CONSTANTS } from '../../../../utils/constants';
 
 const modes: InitMode[] = ['v1'];
 
-// skip: insightsrtm_ endpoints reject PAT tokens entirely (401 regardless of scopes) and require OAuth.
-// Skipped at the outer level so the live-auth setup (setupUnifiedTests + beforeAll) does not run.
+// skip: every method here requires OAuth and rejects PAT (401 regardless of scopes).
+// The Traceview methods reject PAT directly; the governance methods sit on the
+// llmopstenant_ facade which forwards to InsightsRTM (also PAT-rejecting), so PAT
+// still can't reach them. Skipped at the outer level so the live-auth setup
+// (setupUnifiedTests + beforeAll) does not run.
 describe.skip.each(modes)('Agent Traces - Integration Tests [%s]', (mode) => {
   setupUnifiedTests(mode);
 


### PR DESCRIPTION
## What

Routes the two **governance** AgentTraces endpoints from the `insightsrtm_` base to `llmopstenant_/api`:

| Method | Before | After |
|--------|--------|-------|
| `getGovernanceDecisions()` | `insightsrtm_/Governance/agentic/traces` | `llmopstenant_/api/Governance/agentic/traces` |
| `getGovernanceSummary()` | `insightsrtm_/Governance/agentic/summary` | `llmopstenant_/api/Governance/agentic/summary` |


## Scope change (breaking for these 2 methods)

The llmops governance endpoint is a **facade that forwards the request to InsightsRTM internally**. So the token must satisfy **both** hops:

- **`Traces.Api`** — to pass the llmops gateway.
- **`Insights.RealTimeData Insights OR.Folders.Read`** — for the internal forward to `insightsrtm_` (same scopes the direct `insightsrtm_` route always required).

Documented scope for both methods:

`Insights.RealTimeData Insights OR.Folders.Read` → **`Traces.Api Insights.RealTimeData Insights OR.Folders.Read`**

This is **breaking**: existing consumers must add `Traces.Api` to their external app (the InsightsRTM scopes were already required). `docs/oauth-scopes.md` updated.

## E2E

Verified against a real external-app OAuth token in `governancedevs/DefaultTenant`:

- Token with only `Traces.Api` → passed the llmops gateway but **401 on the internal InsightsRTM forward** (`Failed to call insightsrtm_ … Unauthorized`).
- Token with **`Traces.Api Insights.RealTimeData Insights OR.Folders.Read`** → **both governance endpoints return 200** with data.

## Files

| Area | File |
|------|------|
| Endpoint | `src/utils/constants/endpoints/agent-traces.ts` (2 governance constants) |
| Docs | `docs/oauth-scopes.md` (scope for the 2 governance methods) |

## Note / open decision

llmops governance is a **proxy to InsightsRTM** — the migration adds a network hop and an extra required scope (`Traces.Api`) with no functional change versus calling `insightsrtm_` directly. Keeping it because llmops is the canonical route going forward; flag if the extra scope burden isn't worth it.

## TODO before ready-for-review
- [ ] Cloudflare Workers whitelist for `llmopstenant_/api/Governance/agentic/*` (browser consumers / E2E proxy).

*🤖 Draft — pending Cloudflare whitelist + final sign-off.*
