### PR TITLE
feat(data-fabric): align entity create field names with get response

### DIFF
--- a/src/models/data-fabric/entities.constants.ts
+++ b/src/models/data-fabric/entities.constants.ts
@@ -30,7 +30,9 @@ export const EntityMap = {
   createTime: 'createdTime',
   updateTime: 'updatedTime',
   sqlType: 'fieldDataType',
-  fieldDefinition: 'fieldMetaData'
+  fieldDefinition: 'fieldMetaData',
+  // API returns `isInsightsEnabled`; expose it under the SDK name `isAnalyticsEnabled`.
+  isInsightsEnabled: 'isAnalyticsEnabled'
 };
 
 /**

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -665,29 +665,29 @@ export interface EntityServiceModel {
    * const entities = new Entities(sdk);
    *
    * const id = await entities.create("product_catalog", [
-   *   { fieldName: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true },
-   *   { fieldName: "price", type: EntityFieldDataType.INTEGER, defaultValue: "0" },
+   *   { name: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true },
+   *   { name: "price", type: EntityFieldDataType.INTEGER, defaultValue: "0" },
    * ], { displayName: "Product Catalog", description: "Our product catalog", isRbacEnabled: true });
    *
    * // With advanced sqlType constraints (lengthLimit, decimalPrecision, maxValue, minValue) and defaultValue
    * const ordersId = await entities.create("orders", [
-   *   { fieldName: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true, lengthLimit: 500 },
-   *   { fieldName: "price", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
-   *   { fieldName: "quantity", type: EntityFieldDataType.INTEGER, maxValue: 10000, minValue: 1, defaultValue: "0" },
+   *   { name: "product_name", type: EntityFieldDataType.STRING, isRequired: true, isUnique: true, lengthLimit: 500 },
+   *   { name: "price", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *   { name: "quantity", type: EntityFieldDataType.INTEGER, maxValue: 10000, minValue: 1, defaultValue: "0" },
    * ]);
    *
    * // Cross-folder references — link a folder-scoped entity to entities and
    * // system choice sets that live in another folder or at the tenant level.
    * await entities.create("orderLine", [
    *   {
-   *     fieldName: "order",
+   *     name: "order",
    *     type: EntityFieldDataType.RELATIONSHIP,
    *     referenceEntityId: "<orderEntityId>",
    *     referenceFieldId: "<orderEntityPkId>",
    *     referenceFolderKey: "<otherFolderKey>",     // target lives in a different folder
    *   },
    *   {
-   *     fieldName: "userType",
+   *     name: "userType",
    *     type: EntityFieldDataType.CHOICE_SET_SINGLE,
    *     choiceSetId: "<systemUserTypeChoiceSetId>", // tenant-level system choice set
    *     // referenceFolderKey omitted → SDK looks up the target at tenant scope
@@ -730,8 +730,8 @@ export interface EntityServiceModel {
    * ```typescript
    * // Schema-only: add a field and remove another
    * await entities.updateById(<id>, {
-   *   addFields: [{ fieldName: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
-   *   removeFields: [{ fieldName: "old_field" }],
+   *   addFields: [{ name: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
+   *   removeFields: [{ name: "old_field" }],
    * });
    *
    * // Metadata-only: rename the entity
@@ -749,8 +749,8 @@ export interface EntityServiceModel {
    * // Add a STRING/DECIMAL field with explicit advanced sqlType constraints and defaultValue
    * await entities.updateById(<id>, {
    *   addFields: [
-   *     { fieldName: "summary", type: EntityFieldDataType.STRING, lengthLimit: 500, defaultValue: "summary" },
-   *     { fieldName: "amount", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *     { name: "summary", type: EntityFieldDataType.STRING, lengthLimit: 500, defaultValue: "summary" },
+   *     { name: "amount", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
    *   ],
    *   updateFields: [
    *     { id: <fieldId>, lengthLimit: 1000 },
@@ -760,7 +760,7 @@ export interface EntityServiceModel {
    * // Folder-scoped entity: add a field to an entity that lives in a non-tenant folder
    * await entities.updateById(<id>, {
    *   folderKey: "<folderKey>",
-   *   addFields: [{ fieldName: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
+   *   addFields: [{ name: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
    * });
    * ```
    * @internal
@@ -1033,14 +1033,14 @@ export interface EntityMethods {
    * const entity = await entities.getById(<id>);
    * await entity.update({
    *   displayName: "Updated Name",
-   *   addFields: [{ fieldName: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
+   *   addFields: [{ name: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
    * });
    *
    * // Add a STRING/DECIMAL field with explicit advanced sqlType constraints 
    * await entity.update({
    *   addFields: [
-   *     { fieldName: "summary", type: EntityFieldDataType.STRING, lengthLimit: 500, defaultValue: "string" },
-   *     { fieldName: "amount", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
+   *     { name: "summary", type: EntityFieldDataType.STRING, lengthLimit: 500, defaultValue: "string" },
+   *     { name: "amount", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 999999, minValue: 0 },
    *   ],
    * });
    * ```

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -348,8 +348,9 @@ export interface EntityCreateFieldOptions extends EntityFieldBase {
   /**
    * Field name — must start with a letter and contain only
    * letters, numbers, and underscores (e.g., `"productName"`).
+   * Matches the `name` field returned by `getById`.
    */
-  fieldName: string;
+  name: string;
   /** Field data type — one of the {@link EntityFieldDataType} values (default: STRING) */
   type?: EntityFieldDataType;
   /** Choice set ID for choice-set fields */
@@ -393,7 +394,12 @@ export interface EntityCreateOptions extends EntityFolderScopedOptions {
   description?: string;
   /** Whether role-based access control is enabled for this entity (default: false) */
   isRbacEnabled?: boolean;
-  /** Whether Analytics integration is enabled for this entity (default: false) */
+  /**
+   * Whether Analytics integration is enabled for this entity (default: false).
+   * Surfaced by `getById` as `isAnalyticsEnabled`.
+   *
+   * @experimental Analytics integration is in preview — the contract may change.
+   */
   isAnalyticsEnabled?: boolean;
   /** External field source definitions (default: empty) */
   externalFields?: ExternalField[];
@@ -412,7 +418,7 @@ export interface EntityFieldUpdateOptions extends EntityFieldBase {
  */
 export interface EntityRemoveFieldOptions {
   /** Name of the field to remove */
-  fieldName: string;
+  name: string;
 }
 
 /**
@@ -729,7 +735,12 @@ export interface RawEntityGetResponse {
   usedStorageSizeInMB?: number;
   attachmentSizeInByte?: number;
   isRbacEnabled: boolean;
-  isInsightsEnabled?: boolean;
+  /**
+   * Whether Analytics integration is enabled for this entity.
+   *
+   * @experimental Analytics integration is in preview — the contract may change.
+   */
+  isAnalyticsEnabled?: boolean;
   id: string;
   createdBy: string;
   createdTime: string;

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -455,7 +455,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
 
     // Filter out removed fields
     if (options.removeFields?.length) {
-      const removeSet = new Set(options.removeFields.map(r => r.fieldName));
+      const removeSet = new Set(options.removeFields.map(r => r.name));
       fields = fields.filter(f => !removeSet.has(f.name));
     }
 
@@ -511,7 +511,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
           fields: [...fields, ...newFields],
           folderId: raw.folderId ?? DATA_FABRIC_TENANT_FOLDER_ID,
           isRbacEnabled: raw.isRbacEnabled ?? false,
-          isInsightsEnabled: raw.isInsightsEnabled ?? false,
+          // `raw` is the untransformed GET response, so read the wire key `isInsightsEnabled`
+          // directly (it is not on the public type, which exposes it as `isAnalyticsEnabled`).
+          isInsightsEnabled: (raw as { isInsightsEnabled?: boolean }).isInsightsEnabled ?? false,
           externalFields: raw.externalFields ?? [],
         },
       },
@@ -653,12 +655,12 @@ export class EntityService extends BaseService implements EntityServiceModel {
     refMeta?: ResolvedReferenceMeta,
   ): FieldSchemaPayload {
     const fieldType = field.type ?? EntityFieldDataType.STRING;
-    this.validateFieldConstraints(fieldType, field, field.fieldName);
+    this.validateFieldConstraints(fieldType, field, field.name);
     const isRelationship = fieldType === EntityFieldDataType.RELATIONSHIP;
     const isFile = fieldType === EntityFieldDataType.FILE;
     if (isRelationship && (!field.referenceEntityId || !field.referenceFieldId)) {
       throw new ValidationError({
-        message: `Field '${field.fieldName}' of type ${fieldType} requires both referenceEntityId and referenceFieldId (UUIDs of the target entity and field).`,
+        message: `Field '${field.name}' of type ${fieldType} requires both referenceEntityId and referenceFieldId (UUIDs of the target entity and field).`,
       });
     }
     const mapping = EntitySchemaFieldTypeMap[fieldType];
@@ -667,8 +669,8 @@ export class EntityService extends BaseService implements EntityServiceModel {
     const referenceEntityBody = refMeta?.referenceEntity ?? (field.referenceEntityId === undefined ? undefined : { id: field.referenceEntityId });
     const referenceChoiceSetBody = refMeta?.referenceChoiceSet;
     return {
-      name: field.fieldName,
-      displayName: field.displayName ?? field.fieldName,
+      name: field.name,
+      displayName: field.displayName ?? field.name,
       sqlType: {
         name: mapping.sqlTypeName,
         ...this.buildSqlTypeConstraints(fieldType, field),

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -894,7 +894,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
         // 1. Target entity with a user-defined string field we can assert on at L2+.
         const targetId = await entities.create(`sdk_target_${stamp}`, [
-          { fieldName: 'label', type: EntityFieldDataType.STRING, isRequired: true },
+          { name: 'label', type: EntityFieldDataType.STRING, isRequired: true },
         ]);
         createdEntityIds.push(targetId);
 
@@ -906,9 +906,9 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
         // 2. Source entity with a RELATIONSHIP field bound to target.Id.
         const sourceId = await entities.create(`sdk_source_${stamp}`, [
-          { fieldName: 'name', type: EntityFieldDataType.STRING },
+          { name: 'name', type: EntityFieldDataType.STRING },
           {
-            fieldName: 'parent',
+            name: 'parent',
             type: EntityFieldDataType.RELATIONSHIP,
             referenceEntityId: targetId,
             referenceFieldId: targetPk.id,
@@ -1051,8 +1051,8 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
 
       const entityId = await entities.create(name, [
-        { fieldName: 'title', displayName: 'Title', type: EntityFieldDataType.STRING, isRequired: true },
-        { fieldName: 'count', displayName: 'Count', type: EntityFieldDataType.INTEGER },
+        { name: 'title', displayName: 'Title', type: EntityFieldDataType.STRING, isRequired: true },
+        { name: 'count', displayName: 'Count', type: EntityFieldDataType.INTEGER },
       ], { displayName: `SDK Test Entity ${name}`, description: 'Created by integration test' });
 
       expect(typeof entityId).toBe('string');
@@ -1068,7 +1068,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       //    field we'll use as the FK target.
       const targetName = `sdk_target_${stamp}`;
       const targetId = await entities.create(targetName, [
-        { fieldName: 'label', type: EntityFieldDataType.STRING },
+        { name: 'label', type: EntityFieldDataType.STRING },
       ]);
       createdEntityIds.push(targetId);
 
@@ -1082,14 +1082,14 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       // 3. Create the source entity with a RELATIONSHIP field bound to target.Id
       const sourceName = `sdk_source_${stamp}`;
       const sourceId = await entities.create(sourceName, [
-        { fieldName: 'name', type: EntityFieldDataType.STRING },
+        { name: 'name', type: EntityFieldDataType.STRING },
         {
-          fieldName: 'parent',
+          name: 'parent',
           type: EntityFieldDataType.RELATIONSHIP,
           referenceEntityId: targetId,
           referenceFieldId: pkField.id,
         },
-        { fieldName: 'attachfile', type: EntityFieldDataType.FILE },
+        { name: 'attachfile', type: EntityFieldDataType.FILE },
       ]);
       createdEntityIds.push(sourceId);
 
@@ -1133,12 +1133,12 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'base_field', type: EntityFieldDataType.STRING },
+        { name: 'base_field', type: EntityFieldDataType.STRING },
       ]);
       createdEntityIds.push(entityId);
 
       await entities.updateById(entityId, {
-        addFields: [{ fieldName: 'new_field', type: EntityFieldDataType.INTEGER }],
+        addFields: [{ name: 'new_field', type: EntityFieldDataType.INTEGER }],
       });
 
       const updated = await entities.getById(entityId);
@@ -1150,13 +1150,13 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'keep_field', type: EntityFieldDataType.STRING },
-        { fieldName: 'remove_me', type: EntityFieldDataType.INTEGER },
+        { name: 'keep_field', type: EntityFieldDataType.STRING },
+        { name: 'remove_me', type: EntityFieldDataType.INTEGER },
       ]);
       createdEntityIds.push(entityId);
 
       await entities.updateById(entityId, {
-        removeFields: [{ fieldName: 'remove_me' }],
+        removeFields: [{ name: 'remove_me' }],
       });
 
       const updated = await entities.getById(entityId);
@@ -1169,7 +1169,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'updatable_field', displayName: 'Original Name', type: EntityFieldDataType.STRING },
+        { name: 'updatable_field', displayName: 'Original Name', type: EntityFieldDataType.STRING },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1195,8 +1195,8 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'to_update', displayName: 'Before Update', type: EntityFieldDataType.STRING },
-        { fieldName: 'to_remove', type: EntityFieldDataType.INTEGER },
+        { name: 'to_update', displayName: 'Before Update', type: EntityFieldDataType.STRING },
+        { name: 'to_remove', type: EntityFieldDataType.INTEGER },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1207,9 +1207,9 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       }
 
       await entities.updateById(entityId, {
-        addFields: [{ fieldName: 'new_addition', type: EntityFieldDataType.BOOLEAN }],
+        addFields: [{ name: 'new_addition', type: EntityFieldDataType.BOOLEAN }],
         updateFields: [{ id: fieldToUpdate.id, displayName: 'After Update' }],
-        removeFields: [{ fieldName: 'to_remove' }],
+        removeFields: [{ name: 'to_remove' }],
       });
 
       const after = await entities.getById(entityId);
@@ -1231,7 +1231,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_str_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'str_field', type: EntityFieldDataType.STRING },
+        { name: 'str_field', type: EntityFieldDataType.STRING },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1245,7 +1245,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_str_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 500 },
+        { name: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 500 },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1258,7 +1258,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_ml_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'ml_field', type: EntityFieldDataType.MULTILINE_TEXT },
+        { name: 'ml_field', type: EntityFieldDataType.MULTILINE_TEXT },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1271,7 +1271,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_mlmax_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'mlmax_field', type: EntityFieldDataType.MULTILINE_MAX },
+        { name: 'mlmax_field', type: EntityFieldDataType.MULTILINE_MAX },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1285,7 +1285,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_dec_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'dec_field', type: EntityFieldDataType.DECIMAL },
+        { name: 'dec_field', type: EntityFieldDataType.DECIMAL },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1302,7 +1302,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const name = `sdk_dec_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
         {
-          fieldName: 'dec_field',
+          name: 'dec_field',
           type: EntityFieldDataType.DECIMAL,
           decimalPrecision: 4,
           maxValue: 99999,
@@ -1322,7 +1322,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_bit_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'bool_field', type: EntityFieldDataType.BOOLEAN },
+        { name: 'bool_field', type: EntityFieldDataType.BOOLEAN },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1335,7 +1335,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_date_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'date_field', type: EntityFieldDataType.DATE },
+        { name: 'date_field', type: EntityFieldDataType.DATE },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1348,7 +1348,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_dtz_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'dtz_field', type: EntityFieldDataType.DATETIME_WITH_TZ },
+        { name: 'dtz_field', type: EntityFieldDataType.DATETIME_WITH_TZ },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1361,7 +1361,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_upd_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'str_field', type: EntityFieldDataType.STRING },
+        { name: 'str_field', type: EntityFieldDataType.STRING },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1385,7 +1385,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const { entities } = getServices();
       const name = `sdk_upddec_${generateRandomString(8).toLowerCase()}`;
       const entityId = await entities.create(name, [
-        { fieldName: 'dec_field', type: EntityFieldDataType.DECIMAL },
+        { name: 'dec_field', type: EntityFieldDataType.DECIMAL },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1413,7 +1413,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       // SDK validation must throw before any API call is made.
       await expect(
         entities.create(name, [
-          { fieldName: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 5000 },
+          { name: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 5000 },
         ]),
       ).rejects.toThrow(/lengthLimit 5000 out of range \[1, 4000\]/);
 
@@ -1428,7 +1428,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       await expect(
         entities.create(name, [
-          { fieldName: 'ml_field', type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 15000 },
+          { name: 'ml_field', type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 15000 },
         ]),
       ).rejects.toThrow(/lengthLimit 15000 out of range \[1, 10000\]/);
 
@@ -1442,7 +1442,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       await expect(
         entities.create(name, [
-          { fieldName: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 0 },
+          { name: 'str_field', type: EntityFieldDataType.STRING, lengthLimit: 0 },
         ]),
       ).rejects.toThrow(/lengthLimit 0 out of range \[1, 4000\]/);
 
@@ -1455,7 +1455,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const name = `sdk_str_default_${generateRandomString(8).toLowerCase()}`;
 
       const entityId = await entities.create(name, [
-        { fieldName: 'str_field', type: EntityFieldDataType.STRING },
+        { name: 'str_field', type: EntityFieldDataType.STRING },
       ]);
       createdEntityIds.push(entityId);
 
@@ -1471,7 +1471,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       await expect(
         entities.create(name, [
-          { fieldName: 'int_field', type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 },
+          { name: 'int_field', type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 },
         ]),
       ).rejects.toThrow(/minValue 100 >= maxValue 50/);
 
@@ -1492,7 +1492,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
 
       // Create an entity with a MULTILINE_MAX field, then insert a large value.
       const entityId = await entities.create(name, [
-        { fieldName: 'body', type: EntityFieldDataType.MULTILINE_MAX },
+        { name: 'body', type: EntityFieldDataType.MULTILINE_MAX },
       ]);
       createdEntityIds.push(entityId);
 

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -904,7 +904,7 @@ describe("Entity Models", () => {
       const entityData = createBasicEntity();
       const entity = createEntityWithMethods(entityData, mockService);
       const options: EntityUpdateByIdOptions = {
-        addFields: [{ fieldName: "notes" }],
+        addFields: [{ name: "notes" }],
       };
       mockService.updateById = vi.fn().mockResolvedValue(undefined);
 
@@ -921,7 +921,7 @@ describe("Entity Models", () => {
       const entity = createEntityWithMethods(entityData, mockService);
 
       await expect(
-        entity.update({ addFields: [{ fieldName: "notes" }] }),
+        entity.update({ addFields: [{ name: "notes" }] }),
       ).rejects.toThrow(
         ENTITY_TEST_CONSTANTS.ERROR_MESSAGE_ENTITY_ID_UNDEFINED,
       );

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -144,6 +144,16 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
+    it("should expose the wire isInsightsEnabled as isAnalyticsEnabled and drop the raw key", async () => {
+      const mockResponse = createMockEntityResponse({ isInsightsEnabled: true });
+      mockApiClient.get.mockResolvedValue(mockResponse);
+
+      const result = await entityService.getById(ENTITY_TEST_CONSTANTS.ENTITY_ID);
+
+      expect(result.isAnalyticsEnabled).toBe(true);
+      expect(result).not.toHaveProperty("isInsightsEnabled");
+    });
+
     it("should get entity with external fields successfully and transform field metadata", async () => {
       const mockResponse = createMockEntityWithExternalFields();
       mockApiClient.get.mockResolvedValue(mockResponse);
@@ -1931,7 +1941,7 @@ describe("EntityService Unit Tests", () => {
 
       const result = await entityService.create(
         "my_entity",
-        [{ fieldName: "title", type: EntityFieldDataType.STRING }],
+        [{ name: "title", type: EntityFieldDataType.STRING }],
         { displayName: "My Entity", description: "A test entity", isRbacEnabled: true },
       );
 
@@ -1985,7 +1995,7 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should pass isAnalyticsEnabled: true when provided", async () => {
+    it("should map isAnalyticsEnabled to the wire isInsightsEnabled when provided", async () => {
       mockApiClient.post.mockResolvedValue(ENTITY_TEST_CONSTANTS.ENTITY_ID);
 
       await entityService.create("my_entity", [], {
@@ -2042,7 +2052,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default STRING lengthLimit to 200", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "str_field", type: EntityFieldDataType.STRING },
+          { name: "str_field", type: EntityFieldDataType.STRING },
         ]);
         const f = getCreatedFields().find((x) => x.name === "str_field");
         expect(f?.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 200 });
@@ -2050,7 +2060,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should use user-provided lengthLimit for STRING fields", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 500 },
+          { name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 500 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "str_field");
         expect(f?.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 500 });
@@ -2058,7 +2068,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default MULTILINE_TEXT lengthLimit to 200", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT },
+          { name: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT },
         ]);
         const f = getCreatedFields().find((x) => x.name === "ml_field");
         expect(f?.sqlType).toEqual({ name: "MULTILINE", lengthLimit: 200 });
@@ -2066,7 +2076,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default MULTILINE_MAX lengthLimit to 128 KB", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX },
+          { name: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX },
         ]);
         const f = getCreatedFields().find((x) => x.name === "mlmax_field");
         expect(f?.sqlType).toEqual({ name: "MULTILINE_MAX", lengthLimit: 128 * 1024 });
@@ -2074,7 +2084,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should use user-provided lengthLimit for MULTILINE_MAX fields", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX, lengthLimit: 5000 },
+          { name: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX, lengthLimit: 5000 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "mlmax_field");
         expect(f?.sqlType).toEqual({ name: "MULTILINE_MAX", lengthLimit: 5000 });
@@ -2082,7 +2092,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default DECIMAL constraints to default values", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL },
+          { name: "dec_field", type: EntityFieldDataType.DECIMAL },
         ]);
         const f = getCreatedFields().find((x) => x.name === "dec_field");
         expect(f?.sqlType).toEqual({
@@ -2097,7 +2107,7 @@ describe("EntityService Unit Tests", () => {
       it("should allow user to override DECIMAL decimalPrecision, maxValue and minValue", async () => {
         await entityService.create("my_entity", [
           {
-            fieldName: "dec_field",
+            name: "dec_field",
             type: EntityFieldDataType.DECIMAL,
             decimalPrecision: 4,
             maxValue: 9999,
@@ -2112,7 +2122,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default INTEGER min/max to default values", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "int_field", type: EntityFieldDataType.INTEGER },
+          { name: "int_field", type: EntityFieldDataType.INTEGER },
         ]);
         const f = getCreatedFields().find((x) => x.name === "int_field");
         expect(f?.sqlType).toEqual({ name: "INT", maxValue: 1000000000000, minValue: -1000000000000 });
@@ -2120,7 +2130,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should allow user to override INTEGER min/max", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: 500, minValue: -500 },
+          { name: "int_field", type: EntityFieldDataType.INTEGER, maxValue: 500, minValue: -500 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "int_field");
         expect(f?.sqlType).toEqual({ name: "INT", maxValue: 500, minValue: -500 });
@@ -2128,7 +2138,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default BIG_INTEGER min/max to default values", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "bigint_field", type: EntityFieldDataType.BIG_INTEGER },
+          { name: "bigint_field", type: EntityFieldDataType.BIG_INTEGER },
         ]);
         const f = getCreatedFields().find((x) => x.name === "bigint_field");
         expect(f?.sqlType).toEqual({ name: "BIGINT", maxValue: 1000000000000, minValue: -1000000000000 });
@@ -2137,7 +2147,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when STRING lengthLimit exceeds 4000", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4001 },
+            { name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4001 },
           ]),
         ).rejects.toThrow(/lengthLimit 4001 out of range \[1, 4000\]/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2146,7 +2156,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when STRING lengthLimit is less than 1", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 0 },
+            { name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 0 },
           ]),
         ).rejects.toThrow(/lengthLimit 0 out of range \[1, 4000\]/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2155,7 +2165,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when MULTILINE_TEXT lengthLimit exceeds 10000", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10001 },
+            { name: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10001 },
           ]),
         ).rejects.toThrow(/lengthLimit 10001 out of range \[1, 10000\]/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2164,7 +2174,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when MULTILINE_MAX lengthLimit exceeds 128 KB", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX, lengthLimit: 131073 },
+            { name: "mlmax_field", type: EntityFieldDataType.MULTILINE_MAX, lengthLimit: 131073 },
           ]),
         ).rejects.toThrow(/lengthLimit 131073 out of range \[1, 131072\]/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2173,7 +2183,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when DECIMAL decimalPrecision exceeds 10", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 11 },
+            { name: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 11 },
           ]),
         ).rejects.toThrow(/decimalPrecision 11 out of range \[0, 10\]/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2182,7 +2192,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when DECIMAL decimalPrecision is negative", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: -1 },
+            { name: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: -1 },
           ]),
         ).rejects.toThrow(/decimalPrecision -1 out of range \[0, 10\]/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2191,7 +2201,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when INTEGER maxValue exceeds Number.MAX_SAFE_INTEGER", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: Number.MAX_SAFE_INTEGER + 1 },
+            { name: "int_field", type: EntityFieldDataType.INTEGER, maxValue: Number.MAX_SAFE_INTEGER + 1 },
           ]),
         ).rejects.toThrow(/maxValue .* out of range/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2200,7 +2210,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes lengthLimit for BOOLEAN", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "bool_field", type: EntityFieldDataType.BOOLEAN, lengthLimit: 50 },
+            { name: "bool_field", type: EntityFieldDataType.BOOLEAN, lengthLimit: 50 },
           ]),
         ).rejects.toThrow(/does not accept lengthLimit/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2209,7 +2219,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes lengthLimit for INTEGER", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, lengthLimit: 50 },
+            { name: "int_field", type: EntityFieldDataType.INTEGER, lengthLimit: 50 },
           ]),
         ).rejects.toThrow(/does not accept lengthLimit/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2218,7 +2228,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes maxValue for STRING", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "str_field", type: EntityFieldDataType.STRING, maxValue: 100 },
+            { name: "str_field", type: EntityFieldDataType.STRING, maxValue: 100 },
           ]),
         ).rejects.toThrow(/does not accept maxValue/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2227,7 +2237,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes decimalPrecision for INTEGER", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, decimalPrecision: 2 },
+            { name: "int_field", type: EntityFieldDataType.INTEGER, decimalPrecision: 2 },
           ]),
         ).rejects.toThrow(/does not accept decimalPrecision/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2236,7 +2246,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes lengthLimit for DECIMAL (not user-configurable)", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, lengthLimit: 500 },
+            { name: "dec_field", type: EntityFieldDataType.DECIMAL, lengthLimit: 500 },
           ]),
         ).rejects.toThrow(/does not accept lengthLimit/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2244,7 +2254,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should accept STRING lengthLimit at the boundary value 4000", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4000 },
+          { name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4000 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "str_field");
         expect(f?.sqlType).toEqual({ name: "NVARCHAR", lengthLimit: 4000 });
@@ -2252,7 +2262,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should accept MULTILINE_TEXT lengthLimit at the boundary value 10000", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10000 },
+          { name: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10000 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "ml_field");
         expect(f?.sqlType).toEqual({ name: "MULTILINE", lengthLimit: 10000 });
@@ -2260,7 +2270,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should accept FLOAT with user-supplied decimalPrecision in range", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "float_field", type: EntityFieldDataType.FLOAT, decimalPrecision: 5 },
+          { name: "float_field", type: EntityFieldDataType.FLOAT, decimalPrecision: 5 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "float_field");
         expect(f?.sqlType.decimalPrecision).toBe(5);
@@ -2269,7 +2279,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when INTEGER minValue is greater than maxValue", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 },
+            { name: "int_field", type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 },
           ]),
         ).rejects.toThrow(/minValue 100 >= maxValue 50.*minValue must be strictly less than maxValue/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2278,7 +2288,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when DECIMAL minValue equals maxValue", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, minValue: 10, maxValue: 10 },
+            { name: "dec_field", type: EntityFieldDataType.DECIMAL, minValue: 10, maxValue: 10 },
           ]),
         ).rejects.toThrow(/minValue 10 >= maxValue 10/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2287,7 +2297,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when FLOAT minValue is greater than maxValue", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "float_field", type: EntityFieldDataType.FLOAT, minValue: 5, maxValue: -5 },
+            { name: "float_field", type: EntityFieldDataType.FLOAT, minValue: 5, maxValue: -5 },
           ]),
         ).rejects.toThrow(/minValue 5 >= maxValue -5/);
         expect(mockApiClient.post).not.toHaveBeenCalled();
@@ -2295,7 +2305,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should accept INTEGER when minValue is strictly less than maxValue", async () => {
         await entityService.create("my_entity", [
-          { fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: -100, maxValue: 100 },
+          { name: "int_field", type: EntityFieldDataType.INTEGER, minValue: -100, maxValue: 100 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "int_field");
         expect(f?.sqlType.minValue).toBe(-100);
@@ -2305,7 +2315,7 @@ describe("EntityService Unit Tests", () => {
       it("should not enforce minValue < maxValue when only one is user-supplied (other comes from defaults)", async () => {
         // Only minValue is provided; maxValue is filled from defaults — no cross-field check triggers.
         await entityService.create("my_entity", [
-          { fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: -50 },
+          { name: "int_field", type: EntityFieldDataType.INTEGER, minValue: -50 },
         ]);
         const f = getCreatedFields().find((x) => x.name === "int_field");
         expect(f?.sqlType.minValue).toBe(-50);
@@ -2313,7 +2323,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should emit nested referenceEntity / referenceField objects and isForeignKey/referenceType on RELATIONSHIP fields", async () => {
         await entityService.create("my_entity", [{
-          fieldName: "rel_field",
+          name: "rel_field",
           type: EntityFieldDataType.RELATIONSHIP,
           referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
           referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2328,14 +2338,14 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when RELATIONSHIP field is missing reference IDs", async () => {
         await expect(
           entityService.create("my_entity", [
-            { fieldName: "rel_field", type: EntityFieldDataType.RELATIONSHIP },
+            { name: "rel_field", type: EntityFieldDataType.RELATIONSHIP },
           ]),
         ).rejects.toThrow(/requires both referenceEntityId and referenceFieldId/);
       });
 
       it("should embed { id, folderId } in referenceEntity for cross-folder RELATIONSHIP when referenceFolderKey is set", async () => {
         await entityService.create("my_entity", [{
-          fieldName: "rel_field",
+          name: "rel_field",
           type: EntityFieldDataType.RELATIONSHIP,
           referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
           referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2364,7 +2374,7 @@ describe("EntityService Unit Tests", () => {
         });
 
         await entityService.create("my_entity", [{
-          fieldName: "userType",
+          name: "userType",
           type: EntityFieldDataType.CHOICE_SET_SINGLE,
           choiceSetId: ENTITY_TEST_CONSTANTS.CHOICE_SET_TARGET_ID,
           referenceFolderKey: DATA_FABRIC_TENANT_FOLDER_ID,
@@ -2395,7 +2405,7 @@ describe("EntityService Unit Tests", () => {
         });
 
         await entityService.create("my_entity", [{
-          fieldName: "cat",
+          name: "cat",
           type: EntityFieldDataType.CHOICE_SET_SINGLE,
           choiceSetId: ENTITY_TEST_CONSTANTS.CHOICE_SET_TARGET_ID,
           referenceFolderKey: ENTITY_TEST_CONSTANTS.REFERENCE_TARGET_FOLDER_KEY,
@@ -2412,7 +2422,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should emit a bare { id } reference when referenceFolderKey is omitted (same-scope default)", async () => {
         await entityService.create("my_entity", [{
-          fieldName: "rel_field",
+          name: "rel_field",
           type: EntityFieldDataType.RELATIONSHIP,
           referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
           referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2426,7 +2436,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should emit only fieldDisplayType=File on FILE fields, omitting isForeignKey/referenceEntity/referenceField/referenceType (server auto-wires the attachment)", async () => {
         await entityService.create("my_entity", [{
-          fieldName: "file_field",
+          name: "file_field",
           type: EntityFieldDataType.FILE,
         }]);
         const f = getCreatedFields().find((x) => x.name === "file_field");
@@ -2439,7 +2449,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should strip caller-provided referenceEntityId/referenceFieldId on FILE (server discards them anyway)", async () => {
         await entityService.create("my_entity", [{
-          fieldName: "file_field",
+          name: "file_field",
           type: EntityFieldDataType.FILE,
           referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
           referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2515,7 +2525,7 @@ describe("EntityService Unit Tests", () => {
       mockApiClient.post.mockResolvedValue(undefined);
 
       await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-        addFields: [{ fieldName: "count", type: EntityFieldDataType.INTEGER }],
+        addFields: [{ name: "count", type: EntityFieldDataType.INTEGER }],
       });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
@@ -2541,12 +2551,29 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
+    it("should carry forward the entity's Insights setting from the wire GET response", async () => {
+      mockApiClient.get.mockResolvedValue({ ...mockRawEntity, isInsightsEnabled: true });
+      mockApiClient.post.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        addFields: [{ name: "count", type: EntityFieldDataType.INTEGER }],
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
+        expect.objectContaining({
+          entityDefinition: expect.objectContaining({ isInsightsEnabled: true }),
+        }),
+        { headers: {} },
+      );
+    });
+
     it("should remove specified fields from the schema", async () => {
       mockApiClient.get.mockResolvedValue(mockRawEntity);
       mockApiClient.post.mockResolvedValue(undefined);
 
       await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-        removeFields: [{ fieldName: "title" }],
+        removeFields: [{ name: "title" }],
       });
 
       const call = mockApiClient.post.mock.calls[0][1];
@@ -2593,7 +2620,7 @@ describe("EntityService Unit Tests", () => {
       mockApiClient.post.mockResolvedValue(undefined);
 
       await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-        addFields: [{ fieldName: "status", type: EntityFieldDataType.STRING }],
+        addFields: [{ name: "status", type: EntityFieldDataType.STRING }],
       });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
@@ -2612,9 +2639,9 @@ describe("EntityService Unit Tests", () => {
 
       await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
         addFields: [
-          { fieldName: "notes", type: EntityFieldDataType.MULTILINE_TEXT },
+          { name: "notes", type: EntityFieldDataType.MULTILINE_TEXT },
         ],
-        removeFields: [{ fieldName: "title" }],
+        removeFields: [{ name: "title" }],
         updateFields: [],
       });
 
@@ -2695,7 +2722,7 @@ describe("EntityService Unit Tests", () => {
               }
             : {};
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "new_field", type, ...referenceIds }],
+          addFields: [{ name: "new_field", type, ...referenceIds }],
         });
 
         const call = mockApiClient.post.mock.calls[0][1];
@@ -2714,7 +2741,7 @@ describe("EntityService Unit Tests", () => {
       await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
         addFields: [
           {
-            fieldName: "secret_field",
+            name: "secret_field",
             type: EntityFieldDataType.STRING,
             isEncrypted: true,
           },
@@ -2736,7 +2763,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default STRING lengthLimit to 200", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING }],
+          addFields: [{ name: "str_field", type: EntityFieldDataType.STRING }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "str_field");
@@ -2745,7 +2772,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should use user-provided lengthLimit for STRING fields", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 500 }],
+          addFields: [{ name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 500 }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "str_field");
@@ -2754,7 +2781,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default MULTILINE_TEXT lengthLimit to 200", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT }],
+          addFields: [{ name: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "ml_field");
@@ -2763,7 +2790,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default DECIMAL constraints to default values", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL }],
+          addFields: [{ name: "dec_field", type: EntityFieldDataType.DECIMAL }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "dec_field");
@@ -2778,7 +2805,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should allow user to override DECIMAL constraints", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 9999, minValue: -9999 }],
+          addFields: [{ name: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 4, maxValue: 9999, minValue: -9999 }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "dec_field");
@@ -2789,7 +2816,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should set BOOLEAN lengthLimit to fixed value 100", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "bool_field", type: EntityFieldDataType.BOOLEAN }],
+          addFields: [{ name: "bool_field", type: EntityFieldDataType.BOOLEAN }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "bool_field");
@@ -2798,7 +2825,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should set DATE lengthLimit to fixed value 1000", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "date_field", type: EntityFieldDataType.DATE }],
+          addFields: [{ name: "date_field", type: EntityFieldDataType.DATE }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "date_field");
@@ -2807,7 +2834,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should set DATETIME_WITH_TZ lengthLimit to fixed value 1000", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "dtz_field", type: EntityFieldDataType.DATETIME_WITH_TZ }],
+          addFields: [{ name: "dtz_field", type: EntityFieldDataType.DATETIME_WITH_TZ }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "dtz_field");
@@ -2816,7 +2843,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default INTEGER min/max to default values", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER }],
+          addFields: [{ name: "int_field", type: EntityFieldDataType.INTEGER }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "int_field");
@@ -2825,7 +2852,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should allow user to override INTEGER min/max", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: 500, minValue: -500 }],
+          addFields: [{ name: "int_field", type: EntityFieldDataType.INTEGER, maxValue: 500, minValue: -500 }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "int_field");
@@ -2834,7 +2861,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default BIG_INTEGER min/max to default values", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "bigint_field", type: EntityFieldDataType.BIG_INTEGER }],
+          addFields: [{ name: "bigint_field", type: EntityFieldDataType.BIG_INTEGER }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "bigint_field");
@@ -2843,7 +2870,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default FLOAT to defaults including decimalPrecision", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "float_field", type: EntityFieldDataType.FLOAT }],
+          addFields: [{ name: "float_field", type: EntityFieldDataType.FLOAT }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "float_field");
@@ -2852,7 +2879,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should default DOUBLE to defaults including decimalPrecision", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "double_field", type: EntityFieldDataType.DOUBLE }],
+          addFields: [{ name: "double_field", type: EntityFieldDataType.DOUBLE }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "double_field");
@@ -2861,7 +2888,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should set CHOICE_SET_SINGLE sqlType to plain INT (no constraints)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "css_field", type: EntityFieldDataType.CHOICE_SET_SINGLE }],
+          addFields: [{ name: "css_field", type: EntityFieldDataType.CHOICE_SET_SINGLE }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "css_field");
@@ -2871,7 +2898,7 @@ describe("EntityService Unit Tests", () => {
       it("should set FILE lengthLimit to fixed value 300 (UNIQUEIDENTIFIER)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           addFields: [{
-            fieldName: "file_field",
+            name: "file_field",
             type: EntityFieldDataType.FILE,
           }],
         });
@@ -2883,7 +2910,7 @@ describe("EntityService Unit Tests", () => {
       it("should emit only fieldDisplayType=File on FILE fields, omitting isForeignKey/referenceEntity/referenceField/referenceType (server auto-wires the attachment)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           addFields: [{
-            fieldName: "file_field",
+            name: "file_field",
             type: EntityFieldDataType.FILE,
           }],
         });
@@ -2899,7 +2926,7 @@ describe("EntityService Unit Tests", () => {
       it("should strip caller-provided referenceEntityId/referenceFieldId on FILE (server discards them anyway)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           addFields: [{
-            fieldName: "file_field",
+            name: "file_field",
             type: EntityFieldDataType.FILE,
             referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
             referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2914,7 +2941,7 @@ describe("EntityService Unit Tests", () => {
       it("should set RELATIONSHIP lengthLimit to fixed value 300 (UNIQUEIDENTIFIER)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           addFields: [{
-            fieldName: "rel_field",
+            name: "rel_field",
             type: EntityFieldDataType.RELATIONSHIP,
             referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
             referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2928,7 +2955,7 @@ describe("EntityService Unit Tests", () => {
       it("should emit nested referenceEntity / referenceField objects and isForeignKey/referenceType on RELATIONSHIP fields", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           addFields: [{
-            fieldName: "rel_field",
+            name: "rel_field",
             type: EntityFieldDataType.RELATIONSHIP,
             referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
             referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -2945,14 +2972,14 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when RELATIONSHIP field is missing reference IDs", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "rel_field", type: EntityFieldDataType.RELATIONSHIP }],
+            addFields: [{ name: "rel_field", type: EntityFieldDataType.RELATIONSHIP }],
           }),
         ).rejects.toThrow(/requires both referenceEntityId and referenceFieldId/);
       });
 
       it("should set CHOICE_SET_MULTIPLE lengthLimit to fixed value 4000 (NVARCHAR)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "csm_field", type: EntityFieldDataType.CHOICE_SET_MULTIPLE }],
+          addFields: [{ name: "csm_field", type: EntityFieldDataType.CHOICE_SET_MULTIPLE }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "csm_field");
@@ -2961,7 +2988,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should set AUTO_NUMBER sqlType to plain DECIMAL (no constraints)", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "an_field", type: EntityFieldDataType.AUTO_NUMBER }],
+          addFields: [{ name: "an_field", type: EntityFieldDataType.AUTO_NUMBER }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "an_field");
@@ -2979,7 +3006,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes lengthLimit for BOOLEAN", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "bool_field", type: EntityFieldDataType.BOOLEAN, lengthLimit: 50 }],
+            addFields: [{ name: "bool_field", type: EntityFieldDataType.BOOLEAN, lengthLimit: 50 }],
           }),
         ).rejects.toThrow(/does not accept lengthLimit/);
       });
@@ -2987,7 +3014,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes lengthLimit for INTEGER", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, lengthLimit: 50 }],
+            addFields: [{ name: "int_field", type: EntityFieldDataType.INTEGER, lengthLimit: 50 }],
           }),
         ).rejects.toThrow(/does not accept lengthLimit/);
       });
@@ -2995,7 +3022,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes maxValue for STRING", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, maxValue: 100 }],
+            addFields: [{ name: "str_field", type: EntityFieldDataType.STRING, maxValue: 100 }],
           }),
         ).rejects.toThrow(/does not accept maxValue/);
       });
@@ -3003,7 +3030,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes decimalPrecision for INTEGER", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, decimalPrecision: 2 }],
+            addFields: [{ name: "int_field", type: EntityFieldDataType.INTEGER, decimalPrecision: 2 }],
           }),
         ).rejects.toThrow(/does not accept decimalPrecision/);
       });
@@ -3031,7 +3058,7 @@ describe("EntityService Unit Tests", () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
             addFields: [{
-              fieldName: "file_field",
+              name: "file_field",
               type: EntityFieldDataType.FILE,
               lengthLimit: 500,
             }],
@@ -3043,7 +3070,7 @@ describe("EntityService Unit Tests", () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
             addFields: [{
-              fieldName: "rel_field",
+              name: "rel_field",
               type: EntityFieldDataType.RELATIONSHIP,
               referenceEntityId: ENTITY_TEST_CONSTANTS.REFERENCE_ENTITY_ID,
               referenceFieldId: ENTITY_TEST_CONSTANTS.REFERENCE_FIELD_ID,
@@ -3056,7 +3083,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes maxValue for CHOICE_SET_SINGLE", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "css_field", type: EntityFieldDataType.CHOICE_SET_SINGLE, maxValue: 100 }],
+            addFields: [{ name: "css_field", type: EntityFieldDataType.CHOICE_SET_SINGLE, maxValue: 100 }],
           }),
         ).rejects.toThrow(/does not accept maxValue/);
       });
@@ -3064,7 +3091,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when user passes lengthLimit for DATE", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "date_field", type: EntityFieldDataType.DATE, lengthLimit: 500 }],
+            addFields: [{ name: "date_field", type: EntityFieldDataType.DATE, lengthLimit: 500 }],
           }),
         ).rejects.toThrow(/does not accept lengthLimit/);
       });
@@ -3072,7 +3099,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when STRING lengthLimit exceeds 4000", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4001 }],
+            addFields: [{ name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4001 }],
           }),
         ).rejects.toThrow(/lengthLimit 4001 out of range \[1, 4000\]/);
       });
@@ -3080,7 +3107,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when STRING lengthLimit is less than 1", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 0 }],
+            addFields: [{ name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 0 }],
           }),
         ).rejects.toThrow(/lengthLimit 0 out of range \[1, 4000\]/);
       });
@@ -3088,7 +3115,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when MULTILINE_TEXT lengthLimit exceeds 10000", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10001 }],
+            addFields: [{ name: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10001 }],
           }),
         ).rejects.toThrow(/lengthLimit 10001 out of range \[1, 10000\]/);
       });
@@ -3096,7 +3123,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when DECIMAL is given lengthLimit by user (not user-configurable)", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, lengthLimit: 500 }],
+            addFields: [{ name: "dec_field", type: EntityFieldDataType.DECIMAL, lengthLimit: 500 }],
           }),
         ).rejects.toThrow(/does not accept lengthLimit/);
       });
@@ -3104,7 +3131,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when DECIMAL decimalPrecision exceeds 10", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 11 }],
+            addFields: [{ name: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: 11 }],
           }),
         ).rejects.toThrow(/decimalPrecision 11 out of range \[0, 10\]/);
       });
@@ -3112,7 +3139,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when DECIMAL decimalPrecision is negative", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: -1 }],
+            addFields: [{ name: "dec_field", type: EntityFieldDataType.DECIMAL, decimalPrecision: -1 }],
           }),
         ).rejects.toThrow(/decimalPrecision -1 out of range \[0, 10\]/);
       });
@@ -3120,7 +3147,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when INTEGER maxValue exceeds Number.MAX_SAFE_INTEGER", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, maxValue: Number.MAX_SAFE_INTEGER + 1 }],
+            addFields: [{ name: "int_field", type: EntityFieldDataType.INTEGER, maxValue: Number.MAX_SAFE_INTEGER + 1 }],
           }),
         ).rejects.toThrow(/maxValue .* out of range/);
       });
@@ -3128,7 +3155,7 @@ describe("EntityService Unit Tests", () => {
       it("should throw ValidationError when addFields INTEGER minValue >= maxValue", async () => {
         await expect(
           entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-            addFields: [{ fieldName: "int_field", type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 }],
+            addFields: [{ name: "int_field", type: EntityFieldDataType.INTEGER, minValue: 100, maxValue: 50 }],
           }),
         ).rejects.toThrow(/minValue 100 >= maxValue 50.*minValue must be strictly less than maxValue/);
       });
@@ -3155,7 +3182,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should accept FLOAT with user-supplied decimalPrecision in range", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "float_field", type: EntityFieldDataType.FLOAT, decimalPrecision: 5 }],
+          addFields: [{ name: "float_field", type: EntityFieldDataType.FLOAT, decimalPrecision: 5 }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "float_field");
@@ -3164,7 +3191,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should accept STRING lengthLimit at the boundary value 4000", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4000 }],
+          addFields: [{ name: "str_field", type: EntityFieldDataType.STRING, lengthLimit: 4000 }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "str_field");
@@ -3173,7 +3200,7 @@ describe("EntityService Unit Tests", () => {
 
       it("should accept MULTILINE_TEXT lengthLimit at the boundary value 10000", async () => {
         await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10000 }],
+          addFields: [{ name: "ml_field", type: EntityFieldDataType.MULTILINE_TEXT, lengthLimit: 10000 }],
         });
         const fields = mockApiClient.post.mock.calls[0][1].entityDefinition.fields;
         const f = fields.find((x: FieldSchemaPayload) => x.name === "ml_field");
@@ -3260,7 +3287,7 @@ describe("EntityService Unit Tests", () => {
 
       await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
         folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
-        addFields: [{ fieldName: "newcol", type: EntityFieldDataType.STRING }],
+        addFields: [{ name: "newcol", type: EntityFieldDataType.STRING }],
         displayName: "renamed",
       });
 
@@ -3303,7 +3330,7 @@ describe("EntityService Unit Tests", () => {
       mockApiClient.patch.mockResolvedValue(undefined);
 
       await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-        addFields: [{ fieldName: "count", type: EntityFieldDataType.INTEGER }],
+        addFields: [{ name: "count", type: EntityFieldDataType.INTEGER }],
         displayName: "New Display Name",
       });
 
@@ -3333,7 +3360,7 @@ describe("EntityService Unit Tests", () => {
 
       await expect(
         entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
-          addFields: [{ fieldName: "new_field", type: EntityFieldDataType.STRING }],
+          addFields: [{ name: "new_field", type: EntityFieldDataType.STRING }],
         }),
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
     });


### PR DESCRIPTION
## Summary

The entity **create** request used different names than the **get** response for the same concepts. This aligns the create side to the get/API vocabulary — **pure renames only**, the flat/ergonomic create shape is unchanged.

| Concept | Before (create) | After (create) | Matches get |
|---|---|---|---|
| Field name | `fieldName` | `name` | `name` |
| Remove-field name | `fieldName` | `name` | `name` |
| Analytics flag | `isAnalyticsEnabled` | `isInsightsEnabled` | `isInsightsEnabled` |

## Intentionally NOT changed
- **Flattened fields** — scalar `type` + flat constraints (`lengthLimit`, `maxValue`…) and bare-id references (`referenceEntityId`/`referenceFieldId`) vs the nested `fieldDataType`/`referenceEntity`/`referenceField` in the response. These are deliberate create-input ergonomics; the SDK/backend bridge the gap (SDK maps `type` ⇄ `sqlType`+`fieldDisplayType`; backend resolves reference ids to full objects on read).
- **`folderKey` vs `folderId`** — `folderKey` is the SDK-wide folder-scoping input used by every service; `folderId` is the entity's stored attribute in the response. Renaming would break cross-SDK consistency.

## ⚠️ Breaking change
Public create API renames: `EntityCreateFieldOptions.fieldName`→`name`, `EntityRemoveFieldOptions.fieldName`→`name`, `EntityCreateOptions.isAnalyticsEnabled`→`isInsightsEnabled`.

**CLI follow-up needed:** the `data-fabric-tool` `df entities create` command validates `fieldName` and its examples use it — it needs a paired `fieldName`→`name` update when it bumps the SDK. (`isAnalyticsEnabled` isn't used by the CLI create.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)