### PR TITLE
feat: make client side tools public and available with examples

### DIFF
--- a/src/models/conversational-agent/conversational-agent.models.ts
+++ b/src/models/conversational-agent/conversational-agent.models.ts
@@ -99,6 +99,56 @@ import type { ConnectionStatus } from '@/core/websocket';
  * const exchanges = await conversation.exchanges.getAll();
  * ```
  *
+ * ## Client-side tools
+ *
+ * Agents can define tools that execute locally in the client rather than on the server.
+ * When starting an exchange, pass `clientSideTools` to declare which tools this client
+ * supports. The names must match tools defined in the agent's design-time configuration.
+ * Only the declared subset is routed to the client — omitting a tool means the server
+ * handles it (or skips it). This lets each client advertise only the tools it can run.
+ *
+ * When the agent invokes a client-side tool, the SDK fires `onExecutingToolCall` with
+ * the final input. The client executes the tool locally and returns the result via
+ * `sendToolCallEnd`.
+ *
+ * ```typescript
+ * import { ConversationalAgent } from '@uipath/uipath-typescript/conversational-agent';
+ *
+ * const conversationalAgent = new ConversationalAgent(sdk);
+ * const agents = await conversationalAgent.getAll();
+ * const conversation = await agents[0].conversations.create({ label: 'Client Tools Demo' });
+ * const session = conversation.startSession();
+ *
+ * // 1. Listen for tool calls and handle client-side tools
+ * session.onExchangeStart((exchange) => {
+ *   exchange.onMessageStart((message) => {
+ *     message.onToolCallStart((toolCall) => {
+ *       const { isClientSideTool, toolName } = toolCall.startEvent;
+ *       if (!isClientSideTool) return;
+ *
+ *       // 2. Execute when the server signals the tool is ready
+ *       toolCall.onExecutingToolCall(async (event) => {
+ *         const result = await runClientTool(toolName, event.input);
+ *         toolCall.sendToolCallEnd({ output: JSON.stringify(result) });
+ *       });
+ *     });
+ *   });
+ * });
+ *
+ * session.onSessionStarted(() => {
+ *   // 3. Declare the subset of client-side tools this client supports
+ *   //    The agent may define more tools, but only these will be routed here
+ *   const exchange = session.startExchange({
+ *     clientSideTools: [
+ *       { name: 'get_user_location' },
+ *       { name: 'get_clipboard_contents' },
+ *     ],
+ *   });
+ *
+ *   exchange.sendMessageWithContentPart({ data: 'What is the weather near me?' });
+ * });
+ * ```
+ *
  * ## App-scoped authentication (anonymous, sign-in-free chat)
  *
  * Conversational Agents can be driven with an **app-scoped token** — one issued to an

--- a/src/models/conversational-agent/conversations/types/events/protocol.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/protocol.types.ts
@@ -90,13 +90,17 @@ export interface SessionEndingEvent {
 }
 
 /**
- * A client-side tool that the client supports, declared during exchange start
- * so the server knows which tools to route client-side.
- * @internal
+ * A client-side tool declaration passed to {@link ExchangeStartEvent.clientSideTools}
+ * so the server knows which tools to route back to the client for local execution.
+ *
+ * The `name` must match a tool defined in the agent's design-time configuration.
  */
 export interface ClientSideTool {
+  /** Tool name — must match the agent's design-time tool definition */
   name: string;
+  /** JSON Schema describing the tool's expected input */
   inputSchema?: JSONValue;
+  /** JSON Schema describing the tool's expected output */
   outputSchema?: JSONValue;
 }
 
@@ -117,9 +121,10 @@ export interface ExchangeStartEvent {
    */
   timestamp?: string;
   /**
-   * Optional list of client-side tools the client supports. The server validates these against the agent's
-   * design-time definitions and forwards them to the runtime so it knows which tools to route client-side.
-   * @internal
+   * Optional list of client-side tools the client supports. Pass these when calling
+   * `session.startExchange({ clientSideTools: [...] })` so the server routes matching
+   * tool calls back to the client via {@link ToolCallStartEvent.isClientSideTool}.
+   * The server validates names against the agent's design-time tool definitions.
    */
   clientSideTools?: ClientSideTool[];
 }
@@ -391,13 +396,15 @@ export interface ToolCallStartEvent {
    */
   inputSchema?: JSONValue;
   /**
-   * Output schema — used by the client to render the result form for client-side tools.
-   * @internal
+   * JSON Schema describing the tool's expected output. Present on client-side tool calls
+   * so the client can validate or render a form for the result before sending it back
+   * via `sendToolCallEnd`.
    */
   outputSchema?: JSONValue;
   /**
-   * Indicates this tool call should be executed client-side rather than server-side.
-   * @internal
+   * When `true`, this tool call should be executed locally by the client rather than
+   * server-side. The client should listen for {@link ExecutingToolCallEvent} via
+   * `onExecutingToolCall`, run the tool, and return the result with `sendToolCallEnd`.
    */
   isClientSideTool?: boolean;
 }
@@ -442,10 +449,9 @@ export interface ToolCallEndEvent {
 }
 
 /**
- * Signals to the client that the tool is about to be executed. Emitted in all scenarios
- * (server-side and client-side tools). For client-side tools, the client should begin
- * executing its registered handler upon receiving this event.
- * @internal
+ * Signals that the tool is about to be executed. Emitted for both server-side and
+ * client-side tools. For client-side tools, the client should begin executing its
+ * handler upon receiving this event and return the result via `sendToolCallEnd`.
  */
 export interface ExecutingToolCallEvent {
   /**
@@ -501,7 +507,6 @@ export interface ToolCallEvent {
   /**
    * Signals that the tool is about to be executed. For client-side tools,
    * the client should begin executing its handler upon receiving this event.
-   * @internal
    */
   executingToolCall?: ExecutingToolCallEvent;
   /**

--- a/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
+++ b/src/models/conversational-agent/conversations/types/events/tool-call.types.ts
@@ -101,8 +101,8 @@ export type CompletedToolCall = ToolCallStartEvent & ToolCallEndEvent & {
  *   if (!isClientSideTool) return;
  *
  *   toolCall.onExecutingToolCall(async (event) => {
- *     const result = await runLocalProcess(toolName, event.input);
- *     toolCall.sendToolCallEnd({ output: result });
+ *     const result = await runClientTool(toolName, event.input);
+ *     toolCall.sendToolCallEnd({ output: JSON.stringify(result) });
  *   });
  * });
  * ```
@@ -184,19 +184,18 @@ export interface ToolCallStream {
   /**
    * Registers a handler for executingToolCall events. Fired when the tool is about
    * to be executed. For client-side tools, the client should begin executing its
-   * handler upon receiving this event.
+   * handler upon receiving this event and return the result via `sendToolCallEnd`.
    *
-   * @param cb - Callback receiving the executing event
+   * @param cb - Callback receiving the {@link ExecutingToolCallEvent} with the final input
    * @returns Cleanup function to remove the handler
    *
    * @example Handling client-side tool execution
    * ```typescript
    * toolCall.onExecutingToolCall(async (event) => {
-   *   const result = await executeLocally(toolCall.startEvent.toolName, event.input);
-   *   toolCall.sendToolCallEnd({ output: result });
+   *   const result = await runClientTool(toolCall.startEvent.toolName, event.input);
+   *   toolCall.sendToolCallEnd({ output: JSON.stringify(result) });
    * });
    * ```
-   * @internal
    */
   onExecutingToolCall(cb: (event: ExecutingToolCallEvent) => void): () => void;
 

--- a/src/services/conversational-agent/helpers/tool-call-event-helper.ts
+++ b/src/services/conversational-agent/helpers/tool-call-event-helper.ts
@@ -140,7 +140,6 @@ export abstract class ToolCallEventHelper extends ConversationEventHelperBase<
    * Fired when the tool is about to be executed. For client-side tools,
    * the client should begin executing its handler upon receiving this.
    * @returns Cleanup function to remove the handler.
-   * @internal
    */
   public onExecutingToolCall(cb: ExecutingToolCallHandler) {
     this._executingHandlers.push(cb);


### PR DESCRIPTION
Previously internal until client side tools were publicly available. Followup to this PR: https://github.com/UiPath/uipath-typescript/pull/508

Note we still need to change the feature flag to be enabled for all tenants in prod.

Widgets changes are dependent on this PR too

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/080eefb9-0a82-4a76-a74c-cedd5ee2be70" />


<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/2c7b282f-a5a6-493d-a188-adc92db44742" />
