### PR TITLE
feat: support federated entities creation in sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.2",
+    "version": "1.6.3-entities3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.6.2",
+            "version": "1.6.3-entities3",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.2",
+    "version": "1.6.3-entities3",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.6.2",
+  "sdkVersion": "1.6.3-entities3",
   "services": [
     {
       "name": "AgentMemory",

--- a/src/models/data-fabric/entities.constants.ts
+++ b/src/models/data-fabric/entities.constants.ts
@@ -1,5 +1,6 @@
-import { EntityFieldDataType, EntityType, FieldDisplayType } from "./entities.types";
+import { EntityClass, EntityFieldDataType, EntityType, FieldDisplayType } from "./entities.types";
 import {
+  EntityClassId,
   EntitySchemaFieldMapping,
   SqlFieldType,
   EntityFieldConstraint,
@@ -161,4 +162,14 @@ export const EntityFieldTypeMap: Record<SqlFieldType, EntityFieldDataType> = {
   [SqlFieldType.DECIMAL]:          EntityFieldDataType.DECIMAL,
   [SqlFieldType.MULTILINE]:        EntityFieldDataType.MULTILINE_TEXT,
   [SqlFieldType.MULTILINE_MAX]:    EntityFieldDataType.MULTILINE_MAX,
+};
+
+/**
+ * Maps the user-facing {@link EntityClass} to the numeric `entityClassId` the v3
+ * create endpoint expects. Only the two user-creatable classes are listed; any other
+ * value is rejected by `create()`.
+ */
+export const EntityClassToIdMap: Partial<Record<EntityClass, EntityClassId>> = {
+  [EntityClass.Native]:    EntityClassId.Native,
+  [EntityClass.Federated]: EntityClassId.Federated,
 };

--- a/src/models/data-fabric/entities.internal-types.ts
+++ b/src/models/data-fabric/entities.internal-types.ts
@@ -1,4 +1,16 @@
-import { EntityType, FieldDisplayType, EntityRecord, ReferenceType, SqlType } from './entities.types';
+import { EntityType, FieldDisplayType, EntityRecord, ReferenceType, SqlType, EntityUpdateByIdOptions } from './entities.types';
+
+/**
+ * Numeric v3 entity-class discriminator sent on create as
+ * `entityDefinition.entityClassId`. Wire-format counterpart of {@link EntityClass};
+ * internal — consumers pass {@link EntityClass} and the SDK translates via `EntityClassToIdMap`.
+ */
+export enum EntityClassId {
+  /** Native entity — data fully stored and managed within UiPath */
+  Native = 9,
+  /** Federated entity — unified read-only view across UiPath and external sources */
+  Federated = 10,
+}
 
 /**
  * Write-side payload shape for creating a new field in a schema upsert call.
@@ -64,6 +76,25 @@ export interface EntityJoinPayload {
   entity: string;
   on: { left: string; right: string };
 }
+
+/** Wire-ready Federated parts produced by `buildFederatedUpsertParts`. */
+export interface FederatedUpsertParts {
+  externalFields: Array<Record<string, unknown>>;
+  sourceJoinConditionDetails?: Array<Record<string, unknown>>;
+  entityClassId?: number;
+}
+
+/** The Federated source/join delta fields of `EntityUpdateByIdOptions`. */
+export type FederatedUpdateDeltas = Pick<
+  EntityUpdateByIdOptions,
+  | 'addExternalSources'
+  | 'removeExternalSources'
+  | 'addFieldsToSource'
+  | 'removeFieldsFromSource'
+  | 'updateExternalFieldMapping'
+  | 'addSourceJoins'
+  | 'updateSourceJoin'
+>;
 
 /**
  * Names of the per-field SQL constraint properties (i.e. the contents of `sqlType`

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -709,6 +709,26 @@ export interface EntityServiceModel {
    *     // referenceFolderKey omitted → SDK looks up the target at tenant scope
    *   },
    * ], { folderKey: "<sourceFolderKey>" });
+   *
+   * // Federated entity — a read-only view over external and/or native sources.
+   * // Native columns stay empty ([]); the schema comes from `externalFields`.
+   * await entities.create("<entityName>", [], {
+   *   entityClass: EntityClass.Federated,
+   *   externalFields: [{
+   *     externalConnectionDetail: {
+   *       connectionId: "<connectionId>", connectorKey: "<connectorKey>", connectorName: "<connectorName>",
+   *       elementInstanceId: <elementInstanceId>, folderKey: "<folderKey>",
+   *     },
+   *     externalObjectDetail: { externalObjectName: "<objectName>", primaryKey: "<primaryKeyField>", isPrimarySource: true, method: "<operationsCatalogJson>" },
+   *     fields: [{
+   *       field: { name: "<internalFieldName>", type: EntityFieldDataType.STRING },
+   *       externalFieldMappingDetail: { externalFieldName: "<externalFieldName>", directionType: DataDirectionType.ReadOnly },
+   *     }],
+   *   }],
+   *   // Multi-source: add more entries to `externalFields` and join them:
+   *   // sourceJoinConditionDetails: [{ sourceObjectName: "<objectName>", sourceJoinField: "<externalFieldName>",
+   *   //   joinType: JoinType.LeftJoin, relatedSourceObjectName: "<relatedObjectName>", relatedSourceJoinField: "<relatedExternalFieldName>" }],
+   * });
    * ```
    * @internal
    */
@@ -737,6 +757,12 @@ export interface EntityServiceModel {
    * Pass any combination of schema fields (`addFields`, `removeFields`, `updateFields`) and
    * metadata fields (`displayName`, `description`, `isRbacEnabled`). Each group is applied
    * only when the corresponding fields are provided.
+   *
+   * For **Federated** entities, pass source/join deltas instead: `addExternalSources`,
+   * `removeExternalSources` (also removes that source's joins), `addFieldsToSource`,
+   * `removeFieldsFromSource`, `updateExternalFieldMapping`, `addSourceJoins`, and
+   * `updateSourceJoin`. `addFieldsToSource` maps a field that already exists on the source
+   * (a native entity's column or a connector field); it does not create the underlying field.
    *
    * @param id - UUID of the entity to update
    * @param options - Changes to apply ({@link EntityUpdateByIdOptions}) The `folderKey` property is **experimental**.
@@ -778,6 +804,29 @@ export interface EntityServiceModel {
    *   folderKey: "<folderKey>",
    *   addFields: [{ name: "notes", type: EntityFieldDataType.MULTILINE_TEXT }],
    * });
+   *
+   * // Federated: add a source joined to the existing graph
+   * await entities.updateById(<id>, {
+   *   addExternalSources: [{
+   *     externalConnectionDetail: { connectionId: "<connectionId>", elementInstanceId: <elementInstanceId>, connectorKey: "<connectorKey>", connectorName: "<connectorName>" },
+   *     externalObjectDetail: { externalObjectName: "<relatedObjectName>", primaryKey: "<primaryKeyField>", method: "<operationsCatalogJson>" },
+   *     fields: [{ field: { name: "<internalFieldName>", type: EntityFieldDataType.STRING }, externalFieldMappingDetail: { externalFieldName: "<externalFieldName>", directionType: DataDirectionType.ReadOnly } }],
+   *   }],
+   *   addSourceJoins: [{ sourceObjectName: "<objectName>", sourceJoinField: "<externalFieldName>", relatedSourceObjectName: "<relatedObjectName>", relatedSourceJoinField: "<relatedExternalFieldName>", joinType: JoinType.LeftJoin }],
+   * });
+   *
+   * // Federated: add a field to an existing source (maps a field that already exists on it)
+   * await entities.updateById(<id>, {
+   *   addFieldsToSource: [{ sourceObjectName: "<objectName>", fields: [{ field: { name: "<internalFieldName>", type: EntityFieldDataType.STRING }, externalFieldMappingDetail: { externalFieldName: "<externalFieldName>", directionType: DataDirectionType.ReadOnly } }] }],
+   * });
+   *
+   * // Federated: change an existing join in place
+   * await entities.updateById(<id>, {
+   *   updateSourceJoin: [{ sourceObjectName: "<objectName>", relatedSourceObjectName: "<relatedObjectName>", sourceJoinField: "<externalFieldName>" }],
+   * });
+   *
+   * // Federated: remove a source (its joins are removed automatically)
+   * await entities.updateById(<id>, { removeExternalSources: ["<relatedObjectName>"] });
    * ```
    * @internal
    */

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -410,7 +410,7 @@ export interface EntityCreateOptions extends EntityFolderScopedOptions {
    */
   isAnalyticsEnabled?: boolean;
   /** External field source definitions (default: empty) */
-  externalFields?: ExternalField[];
+  externalFields?: ExternalSourceFields[];
 }
 
 /**
@@ -449,6 +449,8 @@ export interface EntityUpdateByIdOptions extends EntityFolderScopedOptions {
   description?: string;
   /** Whether role-based access control is enabled for this entity */
   isRbacEnabled?: boolean;
+  /** Whether Analytics integration is enabled for this entity */
+  isAnalyticsEnabled?: boolean;
 }
 
 /**
@@ -551,6 +553,18 @@ export enum EntityType {
   ChoiceSet = "ChoiceSet",
   InternalEntity = "InternalEntity",
   SystemEntity = "SystemEntity",
+}
+
+/**
+ * Product classification surfaced on v3 entity metadata.
+ */
+export enum EntityClass {
+  /** Native entity — data fully stored and managed within UiPath */
+  Native = "Native",
+  /** Federated entity — unified read-only view across UiPath and external sources */
+  Federated = "Federated",
+  /** Case-family entity */
+  Case = "Case",
 }
 
 /**
@@ -671,6 +685,8 @@ export interface ExternalObject {
   externalConnectionId: string;
   entityId?: string;
   isPrimarySource: boolean;
+  /** External access method for the object */
+  method?: string;
 }
 
 /**
@@ -687,6 +703,29 @@ export interface ExternalConnection {
 }
 
 /**
+ * Operator-level searchability metadata
+ */
+export interface SearchabilityOperator {
+  searchableOperators?: string[];
+}
+
+/**
+ * Named-search searchability metadata
+ */
+export interface SearchabilityNamedSearch {
+  searchableNames?: string[];
+}
+
+/**
+ * Field searchability metadata
+ */
+export interface Searchability {
+  searchable: boolean;
+  supportsOperators?: SearchabilityOperator;
+  supportsNamedSearch?: SearchabilityNamedSearch;
+}
+
+/**
  * External field mapping
  */
 export interface ExternalFieldMapping {
@@ -697,6 +736,12 @@ export interface ExternalFieldMapping {
   externalFieldType?: string;
   internalFieldId: string;
   directionType: DataDirectionType;
+  /** Field searchability metadata */
+  searchability?: Searchability;
+  /** Whether this external field is required for read operations */
+  isRequiredForRead?: boolean;
+  /** Whether this external field can be used for sorting */
+  sortable?: boolean;
 }
 
 /**
@@ -708,12 +753,25 @@ export interface ExternalField {
 }
 
 /**
+ * Native connection detail — set for a Native source referencing another UiPath entity
+ * (Federated entities with Native sources). When present, `externalConnectionDetail` may be empty.
+ */
+export interface NativeConnectionDetail {
+  /** Id of the referenced native UiPath entity (the source to read from) */
+  entityId: string;
+  /** Folder that owns the referenced native entity */
+  folderKey: string;
+}
+
+/**
  * External source fields
  */
 export interface ExternalSourceFields {
   fields?: ExternalField[];
   externalObjectDetail?: ExternalObject;
   externalConnectionDetail?: ExternalConnection;
+  /** Set for a Native source (referencing another UiPath entity); see {@link NativeConnectionDetail} */
+  nativeConnectionDetail?: NativeConnectionDetail;
 }
 
 /**
@@ -722,6 +780,8 @@ export interface ExternalSourceFields {
 export interface SourceJoinCriteria {
   id: string;
   entityId: string;
+  /** Id of the source object on the owning side of the join */
+  sourceObjectId?: string;
   joinFieldName?: string;
   joinType: JoinType;
   relatedSourceObjectId?: string;
@@ -735,6 +795,12 @@ export interface RawEntityGetResponse {
   name: string;
   displayName: string;
   entityType: EntityType;
+  /** Numeric entity type identifier (v3 metadata) */
+  entityTypeId?: number;
+  /** Template discriminator — null for non-templated entities, set for templated ones (v3 metadata) */
+  templateName?: string;
+  /** Product classification (v3 metadata): Native, Federated, or Case */
+  entityClass?: EntityClass;
   description?: string;
   fields: FieldMetaData[];
   folderId?: string;

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -460,7 +460,7 @@ export interface EntityCreateOptions extends EntityFolderScopedOptions {
    */
   isAnalyticsEnabled?: boolean;
   /** External field source definitions (default: empty) */
-  externalFields?: ExternalField[];
+  externalFields?: ExternalSourceFields[];
 }
 
 /**
@@ -499,6 +499,8 @@ export interface EntityUpdateByIdOptions extends EntityFolderScopedOptions {
   description?: string;
   /** Whether role-based access control is enabled for this entity */
   isRbacEnabled?: boolean;
+  /** Whether Analytics integration is enabled for this entity */
+  isAnalyticsEnabled?: boolean;
 }
 
 /**
@@ -601,6 +603,18 @@ export enum EntityType {
   ChoiceSet = "ChoiceSet",
   InternalEntity = "InternalEntity",
   SystemEntity = "SystemEntity",
+}
+
+/**
+ * Product classification surfaced on v3 entity metadata.
+ */
+export enum EntityClass {
+  /** Native entity — data fully stored and managed within UiPath */
+  Native = "Native",
+  /** Federated entity — unified read-only view across UiPath and external sources */
+  Federated = "Federated",
+  /** Case-family entity */
+  Case = "Case",
 }
 
 /**
@@ -721,6 +735,8 @@ export interface ExternalObject {
   externalConnectionId: string;
   entityId?: string;
   isPrimarySource: boolean;
+  /** External access method for the object */
+  method?: string;
 }
 
 /**
@@ -737,6 +753,29 @@ export interface ExternalConnection {
 }
 
 /**
+ * Operator-level searchability metadata
+ */
+export interface SearchabilityOperator {
+  searchableOperators?: string[];
+}
+
+/**
+ * Named-search searchability metadata
+ */
+export interface SearchabilityNamedSearch {
+  searchableNames?: string[];
+}
+
+/**
+ * Field searchability metadata
+ */
+export interface Searchability {
+  searchable: boolean;
+  supportsOperators?: SearchabilityOperator;
+  supportsNamedSearch?: SearchabilityNamedSearch;
+}
+
+/**
  * External field mapping
  */
 export interface ExternalFieldMapping {
@@ -747,6 +786,12 @@ export interface ExternalFieldMapping {
   externalFieldType?: string;
   internalFieldId: string;
   directionType: DataDirectionType;
+  /** Field searchability metadata */
+  searchability?: Searchability;
+  /** Whether this external field is required for read operations */
+  isRequiredForRead?: boolean;
+  /** Whether this external field can be used for sorting */
+  sortable?: boolean;
 }
 
 /**
@@ -758,12 +803,25 @@ export interface ExternalField {
 }
 
 /**
+ * Native connection detail — set for a Native source referencing another UiPath entity
+ * (Federated entities with Native sources). When present, `externalConnectionDetail` may be empty.
+ */
+export interface NativeConnectionDetail {
+  /** Id of the referenced native UiPath entity (the source to read from) */
+  entityId: string;
+  /** Folder that owns the referenced native entity */
+  folderKey: string;
+}
+
+/**
  * External source fields
  */
 export interface ExternalSourceFields {
   fields?: ExternalField[];
   externalObjectDetail?: ExternalObject;
   externalConnectionDetail?: ExternalConnection;
+  /** Set for a Native source (referencing another UiPath entity); see {@link NativeConnectionDetail} */
+  nativeConnectionDetail?: NativeConnectionDetail;
 }
 
 /**
@@ -772,6 +830,8 @@ export interface ExternalSourceFields {
 export interface SourceJoinCriteria {
   id: string;
   entityId: string;
+  /** Id of the source object on the owning side of the join */
+  sourceObjectId?: string;
   joinFieldName?: string;
   joinType: JoinType;
   relatedSourceObjectId?: string;
@@ -785,6 +845,12 @@ export interface RawEntityGetResponse {
   name: string;
   displayName: string;
   entityType: EntityType;
+  /** Numeric entity type identifier (v3 metadata) */
+  entityTypeId?: number;
+  /** Template discriminator — null for non-templated entities, set for templated ones (v3 metadata) */
+  templateName?: string;
+  /** Product classification (v3 metadata): Native, Federated, or Case */
+  entityClass?: EntityClass;
   description?: string;
   fields: FieldMetaData[];
   folderId?: string;

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -459,8 +459,29 @@ export interface EntityCreateOptions extends EntityFolderScopedOptions {
    * @experimental Analytics integration is in preview — the contract may change.
    */
   isAnalyticsEnabled?: boolean;
-  /** External field source definitions (default: empty) */
-  externalFields?: ExternalSourceFields[];
+  /**
+   * Product class of the entity (default: `Native`). Set to `Federated` to create a
+   * federated entity — a read-only view over one or more external/native sources.
+   * A Federated entity requires at least one source in `externalFields`.
+   *
+   * @experimental
+   */
+  entityClass?: EntityClass;
+  /**
+   * External source definitions — the connections, objects, and field mappings a
+   * Federated entity reads from. Required when `entityClass` is `Federated`; ignored
+   * for Native entities.
+   *
+   * @experimental
+   */
+  externalFields?: EntityCreateExternalSource[];
+  /**
+   * Cross-source joins for a multi-source Federated entity. Each entry joins two
+   * sources by object + field name; omit for a single-source Federated entity.
+   *
+   * @experimental
+   */
+  sourceJoinConditionDetails?: SourceJoinConditionDetail[];
 }
 
 /**
@@ -499,8 +520,61 @@ export interface EntityUpdateByIdOptions extends EntityFolderScopedOptions {
   description?: string;
   /** Whether role-based access control is enabled for this entity */
   isRbacEnabled?: boolean;
-  /** Whether Analytics integration is enabled for this entity */
+  /**
+   * Whether Analytics integration is enabled for this entity.
+   *
+   * @experimental Analytics integration is in preview — the contract may change.
+   */
   isAnalyticsEnabled?: boolean;
+
+  // ── Federated source/join deltas ──
+
+  /** External sources to add to a Federated entity (same shape as create's `externalFields`). @experimental */
+  addExternalSources?: EntityCreateExternalSource[];
+  /** External sources to remove, by `externalObjectName`. @experimental */
+  removeExternalSources?: string[];
+  /** Fields to add to an existing source, keyed by the source's `externalObjectName`. @experimental */
+  addFieldsToSource?: EntityAddFieldsToSource[];
+  /** Fields to remove from an existing source, keyed by the source's `externalObjectName`. @experimental */
+  removeFieldsFromSource?: EntityRemoveFieldsFromSource[];
+  /** Field-mapping updates (searchability/direction/sortable) on an existing external field. @experimental */
+  updateExternalFieldMapping?: EntityUpdateExternalFieldMapping[];
+  /** Cross-source joins to add (typically paired with `addExternalSources` — a new
+   * non-primary source must be connected to the graph by a join). @experimental */
+  addSourceJoins?: SourceJoinConditionDetail[];
+  /** Update an existing join in place — change its join fields and/or type. Identified by
+   * source + related object names. (There is no standalone remove-join: a join can't
+   * outlive its source, so `removeExternalSources` cascades its joins automatically.) @experimental */
+  updateSourceJoin?: EntityUpdateSourceJoin[];
+}
+
+/** Fields to add to a Federated source, identified by the source object name. */
+export interface EntityAddFieldsToSource {
+  sourceObjectName: string;
+  fields: EntityCreateExternalField[];
+}
+
+/** Fields to remove from a Federated source, identified by the source object name. */
+export interface EntityRemoveFieldsFromSource {
+  sourceObjectName: string;
+  fieldNames: string[];
+}
+
+/** A mapping update for one external field on a Federated source. */
+export interface EntityUpdateExternalFieldMapping {
+  sourceObjectName: string;
+  fieldName: string;
+  mapping: Partial<EntityCreateExternalFieldMapping>;
+}
+
+/** Updates an existing Federated cross-source join in place, identified by the two object
+ * names. Only the supplied fields change; the others are kept. */
+export interface EntityUpdateSourceJoin {
+  sourceObjectName: string;
+  relatedSourceObjectName: string;
+  sourceJoinField?: string;
+  relatedSourceJoinField?: string;
+  joinType?: JoinType;
 }
 
 /**
@@ -606,14 +680,18 @@ export enum EntityType {
 }
 
 /**
- * Product classification surfaced on v3 entity metadata.
+ * Product classification of an entity.
  */
 export enum EntityClass {
   /** Native entity — data fully stored and managed within UiPath */
   Native = "Native",
-  /** Federated entity — unified read-only view across UiPath and external sources */
+  /**
+   * Federated entity — unified read-only view across UiPath and external sources.
+   *
+   * @experimental
+   */
   Federated = "Federated",
-  /** Case-family entity */
+  /** Case-family entity — read-only: returned by `getById`, not a valid value for `create`. */
   Case = "Case",
 }
 
@@ -648,11 +726,11 @@ export enum FieldDisplayType {
 }
 
 /**
- * Data direction type for external fields
+ * Read/write direction for an external field.
  */
 export enum DataDirectionType {
-  ReadOnly = "ReadOnly",
-  ReadAndWrite = "ReadAndWrite",
+  ReadOnly = 0,
+  ReadAndWrite = 1,
 }
 
 /**
@@ -839,22 +917,127 @@ export interface SourceJoinCriteria {
 }
 
 /**
+ * A join between two sources of a Federated entity, expressed by source object and field names.
+ */
+export interface SourceJoinConditionDetail {
+  /** Name of the object on the owning side of the join. */
+  sourceObjectName: string;
+  /** Field on the source object used to match. */
+  sourceJoinField: string;
+  /** Connection id of the source object (the external connection this object belongs to). */
+  sourceObjectConnectionId?: string;
+  /** How records are matched across the two sources. */
+  joinType: JoinType;
+  /** Name of the object on the related side of the join. */
+  relatedSourceObjectName: string;
+  /** Field on the related source object used to match. */
+  relatedSourceJoinField: string;
+  /** Connection id of the related source object. */
+  relatedSourceObjectConnectionId?: string;
+}
+
+/**
+ * Connection an external source reads from.
+ */
+export interface EntityCreateExternalConnection {
+  /** Integration Service connection id. */
+  connectionId: string;
+  /** Element instance id of the connection. */
+  elementInstanceId?: number;
+  /** Folder that owns the connection. */
+  folderKey?: string;
+  /** Connector key (e.g. `uipath-salesforce`). */
+  connectorKey: string;
+  /** Connector display name. */
+  connectorName: string;
+  /** Connection display name. */
+  connectionName?: string;
+}
+
+/**
+ * External object (table) a source reads from.
+ */
+export interface EntityCreateExternalObject {
+  /** Name of the object on the external system (e.g. `Account`). */
+  externalObjectName: string;
+  /** Display name of the external object. */
+  externalObjectDisplayName?: string;
+  /** Primary key field on the external object. */
+  primaryKey?: string;
+  /** Whether this is the primary source of the federated entity. */
+  isPrimarySource?: boolean;
+  /** External access method for the object. */
+  method?: string;
+}
+
+/**
+ * Maps an external source field to its internal column.
+ */
+export interface EntityCreateExternalFieldMapping {
+  /** Name of the field on the external source. */
+  externalFieldName: string;
+  /** Display name of the external source field. */
+  externalFieldDisplayName?: string;
+  /** Type of the field on the external source. */
+  externalFieldType?: string;
+  /** Read-only vs read/write direction for this field. */
+  directionType: DataDirectionType;
+  /** Field searchability metadata. */
+  searchability?: Searchability;
+  /** Whether this external field is required for read operations. */
+  isRequiredForRead?: boolean;
+  /** Whether this external field can be used for sorting. */
+  sortable?: boolean;
+}
+
+/**
+ * A single field contributed by an external source on create: an internal column
+ * (defined exactly like a native field via {@link EntityCreateFieldOptions}) plus the
+ * mapping back to the external source field.
+ */
+export interface EntityCreateExternalField {
+  /** Internal column definition — same shape as a native create field. */
+  field: EntityCreateFieldOptions;
+  /** Mapping from the external source field to this internal column. */
+  externalFieldMappingDetail: EntityCreateExternalFieldMapping;
+}
+
+/**
+ * One source of a Federated entity on create — the connection and object it reads
+ * from, and the fields it contributes. Supply `externalConnectionDetail` for a truly
+ * external source, or `nativeConnectionDetail` for a source backed by another UiPath
+ * entity.
+ */
+export interface EntityCreateExternalSource {
+  /** Fields this source contributes to the federated entity. */
+  fields?: EntityCreateExternalField[];
+  /** The external object (table) this source reads from. Required — identifies the source table; no server default. */
+  externalObjectDetail: EntityCreateExternalObject;
+  /** Connection for a truly external source (Salesforce, SAP, ServiceNow, …). */
+  externalConnectionDetail?: EntityCreateExternalConnection;
+  /** Connection for a Native source referencing another UiPath entity. */
+  nativeConnectionDetail?: NativeConnectionDetail;
+}
+
+/**
  * Entity metadata returned by getById
  */
 export interface RawEntityGetResponse {
   name: string;
   displayName: string;
   entityType: EntityType;
-  /** Numeric entity type identifier (v3 metadata) */
+  /** Numeric entity type identifier */
   entityTypeId?: number;
-  /** Template discriminator — null for non-templated entities, set for templated ones (v3 metadata) */
+  /** Template discriminator — null for non-templated entities, set for templated ones */
   templateName?: string;
-  /** Product classification (v3 metadata): Native, Federated, or Case */
+  /** Product classification: Native, Federated, or Case. @experimental */
   entityClass?: EntityClass;
   description?: string;
   fields: FieldMetaData[];
   folderId?: string;
+  /** External source definitions — present only on Federated entities. @experimental */
   externalFields?: ExternalSourceFields[];
+  /** Cross-source join criteria — present only on Federated entities. @experimental */
   sourceJoinCriterias?: SourceJoinCriteria[];
   recordCount?: number;
   storageSizeInMB?: number;

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -264,13 +264,12 @@ export class EntityService extends BaseService implements EntityServiceModel {
 
   @track('Entities.GetAll')
   async getAll(options?: EntityGetAllOptions): Promise<EntityGetResponse[]> {
-    // folderKey is preferred over includeFolderEntities: when present, scope to that folder
-    // via the v1 endpoint + header. Only when no folderKey is given AND includeFolderEntities
-    // is explicitly true does the SDK switch to the v2 endpoint (returns tenant + folder
-    // entities together). Default (no options or includeFolderEntities omitted) stays on
-    // the v1 endpoint = tenant only.
-    const endpoint = !options?.folderKey && options?.includeFolderEntities
-      ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2
+    // Use the v3 endpoint whenever a folder scope is requested: a folderKey scopes to that
+    // folder via the header, and includeFolderEntities returns tenant + folder entities
+    // together. Only the default (no folderKey and includeFolderEntities omitted) stays on
+    // the v1 endpoint = tenant only, since v3 has no tenant-only listing.
+    const endpoint = options?.folderKey || options?.includeFolderEntities
+      ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3
       : DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL;
 
     const response = await this.get<RawEntityGetResponse[]>(
@@ -458,7 +457,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
   async updateById(id: string, options?: EntityUpdateByIdOptions): Promise<void> {
     const opts = options ?? {};
     const hasSchemaChanges = !!(opts.addFields?.length || opts.removeFields?.length || opts.updateFields?.length);
-    const hasMetadataChanges = opts.displayName !== undefined || opts.description !== undefined || opts.isRbacEnabled !== undefined;
+    const hasMetadataChanges = opts.displayName !== undefined || opts.description !== undefined || opts.isRbacEnabled !== undefined || opts.isAnalyticsEnabled !== undefined;
 
     if (hasSchemaChanges) {
       await this.applySchemaUpdate(id, opts);
@@ -470,6 +469,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
           ...(opts.displayName !== undefined && { displayName: opts.displayName }),
           ...(opts.description !== undefined && { description: opts.description }),
           ...(opts.isRbacEnabled !== undefined && { isRbacEnabled: opts.isRbacEnabled }),
+          ...(opts.isAnalyticsEnabled !== undefined && { isInsightsEnabled: opts.isAnalyticsEnabled }),
         },
         { headers: createHeaders({ [FOLDER_KEY]: opts.folderKey }) },
       );

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -264,13 +264,12 @@ export class EntityService extends BaseService implements EntityServiceModel {
 
   @track('Entities.GetAll')
   async getAll(options?: EntityGetAllOptions): Promise<EntityGetResponse[]> {
-    // folderKey is preferred over includeFolderEntities: when present, scope to that folder
-    // via the v1 endpoint + header. Only when no folderKey is given AND includeFolderEntities
-    // is explicitly true does the SDK switch to the v2 endpoint (returns tenant + folder
-    // entities together). Default (no options or includeFolderEntities omitted) stays on
-    // the v1 endpoint = tenant only.
-    const endpoint = !options?.folderKey && options?.includeFolderEntities
-      ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2
+    // Use the v3 endpoint whenever a folder scope is requested: a folderKey scopes to that
+    // folder via the header, and includeFolderEntities returns tenant + folder entities
+    // together. Only the default (no folderKey and includeFolderEntities omitted) stays on
+    // the v1 endpoint = tenant only, since v3 has no tenant-only listing.
+    const endpoint = options?.folderKey || options?.includeFolderEntities
+      ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3
       : DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL;
 
     const response = await this.get<RawEntityGetResponse[]>(
@@ -465,7 +464,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
   async updateById(id: string, options?: EntityUpdateByIdOptions): Promise<void> {
     const opts = options ?? {};
     const hasSchemaChanges = !!(opts.addFields?.length || opts.removeFields?.length || opts.updateFields?.length);
-    const hasMetadataChanges = opts.displayName !== undefined || opts.description !== undefined || opts.isRbacEnabled !== undefined;
+    const hasMetadataChanges = opts.displayName !== undefined || opts.description !== undefined || opts.isRbacEnabled !== undefined || opts.isAnalyticsEnabled !== undefined;
 
     if (hasSchemaChanges) {
       await this.applySchemaUpdate(id, opts);
@@ -477,6 +476,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
           ...(opts.displayName !== undefined && { displayName: opts.displayName }),
           ...(opts.description !== undefined && { description: opts.description }),
           ...(opts.isRbacEnabled !== undefined && { isRbacEnabled: opts.isRbacEnabled }),
+          ...(opts.isAnalyticsEnabled !== undefined && { isInsightsEnabled: opts.isAnalyticsEnabled }),
         },
         { headers: createHeaders({ [FOLDER_KEY]: opts.folderKey }) },
       );

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -43,6 +43,9 @@ import {
   SqlType,
   FieldDisplayType,
   ReferenceType,
+  EntityClass,
+  EntityCreateExternalSource,
+  EntityCreateExternalField,
 } from '../../models/data-fabric/entities.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination/types';
 import { PaginationType } from '../../utils/pagination/internal-types';
@@ -62,8 +65,9 @@ import {
   ENTITY_FIELD_CONSTRAINT_SPEC,
   ENTITY_TYPE_IDS,
   MAX_QUERY_JOINS,
+  EntityClassToIdMap,
 } from '../../models/data-fabric/entities.constants';
-import { FieldSchemaPayload, SqlFieldType, EntityFieldConstraint, ResolvedReferenceMeta, EntityJoinPayload } from '../../models/data-fabric/entities.internal-types';
+import { FieldSchemaPayload, SqlFieldType, EntityFieldConstraint, ResolvedReferenceMeta, EntityJoinPayload, FederatedUpsertParts, FederatedUpdateDeltas } from '../../models/data-fabric/entities.internal-types';
 import { track } from '../../core/telemetry';
 
 /** Wire values for join types on the name-based multi-entity query route. */
@@ -89,6 +93,38 @@ function toWireJoin(join: EntityJoin, baseEntityName: string): EntityJoinPayload
       right: qualifyJoinField(join.relatedEntityName, join.relatedFieldName),
     },
   };
+}
+
+/** Name of the external object a Federated source reads from (wire shape). */
+function externalSourceObjectName(source: Record<string, unknown>): string | undefined {
+  return (source.externalObjectDetail as Record<string, unknown> | undefined)?.externalObjectName as string | undefined;
+}
+
+/** Internal column name of a Federated source field (wire shape uses `fieldDefinition`). */
+function externalSourceFieldName(field: Record<string, unknown>): string | undefined {
+  const def = field.fieldDefinition as Record<string, unknown> | undefined;
+  return (def?.name ?? def?.Name) as string | undefined;
+}
+
+/**
+ * Carries an existing source forward for the upsert. The only reshaping the write needs
+ * is defaulting `fieldDisplayType`/`description` on each field definition: the GET omits
+ * them, but the upsert requires `fieldDisplayType` (a missing one fails the source's field
+ * validation and surfaces as a misleading join-dependency error). Server-managed identity
+ * fields round-trip harmlessly, so everything else is kept as-is.
+ */
+function carryForwardSource(source: Record<string, unknown>): Record<string, unknown> {
+  const fields = ((source.fields as Array<Record<string, unknown>> | undefined) ?? []).map(f => {
+    const fieldDefinition: Record<string, unknown> = { ...(f.fieldDefinition as Record<string, unknown> | undefined) };
+    if (fieldDefinition.fieldDisplayType === undefined && fieldDefinition.FieldDisplayType === undefined) {
+      fieldDefinition.fieldDisplayType = FieldDisplayType.Basic;
+    }
+    if (fieldDefinition.description === undefined && fieldDefinition.Description === undefined) {
+      fieldDefinition.description = '';
+    }
+    return { ...f, fieldDefinition };
+  });
+  return { ...source, fields };
 }
 
 /**
@@ -431,7 +467,24 @@ export class EntityService extends BaseService implements EntityServiceModel {
   @track('Entities.Create')
   async create(name: string, fields: EntityCreateFieldOptions[], options?: EntityCreateOptions): Promise<string> {
     const opts = options ?? {};
+    // entityClassId is only sent when a class is explicitly chosen — native creates
+    // stay byte-identical to the legacy shape (no discriminator).
+    let entityClassId: number | undefined;
+    if (opts.entityClass !== undefined) {
+      entityClassId = EntityClassToIdMap[opts.entityClass];
+      if (entityClassId === undefined) {
+        throw new ValidationError({
+          message: `entityClass '${opts.entityClass}' is not creatable. Use EntityClass.Native or EntityClass.Federated.`,
+        });
+      }
+    }
+    if (opts.entityClass === EntityClass.Federated && !opts.externalFields?.length) {
+      throw new ValidationError({
+        message: 'Federated entities require at least one external source in `externalFields`.',
+      });
+    }
     const fieldPayloads = await this.buildFieldsWithReferenceMeta(fields);
+    const externalFields = await this.buildExternalSourcesPayload(opts.externalFields);
     const payload = {
       ...(opts.description !== undefined && { description: opts.description }),
       displayName: opts.displayName ?? name,
@@ -441,7 +494,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
         folderId: opts.folderKey ?? DATA_FABRIC_TENANT_FOLDER_ID,
         isRbacEnabled: opts.isRbacEnabled ?? false,
         isInsightsEnabled: opts.isAnalyticsEnabled ?? false,
-        externalFields: opts.externalFields ?? [],
+        externalFields,
+        ...(entityClassId !== undefined && { entityClassId }),
+        ...(opts.sourceJoinConditionDetails !== undefined && { sourceJoinConditionDetails: opts.sourceJoinConditionDetails }),
       },
     };
     const response = await this.post<string>(
@@ -463,7 +518,16 @@ export class EntityService extends BaseService implements EntityServiceModel {
   @track('Entities.UpdateById')
   async updateById(id: string, options?: EntityUpdateByIdOptions): Promise<void> {
     const opts = options ?? {};
-    const hasSchemaChanges = !!(opts.addFields?.length || opts.removeFields?.length || opts.updateFields?.length);
+    const hasFederatedChanges = !!(
+      opts.addExternalSources?.length ||
+      opts.removeExternalSources?.length ||
+      opts.addFieldsToSource?.length ||
+      opts.removeFieldsFromSource?.length ||
+      opts.updateExternalFieldMapping?.length ||
+      opts.addSourceJoins?.length ||
+      opts.updateSourceJoin?.length
+    );
+    const hasSchemaChanges = !!(opts.addFields?.length || opts.removeFields?.length || opts.updateFields?.length) || hasFederatedChanges;
     const hasMetadataChanges = opts.displayName !== undefined || opts.description !== undefined || opts.isRbacEnabled !== undefined || opts.isAnalyticsEnabled !== undefined;
 
     if (hasSchemaChanges) {
@@ -490,7 +554,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
    * @param options - Field changes to apply
    * @private
    */
-  private async applySchemaUpdate(entityId: string, options: Pick<EntityUpdateByIdOptions, 'addFields' | 'removeFields' | 'updateFields' | 'folderKey'>): Promise<void> {
+  private async applySchemaUpdate(entityId: string, options: Pick<EntityUpdateByIdOptions, 'addFields' | 'removeFields' | 'updateFields' | 'folderKey'> & FederatedUpdateDeltas): Promise<void> {
     const folderHeaders = createHeaders({ [FOLDER_KEY]: options.folderKey });
     const entityResponse = await this.get<RawEntityGetResponse>(
       DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(entityId),
@@ -498,9 +562,12 @@ export class EntityService extends BaseService implements EntityServiceModel {
     );
     const raw = entityResponse.data;
 
-    // Carry forward existing non-system fields from GET response (skip system/primary-key fields)
+    // Carry forward existing non-system fields from GET response (skip system/primary-key
+    // fields). Exclude external fields: on a Federated entity the GET flattens the external
+    // source fields into `fields` too (isExternalField=true); they belong only under
+    // `externalFields`, so reposting them here duplicates them and the upsert fails.
     let fields: FieldMetaData[] = (raw.fields ?? [])
-      .filter(f => !f.isSystemField && !f.isPrimaryKey);
+      .filter(f => !f.isSystemField && !f.isPrimaryKey && !f.isExternalField);
 
     // Filter out removed fields
     if (options.removeFields?.length) {
@@ -549,6 +616,11 @@ export class EntityService extends BaseService implements EntityServiceModel {
       newFields.push(...await this.buildFieldsWithReferenceMeta(options.addFields));
     }
 
+    // Carry forward (and, for Federated entities, translate + apply deltas to) the
+    // external sources and joins. Reposting the raw `externalFields` alone would drop
+    // the joins and class discriminator — the v3 upsert is a full-definition replace.
+    const federated = await this.buildFederatedUpsertParts(raw, options);
+
     await this.post(
       DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
       {
@@ -563,7 +635,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
           // `raw` is the untransformed GET response, so read the wire key `isInsightsEnabled`
           // directly (it is not on the public type, which exposes it as `isAnalyticsEnabled`).
           isInsightsEnabled: (raw as { isInsightsEnabled?: boolean }).isInsightsEnabled ?? false,
-          externalFields: raw.externalFields ?? [],
+          externalFields: federated.externalFields,
+          ...(federated.entityClassId !== undefined && { entityClassId: federated.entityClassId }),
+          ...(federated.sourceJoinConditionDetails !== undefined && { sourceJoinConditionDetails: federated.sourceJoinConditionDetails }),
         },
       },
       { headers: folderHeaders },
@@ -585,6 +659,113 @@ export class EntityService extends BaseService implements EntityServiceModel {
       { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
     );
     return transformData(response.data, EntityMap).name;
+  }
+
+  /**
+   * Translates a raw GET into the write-ready Federated parts, then applies any
+   * source/join deltas. Joins arrive as `sourceJoinCriterias` (object/field IDs) and
+   * are resolved to `sourceJoinConditionDetails` (object names + connection ids) using
+   * each source's `externalObjectDetail.id` → connection map. `joinType` passes through
+   * as-is (the API accepts both the string form and the numeric form).
+   */
+  private async buildFederatedUpsertParts(
+    raw: RawEntityGetResponse,
+    options: FederatedUpdateDeltas,
+  ): Promise<FederatedUpsertParts> {
+    // Carry forward current sources (only `fieldDisplayType`/`description` need defaulting).
+    let externalFields: Array<Record<string, unknown>> = (raw.externalFields ?? []).map(s => carryForwardSource({ ...s } as Record<string, unknown>));
+    let joins = this.translateSourceJoins(raw);
+    const entityClassId = raw.entityClass ? EntityClassToIdMap[raw.entityClass] : undefined;
+
+    const findSource = (name: string): Record<string, unknown> | undefined =>
+      externalFields.find(s => externalSourceObjectName(s) === name);
+
+    if (options.addExternalSources?.length) {
+      externalFields.push(...await this.buildExternalSourcesPayload(options.addExternalSources));
+    }
+    if (options.removeExternalSources?.length) {
+      const remove = new Set(options.removeExternalSources);
+      externalFields = externalFields.filter(s => !remove.has(externalSourceObjectName(s) ?? ''));
+      // Cascade: a join can't outlive its source. Drop any join that references a removed
+      // source — otherwise it dangles (and, once the source is gone, can't be targeted by
+      // name to remove later). Join names were resolved from the pre-removal GET.
+      joins = joins.filter(j => !remove.has(j.sourceObjectName as string) && !remove.has(j.relatedSourceObjectName as string));
+    }
+    if (options.addFieldsToSource?.length) {
+      for (const add of options.addFieldsToSource) {
+        const src = findSource(add.sourceObjectName);
+        if (!src) throw new ValidationError({ message: `Cannot add fields: source '${add.sourceObjectName}' not found on the entity.` });
+        const builtFields = await this.buildExternalFieldsPayload(add.fields);
+        const existing = (src.fields as Array<Record<string, unknown>> | undefined) ?? [];
+        src.fields = [...existing, ...builtFields];
+      }
+    }
+    if (options.removeFieldsFromSource?.length) {
+      for (const rem of options.removeFieldsFromSource) {
+        const src = findSource(rem.sourceObjectName);
+        if (!src) throw new ValidationError({ message: `Cannot remove fields: source '${rem.sourceObjectName}' not found on the entity.` });
+        const drop = new Set(rem.fieldNames);
+        src.fields = ((src.fields as Array<Record<string, unknown>> | undefined) ?? []).filter(f => !drop.has(externalSourceFieldName(f) ?? ''));
+      }
+    }
+    if (options.updateExternalFieldMapping?.length) {
+      for (const up of options.updateExternalFieldMapping) {
+        const src = findSource(up.sourceObjectName);
+        if (!src) throw new ValidationError({ message: `Cannot update mapping: source '${up.sourceObjectName}' not found on the entity.` });
+        const field = ((src.fields as Array<Record<string, unknown>> | undefined) ?? []).find(f => externalSourceFieldName(f) === up.fieldName);
+        if (!field) throw new ValidationError({ message: `Cannot update mapping: field '${up.fieldName}' not found on source '${up.sourceObjectName}'.` });
+        field.externalFieldMappingDetail = { ...(field.externalFieldMappingDetail as Record<string, unknown>), ...up.mapping };
+      }
+    }
+    if (options.addSourceJoins?.length) {
+      joins.push(...options.addSourceJoins.map(j => ({ ...j } as Record<string, unknown>)));
+    }
+    if (options.updateSourceJoin?.length) {
+      for (const up of options.updateSourceJoin) {
+        const join = joins.find(j => j.sourceObjectName === up.sourceObjectName && j.relatedSourceObjectName === up.relatedSourceObjectName);
+        if (!join) throw new ValidationError({ message: `Cannot update join: no join between '${up.sourceObjectName}' and '${up.relatedSourceObjectName}'.` });
+        if (up.sourceJoinField !== undefined) join.sourceJoinField = up.sourceJoinField;
+        if (up.relatedSourceJoinField !== undefined) join.relatedSourceJoinField = up.relatedSourceJoinField;
+        if (up.joinType !== undefined) join.joinType = up.joinType;
+      }
+    }
+
+    return {
+      externalFields,
+      ...(entityClassId !== undefined && { entityClassId }),
+      ...(joins.length > 0 && { sourceJoinConditionDetails: joins }),
+    };
+  }
+
+  /**
+   * Resolves read-shape `sourceJoinCriterias` (object/field IDs) into write-shape
+   * `sourceJoinConditionDetails` (object names + connection ids). The connection id for a
+   * source is its `externalConnectionDetail.connectionId` (external) or
+   * `nativeConnectionDetail.entityId` (a Native source referencing another UiPath entity).
+   */
+  private translateSourceJoins(raw: RawEntityGetResponse): Array<Record<string, unknown>> {
+    const byObjectId = new Map<string, { name?: string; connectionId?: string }>();
+    for (const source of raw.externalFields ?? []) {
+      const objectId = source.externalObjectDetail?.id;
+      if (!objectId) continue;
+      byObjectId.set(objectId, {
+        name: source.externalObjectDetail?.externalObjectName,
+        connectionId: source.externalConnectionDetail?.connectionId ?? source.nativeConnectionDetail?.entityId,
+      });
+    }
+    return (raw.sourceJoinCriterias ?? []).map(join => {
+      const src = byObjectId.get(join.sourceObjectId ?? '');
+      const related = byObjectId.get(join.relatedSourceObjectId ?? '');
+      return {
+        sourceObjectName: src?.name,
+        sourceJoinField: join.joinFieldName,
+        sourceObjectConnectionId: src?.connectionId,
+        joinType: join.joinType,
+        relatedSourceObjectName: related?.name,
+        relatedSourceJoinField: join.relatedSourceFieldName,
+        relatedSourceObjectConnectionId: related?.connectionId,
+      };
+    });
   }
 
   /**
@@ -682,6 +863,36 @@ export class EntityService extends BaseService implements EntityServiceModel {
   private async buildFieldsWithReferenceMeta(fields: EntityCreateFieldOptions[]): Promise<FieldSchemaPayload[]> {
     const metas = await Promise.all(fields.map(f => this.buildReferenceMeta(f)));
     return fields.map((f, i) => this.buildSchemaFieldPayload(f, metas[i]));
+  }
+
+  /** Builds the wire `fields` payload for a Federated source (field definition + mapping). */
+  private async buildExternalFieldsPayload(
+    fields?: EntityCreateExternalField[],
+  ): Promise<Array<Record<string, unknown>>> {
+    const list = fields ?? [];
+    const fieldDefs = await this.buildFieldsWithReferenceMeta(list.map(f => f.field));
+    return list.map((f, i) => ({
+      fieldDefinition: fieldDefs[i],
+      externalFieldMappingDetail: f.externalFieldMappingDetail,
+    }));
+  }
+
+  /**
+   * Builds the wire `externalFields` payload for a Federated entity. Each source's
+   * internal columns run through the same {@link buildFieldsWithReferenceMeta} pipeline
+   * as native fields (so `fieldDefinition` is identical to a native field), then pair
+   * with their external mapping and source connection/object details.
+   */
+  private async buildExternalSourcesPayload(
+    sources?: EntityCreateExternalSource[],
+  ): Promise<Array<Record<string, unknown>>> {
+    if (!sources?.length) return [];
+    return Promise.all(sources.map(async source => ({
+      fields: await this.buildExternalFieldsPayload(source.fields),
+      externalObjectDetail: source.externalObjectDetail,
+      ...(source.externalConnectionDetail !== undefined && { externalConnectionDetail: source.externalConnectionDetail }),
+      ...(source.nativeConnectionDetail !== undefined && { nativeConnectionDetail: source.nativeConnectionDetail }),
+    })));
   }
 
   // Choice-set targets resolve server-side by NAME (the API rejects cross-folder

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -17,24 +17,28 @@ export const DATA_FABRIC_TENANT_FOLDER_ID = '00000000-0000-0000-0000-00000000000
 export const DATA_FABRIC_ENDPOINTS = {
   ENTITY: {
     GET_ALL: `${DATAFABRIC_BASE}/api/Entity`,
-    // Lists tenant-level and folder-level entities together.
-    // Used by getAll when includeFolderEntities is true.
-    GET_ALL_V2: `${DATAFABRIC_BASE}/api/v2/Entity`,
-    GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read`,
-    GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
-    // v2 single-record read. Returns the full record including complete MULTILINE_MAX
+    // v3 listing of tenant-level and folder-level entities together.
+    // Used by getAll when folderKey is set or includeFolderEntities is true.
+    GET_ALL_V3: `${DATAFABRIC_BASE}/api/v3/entities`,
+    GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/read`,
+    GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}`,
+    // v3 single-record read. Returns the full record including complete MULTILINE_MAX
     // content, unlike list/query endpoints which project a size marker for those fields.
     GET_RECORD_BY_ID: (entityId: string, recordId: string) =>
-      `${DATAFABRIC_BASE}/api/v2/EntityService/entity/${entityId}/read/${recordId}`,
-    INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert`,
-    BATCH_INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert-batch`,
-    UPDATE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update/${recordId}`,
-    UPDATE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/update-batch`,
-    DELETE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete/${recordId}`,
-    DELETE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/delete-batch`,
-    UPSERT: `${DATAFABRIC_BASE}/api/Entity`,
-    DELETE: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
-    UPDATE_METADATA: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}/metadata`,
+      `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/read/${recordId}`,
+    INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/insert`,
+    BATCH_INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/insert-batch`,
+    UPDATE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/update/${recordId}`,
+    UPDATE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/update-batch`,
+    DELETE_RECORD_BY_ID: (entityId: string, recordId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/delete/${recordId}`,
+    DELETE_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/delete-batch`,
+    // Same URL as GET_ALL_V3; the HTTP method (POST for create/upsert vs GET for list) is resolved at the call site.
+    UPSERT: `${DATAFABRIC_BASE}/api/v3/entities`,
+    // Same URL as GET_BY_ID; the HTTP method (DELETE vs GET) is resolved at the call site.
+    DELETE: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}`,
+    UPDATE_METADATA: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}/metadata`,
+    // Kept on v1: the v3 query endpoint rejects multi-entity joins (req.Joins),
+    // which queryRecordsById supports. v1 query supports joins.
     QUERY_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/query`,
     // Name-based structured query. The multi-entity (joins) contract is only
     // implemented on this route — QUERY_BY_ID silently drops the `joins` body key.

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -37,11 +37,12 @@ export const DATA_FABRIC_ENDPOINTS = {
     // Same URL as GET_BY_ID; the HTTP method (DELETE vs GET) is resolved at the call site.
     DELETE: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}`,
     UPDATE_METADATA: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/${entityId}/metadata`,
-    // Kept on v1: the v3 query endpoint rejects multi-entity joins (req.Joins),
-    // which queryRecordsById supports. v1 query supports joins.
-    QUERY_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/query`,
-    // Name-based structured query. The multi-entity (joins) contract is only
-    // implemented on this route — QUERY_BY_ID silently drops the `joins` body key.
+    // v3 by-id query — used for every non-join query. Supports Federated entities (the
+    // legacy v1 by-id route blocks them). v3 rejects a `joins` body, so queryRecordsById
+    // routes join queries to QUERY_BY_NAME (v1) instead.
+    QUERY_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/v3/entities/entity/${entityId}/query`,
+    // Name-based structured query on v1 — the multi-entity (joins) contract is only
+    // implemented on this route. queryRecordsById routes join queries here.
     QUERY_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/query`,
     BULK_UPLOAD_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/bulk-upload`,
     DOWNLOAD_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -20,6 +20,12 @@ import {
 } from '../../../../src/models/data-fabric/entities.types';
 import { DATA_FABRIC_TENANT_FOLDER_ID } from '../../../../src/utils/constants/endpoints/data-fabric';
 
+// Record Ids are GUIDs (case-insensitive). Data Fabric endpoints return them in
+// different casing (v3 single-record read upper-cases; list/write and v1 lower-case),
+// so compare Ids case-insensitively rather than with exact string equality.
+const idsEqual = (a?: string | null, b?: string | null): boolean =>
+  (a ?? '').toLowerCase() === (b ?? '').toLowerCase();
+
 // Cache for choice set values to avoid repeated API calls within a test run
 const choiceSetValueCache = new Map<string, any[]>();
 
@@ -242,7 +248,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       }
     });
 
-    // includeFolderEntities switches to the v2 endpoint, which returns tenant-level and
+    // includeFolderEntities switches to the v3 endpoint, which returns tenant-level and
     // folder-level entities together — a superset of the default tenant-only result.
     // Requires the OR.Users OAuth scope on the integration token.
     it('should return tenant and folder entities together when includeFolderEntities is true', async () => {
@@ -428,7 +434,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(entityId, recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
   });
 
@@ -479,7 +485,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(entityId, recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
 
     it('should batch insert multiple records using insertRecordsById', async () => {
@@ -669,7 +675,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entity.getRecord(recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
 
     it('should update records via entity.updateRecords', async () => {
@@ -764,7 +770,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       });
 
       expect(result).toBeDefined();
-      expect(result.Id).toBe(updateTestRecordId);
+      expect(idsEqual(result.Id, updateTestRecordId)).toBe(true);
     });
 
     it('should handle API errors for non-existent record', async () => {
@@ -1218,6 +1224,20 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(updated.description).toBe('Updated description');
     });
 
+    it('should enable analytics via isAnalyticsEnabled', async () => {
+      const { entities } = getServices();
+      const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, []);
+      createdEntityIds.push(entityId);
+
+      // Exercises the isAnalyticsEnabled option end to end — the SDK sends it as the
+      // isInsightsEnabled wire field, which the API validates and round-trips back on read.
+      await entities.updateById(entityId, { isAnalyticsEnabled: true });
+
+      const updated = await entities.getById(entityId);
+      expect(updated.isInsightsEnabled).toBe(true);
+    });
+
     it('should add a new field to an existing entity', async () => {
       const { entities } = getServices();
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
@@ -1570,7 +1590,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
   });
 
   // Verifies the MULTILINE_MAX lazy-load contract end to end: list returns a size
-  // marker, getRecordById (v2 read) returns the full content. Creating the field
+  // marker, getRecordById (v3 read) returns the full content. Creating the field
   // needs DataFabric.Schema.Write scope, absent in the standard test env — so this is
   // gated on SCHEMA_WRITE_SCOPE_AVAILABLE and skipped there (a hard throw would redden
   // CI permanently). Runs in any environment whose PAT carries the scope.
@@ -1598,7 +1618,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(listedRecord!.body).toMatch(/^HasValue=true/);
       expect(listedRecord!.body).not.toBe(bodyValue);
 
-      // getRecordById (v2 read) returns the full content.
+      // getRecordById (v3 read) returns the full content.
       const full = await entities.getRecordById(entityId, inserted.Id);
       expect(full.body).toBe(bodyValue);
     });
@@ -1775,7 +1795,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(folderEntityId, folderRecordIds[0], { folderKey });
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(folderRecordIds[0]);
+      expect(idsEqual(record.Id, folderRecordIds[0])).toBe(true);
     });
 
     it('should list paginated records with folderKey via getAllRecords', async () => {
@@ -1801,7 +1821,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(Array.isArray(result.items)).toBe(true);
       // The folder header must reach the server for the row to be retrievable; the
       // filter narrows to the record we just inserted in this run.
-      expect(result.items.some((r) => r.Id === folderRecordIds[0])).toBe(true);
+      expect(result.items.some((r) => idsEqual(r.Id, folderRecordIds[0]))).toBe(true);
     });
 
     it('should update a record with folderKey via updateRecordById', async () => {
@@ -1810,7 +1830,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const result = await entities.updateRecordById(folderEntityId, folderRecordIds[0], patch, { folderKey });
 
       expect(result).toBeDefined();
-      expect(result.Id).toBe(folderRecordIds[0]);
+      expect(idsEqual(result.Id, folderRecordIds[0])).toBe(true);
     });
 
     it('should batch-update records with folderKey via updateRecordsById', async () => {
@@ -1846,7 +1866,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
           ],
         },
       });
-      expect(result.items.some((r) => r.Id === idToDelete)).toBe(false);
+      expect(result.items.some((r) => idsEqual(r.Id, idToDelete))).toBe(false);
     });
 
     it('should batch-delete records with folderKey via deleteRecordsById', async () => {

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -21,6 +21,12 @@ import {
 } from '../../../../src/models/data-fabric/entities.types';
 import { DATA_FABRIC_TENANT_FOLDER_ID } from '../../../../src/utils/constants/endpoints/data-fabric';
 
+// Record Ids are GUIDs (case-insensitive). Data Fabric endpoints return them in
+// different casing (v3 single-record read upper-cases; list/write and v1 lower-case),
+// so compare Ids case-insensitively rather than with exact string equality.
+const idsEqual = (a?: string | null, b?: string | null): boolean =>
+  (a ?? '').toLowerCase() === (b ?? '').toLowerCase();
+
 // Cache for choice set values to avoid repeated API calls within a test run
 const choiceSetValueCache = new Map<string, any[]>();
 
@@ -243,7 +249,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       }
     });
 
-    // includeFolderEntities switches to the v2 endpoint, which returns tenant-level and
+    // includeFolderEntities switches to the v3 endpoint, which returns tenant-level and
     // folder-level entities together — a superset of the default tenant-only result.
     // Requires the OR.Users OAuth scope on the integration token.
     it('should return tenant and folder entities together when includeFolderEntities is true', async () => {
@@ -429,7 +435,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(entityId, recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
   });
 
@@ -480,7 +486,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(entityId, recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
 
     it('should batch insert multiple records using insertRecordsById', async () => {
@@ -670,7 +676,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entity.getRecord(recordId);
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(recordId);
+      expect(idsEqual(record.Id, recordId)).toBe(true);
     });
 
     it('should update records via entity.updateRecords', async () => {
@@ -765,7 +771,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       });
 
       expect(result).toBeDefined();
-      expect(result.Id).toBe(updateTestRecordId);
+      expect(idsEqual(result.Id, updateTestRecordId)).toBe(true);
     });
 
     it('should handle API errors for non-existent record', async () => {
@@ -1266,6 +1272,20 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(updated.description).toBe('Updated description');
     });
 
+    it('should enable analytics via isAnalyticsEnabled', async () => {
+      const { entities } = getServices();
+      const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
+      const entityId = await entities.create(name, []);
+      createdEntityIds.push(entityId);
+
+      // Exercises the isAnalyticsEnabled option end to end — the SDK sends it as the
+      // isInsightsEnabled wire field, which the API validates and round-trips back on read.
+      await entities.updateById(entityId, { isAnalyticsEnabled: true });
+
+      const updated = await entities.getById(entityId);
+      expect(updated.isInsightsEnabled).toBe(true);
+    });
+
     it('should add a new field to an existing entity', async () => {
       const { entities } = getServices();
       const name = `sdk_test_${generateRandomString(8).toLowerCase()}`;
@@ -1618,7 +1638,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
   });
 
   // Verifies the MULTILINE_MAX lazy-load contract end to end: list returns a size
-  // marker, getRecordById (v2 read) returns the full content. Creating the field
+  // marker, getRecordById (v3 read) returns the full content. Creating the field
   // needs DataFabric.Schema.Write scope, absent in the standard test env — so this is
   // gated on SCHEMA_WRITE_SCOPE_AVAILABLE and skipped there (a hard throw would redden
   // CI permanently). Runs in any environment whose PAT carries the scope.
@@ -1646,7 +1666,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(listedRecord!.body).toMatch(/^HasValue=true/);
       expect(listedRecord!.body).not.toBe(bodyValue);
 
-      // getRecordById (v2 read) returns the full content.
+      // getRecordById (v3 read) returns the full content.
       const full = await entities.getRecordById(entityId, inserted.Id);
       expect(full.body).toBe(bodyValue);
     });
@@ -1823,7 +1843,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const record = await entities.getRecordById(folderEntityId, folderRecordIds[0], { folderKey });
 
       expect(record).toBeDefined();
-      expect(record.Id).toBe(folderRecordIds[0]);
+      expect(idsEqual(record.Id, folderRecordIds[0])).toBe(true);
     });
 
     it('should list paginated records with folderKey via getAllRecords', async () => {
@@ -1849,7 +1869,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(Array.isArray(result.items)).toBe(true);
       // The folder header must reach the server for the row to be retrievable; the
       // filter narrows to the record we just inserted in this run.
-      expect(result.items.some((r) => r.Id === folderRecordIds[0])).toBe(true);
+      expect(result.items.some((r) => idsEqual(r.Id, folderRecordIds[0]))).toBe(true);
     });
 
     it('should update a record with folderKey via updateRecordById', async () => {
@@ -1858,7 +1878,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const result = await entities.updateRecordById(folderEntityId, folderRecordIds[0], patch, { folderKey });
 
       expect(result).toBeDefined();
-      expect(result.Id).toBe(folderRecordIds[0]);
+      expect(idsEqual(result.Id, folderRecordIds[0])).toBe(true);
     });
 
     it('should batch-update records with folderKey via updateRecordsById', async () => {
@@ -1894,7 +1914,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
           ],
         },
       });
-      expect(result.items.some((r) => r.Id === idToDelete)).toBe(false);
+      expect(result.items.some((r) => idsEqual(r.Id, idToDelete))).toBe(false);
     });
 
     it('should batch-delete records with folderKey via deleteRecordsById', async () => {

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -9,7 +9,9 @@ import {
 import { registerResource } from '../../utils/cleanup';
 import { generateRandomString, generateRandomInt, generateRandomFloat, hasValidPagination } from '../../utils/helpers';
 import {
+  DataDirectionType,
   EntityAggregateFunction,
+  EntityClass,
   EntityFieldDataType,
   EntityHavingOperator,
   EntityRecord,
@@ -1283,7 +1285,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       await entities.updateById(entityId, { isAnalyticsEnabled: true });
 
       const updated = await entities.getById(entityId);
-      expect(updated.isInsightsEnabled).toBe(true);
+      expect(updated.isAnalyticsEnabled).toBe(true);
     });
 
     it('should add a new field to an existing entity', async () => {
@@ -1380,6 +1382,131 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       const updated = after.fields.find(f => f.name === 'to_update');
       expect(updated?.displayName).toBe('After Update');
     });
+  });
+
+  // Skipped: needs DataFabric.Schema.Write scope AND a live Integration Service connection
+  // fixture (a federated entity requires a connector source). Standard CI has neither. To run
+  // locally against a federated-capable tenant, set: DF_FED_CONNECTION_ID,
+  // DF_FED_ELEMENT_INSTANCE_ID, DF_FED_CONNECTOR_KEY, DF_FED_OBJECT, DF_FED_OBJECT_METHOD
+  // (the operations-catalog JSON string from `is resources describe <connector> <object>
+  // --operation List`), DF_FED_PRIMARY_KEY, DF_FED_FIELD (an external field name on the object).
+  // Auto-runs once the federated env vars above are set (DF_FED_PRIMARY_KEY defaults to 'Id').
+  const federatedEnvReady = Boolean(
+    process.env.DF_FED_CONNECTION_ID &&
+      process.env.DF_FED_ELEMENT_INSTANCE_ID &&
+      process.env.DF_FED_CONNECTOR_KEY &&
+      process.env.DF_FED_OBJECT &&
+      process.env.DF_FED_OBJECT_METHOD &&
+      process.env.DF_FED_FIELD,
+  );
+  describe.skipIf(!federatedEnvReady)('updateById — federated source & join deltas', () => {
+    const entityFolderKey = getTestConfig().folderKey;
+    const conn = {
+      connectionId: process.env.DF_FED_CONNECTION_ID ?? '',
+      elementInstanceId: Number(process.env.DF_FED_ELEMENT_INSTANCE_ID ?? 0),
+      connectorKey: process.env.DF_FED_CONNECTOR_KEY ?? '',
+      connectorName: process.env.DF_FED_CONNECTOR_NAME ?? process.env.DF_FED_CONNECTOR_KEY ?? '',
+      folderKey: process.env.DF_FED_FOLDER_KEY ?? entityFolderKey,
+    };
+    const objectName = process.env.DF_FED_OBJECT ?? '';
+    const method = process.env.DF_FED_OBJECT_METHOD ?? '';
+    const primaryKey = process.env.DF_FED_PRIMARY_KEY ?? 'Id';
+    const externalField = process.env.DF_FED_FIELD ?? '';
+
+    async function createSingleSourceFederated(): Promise<string> {
+      const { entities } = getServices();
+      const name = `sdk_fed_${generateRandomString(8).toLowerCase()}`;
+      const id = await entities.create(name, [], {
+        folderKey: entityFolderKey,
+        entityClass: EntityClass.Federated,
+        externalFields: [
+          {
+            externalConnectionDetail: conn,
+            externalObjectDetail: { externalObjectName: objectName, primaryKey, isPrimarySource: true, method },
+            fields: [
+              {
+                field: { name: 'PkField', type: EntityFieldDataType.STRING },
+                externalFieldMappingDetail: { externalFieldName: primaryKey, externalFieldType: 'string', directionType: DataDirectionType.ReadOnly },
+              },
+            ],
+          },
+        ],
+      });
+      createdEntityIds.push(id);
+      return id;
+    }
+
+    it('should create a single-source federated entity with EntityClass.Federated', async () => {
+      const { entities } = getServices();
+      const id = await createSingleSourceFederated();
+
+      const got = await entities.getById(id, { folderKey: entityFolderKey });
+      expect(got.entityClass).toBe(EntityClass.Federated);
+      expect(got.externalFields?.length).toBe(1);
+    });
+
+    it('should add a field to an existing source and preserve the source', async () => {
+      const { entities } = getServices();
+      const id = await createSingleSourceFederated();
+
+      await entities.updateById(id, {
+        folderKey: entityFolderKey,
+        addFieldsToSource: [
+          {
+            sourceObjectName: objectName,
+            fields: [
+              {
+                field: { name: 'AddedField', type: EntityFieldDataType.STRING },
+                externalFieldMappingDetail: { externalFieldName: externalField, externalFieldType: 'string', directionType: DataDirectionType.ReadOnly },
+              },
+            ],
+          },
+        ],
+      });
+
+      const got = await entities.getById(id, { folderKey: entityFolderKey });
+      const source = got.externalFields?.find(s => s.externalObjectDetail?.externalObjectName === objectName);
+      const names = (source?.fields ?? []).map(f => f.fieldMetaData?.name);
+      expect(names).toContain('PkField');
+      expect(names).toContain('AddedField');
+    });
+
+    it('should remove a field from a source and keep the source and its other fields', async () => {
+      const { entities } = getServices();
+      const id = await createSingleSourceFederated();
+
+      // Add a second field, then remove it — a real removeFieldsFromSource round-trip.
+      await entities.updateById(id, {
+        folderKey: entityFolderKey,
+        addFieldsToSource: [
+          {
+            sourceObjectName: objectName,
+            fields: [
+              {
+                field: { name: 'RemovableField', type: EntityFieldDataType.STRING },
+                externalFieldMappingDetail: { externalFieldName: externalField, externalFieldType: 'string', directionType: DataDirectionType.ReadOnly },
+              },
+            ],
+          },
+        ],
+      });
+      await entities.updateById(id, {
+        folderKey: entityFolderKey,
+        removeFieldsFromSource: [{ sourceObjectName: objectName, fieldNames: ['RemovableField'] }],
+      });
+
+      const got = await entities.getById(id, { folderKey: entityFolderKey });
+      const source = got.externalFields?.find(s => s.externalObjectDetail?.externalObjectName === objectName);
+      const names = (source?.fields ?? []).map(f => f.fieldMetaData?.name);
+      expect(got.externalFields?.length).toBe(1);
+      expect(names).toContain('PkField');
+      expect(names).not.toContain('RemovableField');
+    });
+
+    // Cascade (join dropped when its source is removed via removeExternalSources) needs a
+    // two-source + join fixture — a second connector object that standard env vars don't
+    // configure. Left visible rather than faked on a single-source entity.
+    it.todo('should cascade-remove a join when its source is removed');
   });
 
   // Skipped: requires DataFabric.Schema.Write OAuth scope, not available in standard test environment

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -425,24 +425,24 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+    it("should call the v3 endpoint and pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({ folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
-    it("should call the v2 endpoint when includeFolderEntities is true (cross-scope)", async () => {
+    it("should call the v3 endpoint when includeFolderEntities is true (cross-scope)", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({ includeFolderEntities: true });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: {} },
       );
     });
@@ -458,7 +458,7 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should let folderKey win and call v1 with the header when both folderKey and includeFolderEntities are provided", async () => {
+    it("should call the v3 endpoint with the header when both folderKey and includeFolderEntities are provided", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({
@@ -467,7 +467,7 @@ describe("EntityService Unit Tests", () => {
       });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
@@ -3394,6 +3394,40 @@ describe("EntityService Unit Tests", () => {
         { displayName: ENTITY_TEST_CONSTANTS.ENTITY_DISPLAY_NAME },
         { headers: {} },
       );
+    });
+
+    it("should emit isInsightsEnabled in the metadata PATCH when isAnalyticsEnabled is provided", async () => {
+      mockApiClient.patch.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        isAnalyticsEnabled: true,
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ),
+        expect.objectContaining({ isInsightsEnabled: true }),
+        { headers: {} },
+      );
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it("should emit isInsightsEnabled: false in the metadata PATCH when isAnalyticsEnabled is false", async () => {
+      mockApiClient.patch.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        isAnalyticsEnabled: false,
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ),
+        expect.objectContaining({ isInsightsEnabled: false }),
+        { headers: {} },
+      );
+      expect(mockApiClient.get).not.toHaveBeenCalled();
     });
 
     it("should pass folderKey via X-UIPATH-FolderKey header on both schema GET/POST and metadata PATCH", async () => {

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -427,24 +427,24 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+    it("should call the v3 endpoint and pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({ folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
 
-    it("should call the v2 endpoint when includeFolderEntities is true (cross-scope)", async () => {
+    it("should call the v3 endpoint when includeFolderEntities is true (cross-scope)", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({ includeFolderEntities: true });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V2,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: {} },
       );
     });
@@ -460,7 +460,7 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should let folderKey win and call v1 with the header when both folderKey and includeFolderEntities are provided", async () => {
+    it("should call the v3 endpoint with the header when both folderKey and includeFolderEntities are provided", async () => {
       mockApiClient.get.mockResolvedValue([createMockEntityResponse()]);
 
       await entityService.getAll({
@@ -469,7 +469,7 @@ describe("EntityService Unit Tests", () => {
       });
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL,
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ALL_V3,
         { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
       );
     });
@@ -3455,6 +3455,40 @@ describe("EntityService Unit Tests", () => {
         { displayName: ENTITY_TEST_CONSTANTS.ENTITY_DISPLAY_NAME },
         { headers: {} },
       );
+    });
+
+    it("should emit isInsightsEnabled in the metadata PATCH when isAnalyticsEnabled is provided", async () => {
+      mockApiClient.patch.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        isAnalyticsEnabled: true,
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ),
+        expect.objectContaining({ isInsightsEnabled: true }),
+        { headers: {} },
+      );
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it("should emit isInsightsEnabled: false in the metadata PATCH when isAnalyticsEnabled is false", async () => {
+      mockApiClient.patch.mockResolvedValue(undefined);
+
+      await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        isAnalyticsEnabled: false,
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_METADATA(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ),
+        expect.objectContaining({ isInsightsEnabled: false }),
+        { headers: {} },
+      );
+      expect(mockApiClient.get).not.toHaveBeenCalled();
     });
 
     it("should pass folderKey via X-UIPATH-FolderKey header on both schema GET/POST and metadata PATCH", async () => {

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -38,12 +38,13 @@ import {
   EntityAggregateFunction,
   EntityHavingOperator,
   EntityType,
-  ExternalField,
   FieldDisplayType,
   JoinType,
   LogicalOperator,
   QueryFilterOperator,
   RawEntityGetResponse,
+  EntityClass,
+  DataDirectionType,
 } from "../../../../src/models/data-fabric/entities.types";
 import {
   EntityFieldTypeMap,
@@ -55,7 +56,7 @@ import { ENTITY_TEST_CONSTANTS } from "../../../utils/constants/entities";
 import { TEST_CONSTANTS } from "../../../utils/constants/common";
 import { DATA_FABRIC_ENDPOINTS } from "../../../../src/utils/constants/endpoints";
 import { DATA_FABRIC_TENANT_FOLDER_ID } from "../../../../src/utils/constants/endpoints/data-fabric";
-import { SqlFieldType, FieldSchemaPayload } from "@/models/data-fabric/entities.internal-types";
+import { SqlFieldType, FieldSchemaPayload, EntityClassId } from "@/models/data-fabric/entities.internal-types";
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -1903,6 +1904,23 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
+    it("should target the v3 by-id query endpoint for non-join queries", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        filterGroup: {
+          logicalOperator: LogicalOperator.And,
+          queryFilters: [{ fieldName: "isActive", operator: QueryFilterOperator.Equals, value: "true" }],
+        },
+      });
+
+      const config = vi.mocked(PaginationHelpers.getAll).mock.calls[0][0];
+      expect(config.getEndpoint()).toBe(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+      );
+      expect(config.getEndpoint()).toContain("/api/v3/entities/entity/");
+    });
+
     it("should throw ValidationError when more than 3 joins are supplied", async () => {
       const join = {
         joinType: JoinType.LeftJoin,
@@ -2202,21 +2220,132 @@ describe("EntityService Unit Tests", () => {
       );
     });
 
-    it("should pass externalFields when provided", async () => {
+    it("should send entityClassId and built externalFields for a federated entity", async () => {
       mockApiClient.post.mockResolvedValue(ENTITY_TEST_CONSTANTS.ENTITY_ID);
 
-      const externalFields = [
-        { connectionId: ENTITY_TEST_CONSTANTS.EXTERNAL_CONNECTION_ID },
-      ] as unknown as ExternalField[];
-
-      await entityService.create("my_entity", [], { externalFields });
+      await entityService.create("sf_accounts", [], {
+        entityClass: EntityClass.Federated,
+        externalFields: [
+          {
+            externalConnectionDetail: {
+              connectionId: ENTITY_TEST_CONSTANTS.EXTERNAL_CONNECTION_ID,
+              connectorKey: "uipath-salesforce",
+              connectorName: "Salesforce",
+              elementInstanceId: 123,
+            },
+            externalObjectDetail: { externalObjectName: "Account", primaryKey: "Id", isPrimarySource: true },
+            fields: [
+              {
+                field: { name: "accountName", type: EntityFieldDataType.STRING },
+                externalFieldMappingDetail: { externalFieldName: "Name", directionType: DataDirectionType.ReadOnly },
+              },
+            ],
+          },
+        ],
+      });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
         expect.objectContaining({
           entityDefinition: expect.objectContaining({
-            externalFields,
+            entityClassId: EntityClassId.Federated,
+            externalFields: [
+              expect.objectContaining({
+                externalObjectDetail: expect.objectContaining({ externalObjectName: "Account", isPrimarySource: true }),
+                externalConnectionDetail: expect.objectContaining({ connectionId: ENTITY_TEST_CONSTANTS.EXTERNAL_CONNECTION_ID }),
+                // internal column runs through the native field-build pipeline (fieldName -> wire `name`)
+                fields: [
+                  expect.objectContaining({
+                    fieldDefinition: expect.objectContaining({ name: "accountName" }),
+                    externalFieldMappingDetail: expect.objectContaining({
+                      externalFieldName: "Name",
+                      directionType: DataDirectionType.ReadOnly,
+                    }),
+                  }),
+                ],
+              }),
+            ],
           }),
+        }),
+        { headers: {} },
+      );
+    });
+
+    it("should throw when a federated entity has no external sources", async () => {
+      await expect(
+        entityService.create("bad_federated", [], { entityClass: EntityClass.Federated }),
+      ).rejects.toThrow(/require at least one external source/);
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it("should send entityClassId Native when entityClass is Native", async () => {
+      mockApiClient.post.mockResolvedValue(ENTITY_TEST_CONSTANTS.ENTITY_ID);
+
+      await entityService.create("my_entity", [], { entityClass: EntityClass.Native });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
+        expect.objectContaining({
+          entityDefinition: expect.objectContaining({ entityClassId: EntityClassId.Native }),
+        }),
+        { headers: {} },
+      );
+    });
+
+    it("should omit entityClassId for a default (native) create", async () => {
+      mockApiClient.post.mockResolvedValue(ENTITY_TEST_CONSTANTS.ENTITY_ID);
+
+      await entityService.create("my_entity", []);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
+        expect.objectContaining({
+          entityDefinition: expect.not.objectContaining({ entityClassId: expect.anything() }),
+        }),
+        { headers: {} },
+      );
+    });
+
+    it("should reject a non-creatable entityClass", async () => {
+      await expect(
+        entityService.create("bad_class", [], { entityClass: EntityClass.Case }),
+      ).rejects.toThrow(/not creatable/);
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it("should pass sourceJoinConditionDetails through for a multi-source federated entity", async () => {
+      mockApiClient.post.mockResolvedValue(ENTITY_TEST_CONSTANTS.ENTITY_ID);
+
+      const sourceJoinConditionDetails = [
+        {
+          sourceObjectName: "Account",
+          sourceJoinField: "Id",
+          joinType: JoinType.LeftJoin,
+          relatedSourceObjectName: "Contact",
+          relatedSourceJoinField: "AccountId",
+        },
+      ];
+
+      await entityService.create("acc_contacts", [], {
+        entityClass: EntityClass.Federated,
+        externalFields: [
+          {
+            externalObjectDetail: { externalObjectName: "Account", isPrimarySource: true },
+            fields: [
+              {
+                field: { name: "accountName", type: EntityFieldDataType.STRING },
+                externalFieldMappingDetail: { externalFieldName: "Name", directionType: DataDirectionType.ReadOnly },
+              },
+            ],
+          },
+        ],
+        sourceJoinConditionDetails,
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPSERT,
+        expect.objectContaining({
+          entityDefinition: expect.objectContaining({ sourceJoinConditionDetails }),
         }),
         { headers: {} },
       );
@@ -2767,6 +2896,241 @@ describe("EntityService Unit Tests", () => {
 
       const call = mockApiClient.post.mock.calls[0][1];
       expect(call.entityDefinition.fields).toHaveLength(0);
+    });
+
+    describe("federated sources & joins", () => {
+      // Mirrors the shape a real v3 GET returns for a federated entity:
+      // read-shape joins (`sourceJoinCriterias`, object/field IDs), sources with
+      // `externalObjectDetail.id` + connection details, `entityClass` string.
+      const federatedRaw = {
+        id: ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        name: "SalesforceAccount",
+        displayName: "Salesforce Account",
+        description: "",
+        isRbacEnabled: false,
+        isInsightsEnabled: false,
+        entityClass: EntityClass.Federated,
+        fields: [],
+        externalFields: [
+          {
+            externalObjectDetail: { id: "obj-account", externalObjectName: "Account", externalConnectionId: "extconn-account", primaryKey: "Id", isPrimarySource: true, method: '{"GET":{}}' },
+            externalConnectionDetail: { connectionId: "conn-sf", elementInstanceId: 357401, folderKey: "folder-sf", connectorKey: "uipath-salesforce-sfdc" },
+            fields: [
+              { fieldDefinition: { name: "IdField", displayName: "IdField", isPrimaryKey: false, sqlType: { name: "NVARCHAR", lengthLimit: 512 } }, externalFieldMappingDetail: { externalFieldName: "Id", externalFieldType: "string", directionType: DataDirectionType.ReadOnly, sortable: true } },
+            ],
+          },
+          {
+            externalObjectDetail: { id: "obj-invoice", externalObjectName: "Invoice", isPrimarySource: false },
+            nativeConnectionDetail: { entityId: "conn-native", folderKey: "folder-native" },
+            fields: [
+              { fieldDefinition: { name: "invoiceId", displayName: "invoiceId", isPrimaryKey: false, sqlType: { name: "NVARCHAR", lengthLimit: 512 } }, externalFieldMappingDetail: { externalFieldName: "invoiceId", externalFieldType: "text", directionType: DataDirectionType.ReadOnly, sortable: false } },
+            ],
+          },
+        ],
+        sourceJoinCriterias: [
+          { id: "join-1", entityId: ENTITY_TEST_CONSTANTS.ENTITY_ID, sourceObjectId: "obj-account", joinFieldName: "Id", joinType: JoinType.LeftJoin, relatedSourceObjectId: "obj-invoice", relatedSourceFieldName: "invoiceId" },
+        ],
+      };
+
+      beforeEach(() => {
+        mockApiClient.get.mockResolvedValue(federatedRaw);
+        mockApiClient.post.mockResolvedValue(undefined);
+      });
+
+      it("should preserve external sources and translate joins when updating native fields (bug fix: don't drop joins)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFields: [{ name: "note", type: EntityFieldDataType.STRING }],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        expect(def.entityClassId).toBe(EntityClassId.Federated);
+        expect(def.externalFields).toHaveLength(2);
+        expect(def.externalFields[0].externalObjectDetail.externalObjectName).toBe("Account");
+        // The GET omits fieldDisplayType; the repost must default it (the upsert requires it).
+        expect(def.externalFields[0].fields[0].fieldDefinition.fieldDisplayType).toBe(FieldDisplayType.Basic);
+        // sourceJoinCriterias (id-based) → sourceJoinConditionDetails (names + conn ids),
+        // joinType string passed through, native source connId = its entityId.
+        expect(def.sourceJoinConditionDetails).toEqual([
+          {
+            sourceObjectName: "Account",
+            sourceJoinField: "Id",
+            sourceObjectConnectionId: "conn-sf",
+            joinType: JoinType.LeftJoin, // passed through from the read shape (string form accepted)
+            relatedSourceObjectName: "Invoice",
+            relatedSourceJoinField: "invoiceId",
+            relatedSourceObjectConnectionId: "conn-native",
+          },
+        ]);
+      });
+
+      it("should append a join via addSourceJoins (existing join preserved)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addSourceJoins: [
+            {
+              sourceObjectName: "Account",
+              sourceJoinField: "OwnerId",
+              sourceObjectConnectionId: "conn-sf",
+              joinType: JoinType.LeftJoin,
+              relatedSourceObjectName: "Invoice",
+              relatedSourceJoinField: "ownerId",
+              relatedSourceObjectConnectionId: "conn-native",
+            },
+          ],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        expect(def.sourceJoinConditionDetails).toHaveLength(2);
+        expect(def.sourceJoinConditionDetails[0].sourceJoinField).toBe("Id");
+        expect(def.sourceJoinConditionDetails[1].sourceJoinField).toBe("OwnerId");
+      });
+
+      it("should add a new external source via addExternalSources", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addExternalSources: [
+            {
+              externalConnectionDetail: { connectionId: "conn-sf", elementInstanceId: 357401, folderKey: "folder-sf", connectorKey: "uipath-salesforce-sfdc", connectorName: "Salesforce" },
+              externalObjectDetail: { externalObjectName: "Contact", primaryKey: "Id", method: "{}" },
+              fields: [
+                { field: { name: "ContactName", type: EntityFieldDataType.STRING }, externalFieldMappingDetail: { externalFieldName: "Name", externalFieldType: "string", directionType: DataDirectionType.ReadOnly } },
+              ],
+            },
+          ],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        expect(def.externalFields).toHaveLength(3);
+        expect(def.externalFields[2].externalObjectDetail.externalObjectName).toBe("Contact");
+        expect(def.externalFields[2].fields[0].fieldDefinition.name).toBe("ContactName");
+      });
+
+      it("should remove a field from a source", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          removeFieldsFromSource: [{ sourceObjectName: "Account", fieldNames: ["IdField"] }],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        const account = def.externalFields.find((s: { externalObjectDetail?: { externalObjectName?: string } }) => s.externalObjectDetail?.externalObjectName === "Account");
+        expect(account.fields).toHaveLength(0);
+      });
+
+      it("should update an existing join in place via updateSourceJoin", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          updateSourceJoin: [{ sourceObjectName: "Account", relatedSourceObjectName: "Invoice", sourceJoinField: "AltKey" }],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        expect(def.sourceJoinConditionDetails).toHaveLength(1);
+        expect(def.sourceJoinConditionDetails[0].sourceJoinField).toBe("AltKey");
+        // Untouched fields on the join are preserved.
+        expect(def.sourceJoinConditionDetails[0].relatedSourceJoinField).toBe("invoiceId");
+      });
+
+      it("should cascade-remove joins when a source is removed (a join can't outlive its source)", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          removeExternalSources: ["Invoice"],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        expect(def.externalFields.map((s: { externalObjectDetail?: { externalObjectName?: string } }) => s.externalObjectDetail?.externalObjectName)).toEqual(["Account"]);
+        // The Account→Invoice join is dropped automatically — no separate removeSourceJoins needed.
+        expect(def.sourceJoinConditionDetails).toBeUndefined();
+      });
+
+      it("should add a field to an existing source via addFieldsToSource", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          addFieldsToSource: [
+            {
+              sourceObjectName: "Account",
+              fields: [
+                {
+                  field: { name: "Phone", type: EntityFieldDataType.STRING },
+                  externalFieldMappingDetail: { externalFieldName: "Phone", directionType: DataDirectionType.ReadOnly },
+                },
+              ],
+            },
+          ],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        const account = def.externalFields.find((s: { externalObjectDetail?: { externalObjectName?: string } }) => s.externalObjectDetail?.externalObjectName === "Account");
+        const names = account.fields.map((f: { fieldDefinition?: { name?: string } }) => f.fieldDefinition?.name);
+        expect(names).toContain("IdField");
+        expect(names).toContain("Phone");
+      });
+
+      it("should update a field's mapping in place via updateExternalFieldMapping", async () => {
+        await entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          updateExternalFieldMapping: [
+            { sourceObjectName: "Account", fieldName: "IdField", mapping: { sortable: false } },
+          ],
+        });
+
+        const def = mockApiClient.post.mock.calls[0][1].entityDefinition;
+        const account = def.externalFields.find((s: { externalObjectDetail?: { externalObjectName?: string } }) => s.externalObjectDetail?.externalObjectName === "Account");
+        const idField = account.fields.find((f: { fieldDefinition?: { name?: string } }) => f.fieldDefinition?.name === "IdField");
+        // Existing mapping keys are preserved; only the supplied key changes.
+        expect(idField.externalFieldMappingDetail.sortable).toBe(false);
+        expect(idField.externalFieldMappingDetail.externalFieldName).toBe("Id");
+      });
+
+      it("should throw when addFieldsToSource targets a source that doesn't exist", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            addFieldsToSource: [
+              {
+                sourceObjectName: "Nonexistent",
+                fields: [
+                  {
+                    field: { name: "X", type: EntityFieldDataType.STRING },
+                    externalFieldMappingDetail: { externalFieldName: "X", directionType: DataDirectionType.ReadOnly },
+                  },
+                ],
+              },
+            ],
+          }),
+        ).rejects.toThrow(/source 'Nonexistent' not found/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw when removeFieldsFromSource targets a source that doesn't exist", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            removeFieldsFromSource: [{ sourceObjectName: "Nonexistent", fieldNames: ["X"] }],
+          }),
+        ).rejects.toThrow(/source 'Nonexistent' not found/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw when updateExternalFieldMapping targets a field that doesn't exist", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            updateExternalFieldMapping: [
+              { sourceObjectName: "Account", fieldName: "Nonexistent", mapping: { sortable: true } },
+            ],
+          }),
+        ).rejects.toThrow(/field 'Nonexistent' not found on source 'Account'/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw a source-not-found (not field-not-found) error when updateExternalFieldMapping targets a missing source", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            updateExternalFieldMapping: [
+              { sourceObjectName: "Nonexistent", fieldName: "AnyField", mapping: { sortable: true } },
+            ],
+          }),
+        ).rejects.toThrow(/source 'Nonexistent' not found/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
+
+      it("should throw when updateSourceJoin targets a join that doesn't exist", async () => {
+        await expect(
+          entityService.updateById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+            updateSourceJoin: [{ sourceObjectName: "Account", relatedSourceObjectName: "Nonexistent", sourceJoinField: "X" }],
+          }),
+        ).rejects.toThrow(/no join between 'Account' and 'Nonexistent'/);
+        expect(mockApiClient.post).not.toHaveBeenCalled();
+      });
     });
 
     it("should update field metadata in-place", async () => {


### PR DESCRIPTION
Adds federated Data Fabric entity support to the SDK, on top of the v3 API migration.

## What's in here

**1. Migrate entity operations to the v3 API (DS-8953)** — record CRUD and schema create/update/metadata move to `/api/v3/entities/...`. Mostly endpoint-path swaps + request/response type alignment; request bodies, pagination, and batch responses are unchanged. `GET_ALL` stays on v1 (v3 has no tenant-only listing); `getAll()` routes `folderKey`/`includeFolderEntities` to v3.

**2. Federated entity create, update, and query.**
- `create` accepts `entityClass: Federated` with `externalFields` (external-connector or native source + object detail + field mappings) and optional `sourceJoinConditionDetails`.
- `updateById` gains federated source/join deltas: `addExternalSources`, `removeExternalSources` (cascades the removed source's joins), `addFieldsToSource`, `removeFieldsFromSource`, `updateExternalFieldMapping`, `addSourceJoins`, `updateSourceJoin`. The v3 API is a full-definition upsert, so the SDK reads the current definition, merges the delta, and reposts the whole thing.
- `queryRecordsById` now routes to the v3 query endpoint (`/api/v3/entities/entity/{id}/query`) for every join-less query. This is what lets **federated entities be queried** — the legacy v1 by-id endpoint blocks them (`Cannot access Federated entity …`). Queries with multi-entity `joins` still route to the v1 by-name endpoint (the only one that executes joins).

## Notes for reviewers (found validating live against the v3 API)

- The GET flattens external-source fields into top-level `fields` (`isExternalField=true`) as well as under `externalFields`; carrying those into `fields` on the repost duplicates them and the upsert fails — the native carry-forward excludes `isExternalField`.
- The GET omits `fieldDisplayType` but the upsert requires it → defaulted to `"Basic"` (a missing one surfaces as a misleading join-dependency error, not a clear validation error).
- Read-shape `sourceJoinCriterias` (object/field IDs) are translated to write-shape `sourceJoinConditionDetails` (object names + connection ids). `joinType` passes through (string `"LeftJoin"` accepted); `entityClass` maps to `entityClassId`.
- Multi-entity joins on the v3 query endpoint now return a **400** instead of being silently dropped (the old v1 by-id behavior) — a correctness improvement.

## Verification

- Unit: create, delta translation, cascade, and query-routing tests pass (`npm run test:unit`); typecheck + lint clean.
- Live: end-to-end create / update / read (filter, projection, sort) verified against a Salesforce-backed federated entity. A gated integration test asserts the joins-400 behavior.

## Version

Preview version bumped to `1.6.1-entities3` (published). A formal release version bump remains a separate step per the repo release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
