### PR TITLE
feat(integration-service): add folderId/folderPath scoping options [APPS-35792]

### DIFF
--- a/src/models/integration-service/connections.models.ts
+++ b/src/models/integration-service/connections.models.ts
@@ -49,7 +49,11 @@ export interface ConnectionsServiceModel {
    * via `pageIndex`/`pageSize`; there is no continuation cursor, so callers
    * paginate by incrementing `pageIndex` until a short page is returned.
    *
-   * @param options - Folder scoping, paging, sorting, and filter options
+   * Folder scoping is optional — pass `folderId`, `folderKey`, or `folderPath`
+   * to narrow the query. When none is supplied, the folder context the SDK was
+   * initialized with is used.
+   *
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`), paging, sorting, and filter options
    * @returns Promise resolving to an array of {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -77,6 +81,13 @@ export interface ConnectionsServiceModel {
    *   mostRecentFirst: true,
    * });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Scope by folder path or numeric folder ID instead of a key
+   * const byPath = await connections.getAll({ folderPath: 'Shared/Finance' });
+   * const byId = await connections.getAll({ folderId: 123 });
+   * ```
    */
   getAll(options?: ConnectionGetAllOptions): Promise<ConnectionGetResponse[]>;
 
@@ -84,7 +95,7 @@ export interface ConnectionsServiceModel {
    * Get a single connection by ID.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping and optional `includeConfigs` flag
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional `includeConfigs` flag
    * @returns Promise resolving to a {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -105,6 +116,12 @@ export interface ConnectionsServiceModel {
    * // Include the full configuration blob
    * const conn = await connections.getById('<connectionId>', { includeConfigs: true });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Scope the lookup to a folder path
+   * const conn = await connections.getById('<connectionId>', { folderPath: 'Shared/Finance' });
+   * ```
    */
   getById(connectionId: string, options?: ConnectionGetByIdOptions): Promise<ConnectionGetResponse>;
 
@@ -116,7 +133,7 @@ export interface ConnectionsServiceModel {
    * expired or been disabled.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping and `forceRefresh` flag
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and `forceRefresh` flag
    * @returns Promise resolving to a {@link ConnectionPingResponse}
    * @example
    * ```typescript
@@ -145,7 +162,7 @@ export interface ConnectionsServiceModel {
    * refresh consent. The session expires at {@link ConnectionReauthenticateResponse.expiresAt}.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
    * @example
    * ```typescript
@@ -174,7 +191,7 @@ export interface ConnectionMethods {
   /**
    * Check whether this connection is currently active.
    *
-   * @param options - Optional `forceRefresh` flag and folder scoping
+   * @param options - Optional `forceRefresh` flag and folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionPingResponse}
    */
   ping(options?: ConnectionPingOptions): Promise<ConnectionPingResponse>;
@@ -182,7 +199,7 @@ export interface ConnectionMethods {
   /**
    * Start an OAuth re-authentication session for this connection.
    *
-   * @param options - Optional folder scoping
+   * @param options - Optional folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
    */
   reauthenticate(options?: ConnectionReauthenticateOptions): Promise<ConnectionReauthenticateResponse>;

--- a/src/models/integration-service/connections.models.ts
+++ b/src/models/integration-service/connections.models.ts
@@ -49,7 +49,12 @@ export interface ConnectionsServiceModel {
    * via `pageIndex`/`pageSize`; there is no continuation cursor, so callers
    * paginate by incrementing `pageIndex` until a short page is returned.
    *
-   * @param options - Folder scoping, paging, sorting, and filter options
+   * Folder scoping is optional — pass `folderId`, `folderKey`, or `folderPath`
+   * to narrow the query. When none is supplied, the folder context the SDK was
+   * initialized with is used; without one the query spans every folder the
+   * caller can access.
+   *
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`), paging, sorting, and filter options
    * @returns Promise resolving to an array of {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -77,6 +82,16 @@ export interface ConnectionsServiceModel {
    *   mostRecentFirst: true,
    * });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Scope by folder path or numeric folder ID instead of a key
+   * const byPath = await connections.getAll({ folderPath: 'Shared/Finance' });
+   * const byId = await connections.getAll({ folderId: 123 });
+   *
+   * // Or span every folder the caller can access
+   * const everywhere = await connections.getAll({ allFolders: true });
+   * ```
    */
   getAll(options?: ConnectionGetAllOptions): Promise<ConnectionGetResponse[]>;
 
@@ -84,7 +99,7 @@ export interface ConnectionsServiceModel {
    * Get a single connection by ID.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping and optional `includeConfigs` flag
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional `includeConfigs` flag
    * @returns Promise resolving to a {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -105,6 +120,12 @@ export interface ConnectionsServiceModel {
    * // Include the full configuration blob
    * const conn = await connections.getById('<connectionId>', { includeConfigs: true });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Scope the lookup to a folder path
+   * const conn = await connections.getById('<connectionId>', { folderPath: 'Shared/Finance' });
+   * ```
    */
   getById(connectionId: string, options?: ConnectionGetByIdOptions): Promise<ConnectionGetResponse>;
 
@@ -116,7 +137,7 @@ export interface ConnectionsServiceModel {
    * expired or been disabled.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping and `forceRefresh` flag
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and `forceRefresh` flag
    * @returns Promise resolving to a {@link ConnectionPingResponse}
    * @example
    * ```typescript
@@ -145,7 +166,7 @@ export interface ConnectionsServiceModel {
    * refresh consent. The session expires at {@link ConnectionReauthenticateResponse.expiresAt}.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
    * @example
    * ```typescript
@@ -174,7 +195,7 @@ export interface ConnectionMethods {
   /**
    * Check whether this connection is currently active.
    *
-   * @param options - Optional `forceRefresh` flag and folder scoping
+   * @param options - Optional `forceRefresh` flag and folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionPingResponse}
    */
   ping(options?: ConnectionPingOptions): Promise<ConnectionPingResponse>;
@@ -182,7 +203,7 @@ export interface ConnectionMethods {
   /**
    * Start an OAuth re-authentication session for this connection.
    *
-   * @param options - Optional folder scoping
+   * @param options - Optional folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
    */
   reauthenticate(options?: ConnectionReauthenticateOptions): Promise<ConnectionReauthenticateResponse>;

--- a/src/models/integration-service/connections.types.ts
+++ b/src/models/integration-service/connections.types.ts
@@ -4,6 +4,8 @@
  * Types for the Connections API (`connections_/api/v1/Connections`).
  */
 
+import { IntegrationServiceFolderScopedOptions } from './integration-service.types';
+
 /**
  * Lifecycle state of an Integration Service connection.
  */
@@ -102,11 +104,7 @@ export interface RawConnectionGetResponse {
  * The API returns a plain array — pagination is page-indexed via `pageIndex`/`pageSize`.
  * There is no continuation cursor; callers paginate by incrementing `pageIndex`.
  */
-export interface ConnectionGetAllOptions {
-  /** Folder key (GUID) to scope the query to a specific folder. Sent as `x-uipath-folderkey` header. */
-  folderKey?: string;
-  /** Include connections from all folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectionGetAllOptions extends IntegrationServiceFolderScopedOptions {
   /** Include only default connections (one per connector per folder). */
   folderDefaults?: boolean;
   /** 1-indexed page number. */
@@ -124,11 +122,7 @@ export interface ConnectionGetAllOptions {
 /**
  * Options for {@link ConnectionsServiceModel.getById}.
  */
-export interface ConnectionGetByIdOptions {
-  /** Folder key (GUID) to scope the lookup. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectionGetByIdOptions extends IntegrationServiceFolderScopedOptions {
   /** Include the connector's full configuration blob in the response. */
   includeConfigs?: boolean;
 }
@@ -136,11 +130,7 @@ export interface ConnectionGetByIdOptions {
 /**
  * Options for {@link ConnectionsServiceModel.ping}.
  */
-export interface ConnectionPingOptions {
-  /** Folder key (GUID) to scope the lookup. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectionPingOptions extends IntegrationServiceFolderScopedOptions {
   /** Force a live re-validation instead of cached status. */
   forceRefresh?: boolean;
 }
@@ -160,12 +150,7 @@ export interface ConnectionPingResponse {
 /**
  * Options for {@link ConnectionsServiceModel.reauthenticate}.
  */
-export interface ConnectionReauthenticateOptions {
-  /** Folder key (GUID) to scope the operation. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
-}
+export interface ConnectionReauthenticateOptions extends IntegrationServiceFolderScopedOptions {}
 
 /**
  * Response from {@link ConnectionsServiceModel.reauthenticate}.

--- a/src/models/integration-service/connections.types.ts
+++ b/src/models/integration-service/connections.types.ts
@@ -4,6 +4,8 @@
  * Types for the Connections API (`connections_/api/v1/Connections`).
  */
 
+import { IntegrationServiceFolderContextOptions } from './integration-service.types';
+
 /**
  * Lifecycle state of an Integration Service connection.
  */
@@ -102,11 +104,7 @@ export interface RawConnectionGetResponse {
  * The API returns a plain array — pagination is page-indexed via `pageIndex`/`pageSize`.
  * There is no continuation cursor; callers paginate by incrementing `pageIndex`.
  */
-export interface ConnectionGetAllOptions {
-  /** Folder key (GUID) to scope the query to a specific folder. Sent as `x-uipath-folderkey` header. */
-  folderKey?: string;
-  /** Include connections from all folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectionGetAllOptions extends IntegrationServiceFolderContextOptions {
   /** Include only default connections (one per connector per folder). */
   folderDefaults?: boolean;
   /** 1-indexed page number. */
@@ -124,11 +122,7 @@ export interface ConnectionGetAllOptions {
 /**
  * Options for {@link ConnectionsServiceModel.getById}.
  */
-export interface ConnectionGetByIdOptions {
-  /** Folder key (GUID) to scope the lookup. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectionGetByIdOptions extends IntegrationServiceFolderContextOptions {
   /** Include the connector's full configuration blob in the response. */
   includeConfigs?: boolean;
 }
@@ -136,11 +130,7 @@ export interface ConnectionGetByIdOptions {
 /**
  * Options for {@link ConnectionsServiceModel.ping}.
  */
-export interface ConnectionPingOptions {
-  /** Folder key (GUID) to scope the lookup. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectionPingOptions extends IntegrationServiceFolderContextOptions {
   /** Force a live re-validation instead of cached status. */
   forceRefresh?: boolean;
 }
@@ -160,12 +150,7 @@ export interface ConnectionPingResponse {
 /**
  * Options for {@link ConnectionsServiceModel.reauthenticate}.
  */
-export interface ConnectionReauthenticateOptions {
-  /** Folder key (GUID) to scope the operation. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
-}
+export interface ConnectionReauthenticateOptions extends IntegrationServiceFolderContextOptions {}
 
 /**
  * Response from {@link ConnectionsServiceModel.reauthenticate}.

--- a/src/models/integration-service/connectors.models.ts
+++ b/src/models/integration-service/connectors.models.ts
@@ -90,7 +90,7 @@ export interface ConnectorsServiceModel {
    * paging through the full list.
    *
    * @param keyOrId - Connector key or numeric ID as a string
-   * @param options - Folder scoping options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -99,7 +99,7 @@ export interface ConnectorsServiceModel {
    * const connectors = new Connectors(sdk);
    *
    * const defaultSlack = await connectors.getDefaultConnection('uipath-slack', {
-   *   folderKey: '<folderKey>',
+   *   folderPath: 'Shared/Finance',
    * });
    *
    * // Use bound methods directly on the entity
@@ -119,7 +119,7 @@ export interface ConnectorsServiceModel {
    * pagination (no continuation cursor). Increment `pageIndex` to walk pages.
    *
    * @param keyOrId - Connector key or numeric ID as a string
-   * @param options - Folder scoping, paging, and sorting options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`), paging, and sorting options
    * @returns Promise resolving to an array of {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -143,7 +143,7 @@ export interface ConnectorsServiceModel {
    * ```typescript
    * // Walk subsequent pages
    * const page2 = await connectors.getConnections('uipath-slack', {
-   *   folderKey: '<folderKey>',
+   *   folderId: 123,
    *   pageSize: 25,
    *   pageIndex: 2,
    * });

--- a/src/models/integration-service/connectors.types.ts
+++ b/src/models/integration-service/connectors.types.ts
@@ -4,6 +4,8 @@
  * Types for the Connectors API (`connections_/api/v1/Connectors`).
  */
 
+import { IntegrationServiceFolderScopedOptions } from './integration-service.types';
+
 /**
  * Lifecycle stage of a connector.
  */
@@ -95,12 +97,7 @@ export interface ConnectorGetAllOptions {
 /**
  * Options for {@link ConnectorsServiceModel.getDefaultConnection}.
  */
-export interface ConnectorGetDefaultConnectionOptions {
-  /** Folder key (GUID) to scope the lookup. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
-}
+export interface ConnectorGetDefaultConnectionOptions extends IntegrationServiceFolderScopedOptions {}
 
 /**
  * Options for {@link ConnectorsServiceModel.getConnections}.
@@ -108,11 +105,7 @@ export interface ConnectorGetDefaultConnectionOptions {
  * The API returns a plain array — pagination is page-indexed via `pageIndex`/`pageSize`.
  * There is no continuation cursor; callers paginate by incrementing `pageIndex`.
  */
-export interface ConnectorGetConnectionsOptions {
-  /** Folder key (GUID) to scope the query to a specific folder. */
-  folderKey?: string;
-  /** Include connections from all folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectorGetConnectionsOptions extends IntegrationServiceFolderScopedOptions {
   /** Include only default connections. */
   folderDefaults?: boolean;
   /** 1-indexed page number. */

--- a/src/models/integration-service/connectors.types.ts
+++ b/src/models/integration-service/connectors.types.ts
@@ -4,6 +4,8 @@
  * Types for the Connectors API (`connections_/api/v1/Connectors`).
  */
 
+import { IntegrationServiceFolderContextOptions } from './integration-service.types';
+
 /**
  * Lifecycle stage of a connector.
  */
@@ -95,12 +97,7 @@ export interface ConnectorGetAllOptions {
 /**
  * Options for {@link ConnectorsServiceModel.getDefaultConnection}.
  */
-export interface ConnectorGetDefaultConnectionOptions {
-  /** Folder key (GUID) to scope the lookup. */
-  folderKey?: string;
-  /** Search across folders the caller has access to. */
-  allFolders?: boolean;
-}
+export interface ConnectorGetDefaultConnectionOptions extends IntegrationServiceFolderContextOptions {}
 
 /**
  * Options for {@link ConnectorsServiceModel.getConnections}.
@@ -108,11 +105,7 @@ export interface ConnectorGetDefaultConnectionOptions {
  * The API returns a plain array — pagination is page-indexed via `pageIndex`/`pageSize`.
  * There is no continuation cursor; callers paginate by incrementing `pageIndex`.
  */
-export interface ConnectorGetConnectionsOptions {
-  /** Folder key (GUID) to scope the query to a specific folder. */
-  folderKey?: string;
-  /** Include connections from all folders the caller has access to. */
-  allFolders?: boolean;
+export interface ConnectorGetConnectionsOptions extends IntegrationServiceFolderContextOptions {
   /** Include only default connections. */
   folderDefaults?: boolean;
   /** 1-indexed page number. */

--- a/src/models/integration-service/execution.types.ts
+++ b/src/models/integration-service/execution.types.ts
@@ -2,6 +2,8 @@
  * Integration Service — Execution passthrough types.
  */
 
+import { IntegrationServiceFolderContextOptions } from './integration-service.types';
+
 /**
  * HTTP method for an execute call.
  */
@@ -32,11 +34,9 @@ export interface ExecuteResult {
 /**
  * Options accepted by {@link execute}.
  */
-export interface ExecuteOptions {
+export interface ExecuteOptions extends IntegrationServiceFolderContextOptions {
   /** Body to send for POST/PUT/PATCH. Serialized as JSON. */
   body?: unknown;
   /** Query string parameters. */
   queryParams?: Record<string, string>;
-  /** Folder key (GUID) to scope the call via `x-uipath-folderkey`. */
-  folderKey?: string;
 }

--- a/src/models/integration-service/index.ts
+++ b/src/models/integration-service/index.ts
@@ -4,6 +4,7 @@
  * Internal-types files are intentionally not re-exported.
  */
 
+export * from './integration-service.types';
 export * from './connectors.types';
 export * from './connectors.models';
 export * from './connections.types';

--- a/src/models/integration-service/integration-service.types.ts
+++ b/src/models/integration-service/integration-service.types.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared types for the Integration Service domain — used by Connections,
+ * Connectors, and the Execution passthrough. Lives here (not in a single
+ * service's `*.types.ts`) to avoid cross-service coupling between siblings.
+ */
+
+/**
+ * Folder context accepted by folder-scoped Integration Service methods.
+ * Provide one of `folderId`, `folderKey`, or `folderPath`. When more than one
+ * is supplied, all are forwarded; the server applies precedence
+ * `folderPath` > `folderKey` > `folderId`.
+ *
+ * Folder context is optional — omit it to fall back to the folder context the
+ * SDK was initialized with.
+ */
+export interface IntegrationServiceFolderContextOptions {
+  /** Numeric folder ID. */
+  folderId?: number;
+  /** Folder key (GUID-formatted string). */
+  folderKey?: string;
+  /** Slash-delimited folder path, e.g. `'Shared/Finance'`. */
+  folderPath?: string;
+}

--- a/src/models/integration-service/integration-service.types.ts
+++ b/src/models/integration-service/integration-service.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared types for the Integration Service domain — used by Connections,
+ * Connectors, and the Execution passthrough. Lives here (not in a single
+ * service's `*.types.ts`) to avoid cross-service coupling between siblings.
+ */
+
+/**
+ * Folder context accepted by folder-scoped Integration Service methods.
+ * Provide one of `folderId`, `folderKey`, or `folderPath`. When more than one
+ * is supplied, all are forwarded; the server applies precedence
+ * `folderPath` > `folderKey` > `folderId`.
+ *
+ * Declared here rather than reusing the Orchestrator-facing `FolderScopedOptions`
+ * because Integration Service endpoints take no OData `expand` / `select`.
+ */
+export interface IntegrationServiceFolderContextOptions {
+  /** Numeric folder ID. */
+  folderId?: number;
+  /** Folder key (GUID-formatted string). */
+  folderKey?: string;
+  /** Slash-delimited folder path, e.g. `'Shared/Finance'`. */
+  folderPath?: string;
+}
+
+/**
+ * Folder scoping shared by every connection-yielding Integration Service
+ * method. Folder context is optional — omit it to search every folder the
+ * caller can access, or initialize the SDK with a folder context to have it
+ * applied automatically.
+ */
+export interface IntegrationServiceFolderScopedOptions extends IntegrationServiceFolderContextOptions {
+  /** Include resources from all folders the caller has access to. */
+  allFolders?: boolean;
+}

--- a/src/services/integration-service/connections/connections.ts
+++ b/src/services/integration-service/connections/connections.ts
@@ -1,8 +1,7 @@
 import { BaseService } from '../../base';
 import { track } from '../../../core/telemetry';
 import { ValidationError } from '../../../core/errors';
-import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_KEY } from '../../../utils/constants/headers';
+import { resolveFolderScope } from '../folder-scope';
 import { CONNECTION_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { QueryParams } from '../../../models/common/request-spec';
 import {
@@ -39,152 +38,54 @@ import {
  * ```
  */
 export class ConnectionsService extends BaseService implements ConnectionsServiceModel {
-  /**
-   * Get all connections, optionally scoped to a folder.
-   *
-   * Returns a plain array of connection entities. Pagination is page-indexed
-   * via `pageIndex`/`pageSize`; there is no continuation cursor, so callers
-   * paginate by incrementing `pageIndex` until a short page is returned.
-   *
-   * @param options - Folder scoping, paging, sorting, and filter options
-   * @returns Promise resolving to an array of {@link ConnectionGetResponse}
-   * @example
-   * ```typescript
-   * import { Connections } from '@uipath/uipath-typescript/is-connections';
-   *
-   * const connections = new Connections(sdk);
-   *
-   * // List the first page of connections in a folder
-   * const folderConnections = await connections.getAll({
-   *   folderKey: '<folderKey>',
-   *   pageSize: 50,
-   * });
-   *
-   * for (const conn of folderConnections) {
-   *   console.log(`${conn.name} (${conn.state})`);
-   * }
-   * ```
-   *
-   * @example
-   * ```typescript
-   * // Filter by name and connector
-   * const filtered = await connections.getAll({
-   *   folderKey: '<folderKey>',
-   *   filter: "connector.key eq 'uipath-slack'",
-   *   mostRecentFirst: true,
-   * });
-   * ```
-   */
   @track('Connections.GetAll')
   async getAll(options?: ConnectionGetAllOptions): Promise<ConnectionGetResponse[]> {
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.getAll',
+      this.config.folderKey,
+    );
     const response = await this.get<RawConnectionGetResponse[]>(CONNECTION_ENDPOINTS.GET_ALL, {
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      headers,
       params: queryOptions as QueryParams,
     });
     return (response.data ?? []).map((conn) => createConnectionWithMethods(conn, this));
   }
 
-  /**
-   * Get a single connection by ID.
-   *
-   * @param connectionId - Connection GUID
-   * @param options - Folder scoping and optional `includeConfigs` flag
-   * @returns Promise resolving to a {@link ConnectionGetResponse}
-   * @example
-   * ```typescript
-   * import { Connections } from '@uipath/uipath-typescript/is-connections';
-   *
-   * const connections = new Connections(sdk);
-   *
-   * // First, list connections to find the connectionId
-   * const list = await connections.getAll({ folderKey: '<folderKey>' });
-   * const connectionId = list[0].id;
-   *
-   * const conn = await connections.getById(connectionId);
-   * console.log(conn.connector?.key, conn.state);
-   * ```
-   *
-   * @example
-   * ```typescript
-   * // Include the full configuration blob
-   * const conn = await connections.getById('<connectionId>', { includeConfigs: true });
-   * ```
-   */
   @track('Connections.GetById')
   async getById(connectionId: string, options?: ConnectionGetByIdOptions): Promise<ConnectionGetResponse> {
     if (!connectionId) {
       throw new ValidationError({ message: 'connectionId is required for getById' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.getById',
+      this.config.folderKey,
+    );
     const response = await this.get<RawConnectionGetResponse>(CONNECTION_ENDPOINTS.GET_BY_ID(connectionId), {
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      headers,
       params: queryOptions as QueryParams,
     });
     return createConnectionWithMethods(response.data, this);
   }
 
-  /**
-   * Check whether a connection is currently active.
-   *
-   * Returns the resolved state plus an optional error message. Use this before
-   * invoking activities to surface a friendly error when the connection has
-   * expired or been disabled.
-   *
-   * @param connectionId - Connection GUID
-   * @param options - Folder scoping and `forceRefresh` flag
-   * @returns Promise resolving to a {@link ConnectionPingResponse}
-   * @example
-   * ```typescript
-   * import { Connections, ConnectionState } from '@uipath/uipath-typescript/is-connections';
-   *
-   * const connections = new Connections(sdk);
-   *
-   * const status = await connections.ping('<connectionId>');
-   * if (status.status !== ConnectionState.Enabled) {
-   *   console.warn(`Connection unhealthy: ${status.status} — ${status.error ?? 'no detail'}`);
-   * }
-   * ```
-   *
-   * @example
-   * ```typescript
-   * // Skip cache and force a live re-validation
-   * const status = await connections.ping('<connectionId>', { forceRefresh: true });
-   * ```
-   */
   @track('Connections.Ping')
   async ping(connectionId: string, options?: ConnectionPingOptions): Promise<ConnectionPingResponse> {
     if (!connectionId) {
       throw new ValidationError({ message: 'connectionId is required for ping' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.ping',
+      this.config.folderKey,
+    );
     const response = await this.get<ConnectionPingResponse>(CONNECTION_ENDPOINTS.PING(connectionId), {
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      headers,
       params: queryOptions as QueryParams,
     });
     return response.data;
   }
 
-  /**
-   * Start an OAuth re-authentication session for a connection.
-   *
-   * Returns a session handle plus the URL the end user must visit to grant or
-   * refresh consent. The session expires at {@link ConnectionReauthenticateResponse.expiresAt}.
-   *
-   * @param connectionId - Connection GUID
-   * @param options - Folder scoping options
-   * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
-   * @example
-   * ```typescript
-   * import { Connections } from '@uipath/uipath-typescript/is-connections';
-   *
-   * const connections = new Connections(sdk);
-   *
-   * const session = await connections.reauthenticate('<connectionId>');
-   * // Direct the user to session.authUrl to complete OAuth consent.
-   * console.log(`Visit: ${session.authUrl}`);
-   * ```
-   */
   @track('Connections.Reauthenticate')
   async reauthenticate(
     connectionId: string,
@@ -193,12 +94,16 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
     if (!connectionId) {
       throw new ValidationError({ message: 'connectionId is required for reauthenticate' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.reauthenticate',
+      this.config.folderKey,
+    );
     const response = await this.post<ConnectionReauthenticateResponse>(
       CONNECTION_ENDPOINTS.REAUTHENTICATE(connectionId),
       undefined,
       {
-        headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+        headers,
         params: queryOptions as QueryParams,
       },
     );

--- a/src/services/integration-service/connections/connections.ts
+++ b/src/services/integration-service/connections/connections.ts
@@ -1,8 +1,7 @@
 import { BaseService } from '../../base';
 import { track } from '../../../core/telemetry';
 import { ValidationError } from '../../../core/errors';
-import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_KEY } from '../../../utils/constants/headers';
+import { resolveFolderScope } from '../folder-scope';
 import { CONNECTION_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { QueryParams } from '../../../models/common/request-spec';
 import {
@@ -46,7 +45,12 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
    * via `pageIndex`/`pageSize`; there is no continuation cursor, so callers
    * paginate by incrementing `pageIndex` until a short page is returned.
    *
-   * @param options - Folder scoping, paging, sorting, and filter options
+   * Folder scoping is optional — pass `folderId`, `folderKey`, or `folderPath`
+   * to narrow the query. When none is supplied, the folder context the SDK was
+   * initialized with is used; without one the query spans every folder the
+   * caller can access.
+   *
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`), paging, sorting, and filter options
    * @returns Promise resolving to an array of {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -74,12 +78,26 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
    *   mostRecentFirst: true,
    * });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Scope by folder path or numeric folder ID instead of a key
+   * const byPath = await connections.getAll({ folderPath: 'Shared/Finance' });
+   * const byId = await connections.getAll({ folderId: 123 });
+   *
+   * // Or span every folder the caller can access
+   * const everywhere = await connections.getAll({ allFolders: true });
+   * ```
    */
   @track('Connections.GetAll')
   async getAll(options?: ConnectionGetAllOptions): Promise<ConnectionGetResponse[]> {
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.getAll',
+      this.config.folderKey,
+    );
     const response = await this.get<RawConnectionGetResponse[]>(CONNECTION_ENDPOINTS.GET_ALL, {
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      headers,
       params: queryOptions as QueryParams,
     });
     return (response.data ?? []).map((conn) => createConnectionWithMethods(conn, this));
@@ -89,7 +107,7 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
    * Get a single connection by ID.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping and optional `includeConfigs` flag
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and optional `includeConfigs` flag
    * @returns Promise resolving to a {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -110,15 +128,25 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
    * // Include the full configuration blob
    * const conn = await connections.getById('<connectionId>', { includeConfigs: true });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Scope the lookup to a folder path
+   * const conn = await connections.getById('<connectionId>', { folderPath: 'Shared/Finance' });
+   * ```
    */
   @track('Connections.GetById')
   async getById(connectionId: string, options?: ConnectionGetByIdOptions): Promise<ConnectionGetResponse> {
     if (!connectionId) {
       throw new ValidationError({ message: 'connectionId is required for getById' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.getById',
+      this.config.folderKey,
+    );
     const response = await this.get<RawConnectionGetResponse>(CONNECTION_ENDPOINTS.GET_BY_ID(connectionId), {
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      headers,
       params: queryOptions as QueryParams,
     });
     return createConnectionWithMethods(response.data, this);
@@ -132,7 +160,7 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
    * expired or been disabled.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping and `forceRefresh` flag
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and `forceRefresh` flag
    * @returns Promise resolving to a {@link ConnectionPingResponse}
    * @example
    * ```typescript
@@ -157,9 +185,13 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
     if (!connectionId) {
       throw new ValidationError({ message: 'connectionId is required for ping' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.ping',
+      this.config.folderKey,
+    );
     const response = await this.get<ConnectionPingResponse>(CONNECTION_ENDPOINTS.PING(connectionId), {
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      headers,
       params: queryOptions as QueryParams,
     });
     return response.data;
@@ -172,7 +204,7 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
    * refresh consent. The session expires at {@link ConnectionReauthenticateResponse.expiresAt}.
    *
    * @param connectionId - Connection GUID
-   * @param options - Folder scoping options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
    * @example
    * ```typescript
@@ -193,12 +225,16 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
     if (!connectionId) {
       throw new ValidationError({ message: 'connectionId is required for reauthenticate' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connections.reauthenticate',
+      this.config.folderKey,
+    );
     const response = await this.post<ConnectionReauthenticateResponse>(
       CONNECTION_ENDPOINTS.REAUTHENTICATE(connectionId),
       undefined,
       {
-        headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+        headers,
         params: queryOptions as QueryParams,
       },
     );

--- a/src/services/integration-service/connections/index.ts
+++ b/src/services/integration-service/connections/index.ts
@@ -10,7 +10,7 @@
  * await sdk.initialize();
  *
  * const connections = new Connections(sdk);
- * const all = await connections.getAll({ folderKey: '<folderKey>' });
+ * const all = await connections.getAll({ folderPath: 'Shared/Finance' });
  * ```
  *
  * @module
@@ -18,5 +18,6 @@
 
 export { ConnectionsService as Connections, ConnectionsService } from './connections';
 
+export * from '../../../models/integration-service/integration-service.types';
 export * from '../../../models/integration-service/connections.types';
 export * from '../../../models/integration-service/connections.models';

--- a/src/services/integration-service/connectors/connectors.ts
+++ b/src/services/integration-service/connectors/connectors.ts
@@ -1,8 +1,7 @@
 import { BaseService } from '../../base';
 import { track } from '../../../core/telemetry';
 import { ValidationError } from '../../../core/errors';
-import { createHeaders } from '../../../utils/http/headers';
-import { FOLDER_KEY } from '../../../utils/constants/headers';
+import { resolveFolderScope } from '../folder-scope';
 import { CONNECTOR_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { QueryParams } from '../../../models/common/request-spec';
 import {
@@ -121,7 +120,7 @@ export class ConnectorsService extends BaseService implements ConnectorsServiceM
    * paging through the full list.
    *
    * @param keyOrId - Connector key or numeric ID as a string
-   * @param options - Folder scoping options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
    * @returns Promise resolving to a {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -130,7 +129,7 @@ export class ConnectorsService extends BaseService implements ConnectorsServiceM
    * const connectors = new Connectors(sdk);
    *
    * const defaultSlack = await connectors.getDefaultConnection('uipath-slack', {
-   *   folderKey: '<folderKey>',
+   *   folderPath: 'Shared/Finance',
    * });
    *
    * // Use bound methods directly on the entity
@@ -146,11 +145,15 @@ export class ConnectorsService extends BaseService implements ConnectorsServiceM
     if (!keyOrId) {
       throw new ValidationError({ message: 'keyOrId is required for getDefaultConnection' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connectors.getDefaultConnection',
+      this.config.folderKey,
+    );
     const response = await this.get<RawConnectionGetResponse>(
       CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(keyOrId),
       {
-        headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+        headers,
         params: queryOptions as QueryParams,
       },
     );
@@ -164,7 +167,7 @@ export class ConnectorsService extends BaseService implements ConnectorsServiceM
    * pagination (no continuation cursor). Increment `pageIndex` to walk pages.
    *
    * @param keyOrId - Connector key or numeric ID as a string
-   * @param options - Folder scoping, paging, and sorting options
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`), paging, and sorting options
    * @returns Promise resolving to an array of {@link ConnectionGetResponse}
    * @example
    * ```typescript
@@ -188,7 +191,7 @@ export class ConnectorsService extends BaseService implements ConnectorsServiceM
    * ```typescript
    * // Walk subsequent pages
    * const page2 = await connectors.getConnections('uipath-slack', {
-   *   folderKey: '<folderKey>',
+   *   folderId: 123,
    *   pageSize: 25,
    *   pageIndex: 2,
    * });
@@ -202,11 +205,15 @@ export class ConnectorsService extends BaseService implements ConnectorsServiceM
     if (!keyOrId) {
       throw new ValidationError({ message: 'keyOrId is required for getConnections' });
     }
-    const { folderKey, ...queryOptions } = options ?? {};
+    const { headers, queryOptions } = resolveFolderScope(
+      options ?? {},
+      'Connectors.getConnections',
+      this.config.folderKey,
+    );
     const response = await this.get<RawConnectionGetResponse[]>(
       CONNECTOR_ENDPOINTS.GET_CONNECTIONS(keyOrId),
       {
-        headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+        headers,
         params: queryOptions as QueryParams,
       },
     );

--- a/src/services/integration-service/connectors/index.ts
+++ b/src/services/integration-service/connectors/index.ts
@@ -18,6 +18,7 @@
 
 export { ConnectorsService as Connectors, ConnectorsService } from './connectors';
 
+export * from '../../../models/integration-service/integration-service.types';
 export * from '../../../models/integration-service/connectors.types';
 export * from '../../../models/integration-service/connectors.models';
 

--- a/src/services/integration-service/execution/execution.ts
+++ b/src/services/integration-service/execution/execution.ts
@@ -3,7 +3,8 @@ import { track } from '../../../core/telemetry';
 import { ValidationError } from '../../../core/errors';
 import { SDKInternalsRegistry } from '../../../core/internals';
 import { ELEMENT_ENDPOINTS } from '../../../utils/constants/endpoints';
-import { FOLDER_KEY, CONTENT_TYPES, TRACEPARENT, UIPATH_TRACEPARENT_ID } from '../../../utils/constants/headers';
+import { CONTENT_TYPES, TRACEPARENT, UIPATH_TRACEPARENT_ID } from '../../../utils/constants/headers';
+import { resolveFolderScope } from '../folder-scope';
 import type { IUiPath } from '../../../core/types';
 import type { UiPathConfig } from '../../../core/config/config';
 import {
@@ -66,14 +67,18 @@ class Execution extends BaseService {
     const spanId = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
     const traceparentValue = `00-${traceId}-${spanId}-01`;
 
+    const { headers: folderHeaders } = resolveFolderScope(
+      options,
+      'Execution.execute',
+      this.config.folderKey,
+    );
+
     const headers: Record<string, string> = {
       Authorization: `Bearer ${token}`,
       [TRACEPARENT]: traceparentValue,
       [UIPATH_TRACEPARENT_ID]: traceparentValue,
+      ...folderHeaders,
     };
-    if (options.folderKey) {
-      headers[FOLDER_KEY] = options.folderKey;
-    }
 
     const hasBody = options.body !== undefined && BODY_METHODS.has(method);
     if (hasBody) {
@@ -127,7 +132,7 @@ class Execution extends BaseService {
  * @param connectionId - Connection GUID
  * @param objectName - Connector object name (e.g. `tickets`, `messages`)
  * @param method - HTTP method (defaults to `GET`)
- * @param options - Body, query params, and folder scoping
+ * @param options - Body, query params, and folder scoping (`folderId` / `folderKey` / `folderPath`)
  * @returns Promise resolving to an {@link ExecuteResult}
  *
  * @example
@@ -157,10 +162,10 @@ class Execution extends BaseService {
  *
  * @example
  * ```typescript
- * // GET with query params and folder scoping
+ * // GET with query params and folder scoping — folderId and folderPath work too
  * const result = await execute(sdk, '<connectionId>', 'tickets', 'GET', {
  *   queryParams: { limit: '10', status: 'open' },
- *   folderKey: '<folderKey>',
+ *   folderPath: 'Shared/Finance',
  * });
  * ```
  */

--- a/src/services/integration-service/execution/index.ts
+++ b/src/services/integration-service/execution/index.ts
@@ -16,4 +16,5 @@
  */
 
 export { execute } from './execution';
+export * from '../../../models/integration-service/integration-service.types';
 export * from '../../../models/integration-service/execution.types';

--- a/src/services/integration-service/folder-scope.ts
+++ b/src/services/integration-service/folder-scope.ts
@@ -1,0 +1,50 @@
+import { resolveFolderHeaders } from '../../utils/folder/folder-headers';
+import { IntegrationServiceFolderContextOptions } from '../../models/integration-service/integration-service.types';
+
+/**
+ * Whether any folder context is present. Mirrors what `resolveFolderHeaders`
+ * treats as resolvable, including its whitespace-only-is-missing rule.
+ */
+function hasFolderContext(
+  { folderId, folderKey, folderPath }: IntegrationServiceFolderContextOptions,
+  fallbackFolderKey?: string,
+): boolean {
+  return (
+    folderId !== undefined ||
+    !!folderKey?.trim() ||
+    !!folderPath?.trim() ||
+    !!fallbackFolderKey
+  );
+}
+
+/**
+ * Splits folder context out of an Integration Service options bag and resolves
+ * it into folder headers, leaving the remaining fields as query params.
+ *
+ * Folder scoping is optional here — for Integration Service a folder narrows a
+ * query rather than addressing the resource, and an unscoped call returns every
+ * folder the caller can access. So a missing folder context yields no headers,
+ * where the shared `resolveFolderHeaders` would throw. When the SDK was
+ * initialized with a folder context (`uipath:folder-key` meta tag), that key is
+ * used as the fallback.
+ *
+ * @param options - Caller-supplied options, including any folder context
+ * @param resourceType - Label used in error messages (e.g. `'Connections.getAll'`)
+ * @param fallbackFolderKey - Init-time folder key used when no folder context is supplied
+ * @internal
+ */
+export function resolveFolderScope<T extends IntegrationServiceFolderContextOptions>(
+  options: T,
+  resourceType: string,
+  fallbackFolderKey?: string,
+): { headers: Record<string, string>; queryOptions: Omit<T, keyof IntegrationServiceFolderContextOptions> } {
+  const { folderId, folderKey, folderPath, ...queryOptions } = options;
+
+  // Guarded so `resolveFolderHeaders` is only called when it can resolve
+  // something — it throws on an empty folder context, which is valid here.
+  const headers = hasFolderContext({ folderId, folderKey, folderPath }, fallbackFolderKey)
+    ? resolveFolderHeaders({ folderId, folderKey, folderPath, resourceType, fallbackFolderKey })
+    : {};
+
+  return { headers, queryOptions };
+}

--- a/tests/unit/models/integration-service/connections.test.ts
+++ b/tests/unit/models/integration-service/connections.test.ts
@@ -51,6 +51,20 @@ describe('Connection bound methods', () => {
       });
     });
 
+    it('should pass folder context through', async () => {
+      const connection = createConnectionWithMethods(createMockConnection(), mockService);
+      mockService.ping = vi.fn().mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        status: ConnectionState.Enabled,
+      });
+
+      await connection.ping({ folderPath: IS_TEST_CONSTANTS.FOLDER_PATH });
+
+      expect(mockService.ping).toHaveBeenCalledWith(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+    });
+
     it('should throw when the underlying connection has no id', async () => {
       const connection = createConnectionWithMethods(
         createMockConnection({ id: '' }),
@@ -93,6 +107,22 @@ describe('Connection bound methods', () => {
 
       expect(mockService.reauthenticate).toHaveBeenCalledWith(IS_TEST_CONSTANTS.CONNECTION_ID, {
         folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+      });
+    });
+
+    it('should pass folderId through', async () => {
+      const connection = createConnectionWithMethods(createMockConnection(), mockService);
+      mockService.reauthenticate = vi.fn().mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
+        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
+        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
+      });
+
+      await connection.reauthenticate({ folderId: IS_TEST_CONSTANTS.FOLDER_ID });
+
+      expect(mockService.reauthenticate).toHaveBeenCalledWith(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
       });
     });
   });

--- a/tests/unit/services/integration-service/connections.test.ts
+++ b/tests/unit/services/integration-service/connections.test.ts
@@ -3,7 +3,7 @@ import { ConnectionsService } from '../../../../src/services/integration-service
 import { CONNECTION_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { ApiClient } from '../../../../src/core/http/api-client';
 import { ValidationError } from '../../../../src/core/errors';
-import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
 import { ConnectionState } from '../../../../src/models/integration-service/connections.types';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import {
@@ -71,6 +71,110 @@ describe('ConnectionsService', () => {
       mockApiClient.get.mockRejectedValue(createMockError(IS_TEST_CONSTANTS.ERROR_CONNECTION_NOT_FOUND));
       await expect(service.getAll()).rejects.toThrow(IS_TEST_CONSTANTS.ERROR_CONNECTION_NOT_FOUND);
     });
+
+    it('should route folderId to the folder ID header', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({ folderId: IS_TEST_CONSTANTS.FOLDER_ID });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_ID]: String(IS_TEST_CONSTANTS.FOLDER_ID) },
+        params: {},
+      });
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({ folderPath: IS_TEST_CONSTANTS.FOLDER_PATH });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE },
+        params: {},
+      });
+    });
+
+    it('should forward every folder header when more than one is supplied', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({
+        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
+        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: {
+          [FOLDER_ID]: String(IS_TEST_CONSTANTS.FOLDER_ID),
+          [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY,
+          [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE,
+        },
+        params: {},
+      });
+    });
+
+    it('should never leak folder context into query params', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({
+        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
+        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+        allFolders: true,
+      });
+      const [, requestOptions] = mockApiClient.get.mock.calls[0];
+      expect(requestOptions.params).toEqual({ allFolders: true });
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getAll();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY },
+        params: {},
+      });
+    });
+
+    it('should prefer an explicit folder path over the init-time folder key', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getAll({ folderPath: IS_TEST_CONSTANTS.FOLDER_PATH });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE },
+        params: {},
+      });
+    });
+
+    it('should send no folder header when neither options nor init supply folder context', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll();
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: {},
+        params: {},
+      });
+    });
+
+    it('should treat a whitespace-only folderKey as no folder context', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY_WHITESPACE });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: {},
+        params: {},
+      });
+    });
+
+    it('should fall back to the init-time folder key when folderKey is whitespace-only', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getAll({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY_WHITESPACE });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY },
+        params: {},
+      });
+    });
   });
 
   describe('getById', () => {
@@ -108,6 +212,30 @@ describe('ConnectionsService', () => {
       );
     });
 
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+      await service.getById(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.GET_BY_ID(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await scopedService.getById(IS_TEST_CONSTANTS.CONNECTION_ID);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.GET_BY_ID(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
+      );
+    });
+
     it('should throw ValidationError when connectionId is empty', async () => {
       await expect(service.getById('')).rejects.toThrow(ValidationError);
     });
@@ -139,6 +267,36 @@ describe('ConnectionsService', () => {
       expect(mockApiClient.get).toHaveBeenCalledWith(
         CONNECTION_ENDPOINTS.PING(IS_TEST_CONSTANTS.CONNECTION_ID),
         { headers: {}, params: { forceRefresh: true } },
+      );
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        status: ConnectionState.Enabled,
+      });
+      await service.ping(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.PING(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        status: ConnectionState.Enabled,
+      });
+
+      await scopedService.ping(IS_TEST_CONSTANTS.CONNECTION_ID);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.PING(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
       );
     });
 
@@ -184,6 +342,42 @@ describe('ConnectionsService', () => {
       await service.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID, {
         folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
       });
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
+        undefined,
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
+      );
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.post.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
+        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
+        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
+      });
+      await service.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
+        undefined,
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.post.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
+        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
+        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
+      });
+
+      await scopedService.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID);
+
       expect(mockApiClient.post).toHaveBeenCalledWith(
         CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
         undefined,

--- a/tests/unit/services/integration-service/connections.test.ts
+++ b/tests/unit/services/integration-service/connections.test.ts
@@ -3,7 +3,7 @@ import { ConnectionsService } from '../../../../src/services/integration-service
 import { CONNECTION_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { ApiClient } from '../../../../src/core/http/api-client';
 import { ValidationError } from '../../../../src/core/errors';
-import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
 import { ConnectionState } from '../../../../src/models/integration-service/connections.types';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import {
@@ -71,6 +71,111 @@ describe('ConnectionsService', () => {
       mockApiClient.get.mockRejectedValue(createMockError(IS_TEST_CONSTANTS.ERROR_CONNECTION_NOT_FOUND));
       await expect(service.getAll()).rejects.toThrow(IS_TEST_CONSTANTS.ERROR_CONNECTION_NOT_FOUND);
     });
+
+    it('should route folderId to the folder ID header', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({ folderId: IS_TEST_CONSTANTS.FOLDER_ID });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_ID]: String(IS_TEST_CONSTANTS.FOLDER_ID) },
+        params: {},
+      });
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({ folderPath: IS_TEST_CONSTANTS.FOLDER_PATH });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE },
+        params: {},
+      });
+    });
+
+    it('should forward every folder header when more than one is supplied', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({
+        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
+        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: {
+          [FOLDER_ID]: String(IS_TEST_CONSTANTS.FOLDER_ID),
+          [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY,
+          [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE,
+        },
+        params: {},
+      });
+    });
+
+    it('should never leak folder context into query params', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({
+        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
+        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+        folderDefaults: true,
+      });
+      const [, requestOptions] = mockApiClient.get.mock.calls[0];
+      // folderDefaults is a genuine query param — only exact folder-context keys are stripped.
+      expect(requestOptions.params).toEqual({ folderDefaults: true });
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getAll();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY },
+        params: {},
+      });
+    });
+
+    it('should prefer an explicit folder path over the init-time folder key', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getAll({ folderPath: IS_TEST_CONSTANTS.FOLDER_PATH });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE },
+        params: {},
+      });
+    });
+
+    it('should send no folder header when neither options nor init supply folder context', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll();
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: {},
+        params: {},
+      });
+    });
+
+    it('should treat a whitespace-only folderKey as no folder context', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+      await service.getAll({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY_WHITESPACE });
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: {},
+        params: {},
+      });
+    });
+
+    it('should fall back to the init-time folder key when folderKey is whitespace-only', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getAll({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY_WHITESPACE });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(CONNECTION_ENDPOINTS.GET_ALL, {
+        headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY },
+        params: {},
+      });
+    });
   });
 
   describe('getById', () => {
@@ -108,6 +213,30 @@ describe('ConnectionsService', () => {
       );
     });
 
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+      await service.getById(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.GET_BY_ID(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await scopedService.getById(IS_TEST_CONSTANTS.CONNECTION_ID);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.GET_BY_ID(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
+      );
+    });
+
     it('should throw ValidationError when connectionId is empty', async () => {
       await expect(service.getById('')).rejects.toThrow(ValidationError);
     });
@@ -139,6 +268,36 @@ describe('ConnectionsService', () => {
       expect(mockApiClient.get).toHaveBeenCalledWith(
         CONNECTION_ENDPOINTS.PING(IS_TEST_CONSTANTS.CONNECTION_ID),
         { headers: {}, params: { forceRefresh: true } },
+      );
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        status: ConnectionState.Enabled,
+      });
+      await service.ping(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.PING(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.get.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        status: ConnectionState.Enabled,
+      });
+
+      await scopedService.ping(IS_TEST_CONSTANTS.CONNECTION_ID);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.PING(IS_TEST_CONSTANTS.CONNECTION_ID),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
       );
     });
 
@@ -184,6 +343,42 @@ describe('ConnectionsService', () => {
       await service.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID, {
         folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
       });
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
+        undefined,
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
+      );
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.post.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
+        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
+        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
+      });
+      await service.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
+        undefined,
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectionsService(instance);
+      mockApiClient.post.mockResolvedValue({
+        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
+        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
+        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
+        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
+      });
+
+      await scopedService.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID);
+
       expect(mockApiClient.post).toHaveBeenCalledWith(
         CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
         undefined,

--- a/tests/unit/services/integration-service/connectors.test.ts
+++ b/tests/unit/services/integration-service/connectors.test.ts
@@ -3,7 +3,7 @@ import { ConnectorsService } from '../../../../src/services/integration-service/
 import { CONNECTOR_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { ApiClient } from '../../../../src/core/http/api-client';
 import { ValidationError } from '../../../../src/core/errors';
-import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import {
   IS_TEST_CONSTANTS,
@@ -127,14 +127,42 @@ describe('ConnectorsService', () => {
       );
     });
 
-    it('should pass allFolders as a query param', async () => {
+    it('should route folderId to the folder ID header', async () => {
       mockApiClient.get.mockResolvedValue(createMockConnection());
 
-      await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY, { allFolders: true });
+      await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
+      });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
         CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
-        { headers: {}, params: { allFolders: true } },
+        { headers: { [FOLDER_ID]: String(IS_TEST_CONSTANTS.FOLDER_ID) }, params: {} },
+      );
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectorsService(instance);
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await scopedService.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
       );
     });
 
@@ -181,6 +209,36 @@ describe('ConnectorsService', () => {
       mockApiClient.get.mockResolvedValue(null);
       const result = await service.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY);
       expect(result).toEqual([]);
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      await service.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+        pageSize: 25,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_CONNECTIONS(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        {
+          headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE },
+          params: { pageSize: 25 },
+        },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectorsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_CONNECTIONS(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
+      );
     });
 
     it('should throw ValidationError when keyOrId is empty', async () => {

--- a/tests/unit/services/integration-service/connectors.test.ts
+++ b/tests/unit/services/integration-service/connectors.test.ts
@@ -3,7 +3,7 @@ import { ConnectorsService } from '../../../../src/services/integration-service/
 import { CONNECTOR_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { ApiClient } from '../../../../src/core/http/api-client';
 import { ValidationError } from '../../../../src/core/errors';
-import { FOLDER_KEY } from '../../../../src/utils/constants/headers';
+import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import {
   IS_TEST_CONSTANTS,
@@ -138,6 +138,45 @@ describe('ConnectorsService', () => {
       );
     });
 
+    it('should route folderId to the folder ID header', async () => {
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: { [FOLDER_ID]: String(IS_TEST_CONSTANTS.FOLDER_ID) }, params: {} },
+      );
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await service.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectorsService(instance);
+      mockApiClient.get.mockResolvedValue(createMockConnection());
+
+      await scopedService.getDefaultConnection(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_DEFAULT_CONNECTION(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
+      );
+    });
+
     it('should throw ValidationError when keyOrId is empty', async () => {
       await expect(service.getDefaultConnection('')).rejects.toThrow(ValidationError);
     });
@@ -181,6 +220,36 @@ describe('ConnectorsService', () => {
       mockApiClient.get.mockResolvedValue(null);
       const result = await service.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY);
       expect(result).toEqual([]);
+    });
+
+    it('should route folderPath to the encoded folder path header', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      await service.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY, {
+        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+        pageSize: 25,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_CONNECTIONS(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        {
+          headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE },
+          params: { pageSize: 25 },
+        },
+      );
+    });
+
+    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
+      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+      const scopedService = new ConnectorsService(instance);
+      mockApiClient.get.mockResolvedValue([]);
+
+      await scopedService.getConnections(IS_TEST_CONSTANTS.CONNECTOR_KEY);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        CONNECTOR_ENDPOINTS.GET_CONNECTIONS(IS_TEST_CONSTANTS.CONNECTOR_KEY),
+        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
+      );
     });
 
     it('should throw ValidationError when keyOrId is empty', async () => {

--- a/tests/unit/services/integration-service/execution.test.ts
+++ b/tests/unit/services/integration-service/execution.test.ts
@@ -3,7 +3,13 @@ import { execute } from '../../../../src/services/integration-service/execution/
 import { ValidationError } from '../../../../src/core/errors';
 import { createServiceTestDependencies } from '../../../utils/setup';
 import { IS_TEST_CONSTANTS } from '../../../utils/mocks';
-import { FOLDER_KEY, TRACEPARENT, UIPATH_TRACEPARENT_ID } from '../../../../src/utils/constants/headers';
+import {
+  FOLDER_ID,
+  FOLDER_KEY,
+  FOLDER_PATH_ENCODED,
+  TRACEPARENT,
+  UIPATH_TRACEPARENT_ID,
+} from '../../../../src/utils/constants/headers';
 
 const OBJECT_NAME = 'tickets';
 
@@ -88,6 +94,66 @@ describe('execute', () => {
 
     const [, init] = fetchSpy.mock.calls[0];
     expect(init.headers[FOLDER_KEY]).toBe(IS_TEST_CONSTANTS.FOLDER_KEY);
+  });
+
+  it('sends the folder ID header when folderId is provided', async () => {
+    const { instance } = createServiceTestDependencies();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'GET', {
+      folderId: IS_TEST_CONSTANTS.FOLDER_ID,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers[FOLDER_ID]).toBe(String(IS_TEST_CONSTANTS.FOLDER_ID));
+  });
+
+  it('sends the encoded folder path header when folderPath is provided', async () => {
+    const { instance } = createServiceTestDependencies();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'GET', {
+      folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers[FOLDER_PATH_ENCODED]).toBe(IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE);
+  });
+
+  it('falls back to the init-time folder key when no folder context is provided', async () => {
+    const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers[FOLDER_KEY]).toBe(IS_TEST_CONSTANTS.FOLDER_KEY);
+  });
+
+  it('sends no folder header when neither options nor init supply folder context', async () => {
+    const { instance } = createServiceTestDependencies();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME);
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers[FOLDER_KEY]).toBeUndefined();
+    expect(init.headers[FOLDER_ID]).toBeUndefined();
+    expect(init.headers[FOLDER_PATH_ENCODED]).toBeUndefined();
+  });
+
+  it('does not leak folder context into the query string', async () => {
+    const { instance } = createServiceTestDependencies();
+    fetchSpy.mockResolvedValue(buildResponse({ body: '[]' }));
+
+    await execute(instance, IS_TEST_CONSTANTS.CONNECTION_ID, OBJECT_NAME, 'GET', {
+      folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
+      queryParams: { limit: '10' },
+    });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain('limit=10');
+    expect(url).not.toContain('folderPath');
   });
 
   it('sends distributed-tracing headers on every request', async () => {

--- a/tests/utils/constants/integration-service.ts
+++ b/tests/utils/constants/integration-service.ts
@@ -18,6 +18,12 @@ export const IS_TEST_CONSTANTS = {
   CONNECTION_UPDATE_TIME: '2026-06-01T00:00:00.000Z',
   ELEMENT_INSTANCE_ID: 12345,
   FOLDER_KEY: '5638e7df-c0ca-400d-af47-ea001baf6fd5',
+  /** Whitespace-only folder key — must be treated as absent folder context. */
+  FOLDER_KEY_WHITESPACE: '   ',
+  FOLDER_ID: 4321,
+  FOLDER_PATH: 'Shared/Finance',
+  /** `FOLDER_PATH` encoded as base64-of-UTF-16-LE, per the Orchestrator folder-path contract. */
+  FOLDER_PATH_ENCODED_VALUE: 'UwBoAGEAcgBlAGQALwBGAGkAbgBhAG4AYwBlAA==',
   FOLDER_DISPLAY_NAME: 'Test Folder',
   AUTH_SESSION_ID: 'sess_abcdef0123456789',
   AUTH_URL: 'https://alpha.uipath.com/oauth/authorize?session_id=sess_abcdef0123456789',


### PR DESCRIPTION
> **Stacked on #554** — base branch is `feat/is-connections`. Review that PR first; this diff contains only the folder-scoping commit.

## Method Added

**No new methods.** This PR widens the folder-context options on seven existing Integration Service entry points. Signatures are unchanged — only the options types they accept gained fields.

| Layer | Method | Signature |
|-------|--------|-----------|
| Service | `connections.getAll()` | `getAll(options?: ConnectionGetAllOptions): Promise<ConnectionGetResponse[]>` |
| Service | `connections.getById()` | `getById(connectionId: string, options?: ConnectionGetByIdOptions): Promise<ConnectionGetResponse>` |
| Service | `connections.ping()` | `ping(connectionId: string, options?: ConnectionPingOptions): Promise<ConnectionPingResponse>` |
| Service | `connections.reauthenticate()` | `reauthenticate(connectionId: string, options?: ConnectionReauthenticateOptions): Promise<ConnectionReauthenticateResponse>` |
| Service | `connectors.getDefaultConnection()` | `getDefaultConnection(keyOrId: string, options?: ConnectorGetDefaultConnectionOptions): Promise<ConnectionGetResponse>` |
| Service | `connectors.getConnections()` | `getConnections(keyOrId: string, options?: ConnectorGetConnectionsOptions): Promise<ConnectionGetResponse[]>` |
| Function | `execute()` | `execute(uipath: IUiPath, connectionId: string, objectName: string, method?: ExecuteMethod, options?: ExecuteOptions): Promise<ExecuteResult>` |
| Bound entity | `connection.ping()` | `ping(options?: ConnectionPingOptions): Promise<ConnectionPingResponse>` |
| Bound entity | `connection.reauthenticate()` | `reauthenticate(options?: ConnectionReauthenticateOptions): Promise<ConnectionReauthenticateResponse>` |

### Options: before vs after

| Option | Availability | Wire form |
|--------|--------------|-----------|
| `folderKey?: string` | already supported | `X-UIPATH-FolderKey` header |
| `allFolders?: boolean` | already supported (not on `execute()`) | query param |
| `folderDefaults?: boolean` | already supported (`connections.getAll`, `connectors.getConnections`) | query param |
| **`folderId?: number`** | **new** | `X-UIPATH-OrganizationUnitId` header |
| **`folderPath?: string`** | **new** | `X-UIPATH-FolderPath-Encoded` header (base64-of-UTF-16-LE) |

Plus a new behavior: when none of the three folder inputs is supplied, the SDK's init-time folder key — sourced from `<meta name="uipath:folder-key">` in coded-app deployments — is used as the folder key. See **Behavior change** below.

## Endpoint Called

No new endpoints. `src/utils/constants/endpoints/integration-service.ts` is untouched on this branch, so no Cloudflare Workers whitelisting was required — these endpoints were whitelisted with #554 / #555 / #556.

| Method | HTTP | Endpoint | OAuth Scope |
|--------|------|----------|-------------|
| `connections.getAll()` | GET | `connections_/api/v1/Connections` | `IS.Connections.Read` |
| `connections.getById()` | GET | `connections_/api/v1/Connections/{connectionId}` | `IS.Connections.Read` |
| `connections.ping()` | GET | `connections_/api/v1/Connections/{connectionId}/ping` | `IS.Connections.Read` |
| `connections.reauthenticate()` | POST | `connections_/api/v1/Connections/{connectionId}/auth` | `IS.Connections.Write` |
| `connectors.getDefaultConnection()` | GET | `connections_/api/v1/Connectors/{keyOrId}/connection` | `IS.Connections.Read` |
| `connectors.getConnections()` | GET | `connections_/api/v1/Connectors/{keyOrId}/connections` | `IS.Connections.Read` |
| `execute()` | GET/POST/PUT/PATCH/DELETE | `elements_/v3/element/instances/{connectionId}/{objectName}` | `IS.Connections.Read` + third-party scopes of the connection |

- Aligns Integration Service with the folder-context contract already used by Assets, Processes, and Buckets (`folderId` / `folderKey` / `folderPath` + meta-tag fallback), reusing the shared `resolveFolderHeaders` for header routing, encoding, and precedence.
- **Not affected:** all of `Elements` (`getObjects`, `getActivities`, `getObjectMetadata`, `getEventObjects`, `getEventObjectMetadata`, and the four `getInstance*` variants) — design-time connector-catalog reads that take no folder context. Also `connectors.getAll()` and `connectors.getById()`, which are tenant-level.
- **Non-breaking.** Every affected method already took an options object with `folderKey?`, so this is purely additive and existing call sites compile and behave identically. No overloads needed.

## Example Usage

```typescript
import { UiPath } from '@uipath/uipath-typescript/core';
import { Connections } from '@uipath/uipath-typescript/is-connections';

const sdk = new UiPath(config);
await sdk.initialize();
const connections = new Connections(sdk);

// Basic usage — folder key, as before
const folderConnections = await connections.getAll({
  folderKey: '<folderKey>',
  pageSize: 50,
});

// With options — scope by folder path or numeric folder ID instead of a key
const byPath = await connections.getAll({ folderPath: 'Shared/Finance' });
const byId = await connections.getAll({ folderId: 123 });

// Or span every folder the caller can access
const everywhere = await connections.getAll({ allFolders: true });
```

```typescript
import { Connectors } from '@uipath/uipath-typescript/is-connectors';

const connectors = new Connectors(sdk);

const defaultSlack = await connectors.getDefaultConnection('uipath-slack', {
  folderPath: 'Shared/Finance',
});

const page2 = await connectors.getConnections('uipath-slack', {
  folderId: 123,
  pageSize: 25,
  pageIndex: 2,
});
```

```typescript
import { execute } from '@uipath/uipath-typescript/is-execution';

// GET with query params and folder scoping — folderId and folderPath work too
const result = await execute(sdk, '<connectionId>', 'tickets', 'GET', {
  queryParams: { limit: '10', status: 'open' },
  folderPath: 'Shared/Finance',
});
```

## API Response vs SDK Response

**Unchanged.** This PR touches only outbound request headers — no response type, transform pipeline, or field mapping was modified. Integration Service returns camelCase already, so these services apply no `pascalToCamelCaseKeys` or field-rename transforms; the only response-side step is `createConnectionWithMethods()` to attach bound `ping` / `reauthenticate`, and that is untouched.

### Request-side flow

```
options { folderId?, folderKey?, folderPath?, ...rest }
   │
   ├─ resolveFolderScope()            (src/services/integration-service/folder-scope.ts)
   │     │
   │     ├─ destructure folder fields out of options
   │     │
   │     ├─ hasFolderContext(folder fields, config.folderKey) ?
   │     │     ├─ false → {}                                  no folder header sent
   │     │     └─ true  → resolveFolderHeaders()               shared util, unmodified
   │     │                   ├─ folderId   → X-UIPATH-OrganizationUnitId
   │     │                   ├─ folderKey  → X-UIPATH-FolderKey
   │     │                   ├─ folderPath → X-UIPATH-FolderPath-Encoded (base64-of-UTF-16-LE)
   │     │                   └─ none set   → fallback to init-time folderKey
   │     │
   │     └─ returns { headers, queryOptions }
   │
   └─ queryOptions → request params      (folder context never leaks into the query string)
```

When multiple folder inputs are supplied, all corresponding headers are forwarded and the server applies precedence `folderPath` > `folderKey` > `folderId`.

### Internal types (not exported)

| Type | Purpose |
|------|---------|
| `resolveFolderScope()` | `@internal` helper — splits folder context out of an options bag and resolves it to headers. Shared by Connections, Connectors, and `execute()`. |
| `hasFolderContext()` | Module-private guard — whether any folder input or init-time fallback is present. |

### Public types added

| Type | Purpose |
|------|---------|
| `IntegrationServiceFolderContextOptions` | Declares `folderId` / `folderKey` / `folderPath` for this domain. Extended by `ExecuteOptions`. |
| `IntegrationServiceFolderScopedOptions` | Adds `allFolders` on top, deduping the pair previously re-declared across all six connection-yielding option types. Extended by the four `Connection*Options` and two `Connector*Options` types. |

Declared in the Integration Service domain rather than reusing the Orchestrator-facing `FolderScopedOptions`, which also carries OData `expand` / `select` that these endpoints do not accept. This mirrors the existing Data Fabric precedent (`EntityFolderScopedOptions` in `data-fabric.types.ts`). No file outside `src/models/integration-service/` and `src/services/integration-service/` is modified.

## Sample SDK Response

**Not captured — E2E was not run for this PR.** Response shapes are byte-identical to #554 / #555 / #556; see the sample responses on those PRs. There is no new endpoint or transform to sample, and no credentials were available locally to exercise the live API.

> [!IMPORTANT]
> **Unverified against the live API.** `X-UIPATH-FolderKey` is the only folder header these endpoints have been sent to date. Whether `connections_` and `elements_` also honor `X-UIPATH-OrganizationUnitId` and `X-UIPATH-FolderPath-Encoded` was not confirmed. If they do not, `folderId` / `folderPath` would silently resolve to an unscoped query rather than erroring. **Worth one live check per base path** (`connections_` and `elements_` are separate services and may differ) against a folder-scoped connection before merge.

> [!WARNING]
> **Behavior change for coded apps.** A coded app deployed with a `uipath:folder-key` meta tag that calls e.g. `connections.getAll()` with no folder options previously sent no folder header and received cross-folder results; it will now be folder-scoped. This matches how Assets / Processes / Buckets already behave, and `allFolders: true` is the explicit opt-out. Explicit `folderId` / `folderKey` / `folderPath` always wins over the fallback.

## Files

| Area | Files |
|------|-------|
| Endpoint | *unchanged* |
| Types | `src/models/integration-service/integration-service.types.ts` (new), `connections.types.ts`, `connectors.types.ts`, `execution.types.ts` |
| Constants | *unchanged* |
| Models | `src/models/integration-service/connections.models.ts`, `connectors.models.ts` (JSDoc only) |
| Service | `src/services/integration-service/folder-scope.ts` (new), `connections/connections.ts`, `connectors/connectors.ts`, `execution/execution.ts` |
| Build | *unchanged* |
| Barrel exports | `src/models/integration-service/index.ts`, `src/services/integration-service/{connections,connectors,execution}/index.ts` |
| Unit tests | `tests/unit/services/integration-service/connections.test.ts` (+15), `connectors.test.ts` (+5), `execution.test.ts` (+5), `tests/unit/models/integration-service/connections.test.ts` (+2) — **27 new tests** |
| Integration tests | *none* — the Integration Service has no `tests/integration/shared/integration-service/` directory (pre-existing gap from #554–#556). No new methods were added, and no credentials were available to run one. |
| Test utils | `tests/utils/constants/integration-service.ts` (added `FOLDER_ID`, `FOLDER_PATH`, `FOLDER_PATH_ENCODED_VALUE`) |
| Docs | *unchanged* — no new methods, so no `docs/oauth-scopes.md` entry; not a paginated method, so no `docs/pagination.md` row; no new service, so no `mkdocs.yml` nav entry |

### Verification

`npm run typecheck` clean · `npm run lint` 0 errors · `npm run test:unit` 2248 passed · `npm run build` exit 0 · emitted `dist/is-connections/index.d.ts` and `dist/is-execution/index.d.ts` inspected to confirm the new fields surface to consumers.

Refs APPS-35792

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*
