### PR TITLE
fix: update Quick Reference Table

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -122,10 +122,11 @@ console.log(`Total count: ${allAssets.totalCount}`);
 | Assets | `getAll()` | ✅ Yes |
 | Buckets | `getAll()` | ✅ Yes |
 | Buckets | `getFiles()` | ✅ Yes |
+| Buckets | `getFileMetaData()` | ❌ No |
 | Jobs | `getAll()` | ✅ Yes |
-| Entities | `getAll()` | ✅ Yes |
 | Entities | `getAllRecords()` | ✅ Yes |
 | Entities | `queryRecordsById()` | ✅ Yes |
+| ChoiceSets | `getById()` | ✅ Yes |
 | Processes | `getAll()` | ✅ Yes |
 | ProcessInstances | `getAll()` | ❌ No |
 | CaseInstances | `getAll()` | ❌ No |
@@ -138,6 +139,4 @@ console.log(`Total count: ${allAssets.totalCount}`);
 | ConversationalAgent.exchanges | `getAll()` | ❌ No |
 | Feedback | `getAll()` | ✅ Yes |
 | Feedback | `getCategories()` | ✅ Yes |
-| Traces | `getById()` | ❌ No |
-| Traces | `getSpansByIds()` | ❌ No |
 | Governance | `getPolicyTraces()` | ✅ Yes |


### PR DESCRIPTION
Added Buckets' `getFileMetaData()` and  ChoiceSets' `getById()` 
 Removed the methods which dont support pagination at all. 