### PR TITLE
ci: Remove admin approval for publishing to github

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
   publish-sdk:
     if: github.event.inputs.package == 'ts-sdk'
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.github_packages_only && 'github-packages-dev' || 'production' }}
     permissions:
       contents: read
       packages: write
@@ -141,7 +141,7 @@ jobs:
   publish-coded-action-app-sdk:
     if: github.event.inputs.package == 'coded-action-app-sdk'
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.github_packages_only && 'github-packages-dev' || 'production' }}
     permissions:
       contents: read
       packages: write
@@ -232,7 +232,7 @@ jobs:
   publish-telemetry:
     if: github.event.inputs.package == 'telemetry'
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.github_packages_only && 'github-packages-dev' || 'production' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What

Makes the `environment:` on all three publish jobs dynamic:

```yaml
environment: ${{ inputs.github_packages_only && 'github-packages-dev' || 'production' }}
```

## Why

The `production` environment has a required-reviewers protection rule, so **every** run of this workflow waits for admin approval — including `github_packages_only` prerelease publishes that never touch the public npm registry. GitHub evaluates environment gates before the job starts, so the flag alone can't bypass the approval.

With this change:

| Run type | Environment | Admin approval |
|---|---|---|
| Official release (default) | `production` | ✅ still required |
| `github_packages_only` prerelease | `github-packages-dev` | ⏭️ not required |

## Notes

- The existing safeguards on GitHub-only publishes still apply: prerelease version required in `package.json`, npm publish step skipped, `dev` dist-tag, docs/CF-worker jobs skipped.
- The expression uses the typed boolean `inputs` context in a job-level key only — no untrusted input reaches any `run:` script.
- The `github-packages-dev` environment is auto-created (unprotected) by GitHub on the first run that references it; no secrets are environment-scoped, and `GITHUB_TOKEN`'s `packages: write` permission works in any environment. If we ever want to gate prereleases differently, protection rules can be added to `github-packages-dev` later.

## Files

| Area | Files |
|------|-------|
| CI | `.github/workflows/publish.yml` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)