### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.5.5",
+    "version": "1.5.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.5.5",
+            "version": "1.5.6",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.5.6",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.5.6",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.5.5",
+    "version": "1.5.6",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.5.6",
+    "version": "1.6.0",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.5.5",
+  "sdkVersion": "1.5.6",
   "services": [
     {
       "name": "AgentMemory",

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.5.6",
+  "sdkVersion": "1.6.0",
   "services": [
     {
       "name": "AgentMemory",


### PR DESCRIPTION
## Summary

Version bump `1.5.5` → `1.6.0` for today's release. Merge **after** #627 so the new release automatically gets the air-gapped bundle attached when the draft notes are published.

**Why minor, not patch:** #619 renamed public fields on the Data Fabric entity schema APIs — `fieldName` → `name` in `EntityCreateFieldOptions` / `EntityRemoveFieldOptions` (inputs), and `isInsightsEnabled` → `isAnalyticsEnabled` on entity get responses. Additionally, #604 changed the required OAuth scopes for the two traces governance methods (`Traces.Api` now required). These are breaking for existing callers, so the release carries a Breaking Changes section (below) and a minor bump.

`release-metadata.json` regenerates automatically on this PR — no manual edit.

## Draft release notes (1.6.0)

Copy-paste content for the draft release, following the 1.4.0/1.5.0 format for minors with breaking changes:

````markdown
### New Features & Improvements

- Added `getVariables()` to CaseInstances, matching the existing `ProcessInstances.getVariables()` (#626)
- The published package now includes `release-metadata.json`, which maps each service and method to the SDK version that introduced it (#611)
- Release assets now include an air-gapped bundle containing `@uipath/uipath-typescript`, `@uipath/coded-action-app`, and all their dependencies for installation without public npm access (#627)

---

### Bug Fixes

- Fixed multi-join entity queries silently returning un-joined results, the SDK now routes multi-join requests to the correct endpoint (#591)

---

### Breaking Changes

- **`getGovernanceDecisions()` and `getGovernanceSummary()` now require the `Traces.Api` OAuth scope** (#604). Existing external apps must add `Traces.Api` to their scopes; the previously required scopes are unchanged.

- **Entity field definitions now use `name` instead of `fieldName`** (#619). Applies to field objects passed to `Entities.create()` and to remove-field options on entity updates:

  ```typescript
  // Before (1.5.x)
  { fieldName: "product_name", type: EntityFieldDataType.STRING }
  // After (1.6.0)
  { name: "product_name", type: EntityFieldDataType.STRING }
  ```

- **Entity get responses now return `isAnalyticsEnabled` instead of `isInsightsEnabled`** (#619).

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.5.5...1.6.0
````

Excluded as not user-facing: #517 (internal), #621/#602/#615/#598 (docs), #606 (sample app), #595/#624 (CI/chore).

