### PR TITLE
fix(data-fabric): export roles and directory types from barrels [AGVSOL-3062]

### DIFF
--- a/src/models/data-fabric/index.ts
+++ b/src/models/data-fabric/index.ts
@@ -2,3 +2,7 @@ export * from './entities.types';
 export * from './entities.models';
 export * from './choicesets.types';
 export * from './choicesets.models';
+export * from './roles.types';
+export * from './roles.models';
+export * from './directory.types';
+export * from './directory.models';

--- a/src/services/data-fabric/index.ts
+++ b/src/services/data-fabric/index.ts
@@ -37,3 +37,7 @@ export { LogicalOperator, QueryFilterOperator } from '../../models/data-fabric/e
 export * from '../../models/data-fabric/entities.models';
 export * from '../../models/data-fabric/choicesets.types';
 export * from '../../models/data-fabric/choicesets.models';
+export * from '../../models/data-fabric/roles.types';
+export * from '../../models/data-fabric/roles.models';
+export * from '../../models/data-fabric/directory.types';
+export * from '../../models/data-fabric/directory.models';

--- a/tests/unit/services/data-fabric/exports.test.ts
+++ b/tests/unit/services/data-fabric/exports.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DataFabricDirectoryEntityType,
+  DataFabricDirectoryEntityTypeName,
+  DataFabricDirectoryService,
+  DataFabricRoleService,
+  DataFabricRoleType,
+  type DataFabricDirectoryAssignOptions,
+  type DataFabricDirectoryAssignmentResult,
+  type DataFabricDirectoryEntityTypeInput,
+  type DataFabricDirectoryEntry,
+  type DataFabricDirectoryGetAllOptions,
+  type DataFabricDirectoryListOptions,
+  type DataFabricDirectoryListResponse,
+  type DataFabricDirectoryServiceModel,
+  type DataFabricRole,
+  type DataFabricRoleGetAllOptions,
+  type DataFabricRoleServiceModel,
+} from '../../../../src/services/data-fabric';
+
+describe('Data Fabric barrel exports', () => {
+  it('should export roles and directory runtime values from the entities subpath barrel', () => {
+    expect(DataFabricDirectoryService).toBeTypeOf('function');
+    expect(DataFabricRoleService).toBeTypeOf('function');
+    expect(DataFabricDirectoryEntityType.Group).toBe(1);
+    expect(DataFabricDirectoryEntityTypeName.Group).toBe('Group');
+    expect(DataFabricRoleType.System).toBe('System');
+  });
+
+  it('should export roles and directory types usable in consumer signatures', () => {
+    // Compile-time check: assigning to the exported types verifies they are
+    // re-exported through the barrel; a removal breaks typecheck, not runtime.
+    const principalType: DataFabricDirectoryEntityTypeInput =
+      DataFabricDirectoryEntityTypeName.User;
+    const assignOptions: DataFabricDirectoryAssignOptions = { preserveExisting: false };
+    const listOptions: DataFabricDirectoryListOptions = { top: 1 };
+    const getAllOptions: DataFabricDirectoryGetAllOptions = { pageSize: 1 };
+    const roleOptions: DataFabricRoleGetAllOptions = { stats: false };
+    const role: DataFabricRole = {
+      id: 'role-id',
+      name: 'DataWriter',
+      type: DataFabricRoleType.UserDefined,
+    };
+    const entry: DataFabricDirectoryEntry = {
+      externalId: 'external-id',
+      name: 'Automation Users',
+      type: DataFabricDirectoryEntityTypeName.Group,
+      roles: [{ id: role.id, name: role.name }],
+      isUIEnabled: true,
+    };
+    const listResponse: DataFabricDirectoryListResponse = {
+      totalCount: 1,
+      results: [entry],
+    };
+    const assignmentResult: DataFabricDirectoryAssignmentResult = {
+      principalId: entry.externalId,
+      roleIds: [role.id],
+    };
+    const directoryModel: DataFabricDirectoryServiceModel | undefined = undefined;
+    const roleModel: DataFabricRoleServiceModel | undefined = undefined;
+
+    expect(principalType).toBe(DataFabricDirectoryEntityTypeName.User);
+    expect(assignOptions.preserveExisting).toBe(false);
+    expect(listOptions.top).toBe(1);
+    expect(getAllOptions.pageSize).toBe(1);
+    expect(roleOptions.stats).toBe(false);
+    expect(listResponse.results[0]).toBe(entry);
+    expect(assignmentResult.roleIds).toEqual([role.id]);
+    expect(directoryModel).toBeUndefined();
+    expect(roleModel).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to review comments on [UiPath/cli#2891](https://github.com/UiPath/cli/pull/2891): the `DataFabricRoleService` and `DataFabricDirectoryService` classes are exported from the `/entities` subpath, but their types and enums were not, so the CLI had to derive the principal-type input from the method signature:

```typescript
// CLI workaround this PR removes the need for
type PrincipalTypeInput = Parameters<
    DataFabricClient["entities"]["directory"]["assignRoles"]
>[1];
```

This PR re-exports the roles/directory types through the barrels so consumers can import them directly. No new methods or endpoints — export surface only.

## Exports Added

| Symbol | Kind | Now importable from |
|--------|------|---------------------|
| `DataFabricDirectoryEntityType` | enum (runtime) | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricDirectoryEntityTypeName` | enum (runtime) | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricDirectoryEntityTypeInput` | type | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricDirectoryRole`, `DataFabricDirectoryEntry` | types | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricDirectoryListOptions`, `DataFabricDirectoryGetAllOptions`, `DataFabricDirectoryListResponse` | types | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricDirectoryAssignOptions`, `DataFabricDirectoryAssignmentResult` | types | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricDirectoryServiceModel` | interface | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricRoleType` | enum (runtime) | `@uipath/uipath-typescript/entities`, main entry |
| `DataFabricRole`, `DataFabricRoleGetAllOptions`, `DataFabricRoleServiceModel` | types | `@uipath/uipath-typescript/entities`, main entry |

All symbols keep their `@internal` JSDoc tags — `excludeInternal: true` in `typedoc.json` keeps them out of the generated docs, matching the "keep it internal for now" decision on the CLI PR. The `*.internal-types.ts` files remain private.

## Example Usage

```typescript
import {
  DataFabricDirectoryEntityTypeName,
  DataFabricDirectoryService,
  DataFabricRoleService,
} from '@uipath/uipath-typescript/entities';

const roles = new DataFabricRoleService(sdk);
const directory = new DataFabricDirectoryService(sdk);

const dataWriter = (await roles.getAll()).find(role => role.name === 'DataWriter');
await directory.assignRoles('<identity-group-id>', DataFabricDirectoryEntityTypeName.Group, [dataWriter.id]);
```

## Files

| Area | Files |
|------|-------|
| Barrel exports | `src/services/data-fabric/index.ts` (`/entities` subpath), `src/models/data-fabric/index.ts` (main entry) |
| Unit tests | `tests/unit/services/data-fabric/exports.test.ts` (2 tests — runtime export surface + compile-time type re-export check) |

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run test:unit` — 2092 passed
- `npm run build` — verified `dist/entities/index.d.ts` and `dist/index.cjs` now expose the enums/types

Refs AGVSOL-3062

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)