### PR TITLE
ci: tag GitHub Packages-only publishes as dev and require prerelease version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,12 +53,17 @@ jobs:
           echo "Updated telemetry constants with:"
           echo "- SDK_VERSION (from root package): $SDK_VERSION"
 
-      - name: Validate prerelease version
-        if: ${{ inputs.github_packages_only }}
+      - name: Validate version matches publish mode
+        env:
+          GITHUB_PACKAGES_ONLY: ${{ inputs.github_packages_only }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" != *-* ]]; then
+          if [[ "$GITHUB_PACKAGES_ONLY" == "true" && "$VERSION" != *-* ]]; then
             echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
+            exit 1
+          fi
+          if [[ "$GITHUB_PACKAGES_ONLY" != "true" && "$VERSION" == *-* ]]; then
+            echo "::error::refusing to publish prerelease version $VERSION to npm as latest — set github_packages_only=true"
             exit 1
           fi
 
@@ -81,9 +86,10 @@ jobs:
         run: |
           echo "@uipath:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          npm publish --tag ${{ inputs.github_packages_only && 'dev' || 'latest' }}
+          npm publish --tag "$NPM_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TAG: ${{ inputs.github_packages_only && 'dev' || 'latest' }}
 
       - name: Generate Summary
         env:
@@ -172,12 +178,17 @@ jobs:
           echo "Updated telemetry constants with:"
           echo "- CODED_ACTION_APP_SDK_VERSION: $SDK_VERSION"
 
-      - name: Validate prerelease version
-        if: ${{ inputs.github_packages_only }}
+      - name: Validate version matches publish mode
+        env:
+          GITHUB_PACKAGES_ONLY: ${{ inputs.github_packages_only }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" != *-* ]]; then
+          if [[ "$GITHUB_PACKAGES_ONLY" == "true" && "$VERSION" != *-* ]]; then
             echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
+            exit 1
+          fi
+          if [[ "$GITHUB_PACKAGES_ONLY" != "true" && "$VERSION" == *-* ]]; then
+            echo "::error::refusing to publish prerelease version $VERSION to npm as latest — set github_packages_only=true"
             exit 1
           fi
 
@@ -200,9 +211,10 @@ jobs:
         run: |
           echo "@uipath:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          npm publish --tag ${{ inputs.github_packages_only && 'dev' || 'latest' }}
+          npm publish --tag "$NPM_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TAG: ${{ inputs.github_packages_only && 'dev' || 'latest' }}
 
       - name: Generate Summary
         env:
@@ -261,12 +273,17 @@ jobs:
 
           echo "Replaced connection string"
 
-      - name: Validate prerelease version
-        if: ${{ inputs.github_packages_only }}
+      - name: Validate version matches publish mode
+        env:
+          GITHUB_PACKAGES_ONLY: ${{ inputs.github_packages_only }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" != *-* ]]; then
+          if [[ "$GITHUB_PACKAGES_ONLY" == "true" && "$VERSION" != *-* ]]; then
             echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
+            exit 1
+          fi
+          if [[ "$GITHUB_PACKAGES_ONLY" != "true" && "$VERSION" == *-* ]]; then
+            echo "::error::refusing to publish prerelease version $VERSION to npm as latest — set github_packages_only=true"
             exit 1
           fi
 
@@ -292,9 +309,10 @@ jobs:
         run: |
           echo "@uipath:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          npm publish --tag ${{ inputs.github_packages_only && 'dev' || 'latest' }}
+          npm publish --tag "$NPM_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TAG: ${{ inputs.github_packages_only && 'dev' || 'latest' }}
 
       - name: Generate Summary
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,15 @@ jobs:
           echo "Updated telemetry constants with:"
           echo "- SDK_VERSION (from root package): $SDK_VERSION"
 
+      - name: Validate prerelease version
+        if: ${{ inputs.github_packages_only }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" != *-* ]]; then
+            echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
+            exit 1
+          fi
+
       - name: Build
         run: npm run build
 
@@ -72,7 +81,7 @@ jobs:
         run: |
           echo "@uipath:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          npm publish
+          npm publish --tag ${{ inputs.github_packages_only && 'dev' || 'latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -163,6 +172,15 @@ jobs:
           echo "Updated telemetry constants with:"
           echo "- CODED_ACTION_APP_SDK_VERSION: $SDK_VERSION"
 
+      - name: Validate prerelease version
+        if: ${{ inputs.github_packages_only }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" != *-* ]]; then
+            echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
+            exit 1
+          fi
+
       - name: Build
         run: npm run build
 
@@ -182,7 +200,7 @@ jobs:
         run: |
           echo "@uipath:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          npm publish --tag latest
+          npm publish --tag ${{ inputs.github_packages_only && 'dev' || 'latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -243,6 +261,15 @@ jobs:
 
           echo "Replaced connection string"
 
+      - name: Validate prerelease version
+        if: ${{ inputs.github_packages_only }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" != *-* ]]; then
+            echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
+            exit 1
+          fi
+
       - name: Build
         run: npm run build
 
@@ -265,7 +292,7 @@ jobs:
         run: |
           echo "@uipath:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          npm publish --tag latest
+          npm publish --tag ${{ inputs.github_packages_only && 'dev' || 'latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,17 +53,12 @@ jobs:
           echo "Updated telemetry constants with:"
           echo "- SDK_VERSION (from root package): $SDK_VERSION"
 
-      - name: Validate version matches publish mode
-        env:
-          GITHUB_PACKAGES_ONLY: ${{ inputs.github_packages_only }}
+      - name: Validate prerelease version
+        if: ${{ inputs.github_packages_only }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if [[ "$GITHUB_PACKAGES_ONLY" == "true" && "$VERSION" != *-* ]]; then
+          if [[ "$VERSION" != *-* ]]; then
             echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
-            exit 1
-          fi
-          if [[ "$GITHUB_PACKAGES_ONLY" != "true" && "$VERSION" == *-* ]]; then
-            echo "::error::refusing to publish prerelease version $VERSION to npm as latest — set github_packages_only=true"
             exit 1
           fi
 
@@ -178,17 +173,12 @@ jobs:
           echo "Updated telemetry constants with:"
           echo "- CODED_ACTION_APP_SDK_VERSION: $SDK_VERSION"
 
-      - name: Validate version matches publish mode
-        env:
-          GITHUB_PACKAGES_ONLY: ${{ inputs.github_packages_only }}
+      - name: Validate prerelease version
+        if: ${{ inputs.github_packages_only }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if [[ "$GITHUB_PACKAGES_ONLY" == "true" && "$VERSION" != *-* ]]; then
+          if [[ "$VERSION" != *-* ]]; then
             echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
-            exit 1
-          fi
-          if [[ "$GITHUB_PACKAGES_ONLY" != "true" && "$VERSION" == *-* ]]; then
-            echo "::error::refusing to publish prerelease version $VERSION to npm as latest — set github_packages_only=true"
             exit 1
           fi
 
@@ -273,17 +263,12 @@ jobs:
 
           echo "Replaced connection string"
 
-      - name: Validate version matches publish mode
-        env:
-          GITHUB_PACKAGES_ONLY: ${{ inputs.github_packages_only }}
+      - name: Validate prerelease version
+        if: ${{ inputs.github_packages_only }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if [[ "$GITHUB_PACKAGES_ONLY" == "true" && "$VERSION" != *-* ]]; then
+          if [[ "$VERSION" != *-* ]]; then
             echo "::error::github_packages_only=true requires a prerelease version (e.g. 1.2.3-dev.0), but package.json version is $VERSION"
-            exit 1
-          fi
-          if [[ "$GITHUB_PACKAGES_ONLY" != "true" && "$VERSION" == *-* ]]; then
-            echo "::error::refusing to publish prerelease version $VERSION to npm as latest — set github_packages_only=true"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- **`--tag dev` for GitHub Packages-only publishes** — when `github_packages_only` is `true`, `npm publish` to GitHub Packages now uses `--tag dev` so prerelease builds don't take over the `latest` tag. Regular releases keep `--tag latest`.
- **Prerelease version guard** — a new `Validate prerelease version` step fails the workflow (before build/publish) when `github_packages_only=true` but `package.json` doesn't contain a prerelease version (no `-` suffix, e.g. `1.2.3-dev.0`).

Applied consistently to all three jobs (`publish-sdk`, `publish-coded-action-app-sdk`, `publish-telemetry`) since the `github_packages_only` input affects all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)