### PR TITLE
ci: attach air-gapped SDK bundle to GitHub releases [PLT-108405]

### DIFF
--- a/.github/workflows/export-airgap-bundle.yml
+++ b/.github/workflows/export-airgap-bundle.yml
@@ -4,9 +4,9 @@ name: Export air-gapped SDK bundle
 # published npm tarballs for @uipath/uipath-typescript + @uipath/coded-action-app
 # and their full transitive dependency closure, VERIFY it by publishing every
 # tarball into a throwaway Verdaccio and installing both SDKs from it alone
-# (no uplinks — completeness is genuinely tested), then attach the SDK tarball
-# and the bundle ZIP to the GitHub release. Verdaccio is a test harness only —
-# it is not part of the bundle.
+# (no uplinks — completeness is genuinely tested), then attach the bundle ZIP
+# to the GitHub release. Verdaccio is a test harness only — it is not part of
+# the bundle.
 #
 # Releases stay human-created (draft notes published manually — this workflow
 # never creates releases or tags, it only adds assets to an existing release;
@@ -159,8 +159,6 @@ jobs:
           name: ${{ needs.build.outputs.bundle_name }}
           path: airgap-bundle
 
-      # Attaches both the standalone SDK tarball (registry-fetched, so
-      # byte-identical to what npm serves) and the full bundle ZIP.
       # Tag passed via env (never interpolated into the script) to avoid
       # shell injection through a crafted tag name.
       - name: Upload to GitHub Release
@@ -170,6 +168,5 @@ jobs:
           BUNDLE_NAME: ${{ needs.build.outputs.bundle_name }}
         run: |
           (cd airgap-bundle && zip -qr "${GITHUB_WORKSPACE}/${BUNDLE_NAME}.zip" .)
-          gh release upload "$TAG_NAME" "${BUNDLE_NAME}.zip" airgap-bundle/uipath-uipath-typescript-*.tgz \
-            --clobber --repo "$GITHUB_REPOSITORY"
-          echo "- Attached \`${BUNDLE_NAME}.zip\` and the SDK tarball to release \`${TAG_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+          gh release upload "$TAG_NAME" "${BUNDLE_NAME}.zip" --clobber --repo "$GITHUB_REPOSITORY"
+          echo "- Attached \`${BUNDLE_NAME}.zip\` to release \`${TAG_NAME}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/export-airgap-bundle.yml
+++ b/.github/workflows/export-airgap-bundle.yml
@@ -1,0 +1,189 @@
+name: Export air-gapped SDK bundle
+
+# Mirrors UiPath/cli's export-airgapped workflow: build a bundle of the exact
+# published npm tarballs for @uipath/uipath-typescript + @uipath/coded-action-app
+# and their full transitive dependency closure, VERIFY it by publishing every
+# tarball into a throwaway Verdaccio and installing both SDKs from it alone
+# (no uplinks — completeness is genuinely tested), then attach the ZIP to the
+# GitHub release. Verdaccio is a test harness only — it is not part of the
+# bundle.
+#
+# Triggers:
+#   - release published: bundles the released version, attaches to that release.
+#     Covers manually created releases; releases created by publish.yml's own
+#     GITHUB_TOKEN cannot fire this event (recursion guard), so publish.yml
+#     also dispatches this workflow explicitly.
+#   - workflow_dispatch: on-demand builds, optionally attached to a release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      sdk_version:
+        description: >-
+          Version of @uipath/uipath-typescript to bundle (exact, e.g. 1.5.5).
+          Empty = latest.
+        required: false
+        type: string
+      coded_action_app_version:
+        description: >-
+          Version of @uipath/coded-action-app to bundle (exact, incl.
+          prerelease). Empty = latest.
+        required: false
+        type: string
+      release_tag:
+        description: >-
+          Attach the ZIP to an EXISTING GitHub release with this tag
+          (e.g. 1.5.5). Empty = leave as a workflow artifact only.
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build bundle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sdk_version: ${{ steps.meta.outputs.sdk_version }}
+      caa_version: ${{ steps.meta.outputs.caa_version }}
+      bundle_name: ${{ steps.meta.outputs.bundle_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      # On a release event the tag IS the SDK version. Inputs reach the script
+      # via env only; it regex-validates them before any npm command.
+      - name: Build bundle
+        env:
+          OUT_DIR: ${{ github.workspace }}/airgap-bundle
+          SDK_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.sdk_version }}
+          CAA_VERSION: ${{ inputs.coded_action_app_version }}
+        run: node scripts/airgap/build-airgap-bundle.mjs
+
+      - name: Resolve bundle metadata
+        id: meta
+        run: |
+          SDK_VERSION=$(jq -r '.roots[] | select(.name == "@uipath/uipath-typescript").version' airgap-bundle/manifest.json)
+          CAA_VERSION=$(jq -r '.roots[] | select(.name == "@uipath/coded-action-app").version' airgap-bundle/manifest.json)
+          echo "sdk_version=$SDK_VERSION" >> "$GITHUB_OUTPUT"
+          echo "caa_version=$CAA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "bundle_name=uipath-sdk-airgap-bundle-${SDK_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "## Air-gapped bundle" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`@uipath/uipath-typescript@${SDK_VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`@uipath/coded-action-app@${CAA_VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '"- Tarballs: \(.packages | length)"' airgap-bundle/manifest.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.bundle_name }}
+          if-no-files-found: error
+          retention-days: 30
+          path: airgap-bundle/
+
+  verify:
+    name: Verify bundle installs offline
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Download bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.bundle_name }}
+          path: airgap-bundle
+
+      # No uplinks: Verdaccio can only serve what the bundle publishes into
+      # it, so a missing dependency fails the install below.
+      - name: Start Verdaccio (test harness)
+        run: |
+          mkdir -p "$RUNNER_TEMP/verd/storage"
+          cat > "$RUNNER_TEMP/verd/config.yaml" <<'EOF'
+          storage: ./storage
+          auth:
+            htpasswd:
+              file: ./htpasswd
+          packages:
+            '**':
+              access: $all
+              publish: $all
+          uplinks: {}
+          log: { type: stdout, level: warn }
+          EOF
+          (cd "$RUNNER_TEMP/verd" && npx --yes verdaccio@6 --config config.yaml --listen 4873 > server.log 2>&1 &)
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:4873/-/ping > /dev/null 2>&1; then
+              echo "Verdaccio up after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Verdaccio failed to start"; cat "$RUNNER_TEMP/verd/server.log"; exit 1
+
+      # --tag latest: npm refuses to publish prerelease versions (the
+      # coded-action-app betas) without an explicit tag.
+      - name: Publish bundle tarballs into Verdaccio
+        run: |
+          NPMRC="$RUNNER_TEMP/verd/publish.npmrc"
+          printf 'registry=http://localhost:4873/\n@uipath:registry=http://localhost:4873/\n//localhost:4873/:_authToken=anonymous\n' > "$NPMRC"
+          count=0
+          for t in airgap-bundle/*.tgz; do
+            npm publish "./$t" --userconfig="$NPMRC" \
+              --registry=http://localhost:4873/ --@uipath:registry=http://localhost:4873/ \
+              --tag latest > /dev/null
+            count=$((count + 1))
+          done
+          echo "Published $count tarballs into Verdaccio"
+
+      - name: Install both SDKs from the offline registry
+        env:
+          SDK_VERSION: ${{ needs.build.outputs.sdk_version }}
+          CAA_VERSION: ${{ needs.build.outputs.caa_version }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/install-test" && cd "$RUNNER_TEMP/install-test"
+          npm init -y > /dev/null
+          npm install "@uipath/uipath-typescript@${SDK_VERSION}" "@uipath/coded-action-app@${CAA_VERSION}" \
+            --registry=http://localhost:4873/ --@uipath:registry=http://localhost:4873/ \
+            --ignore-scripts --no-audit --no-fund
+          node -e "require('@uipath/uipath-typescript'); require('@uipath/coded-action-app'); console.log('both SDKs install and load from the bundle alone')"
+
+  attach:
+    name: Attach bundle to release
+    needs: [build, verify]
+    if: github.event_name == 'release' || inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.bundle_name }}
+          path: airgap-bundle
+
+      # Tag passed via env (never interpolated into the script) to avoid
+      # shell injection through a crafted tag name.
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.release_tag }}
+          BUNDLE_NAME: ${{ needs.build.outputs.bundle_name }}
+        run: |
+          (cd airgap-bundle && zip -qr "${GITHUB_WORKSPACE}/${BUNDLE_NAME}.zip" .)
+          gh release upload "$TAG_NAME" "${BUNDLE_NAME}.zip" --clobber --repo "$GITHUB_REPOSITORY"
+          echo "- Attached \`${BUNDLE_NAME}.zip\` to release \`${TAG_NAME}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/export-airgap-bundle.yml
+++ b/.github/workflows/export-airgap-bundle.yml
@@ -10,38 +10,18 @@ name: Export air-gapped SDK bundle
 #
 # Releases stay human-created (draft notes published manually — this workflow
 # never creates releases or tags, it only adds assets to an existing release;
-# publishing a draft fires the release trigger below).
-#
-# Triggers:
-#   - release published: bundles the released version (tag = SDK version) and
-#     attaches the assets to that release. This is the primary path.
-#   - workflow_dispatch: backfill for past releases, recovery after a failed
-#     run, refreshing the coded-action-app side, or artifact-only dry runs
-#     (leave release_tag empty).
+# publishing a draft fires the release trigger below). Publishing the draft is
+# the human approval for the attach, so there is no extra environment gate,
+# and the workflow is deliberately NOT manually runnable: it never publishes
+# to any registry (the verify job's `npm publish` targets a throwaway
+# localhost Verdaccio that dies with the runner), so its only side effect is
+# adding assets to the release that was just published. To backfill an older
+# release, run scripts/airgap/build-airgap-bundle.mjs locally and
+# `gh release upload` the results.
 
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      sdk_version:
-        description: >-
-          Version of @uipath/uipath-typescript to bundle (exact, e.g. 1.5.5).
-          Empty = latest.
-        required: false
-        type: string
-      coded_action_app_version:
-        description: >-
-          Version of @uipath/coded-action-app to bundle (exact, incl.
-          prerelease). Empty = latest.
-        required: false
-        type: string
-      release_tag:
-        description: >-
-          Attach the ZIP to an EXISTING GitHub release with this tag
-          (e.g. 1.5.5). Empty = leave as a workflow artifact only.
-        required: false
-        type: string
 
 permissions: {}
 
@@ -66,13 +46,13 @@ jobs:
         with:
           node-version: '24'
 
-      # On a release event the tag IS the SDK version. Inputs reach the script
-      # via env only; it regex-validates them before any npm command.
+      # The release tag IS the SDK version (bare-version tags, e.g. 1.5.5).
+      # It reaches the script via env only; the script regex-validates it
+      # before any npm command. coded-action-app defaults to latest.
       - name: Build bundle
         env:
           OUT_DIR: ${{ github.workspace }}/airgap-bundle
-          SDK_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.sdk_version }}
-          CAA_VERSION: ${{ inputs.coded_action_app_version }}
+          SDK_VERSION: ${{ github.event.release.tag_name }}
         run: node scripts/airgap/build-airgap-bundle.mjs
 
       - name: Resolve bundle metadata
@@ -169,11 +149,7 @@ jobs:
   attach:
     name: Attach assets to release
     needs: [build, verify]
-    if: github.event_name == 'release' || inputs.release_tag != ''
     runs-on: ubuntu-latest
-    # The only side-effecting job: writing assets to a customer-facing release
-    # requires the production environment's approval rules.
-    environment: production
     permissions:
       contents: write
     steps:
@@ -190,7 +166,7 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.event.release.tag_name || inputs.release_tag }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
           BUNDLE_NAME: ${{ needs.build.outputs.bundle_name }}
         run: |
           (cd airgap-bundle && zip -qr "${GITHUB_WORKSPACE}/${BUNDLE_NAME}.zip" .)

--- a/.github/workflows/export-airgap-bundle.yml
+++ b/.github/workflows/export-airgap-bundle.yml
@@ -4,16 +4,20 @@ name: Export air-gapped SDK bundle
 # published npm tarballs for @uipath/uipath-typescript + @uipath/coded-action-app
 # and their full transitive dependency closure, VERIFY it by publishing every
 # tarball into a throwaway Verdaccio and installing both SDKs from it alone
-# (no uplinks — completeness is genuinely tested), then attach the ZIP to the
-# GitHub release. Verdaccio is a test harness only — it is not part of the
-# bundle.
+# (no uplinks — completeness is genuinely tested), then attach the SDK tarball
+# and the bundle ZIP to the GitHub release. Verdaccio is a test harness only —
+# it is not part of the bundle.
+#
+# Releases stay human-created (draft notes published manually — this workflow
+# never creates releases or tags, it only adds assets to an existing release;
+# publishing a draft fires the release trigger below).
 #
 # Triggers:
-#   - release published: bundles the released version, attaches to that release.
-#     Covers manually created releases; releases created by publish.yml's own
-#     GITHUB_TOKEN cannot fire this event (recursion guard), so publish.yml
-#     also dispatches this workflow explicitly.
-#   - workflow_dispatch: on-demand builds, optionally attached to a release.
+#   - release published: bundles the released version (tag = SDK version) and
+#     attaches the assets to that release. This is the primary path.
+#   - workflow_dispatch: backfill for past releases, recovery after a failed
+#     run, refreshing the coded-action-app side, or artifact-only dry runs
+#     (leave release_tag empty).
 
 on:
   release:
@@ -163,10 +167,13 @@ jobs:
           node -e "require('@uipath/uipath-typescript'); require('@uipath/coded-action-app'); console.log('both SDKs install and load from the bundle alone')"
 
   attach:
-    name: Attach bundle to release
+    name: Attach assets to release
     needs: [build, verify]
     if: github.event_name == 'release' || inputs.release_tag != ''
     runs-on: ubuntu-latest
+    # The only side-effecting job: writing assets to a customer-facing release
+    # requires the production environment's approval rules.
+    environment: production
     permissions:
       contents: write
     steps:
@@ -176,6 +183,8 @@ jobs:
           name: ${{ needs.build.outputs.bundle_name }}
           path: airgap-bundle
 
+      # Attaches both the standalone SDK tarball (registry-fetched, so
+      # byte-identical to what npm serves) and the full bundle ZIP.
       # Tag passed via env (never interpolated into the script) to avoid
       # shell injection through a crafted tag name.
       - name: Upload to GitHub Release
@@ -185,5 +194,6 @@ jobs:
           BUNDLE_NAME: ${{ needs.build.outputs.bundle_name }}
         run: |
           (cd airgap-bundle && zip -qr "${GITHUB_WORKSPACE}/${BUNDLE_NAME}.zip" .)
-          gh release upload "$TAG_NAME" "${BUNDLE_NAME}.zip" --clobber --repo "$GITHUB_REPOSITORY"
-          echo "- Attached \`${BUNDLE_NAME}.zip\` to release \`${TAG_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+          gh release upload "$TAG_NAME" "${BUNDLE_NAME}.zip" airgap-bundle/uipath-uipath-typescript-*.tgz \
+            --clobber --repo "$GITHUB_REPOSITORY"
+          echo "- Attached \`${BUNDLE_NAME}.zip\` and the SDK tarball to release \`${TAG_NAME}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
           for attempt in 1 2 3; do
             attach && exit 0
             echo "Attach attempt $attempt failed"
-            sleep 10
+            [ "$attempt" -lt 3 ] && sleep 10
           done
           echo "::error::Failed to attach tarball to release $SDK_VERSION after 3 attempts"
           exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,33 +98,19 @@ jobs:
           echo "::error::Failed to attach tarball to release $SDK_VERSION after 3 attempts"
           exit 1
 
-      # Bundle the just-published SDK + @uipath/coded-action-app (latest) with
-      # their full transitive dependency closure so registry-restricted
-      # customers can install both offline. Retried because the bundle pulls
-      # the SDK version published moments ago from the registry, which may
-      # need a short propagation window.
-      - name: Attach air-gapped bundle to GitHub Release
+      # The release created above by GITHUB_TOKEN cannot fire the airgap
+      # workflow's `release: published` trigger (recursion guard), so dispatch
+      # it explicitly. It builds the bundle (SDK + coded-action-app + full
+      # dependency closure), verifies it installs from a throwaway Verdaccio
+      # alone, and attaches the ZIP to this release.
+      - name: Trigger air-gapped bundle export
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OUT_DIR: ${{ github.workspace }}/airgap-bundle
         run: |
           SDK_VERSION=$(node -p "require('./package.json').version")
-          built=false
-          for attempt in 1 2 3; do
-            if SDK_VERSION="$SDK_VERSION" node scripts/airgap/build-airgap-bundle.mjs; then
-              built=true
-              break
-            fi
-            echo "Bundle build attempt $attempt failed (registry propagation?)"
-            sleep 30
-          done
-          if [ "$built" != "true" ]; then
-            echo "::error::Failed to build air-gapped bundle for $SDK_VERSION"
-            exit 1
-          fi
-          BUNDLE="uipath-sdk-airgap-bundle-${SDK_VERSION}.zip"
-          (cd "$OUT_DIR" && zip -qr "${GITHUB_WORKSPACE}/${BUNDLE}" .)
-          gh release upload "$SDK_VERSION" "$BUNDLE" --clobber --repo "$GITHUB_REPOSITORY"
+          gh workflow run export-airgap-bundle.yml --repo "$GITHUB_REPOSITORY" \
+            --field sdk_version="$SDK_VERSION" \
+            --field release_tag="$SDK_VERSION"
 
       - name: Generate Summary
         run: |
@@ -138,7 +125,7 @@ jobs:
           echo "- Published to npm registry (public access, with provenance)" >> $GITHUB_STEP_SUMMARY
           echo "- Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
           echo "- Attached packed tarball to GitHub Release" >> $GITHUB_STEP_SUMMARY
-          echo "- Attached air-gapped bundle (SDK + coded-action-app + dependency closure) to GitHub Release" >> $GITHUB_STEP_SUMMARY
+          echo "- Triggered air-gapped bundle export (build, Verdaccio verify, attach to release)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Package Details:" >> $GITHUB_STEP_SUMMARY
           echo "- **Package:** @uipath/uipath-typescript" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
-      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,47 +70,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Pack in the same run so the release asset is byte-identical to the npm
-      # publish (the build above has the telemetry version stamped in).
-      # Retried because this is the only fallible step after npm publish — a
-      # re-run of the whole workflow would fail on the already-published
-      # version and never reach this step.
-      - name: Attach package tarball to GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SDK_VERSION=$(node -p "require('./package.json').version")
-          npm pack
-          TARBALL="uipath-uipath-typescript-${SDK_VERSION}.tgz"
-          attach() {
-            if gh release view "$SDK_VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-              gh release upload "$SDK_VERSION" "$TARBALL" --clobber --repo "$GITHUB_REPOSITORY"
-            else
-              gh release create "$SDK_VERSION" "$TARBALL" --title "$SDK_VERSION" --target "$GITHUB_SHA" --generate-notes --repo "$GITHUB_REPOSITORY"
-            fi
-          }
-          for attempt in 1 2 3; do
-            attach && exit 0
-            echo "Attach attempt $attempt failed"
-            [ "$attempt" -lt 3 ] && sleep 10
-          done
-          echo "::error::Failed to attach tarball to release $SDK_VERSION after 3 attempts"
-          exit 1
-
-      # The release created above by GITHUB_TOKEN cannot fire the airgap
-      # workflow's `release: published` trigger (recursion guard), so dispatch
-      # it explicitly. It builds the bundle (SDK + coded-action-app + full
-      # dependency closure), verifies it installs from a throwaway Verdaccio
-      # alone, and attaches the ZIP to this release.
-      - name: Trigger air-gapped bundle export
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SDK_VERSION=$(node -p "require('./package.json').version")
-          gh workflow run export-airgap-bundle.yml --repo "$GITHUB_REPOSITORY" \
-            --field sdk_version="$SDK_VERSION" \
-            --field release_tag="$SDK_VERSION"
-
       - name: Generate Summary
         run: |
           SDK_VERSION=$(node -p "require('./package.json').version")
@@ -124,8 +82,6 @@ jobs:
           echo "- Built TypeScript package" >> $GITHUB_STEP_SUMMARY
           echo "- Published to npm registry (public access, with provenance)" >> $GITHUB_STEP_SUMMARY
           echo "- Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
-          echo "- Attached packed tarball to GitHub Release" >> $GITHUB_STEP_SUMMARY
-          echo "- Triggered air-gapped bundle export (build, Verdaccio verify, attach to release)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Package Details:" >> $GITHUB_STEP_SUMMARY
           echo "- **Package:** @uipath/uipath-typescript" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     steps:
@@ -70,6 +70,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Pack in the same run so the release asset is byte-identical to the npm
+      # publish (the build above has the telemetry version stamped in).
+      - name: Attach package tarball to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SDK_VERSION=$(node -p "require('./package.json').version")
+          npm pack
+          TARBALL="uipath-uipath-typescript-${SDK_VERSION}.tgz"
+          if gh release view "$SDK_VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release upload "$SDK_VERSION" "$TARBALL" --clobber --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$SDK_VERSION" "$TARBALL" --title "$SDK_VERSION" --generate-notes --repo "$GITHUB_REPOSITORY"
+          fi
+
       - name: Generate Summary
         run: |
           SDK_VERSION=$(node -p "require('./package.json').version")
@@ -82,6 +97,7 @@ jobs:
           echo "- Built TypeScript package" >> $GITHUB_STEP_SUMMARY
           echo "- Published to npm registry (public access, with provenance)" >> $GITHUB_STEP_SUMMARY
           echo "- Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
+          echo "- Attached packed tarball to GitHub Release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Package Details:" >> $GITHUB_STEP_SUMMARY
           echo "- **Package:** @uipath/uipath-typescript" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,6 +97,34 @@ jobs:
           echo "::error::Failed to attach tarball to release $SDK_VERSION after 3 attempts"
           exit 1
 
+      # Bundle the just-published SDK + @uipath/coded-action-app (latest) with
+      # their full transitive dependency closure so registry-restricted
+      # customers can install both offline. Retried because the bundle pulls
+      # the SDK version published moments ago from the registry, which may
+      # need a short propagation window.
+      - name: Attach air-gapped bundle to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUT_DIR: ${{ github.workspace }}/airgap-bundle
+        run: |
+          SDK_VERSION=$(node -p "require('./package.json').version")
+          built=false
+          for attempt in 1 2 3; do
+            if SDK_VERSION="$SDK_VERSION" node scripts/airgap/build-airgap-bundle.mjs; then
+              built=true
+              break
+            fi
+            echo "Bundle build attempt $attempt failed (registry propagation?)"
+            sleep 30
+          done
+          if [ "$built" != "true" ]; then
+            echo "::error::Failed to build air-gapped bundle for $SDK_VERSION"
+            exit 1
+          fi
+          BUNDLE="uipath-sdk-airgap-bundle-${SDK_VERSION}.zip"
+          (cd "$OUT_DIR" && zip -qr "${GITHUB_WORKSPACE}/${BUNDLE}" .)
+          gh release upload "$SDK_VERSION" "$BUNDLE" --clobber --repo "$GITHUB_REPOSITORY"
+
       - name: Generate Summary
         run: |
           SDK_VERSION=$(node -p "require('./package.json').version")
@@ -110,6 +138,7 @@ jobs:
           echo "- Published to npm registry (public access, with provenance)" >> $GITHUB_STEP_SUMMARY
           echo "- Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
           echo "- Attached packed tarball to GitHub Release" >> $GITHUB_STEP_SUMMARY
+          echo "- Attached air-gapped bundle (SDK + coded-action-app + dependency closure) to GitHub Release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Package Details:" >> $GITHUB_STEP_SUMMARY
           echo "- **Package:** @uipath/uipath-typescript" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,9 @@ jobs:
 
       # Pack in the same run so the release asset is byte-identical to the npm
       # publish (the build above has the telemetry version stamped in).
+      # Retried because this is the only fallible step after npm publish — a
+      # re-run of the whole workflow would fail on the already-published
+      # version and never reach this step.
       - name: Attach package tarball to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,11 +82,20 @@ jobs:
           SDK_VERSION=$(node -p "require('./package.json').version")
           npm pack
           TARBALL="uipath-uipath-typescript-${SDK_VERSION}.tgz"
-          if gh release view "$SDK_VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-            gh release upload "$SDK_VERSION" "$TARBALL" --clobber --repo "$GITHUB_REPOSITORY"
-          else
-            gh release create "$SDK_VERSION" "$TARBALL" --title "$SDK_VERSION" --generate-notes --repo "$GITHUB_REPOSITORY"
-          fi
+          attach() {
+            if gh release view "$SDK_VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+              gh release upload "$SDK_VERSION" "$TARBALL" --clobber --repo "$GITHUB_REPOSITORY"
+            else
+              gh release create "$SDK_VERSION" "$TARBALL" --title "$SDK_VERSION" --target "$GITHUB_SHA" --generate-notes --repo "$GITHUB_REPOSITORY"
+            fi
+          }
+          for attempt in 1 2 3; do
+            attach && exit 0
+            echo "Attach attempt $attempt failed"
+            sleep 10
+          done
+          echo "::error::Failed to attach tarball to release $SDK_VERSION after 3 attempts"
+          exit 1
 
       - name: Generate Summary
         run: |

--- a/scripts/airgap/build-airgap-bundle.mjs
+++ b/scripts/airgap/build-airgap-bundle.mjs
@@ -1,22 +1,15 @@
 #!/usr/bin/env node
 
 /**
- * Build an air-gapped bundle of the UiPath TypeScript SDKs: the exact
- * published npm tarballs for @uipath/uipath-typescript and
- * @uipath/coded-action-app plus every transitive runtime dependency
- * (@uipath/core-telemetry, socket.io-client chain, ...), with a manifest and
- * an offline-install README.
+ * Build an air-gapped bundle: the exact published npm tarballs for
+ * @uipath/uipath-typescript and @uipath/coded-action-app plus every
+ * transitive runtime dependency, with a manifest and offline-install README.
  *
- * The dependency closure is resolved by npm itself — a throwaway project is
- * installed with both roots and the lockfile is walked — so nothing is
- * hand-listed and the bundle can never miss a newly added dependency.
- * Every tarball is then fetched from the public registry via `npm pack`,
- * so the bundle contains the published bits, not a local rebuild.
+ * npm resolves the dependency closure itself (throwaway install + lockfile
+ * walk), so nothing is hand-listed, and every tarball is fetched from the
+ * public registry via `npm pack`, so the bundle contains the published bits.
  *
- * Env:
- *   OUT_DIR      output directory for tarballs + manifest + README (required)
- *   SDK_VERSION  version of @uipath/uipath-typescript (default: latest)
- *   CAA_VERSION  version of @uipath/coded-action-app (default: latest)
+ * Env: OUT_DIR (required), SDK_VERSION, CAA_VERSION (both default: latest)
  */
 
 import { execFileSync } from "node:child_process";
@@ -29,247 +22,134 @@ import {
     rmSync,
     writeFileSync,
 } from "node:fs";
-import { homedir, tmpdir } from "node:os";
-import { join, parse, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 const REGISTRY = "https://registry.npmjs.org/";
-
-// Resolved eagerly: npm commands below run from a temp cwd, so a relative
-// OUT_DIR would otherwise mean different directories to fs calls and to
-// `npm pack --pack-destination`.
-const OUT_DIR = process.env.OUT_DIR ? resolve(process.env.OUT_DIR) : undefined;
-if (!OUT_DIR) {
-    throw new Error("OUT_DIR env var is required (the bundle output directory)");
-}
-
-// Exact semver (prerelease allowed) or the literal "latest". Validated before
-// the value reaches any npm command line.
+// Exact semver (prerelease allowed) or "latest" — validated before reaching
+// any npm command line.
 const SAFE_VERSION = /^(latest|\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?)$/;
-
+const NM = "node_modules/";
 const ROOTS = [
-    {
-        name: "@uipath/uipath-typescript",
-        version: process.env.SDK_VERSION || "latest",
-    },
-    {
-        name: "@uipath/coded-action-app",
-        version: process.env.CAA_VERSION || "latest",
-    },
+    { name: "@uipath/uipath-typescript", version: process.env.SDK_VERSION || "latest" },
+    { name: "@uipath/coded-action-app", version: process.env.CAA_VERSION || "latest" },
 ];
-for (const root of ROOTS) {
-    if (!SAFE_VERSION.test(root.version)) {
-        throw new Error(`Invalid version for ${root.name}: "${root.version}"`);
+
+if (!process.env.OUT_DIR) throw new Error("OUT_DIR env var is required");
+// npm pack runs from a temp cwd, so OUT_DIR must be absolute for fs calls and
+// --pack-destination to agree on where the bundle lives.
+const OUT_DIR = resolve(process.env.OUT_DIR);
+for (const { name, version } of ROOTS) {
+    if (!SAFE_VERSION.test(version)) {
+        throw new Error(`Invalid version for ${name}: "${version}"`);
     }
 }
 
-const log = (message) => console.log(`[airgap-bundle] ${message}`);
+const log = (m) => console.log(`[airgap-bundle] ${m}`);
 
-/**
- * Wiping OUT_DIR is only safe when it is clearly ours: missing, empty, or a
- * previous bundle (has manifest.json). Anything else — including obviously
- * catastrophic paths — is refused rather than deleted.
- */
-function prepareOutDir() {
-    if (OUT_DIR === parse(OUT_DIR).root || OUT_DIR === homedir()) {
-        throw new Error(`Refusing to use OUT_DIR=${OUT_DIR}`);
-    }
-    if (existsSync(OUT_DIR)) {
-        const entries = readdirSync(OUT_DIR);
-        if (entries.length > 0 && !entries.includes("manifest.json")) {
-            throw new Error(
-                `OUT_DIR ${OUT_DIR} exists and is not a previous bundle — refusing to wipe it`,
-            );
-        }
-        rmSync(OUT_DIR, { recursive: true, force: true });
-    }
-    mkdirSync(OUT_DIR, { recursive: true });
-}
-
-// All npm calls run from a temp cwd (never the repo — its .npmrc routes
-// @uipath to GitHub Packages). The scoped override is still required because
-// a user-level ~/.npmrc @uipath:registry mapping beats the generic --registry
-// flag and would silently source the @uipath tarballs from the wrong registry.
-function npm(args, cwd) {
-    return execFileSync(
+// Temp cwd keeps the repo .npmrc out of play; the scoped override beats any
+// user-level @uipath:registry mapping that would reroute the @uipath tarballs.
+const npm = (args, cwd) =>
+    execFileSync(
         "npm",
         [...args, `--registry=${REGISTRY}`, `--@uipath:registry=${REGISTRY}`],
-        {
-            cwd,
-            encoding: "utf-8",
-            stdio: ["ignore", "pipe", "inherit"],
-        },
+        { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "inherit"] },
     ).trim();
+
+// Wipe OUT_DIR only when it is clearly ours: missing, empty, or a previous
+// bundle (has manifest.json).
+if (existsSync(OUT_DIR)) {
+    const entries = readdirSync(OUT_DIR);
+    if (entries.length > 0 && !entries.includes("manifest.json")) {
+        throw new Error(`OUT_DIR ${OUT_DIR} is not a previous bundle — refusing to wipe it`);
+    }
+    rmSync(OUT_DIR, { recursive: true, force: true });
 }
+mkdirSync(OUT_DIR, { recursive: true });
 
-/**
- * Resolve the full dependency closure of the root packages: install them into
- * a throwaway project (scripts disabled — nothing in the closure needs to
- * execute at resolve time) and read the exact name@version set from the
- * lockfile. Returns [{name, version}] sorted by name, roots included.
- */
-function resolveClosure(workDir) {
-    const projectDir = join(workDir, "resolve");
-    mkdirSync(projectDir, { recursive: true });
-    writeFileSync(
-        join(projectDir, "package.json"),
-        `${JSON.stringify({ name: "airgap-resolve", private: true }, null, 2)}\n`,
-    );
-
-    const specs = ROOTS.map((root) => `${root.name}@${root.version}`);
+const workDir = mkdtempSync(join(tmpdir(), "airgap-bundle-"));
+try {
+    const specs = ROOTS.map((r) => `${r.name}@${r.version}`);
     log(`resolving dependency closure of: ${specs.join(", ")}`);
-    // Peer and optional deps stay in so the bundle covers everything npm
-    // would install for a connected user (--omit=dev is belt-and-braces; it
-    // only affects the throwaway root, which has no dev deps).
-    npm(
-        ["install", ...specs, "--ignore-scripts", "--no-audit", "--no-fund", "--omit=dev"],
-        projectDir,
-    );
+    writeFileSync(join(workDir, "package.json"), '{"name":"airgap-resolve","private":true}\n');
+    npm(["install", ...specs, "--ignore-scripts", "--no-audit", "--no-fund"], workDir);
 
-    const lock = JSON.parse(
-        readFileSync(join(projectDir, "package-lock.json"), "utf-8"),
-    );
-    const seen = new Map();
+    const lock = JSON.parse(readFileSync(join(workDir, "package-lock.json"), "utf-8"));
+    const closure = new Map();
     for (const [path, entry] of Object.entries(lock.packages)) {
         if (path === "") continue; // the throwaway root project
-        if (!path.includes("node_modules/")) {
-            throw new Error(`Unexpected non-registry lockfile entry: ${path}`);
-        }
-        // Every entry must have come from the registry — a git/file/link
-        // resolution would make `npm pack name@version` fetch a different
-        // artifact than what the closure actually resolved.
-        if (entry.resolved && !entry.resolved.startsWith(REGISTRY)) {
-            throw new Error(
-                `${path} resolved outside ${REGISTRY}: ${entry.resolved}`,
-            );
-        }
-        // Lockfile keys are node_modules paths; the package name is everything
-        // after the last "node_modules/" (covers nested dedup copies).
-        // entry.name (set for npm-aliased deps) wins over the path-derived
-        // alias so `npm pack` fetches the real package.
-        const name =
-            entry.name ??
-            path.slice(path.lastIndexOf("node_modules/") + "node_modules/".length);
-        if (!entry.version) {
-            throw new Error(`Lockfile entry for ${name} has no version`);
-        }
-        seen.set(`${name}@${entry.version}`, { name, version: entry.version });
+        // Name = segment after the last node_modules/ (covers nested dedup
+        // copies); entry.name (set for npm-aliased deps) wins over the alias.
+        const name = entry.name ?? path.slice(path.lastIndexOf(NM) + NM.length);
+        closure.set(`${name}@${entry.version}`, { name, version: entry.version });
     }
-    return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
-}
+    log(`closure resolved: ${closure.size} packages`);
 
-/** Fetch the published tarball for name@version into OUT_DIR via npm pack. */
-function packPublished(pkg, workDir) {
-    // --ignore-scripts is a no-op for registry specs today (npm only runs
-    // lifecycle scripts when packing local/git specs) but keeps the
-    // no-code-execution invariant explicit.
-    const output = npm(
-        ["pack", `${pkg.name}@${pkg.version}`, "--pack-destination", OUT_DIR, "--ignore-scripts"],
-        workDir,
+    const packages = [...closure.values()]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((pkg) => {
+            // npm pack prints the generated filename as its last stdout line.
+            // --ignore-scripts is a no-op for registry specs, kept so the
+            // no-code-execution invariant stays explicit.
+            const tarball = npm(
+                ["pack", `${pkg.name}@${pkg.version}`, "--pack-destination", OUT_DIR, "--ignore-scripts"],
+                workDir,
+            )
+                .split("\n")
+                .pop()
+                .trim();
+            log(`  packed ${pkg.name}@${pkg.version} -> ${tarball}`);
+            return { ...pkg, tarball };
+        });
+
+    const roots = ROOTS.map(({ name }) => ({
+        name,
+        version: packages.find((pkg) => pkg.name === name).version,
+    }));
+    writeFileSync(
+        join(OUT_DIR, "manifest.json"),
+        `${JSON.stringify(
+            { generatedAt: new Date().toISOString(), registry: REGISTRY, roots, packages },
+            null,
+            2,
+        )}\n`,
     );
-    // npm pack prints the generated filename as its last stdout line.
-    const tarball = output.split("\n").pop().trim();
-    if (!tarball || !existsSync(join(OUT_DIR, tarball))) {
-        throw new Error(`npm pack produced no tarball for ${pkg.name}@${pkg.version}`);
-    }
-    log(`  packed ${pkg.name}@${pkg.version} -> ${tarball}`);
-    return tarball;
-}
-
-function writeReadme(packages, roots) {
-    const rootLines = roots
-        .map((root) => `- \`${root.name}@${root.resolvedVersion}\``)
-        .join("\n");
-    const readme = `# UiPath TypeScript SDK — air-gapped bundle
+    writeFileSync(
+        join(OUT_DIR, "README.md"),
+        `# UiPath TypeScript SDK — air-gapped bundle
 
 Published npm tarballs for:
 
-${rootLines}
+${roots.map((r) => `- \`${r.name}@${r.version}\``).join("\n")}
 
-plus every transitive runtime dependency (${packages.length} tarballs total —
-see \`manifest.json\`). All tarballs are the exact bits published to
-registry.npmjs.org.
+plus every transitive runtime dependency (${packages.length} tarballs total — see
+\`manifest.json\`). All tarballs are the exact bits published to registry.npmjs.org.
 
 ## Installing without registry access
 
 **Option A (recommended): publish into your internal npm registry**
-(Artifactory, Nexus, Verdaccio, ...), then install normally:
+(Artifactory, Nexus, Verdaccio, ...), then install normally. Make sure your
+\`.npmrc\` routes the \`@uipath\` scope to that registry:
 
 \`\`\`bash
-for t in *.tgz; do
-  npm publish "./$t" --registry=https://<your-internal-registry>/
-done
+for t in *.tgz; do npm publish "./$t" --registry=https://<your-internal-registry>/; done
 \`\`\`
 
-Make sure your project's \`.npmrc\` routes the \`@uipath\` scope to that
-registry and does not override it per command.
-
-**Option B: install the tarballs directly, fully offline** — seed npm's
-cache from the tarballs, then install every tarball in one command with
-\`--offline\` so npm never queries a registry:
+**Option B: install the tarballs directly, fully offline** — seed npm's cache,
+then install every tarball in one command with \`--offline\` so npm never
+queries a registry (without \`--offline\` npm still fetches dependency metadata
+and hangs when the registry is blocked):
 
 \`\`\`bash
 for t in *.tgz; do npm cache add "./$t"; done
 npm install ./*.tgz --offline
 \`\`\`
 
-Both steps are required: without \`--offline\` npm still fetches dependency
-metadata from the registry (and hangs when it is blocked), and \`--offline\`
-resolves only from the cache seeded in the first step.
-
-Option A is the robust path: it keeps normal \`npm install\` semantics for
-every project. Option B pins the whole closure as direct dependencies of one
-project and must be repeated per project.
-
-> Note: this bundle covers only the UiPath SDK packages and their
-> dependencies. Third-party toolchain packages (vite, react, tailwind, ...)
-> are not included — they come from your internal registry mirror.
-`;
-    writeFileSync(join(OUT_DIR, "README.md"), readme);
+> Third-party toolchain packages (vite, react, tailwind, ...) are not included —
+> those come from your internal registry mirror.
+`,
+    );
+    log(`bundle written to ${OUT_DIR} (${packages.length} tarballs)`);
+} finally {
+    rmSync(workDir, { recursive: true, force: true });
 }
-
-function main() {
-    prepareOutDir();
-    const workDir = mkdtempSync(join(tmpdir(), "airgap-bundle-"));
-
-    try {
-        const closure = resolveClosure(workDir);
-        log(`closure resolved: ${closure.length} packages`);
-
-        const packages = closure.map((pkg) => ({
-            ...pkg,
-            tarball: packPublished(pkg, workDir),
-        }));
-
-        const roots = ROOTS.map((root) => ({
-            ...root,
-            resolvedVersion: closure.find((pkg) => pkg.name === root.name)?.version,
-        }));
-        for (const root of roots) {
-            if (!root.resolvedVersion) {
-                throw new Error(`Root package ${root.name} missing from closure`);
-            }
-        }
-
-        const manifest = {
-            generatedAt: new Date().toISOString(),
-            registry: REGISTRY,
-            roots: roots.map(({ name, resolvedVersion }) => ({
-                name,
-                version: resolvedVersion,
-            })),
-            packageCount: packages.length,
-            packages,
-        };
-        writeFileSync(
-            join(OUT_DIR, "manifest.json"),
-            `${JSON.stringify(manifest, null, 2)}\n`,
-        );
-        writeReadme(packages, roots);
-
-        log(`bundle written to ${OUT_DIR} (${packages.length} tarballs)`);
-    } finally {
-        rmSync(workDir, { recursive: true, force: true });
-    }
-}
-
-main();

--- a/scripts/airgap/build-airgap-bundle.mjs
+++ b/scripts/airgap/build-airgap-bundle.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+/**
+ * Build an air-gapped bundle of the UiPath TypeScript SDKs: the exact
+ * published npm tarballs for @uipath/uipath-typescript and
+ * @uipath/coded-action-app plus every transitive runtime dependency
+ * (@uipath/core-telemetry, socket.io-client chain, ...), with a manifest and
+ * an offline-install README.
+ *
+ * The dependency closure is resolved by npm itself — a throwaway project is
+ * installed with both roots and the lockfile is walked — so nothing is
+ * hand-listed and the bundle can never miss a newly added dependency.
+ * Every tarball is then fetched from the public registry via `npm pack`,
+ * so the bundle contains the published bits, not a local rebuild.
+ *
+ * Env:
+ *   OUT_DIR      output directory for tarballs + manifest + README (required)
+ *   SDK_VERSION  version of @uipath/uipath-typescript (default: latest)
+ *   CAA_VERSION  version of @uipath/coded-action-app (default: latest)
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, parse, resolve } from "node:path";
+
+const REGISTRY = "https://registry.npmjs.org/";
+
+// Resolved eagerly: npm commands below run from a temp cwd, so a relative
+// OUT_DIR would otherwise mean different directories to fs calls and to
+// `npm pack --pack-destination`.
+const OUT_DIR = process.env.OUT_DIR ? resolve(process.env.OUT_DIR) : undefined;
+if (!OUT_DIR) {
+    throw new Error("OUT_DIR env var is required (the bundle output directory)");
+}
+
+// Exact semver (prerelease allowed) or the literal "latest". Validated before
+// the value reaches any npm command line.
+const SAFE_VERSION = /^(latest|\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?)$/;
+
+const ROOTS = [
+    {
+        name: "@uipath/uipath-typescript",
+        version: process.env.SDK_VERSION || "latest",
+    },
+    {
+        name: "@uipath/coded-action-app",
+        version: process.env.CAA_VERSION || "latest",
+    },
+];
+for (const root of ROOTS) {
+    if (!SAFE_VERSION.test(root.version)) {
+        throw new Error(`Invalid version for ${root.name}: "${root.version}"`);
+    }
+}
+
+const log = (message) => console.log(`[airgap-bundle] ${message}`);
+
+/**
+ * Wiping OUT_DIR is only safe when it is clearly ours: missing, empty, or a
+ * previous bundle (has manifest.json). Anything else — including obviously
+ * catastrophic paths — is refused rather than deleted.
+ */
+function prepareOutDir() {
+    if (OUT_DIR === parse(OUT_DIR).root || OUT_DIR === homedir()) {
+        throw new Error(`Refusing to use OUT_DIR=${OUT_DIR}`);
+    }
+    if (existsSync(OUT_DIR)) {
+        const entries = readdirSync(OUT_DIR);
+        if (entries.length > 0 && !entries.includes("manifest.json")) {
+            throw new Error(
+                `OUT_DIR ${OUT_DIR} exists and is not a previous bundle — refusing to wipe it`,
+            );
+        }
+        rmSync(OUT_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(OUT_DIR, { recursive: true });
+}
+
+// All npm calls run from a temp cwd (never the repo — its .npmrc routes
+// @uipath to GitHub Packages). The scoped override is still required because
+// a user-level ~/.npmrc @uipath:registry mapping beats the generic --registry
+// flag and would silently source the @uipath tarballs from the wrong registry.
+function npm(args, cwd) {
+    return execFileSync(
+        "npm",
+        [...args, `--registry=${REGISTRY}`, `--@uipath:registry=${REGISTRY}`],
+        {
+            cwd,
+            encoding: "utf-8",
+            stdio: ["ignore", "pipe", "inherit"],
+        },
+    ).trim();
+}
+
+/**
+ * Resolve the full dependency closure of the root packages: install them into
+ * a throwaway project (scripts disabled — nothing in the closure needs to
+ * execute at resolve time) and read the exact name@version set from the
+ * lockfile. Returns [{name, version}] sorted by name, roots included.
+ */
+function resolveClosure(workDir) {
+    const projectDir = join(workDir, "resolve");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+        join(projectDir, "package.json"),
+        `${JSON.stringify({ name: "airgap-resolve", private: true }, null, 2)}\n`,
+    );
+
+    const specs = ROOTS.map((root) => `${root.name}@${root.version}`);
+    log(`resolving dependency closure of: ${specs.join(", ")}`);
+    // Peer and optional deps stay in so the bundle covers everything npm
+    // would install for a connected user (--omit=dev is belt-and-braces; it
+    // only affects the throwaway root, which has no dev deps).
+    npm(
+        ["install", ...specs, "--ignore-scripts", "--no-audit", "--no-fund", "--omit=dev"],
+        projectDir,
+    );
+
+    const lock = JSON.parse(
+        readFileSync(join(projectDir, "package-lock.json"), "utf-8"),
+    );
+    const seen = new Map();
+    for (const [path, entry] of Object.entries(lock.packages)) {
+        if (path === "") continue; // the throwaway root project
+        if (!path.includes("node_modules/")) {
+            throw new Error(`Unexpected non-registry lockfile entry: ${path}`);
+        }
+        // Every entry must have come from the registry — a git/file/link
+        // resolution would make `npm pack name@version` fetch a different
+        // artifact than what the closure actually resolved.
+        if (entry.resolved && !entry.resolved.startsWith(REGISTRY)) {
+            throw new Error(
+                `${path} resolved outside ${REGISTRY}: ${entry.resolved}`,
+            );
+        }
+        // Lockfile keys are node_modules paths; the package name is everything
+        // after the last "node_modules/" (covers nested dedup copies).
+        // entry.name (set for npm-aliased deps) wins over the path-derived
+        // alias so `npm pack` fetches the real package.
+        const name =
+            entry.name ??
+            path.slice(path.lastIndexOf("node_modules/") + "node_modules/".length);
+        if (!entry.version) {
+            throw new Error(`Lockfile entry for ${name} has no version`);
+        }
+        seen.set(`${name}@${entry.version}`, { name, version: entry.version });
+    }
+    return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Fetch the published tarball for name@version into OUT_DIR via npm pack. */
+function packPublished(pkg, workDir) {
+    // --ignore-scripts is a no-op for registry specs today (npm only runs
+    // lifecycle scripts when packing local/git specs) but keeps the
+    // no-code-execution invariant explicit.
+    const output = npm(
+        ["pack", `${pkg.name}@${pkg.version}`, "--pack-destination", OUT_DIR, "--ignore-scripts"],
+        workDir,
+    );
+    // npm pack prints the generated filename as its last stdout line.
+    const tarball = output.split("\n").pop().trim();
+    if (!tarball || !existsSync(join(OUT_DIR, tarball))) {
+        throw new Error(`npm pack produced no tarball for ${pkg.name}@${pkg.version}`);
+    }
+    log(`  packed ${pkg.name}@${pkg.version} -> ${tarball}`);
+    return tarball;
+}
+
+function writeReadme(packages, roots) {
+    const rootLines = roots
+        .map((root) => `- \`${root.name}@${root.resolvedVersion}\``)
+        .join("\n");
+    const readme = `# UiPath TypeScript SDK — air-gapped bundle
+
+Published npm tarballs for:
+
+${rootLines}
+
+plus every transitive runtime dependency (${packages.length} tarballs total —
+see \`manifest.json\`). All tarballs are the exact bits published to
+registry.npmjs.org.
+
+## Installing without registry access
+
+**Option A (recommended): publish into your internal npm registry**
+(Artifactory, Nexus, Verdaccio, ...), then install normally:
+
+\`\`\`bash
+for t in *.tgz; do
+  npm publish "./$t" --registry=https://<your-internal-registry>/
+done
+\`\`\`
+
+Make sure your project's \`.npmrc\` routes the \`@uipath\` scope to that
+registry and does not override it per command.
+
+**Option B: install the tarballs directly, fully offline** — seed npm's
+cache from the tarballs, then install every tarball in one command with
+\`--offline\` so npm never queries a registry:
+
+\`\`\`bash
+for t in *.tgz; do npm cache add "./$t"; done
+npm install ./*.tgz --offline
+\`\`\`
+
+Both steps are required: without \`--offline\` npm still fetches dependency
+metadata from the registry (and hangs when it is blocked), and \`--offline\`
+resolves only from the cache seeded in the first step.
+
+Option A is the robust path: it keeps normal \`npm install\` semantics for
+every project. Option B pins the whole closure as direct dependencies of one
+project and must be repeated per project.
+
+> Note: this bundle covers only the UiPath SDK packages and their
+> dependencies. Third-party toolchain packages (vite, react, tailwind, ...)
+> are not included — they come from your internal registry mirror.
+`;
+    writeFileSync(join(OUT_DIR, "README.md"), readme);
+}
+
+function main() {
+    prepareOutDir();
+    const workDir = mkdtempSync(join(tmpdir(), "airgap-bundle-"));
+
+    try {
+        const closure = resolveClosure(workDir);
+        log(`closure resolved: ${closure.length} packages`);
+
+        const packages = closure.map((pkg) => ({
+            ...pkg,
+            tarball: packPublished(pkg, workDir),
+        }));
+
+        const roots = ROOTS.map((root) => ({
+            ...root,
+            resolvedVersion: closure.find((pkg) => pkg.name === root.name)?.version,
+        }));
+        for (const root of roots) {
+            if (!root.resolvedVersion) {
+                throw new Error(`Root package ${root.name} missing from closure`);
+            }
+        }
+
+        const manifest = {
+            generatedAt: new Date().toISOString(),
+            registry: REGISTRY,
+            roots: roots.map(({ name, resolvedVersion }) => ({
+                name,
+                version: resolvedVersion,
+            })),
+            packageCount: packages.length,
+            packages,
+        };
+        writeFileSync(
+            join(OUT_DIR, "manifest.json"),
+            `${JSON.stringify(manifest, null, 2)}\n`,
+        );
+        writeReadme(packages, roots);
+
+        log(`bundle written to ${OUT_DIR} (${packages.length} tarballs)`);
+    } finally {
+        rmSync(workDir, { recursive: true, force: true });
+    }
+}
+
+main();

--- a/scripts/airgap/build-airgap-bundle.mjs
+++ b/scripts/airgap/build-airgap-bundle.mjs
@@ -102,10 +102,11 @@ try {
             return { ...pkg, tarball };
         });
 
-    const roots = ROOTS.map(({ name }) => ({
-        name,
-        version: packages.find((pkg) => pkg.name === name).version,
-    }));
+    const roots = ROOTS.map(({ name }) => {
+        const found = packages.find((pkg) => pkg.name === name);
+        if (!found) throw new Error(`Root package ${name} not found in resolved closure`);
+        return { name, version: found.version };
+    });
     writeFileSync(
         join(OUT_DIR, "manifest.json"),
         `${JSON.stringify(


### PR DESCRIPTION
## Summary

Adopts the release-asset pattern from [`UiPath/cli`'s `export-airgapped.yml`](https://github.com/UiPath/cli/blob/main/.github/workflows/export-airgapped.yml) so air-gapped / registry-restricted customers can install the SDKs from a GitHub release asset instead of npm ([customer escalation](https://uipath-product.slack.com/archives/C0APWF020DN/p1785309458572639?thread_ts=1784723385.674109&cid=C0APWF020DN)).

**`publish.yml` is untouched** and the release flow is preserved: draft notes are written and published by a human, as today. Publishing the draft fires the new workflow.

### New `export-airgap-bundle.yml` — build → verify → attach (the cli pattern)

Runs **only** on `release: published` (the release tag = SDK version), so it takes effect for releases published after this merges — see Backfill below for earlier ones. Publishing the draft is the human approval; the workflow is not manually runnable and publishes nothing to any registry — its only side effect is attaching the bundle to the release that fired it.

- **Build**: `scripts/airgap/build-airgap-bundle.mjs` packs the **published** tarballs for `@uipath/uipath-typescript` + `@uipath/coded-action-app` **plus their full transitive dependency closure** (currently 19 tarballs — resolved by npm via lockfile walk, so the set tracks dependency changes automatically — nothing hand-listed) with a manifest + offline-install README.
- **Verify**: publishes every tarball into a throwaway **no-uplink localhost Verdaccio** and installs both SDKs from it alone — an incomplete bundle can never reach a release.
- **Attach**: uploads the bundle ZIP to the release (one asset, matching the cli approach — the SDK tarball ships inside the bundle, registry-fetched so byte-identical to what npm serves). Never creates releases or tags.

### Differences from the cli repo
- One platform-neutral bundle instead of per-OS archives (all closure packages are pure JS).
- Verify uses no uplinks at all (cli proxies third-party to npmjs) — completeness is tested strictly.
- No manual dispatch: cli keeps one for dev builds; here release-publication is the single entry point, so no environment gate is needed (per review discussion).

## Permissions
All inside the new workflow: `build` = `contents: read`, `verify` = none, `attach` = `contents: write` (job-scoped; releases have no narrower scope). `publish.yml` unchanged.

## Testing (all local)
- Bundle build against live npm; full Verdaccio verify flow (publish 19 tarballs, install + load both SDKs from it alone).
- Cache-based offline install (`npm cache add` + `npm install ./*.tgz --offline`) against an unreachable registry.
- YAML + oxlint clean.

## Backfill (e.g. 1.5.5)
One-off local run: `OUT_DIR=./bundle SDK_VERSION=1.5.5 node scripts/airgap/build-airgap-bundle.mjs`, zip, `gh release upload 1.5.5 ...`.

