### PR TITLE
build: ship docs/oauth-scopes.md in the npm package [PLT-107543]

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,8 @@
     },
     "files": [
         "dist",
-        "README.md"
+        "README.md",
+        "docs/oauth-scopes.md"
     ],
     "scripts": {
         "prepack": "rimraf *.tgz",


### PR DESCRIPTION
## Summary

Ships `docs/oauth-scopes.md` inside the npm package by adding it to the `files` field in `package.json`. One line, no code change.

## Why

OAuth scopes are enforced server-side and appear nowhere in the shipped TypeScript types. Code that requests the wrong scopes compiles cleanly and then fails at runtime with a 401/403. Today the per-method scope reference (`docs/oauth-scopes.md`) exists in the repo but is not part of the published package, so consumers of the installed SDK (developers, IDEs, and AI coding agents) have no version-exact scope reference on disk. They have to know the GitHub URL and fetch it separately.

Adding the file to the package gives every install a scope reference that matches the installed version exactly, sitting right next to the `.d.ts` that developers already read at `node_modules/@uipath/uipath-typescript/`.

## Impact

- Tarball grows by ~10 kB (a 1.6 MB package), verified via `npm pack --dry-run`.
- No code, no API change, no runtime effect.

## Context

This unblocks a companion change in the uipath/skills repo (PR #1907), which slims the coded-apps skill's hand-maintained SDK docs and instead routes agents to the installed package. Per-method scopes are the one piece the package does not ship today; this closes that gap.
