### PR TITLE
feat(data-fabric): migrate entities to v3 APIs [DS-8953]

### DIFF
--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -396,7 +396,7 @@ export interface EntityCreateOptions extends EntityFolderScopedOptions {
   /** Whether Analytics integration is enabled for this entity (default: false) */
   isAnalyticsEnabled?: boolean;
   /** External field source definitions (default: empty) */
-  externalFields?: ExternalField[];
+  externalFields?: ExternalSourceFields[];
 }
 
 /**
@@ -435,6 +435,8 @@ export interface EntityUpdateByIdOptions extends EntityFolderScopedOptions {
   description?: string;
   /** Whether role-based access control is enabled for this entity */
   isRbacEnabled?: boolean;
+  /** Whether Analytics integration is enabled for this entity */
+  isAnalyticsEnabled?: boolean;
 }
 
 /**
@@ -537,6 +539,18 @@ export enum EntityType {
   ChoiceSet = "ChoiceSet",
   InternalEntity = "InternalEntity",
   SystemEntity = "SystemEntity",
+}
+
+/**
+ * Product classification surfaced on v3 entity metadata.
+ */
+export enum EntityClass {
+  /** Native entity — data fully stored and managed within UiPath */
+  Native = "Native",
+  /** Federated entity — unified read-only view across UiPath and external sources */
+  Federated = "Federated",
+  /** Case-family entity */
+  Case = "Case",
 }
 
 /**
@@ -655,6 +669,8 @@ export interface ExternalObject {
   externalConnectionId: string;
   entityId?: string;
   isPrimarySource: boolean;
+  /** External access method for the object */
+  method?: string;
 }
 
 /**
@@ -671,6 +687,29 @@ export interface ExternalConnection {
 }
 
 /**
+ * Operator-level searchability metadata
+ */
+export interface SearchabilityOperator {
+  searchableOperators?: string[];
+}
+
+/**
+ * Named-search searchability metadata
+ */
+export interface SearchabilityNamedSearch {
+  searchableNames?: string[];
+}
+
+/**
+ * Field searchability metadata
+ */
+export interface Searchability {
+  searchable: boolean;
+  supportsOperators?: SearchabilityOperator;
+  supportsNamedSearch?: SearchabilityNamedSearch;
+}
+
+/**
  * External field mapping
  */
 export interface ExternalFieldMapping {
@@ -681,6 +720,12 @@ export interface ExternalFieldMapping {
   externalFieldType?: string;
   internalFieldId: string;
   directionType: DataDirectionType;
+  /** Field searchability metadata */
+  searchability?: Searchability;
+  /** Whether this external field is required for read operations */
+  isRequiredForRead?: boolean;
+  /** Whether this external field can be used for sorting */
+  sortable?: boolean;
 }
 
 /**
@@ -692,12 +737,25 @@ export interface ExternalField {
 }
 
 /**
+ * Native connection detail — set for a Native source referencing another UiPath entity
+ * (Federated entities with Native sources). When present, `externalConnectionDetail` may be empty.
+ */
+export interface NativeConnectionDetail {
+  /** Id of the referenced native UiPath entity (the source to read from) */
+  entityId: string;
+  /** Folder that owns the referenced native entity */
+  folderKey: string;
+}
+
+/**
  * External source fields
  */
 export interface ExternalSourceFields {
   fields?: ExternalField[];
   externalObjectDetail?: ExternalObject;
   externalConnectionDetail?: ExternalConnection;
+  /** Set for a Native source (referencing another UiPath entity); see {@link NativeConnectionDetail} */
+  nativeConnectionDetail?: NativeConnectionDetail;
 }
 
 /**
@@ -706,6 +764,8 @@ export interface ExternalSourceFields {
 export interface SourceJoinCriteria {
   id: string;
   entityId: string;
+  /** Id of the source object on the owning side of the join */
+  sourceObjectId?: string;
   joinFieldName?: string;
   joinType: JoinType;
   relatedSourceObjectId?: string;
@@ -719,6 +779,12 @@ export interface RawEntityGetResponse {
   name: string;
   displayName: string;
   entityType: EntityType;
+  /** Numeric entity type identifier (v3 metadata) */
+  entityTypeId?: number;
+  /** Template discriminator — null for non-templated entities, set for templated ones (v3 metadata) */
+  templateName?: string;
+  /** Product classification (v3 metadata): Native, Federated, or Case */
+  entityClass?: EntityClass;
   description?: string;
   fields: FieldMetaData[];
   folderId?: string;

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -237,13 +237,12 @@ export class EntityService extends BaseService implements EntityServiceModel {
 
   @track('Entities.GetAll')
   async getAll(options?: EntityGetAllOptions): Promise<EntityGetResponse[]> {
-    // folderKey is preferred over includeFolderEntities: when present, scope to that folder
-    // via the v1 endpoint + header. Only when no folderKey is given AND includeFolderEntities
-    // is explicitly true does the SDK switch to the v2 endpoint (returns tenant + folder
-    // entities together). Default (no options or includeFolderEntities omitted) stays on
-    // the v1 endpoint = tenant only.
-    const endpoint = !options?.folderKey && options?.includeFolderEntities
-      ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2
+    // Use the v3 endpoint whenever a folder scope is requested: a folderKey scopes to that
+    // folder via the header, and includeFolderEntities returns tenant + folder entities
+    // together. Only the default (no folderKey and includeFolderEntities omitted) stays on
+    // the v1 endpoint = tenant only, since v3 has no tenant-only listing.
+    const endpoint = options?.folderKey || options?.includeFolderEntities
+      ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3
       : DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL;
 
     const response = await this.get<RawEntityGetResponse[]>(
@@ -416,7 +415,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
   async updateById(id: string, options?: EntityUpdateByIdOptions): Promise<void> {
     const opts = options ?? {};
     const hasSchemaChanges = !!(opts.addFields?.length || opts.removeFields?.length || opts.updateFields?.length);
-    const hasMetadataChanges = opts.displayName !== undefined || opts.description !== undefined || opts.isRbacEnabled !== undefined;
+    const hasMetadataChanges = opts.displayName !== undefined || opts.description !== undefined || opts.isRbacEnabled !== undefined || opts.isAnalyticsEnabled !== undefined;
 
     if (hasSchemaChanges) {
       await this.applySchemaUpdate(id, opts);
@@ -428,6 +427,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
           ...(opts.displayName !== undefined && { displayName: opts.displayName }),
           ...(opts.description !== undefined && { description: opts.description }),
           ...(opts.isRbacEnabled !== undefined && { isRbacEnabled: opts.isRbacEnabled }),
+          ...(opts.isAnalyticsEnabled !== undefined && { isInsightsEnabled: opts.isAnalyticsEnabled }),
         },
         { headers: createHeaders({ [FOLDER_KEY]: opts.folderKey }) },
       );

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -17,24 +17,28 @@ export const DATA_FABRIC_TENANT_FOLDER_ID = '00000000-0000-0000-0000-00000000000
 export const DATA_FABRIC_ENDPOINTS = {
   ENTITY: {
     GET_ALL: `${DATAFABRIC_BASE}/api/Entity`,
-    // Lists tenant-level and folder-level entities together.
-    // Used by getAll when includeFolderEntities is true.
-    GET_ALL_V2: `${DATAFABRIC_BASE}/api/v2/Entity`,
-    GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read`,
-    GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
-    // v2 single-record read. Returns the full record including complete MULTILINE_MAX
+    // v3 listing of tenant-level and folder-level entities together.
+    // Used by getAll when folderKey is set or includeFolderEntities is true.
+    GET_ALL_V3: `${DATAFABRIC_BASE}/api/v3/entities`,
+    GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/read`,
+    GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}`,
+    // v3 single-record read. Returns the full record including complete MULTILINE_MAX
     // content, unlike list/query endpoints which project a size marker for those fields.
     GET_RECORD_BY_ID: (entityId: string, recordId: string) =>
-      `${DATAFABRIC_BASE}/api/v2/EntityService/entity/${entityId}/read/${recordId}`,
-    INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert`,
-    BATCH_INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert-batch`,
-    UPDATE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update/${recordId}`,
-    UPDATE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update-batch`,
-    DELETE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete/${recordId}`,
-    DELETE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete-batch`,
-    UPSERT: `${DATAFABRIC_BASE}/api/Entity`,
-    DELETE: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
-    UPDATE_METADATA: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}/metadata`,
+      `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/read/${recordId}`,
+    INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/insert`,
+    BATCH_INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/insert-batch`,
+    UPDATE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/update/${recordId}`,
+    UPDATE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/update-batch`,
+    DELETE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/delete/${recordId}`,
+    DELETE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/delete-batch`,
+    // Same URL as GET_ALL_V3; the HTTP method (POST for create/upsert vs GET for list) is resolved at the call site.
+    UPSERT: `${DATAFABRIC_BASE}/api/v3/entities`,
+    // Same URL as GET_BY_ID; the HTTP method (DELETE vs GET) is resolved at the call site.
+    DELETE: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}`,
+    UPDATE_METADATA: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}/metadata`,
+    // Kept on v1: the v3 query endpoint rejects multi-entity joins (req.Joins),
+    // which queryRecordsById supports. v1 query supports joins.
     QUERY_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/query`,
     BULK_UPLOAD_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/bulk-upload`,
     DOWNLOAD_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -20,6 +20,12 @@ import {
 } from '../../../../src/models/data-fabric/entities.types';
 import { DATA_FABRIC_TENANT_FOLDER_ID } from '../../../../src/utils/constants/endpoints/data-fabric';
 
+// Record Ids are GUIDs (case-insensitive). Data Fabric endpoints return them in
+// different casing (v3 single-record read upper-cases; list/write and v1 lower-case),
+// so compare Ids case-insensitively rather than with exact string equality.
+const idsEqual = (a?: string | null, b?: string | null): boolean =>
+  (a ?? '').toLowerCase() === (b ?? '').toLowerCase();
+
 // Cache for choice set values to avoid repeated API calls within a test run
 const choiceSetValueCache = new Map<string, any[]>();
 
@@ -242,7 +248,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       }
     });
 
-    // includeFolderEntities switches to the v2 endpoint, which returns tenant-level and
+    // includeFolderEntities switches to the v3 endpoint, which returns tenant-level and
     // folder-level entities together — a superset of the default tenant-only result.
     // Requires the OR.Users OAuth scope on the integration token.
     it('should return tenant and folder entities together when includeFolderEntities is true', async () => {
@@ -428,7 +434,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(entityId, recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
   });
 
@@ -479,7 +485,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(entityId, recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
 
     it('should batch insert multiple records using insertRecordsById', async () => {
@@ -669,7 +675,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entity.getRecord(recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
 
     it('should update records via entity.updateRecords', async () => {
@@ -764,7 +770,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       });
 
       expect(result).toBeDefined();
-      expect(result.Id).toBe(updateTestRecordId);
+      expect(idsEqual(result.Id, updateTestRecordId)).toBe(true);
     });
 
     it('should handle API errors for non-existent record', async () => {
@@ -1129,6 +1135,20 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(updated.description).toBe('Updated description');
     });
 
+    it('should enable analytics via isAnalyticsEnabled', async () => {
+      const { entities } = getServices();
+      const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, []);
+      createdEntityIds.push(entityId);
+
+      // Exercises the isAnalyticsEnabled option end to end — the SDK sends it as the
+      // isInsightsEnabled wire field, which the API validates and round-trips back on read.
+      await entities.updateById(entityId, { isAnalyticsEnabled: true });
+
+      const updated = await entities.getById(entityId);
+      expect(updated.isInsightsEnabled).toBe(true);
+    });
+
     it('should add a new field to an existing entity', async () => {
       const { entities } = getServices();
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
@@ -1481,7 +1501,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
   });
 
   // Verifies the MULTILINE_MAX lazy-load contract end to end: list returns a size
-  // marker, getRecordById (v2 read) returns the full content. Creating the field
+  // marker, getRecordById (v3 read) returns the full content. Creating the field
   // needs DataFabric.Schema.Write scope, absent in the standard test env — so this is
   // gated on SCHEMA_WRITE_SCOPE_AVAILABLE and skipped there (a hard throw would redden
   // CI permanently). Runs in any environment whose PAT carries the scope.
@@ -1509,7 +1529,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(listedRecord!.body).toMatch(/^HasValue=true/);
       expect(listedRecord!.body).not.toBe(bodyValue);
 
-      // getRecordById (v2 read) returns the full content.
+      // getRecordById (v3 read) returns the full content.
       const full = await entities.getRecordById(entityId, inserted.Id);
       expect(full.body).toBe(bodyValue);
     });
@@ -1686,7 +1706,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(folderEntityId, folderRecordIds[0], { folderKey });
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(folderRecordIds[0]);
+      expect(idsEqual(record.Id, folderRecordIds[0])).toBe(true);
     });
 
     it('should list paginated records with folderKey via getAllRecords', async () => {
@@ -1712,7 +1732,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(Array.isArray(result.items)).toBe(true);
       // The folder header must reach the server for the row to be retrievable; the
       // filter narrows to the record we just inserted in this run.
-      expect(result.items.some((r) => r.Id === folderRecordIds[0])).toBe(true);
+      expect(result.items.some((r) => idsEqual(r.Id, folderRecordIds[0]))).toBe(true);
     });
 
     it('should update a record with folderKey via updateRecordById', async () => {
@@ -1721,7 +1741,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const result = await entities.updateRecordById(folderEntityId, folderRecordIds[0], patch, { folderKey });
 
       expect(result).toBeDefined();
-      expect(result.Id).toBe(folderRecordIds[0]);
+      expect(idsEqual(result.Id, folderRecordIds[0])).toBe(true);
     });
 
     it('should batch-update records with folderKey via updateRecordsById', async () => {
@@ -1757,7 +1777,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
           ],
         },
       });
-      expect(result.items.some((r) => r.Id === idToDelete)).toBe(false);
+      expect(result.items.some((r) => idsEqual(r.Id, idToDelete))).toBe(false);
     });
 
     it('should batch-delete records with folderKey via deleteRecordsById', async () => {

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -415,24 +415,24 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+    it("should call the v3 endpoint and pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({ folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
-    it("should call the v2 endpoint when includeFolderEntities is true (cross-scope)", async () => {
+    it("should call the v3 endpoint when includeFolderEntities is true (cross-scope)", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({ includeFolderEntities: true });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: {} },
       );
     });
@@ -448,7 +448,7 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should let folderKey win and call v1 with the header when both folderKey and includeFolderEntities are provided", async () => {
+    it("should call the v3 endpoint with the header when both folderKey and includeFolderEntities are provided", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({
@@ -457,7 +457,7 @@ describe("EntityService Unit Tests", () => {
       });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
@@ -3239,6 +3239,40 @@ describe("EntityService Unit Tests", () => {
         { displayName: ENTITY_TEST_CONSTANTS.ENTITY_DISPLAY_NAME },
         { headers: {} },
       );
+    });
+
+    it("should emit isInsightsEnabled in the metadata PATCH when isAnalyticsEnabled is provided", async () => {
+      mockApiClient.patch.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        isAnalyticsEnabled: true,
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ),
+        expect.objectContaining({ isInsightsEnabled: true }),
+        { headers: {} },
+      );
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it("should emit isInsightsEnabled: false in the metadata PATCH when isAnalyticsEnabled is false", async () => {
+      mockApiClient.patch.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        isAnalyticsEnabled: false,
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ),
+        expect.objectContaining({ isInsightsEnabled: false }),
+        { headers: {} },
+      );
+      expect(mockApiClient.get).not.toHaveBeenCalled();
     });
 
     it("should pass folderKey via X-UIPATH-FolderKey header on both schema GET/POST and metadata PATCH", async () => {


### PR DESCRIPTION
## Summary

Migrates Data Fabric entity operations in the SDK from the v1/v2 APIs to the **v3** surface (`/api/v3/entities/…`). The change is primarily endpoint-path swaps plus request/response type alignment.

Jira: **[DS-8953](https://uipath.atlassian.net/browse/DS-8953)**

## Changes

**Endpoints** (`src/utils/constants/endpoints/data-fabric.ts`)
- Migrated record CRUD, query, and schema create/update/metadata endpoints to v3.
- Renamed `GET_ALL_V2` → `GET_ALL_V3` (`/api/v3/entities`).
- `GET_ALL` stays on v1

**Service** (`src/services/data-fabric/entities.ts`)
- `getAll()` routes `folderKey` / `includeFolderEntities` to v3; default stays tenant-only on v1.
- `updateById()` emits `isInsightsEnabled` from the new `isAnalyticsEnabled` option.

**Types** (`src/models/data-fabric/entities.types.ts`)
- Added `entityTypeId` / `templateName` / `entityClass` to the entity read response.
- New `EntityClass` enum, `NativeConnectionDetail`, `Searchability` types.
- Added `nativeConnectionDetail` / `method` / `searchability` / `isRequiredForRead` / `sortable` / `sourceObjectId` to external-source metadata types.
- Fixed `EntityCreateOptions.externalFields` type (`ExternalField[]` → `ExternalSourceFields[]`).

## Out of scope / deferred
- Attachments and bulk-upload stay on v1 (no id-based v3 attachment route yet / no v3 equivalent).


[DS-8953]: https://uipath.atlassian.net/browse/DS-8953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ