### PR TITLE
APPS-35455: SDK public (anonymous) mode [draft]

### DIFF
--- a/src/core/config/config-utils.ts
+++ b/src/core/config/config-utils.ts
@@ -3,7 +3,7 @@ import { UiPathSDKConfig, PartialUiPathConfig, hasOAuthConfig, hasSecretConfig }
 /**
  * Check if config has all required base fields
  */
-function hasRequiredBaseFields(config: PartialUiPathConfig): boolean {
+export function hasRequiredBaseFields(config: PartialUiPathConfig): boolean {
   return Boolean(config.baseUrl && config.orgName && config.tenantName);
 }
 

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -8,6 +8,8 @@ export const ConfigSchema = z.object({
   clientId: z.string().optional(),
   redirectUri: z.string().url().optional(),
   scope: z.string().optional(),
+  runtimeAuthMode: z.string().optional(),
+  appId: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -20,6 +22,8 @@ interface ConfigOptions {
   clientId?: string;
   redirectUri?: string;
   scope?: string;
+  runtimeAuthMode?: string;
+  appId?: string;
 }
 
 export class UiPathConfig {
@@ -30,6 +34,10 @@ export class UiPathConfig {
   public readonly clientId?: string;
   public readonly redirectUri?: string;
   public readonly scope?: string;
+  /** 'application' when the app runs in public mode (no user login). */
+  public readonly runtimeAuthMode?: string;
+  /** Deployment id used to build Apps-gateway routes in public mode. */
+  public readonly appId?: string;
 
   constructor(options: ConfigOptions) {
     this.baseUrl = options.baseUrl;
@@ -39,6 +47,8 @@ export class UiPathConfig {
     this.clientId = options.clientId;
     this.redirectUri = options.redirectUri;
     this.scope = options.scope;
+    this.runtimeAuthMode = options.runtimeAuthMode;
+    this.appId = options.appId;
   }
 }
 

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -8,6 +8,8 @@ export const ConfigSchema = z.object({
   clientId: z.string().optional(),
   redirectUri: z.string().url().optional(),
   scope: z.string().optional(),
+  runtimeAuthMode: z.string().optional(),
+  appId: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -20,6 +22,8 @@ interface ConfigOptions {
   clientId?: string;
   redirectUri?: string;
   scope?: string;
+  runtimeAuthMode?: string;
+  appId?: string;
 }
 
 export class UiPathConfig {
@@ -30,6 +34,10 @@ export class UiPathConfig {
   public readonly clientId?: string;
   public readonly redirectUri?: string;
   public readonly scope?: string;
+  /** 'anonymous' when the app runs in public mode (no user login). */
+  public readonly runtimeAuthMode?: string;
+  /** Deployment id used to build Apps-gateway routes in public mode. */
+  public readonly appId?: string;
 
   constructor(options: ConfigOptions) {
     this.baseUrl = options.baseUrl;
@@ -39,6 +47,8 @@ export class UiPathConfig {
     this.clientId = options.clientId;
     this.redirectUri = options.redirectUri;
     this.scope = options.scope;
+    this.runtimeAuthMode = options.runtimeAuthMode;
+    this.appId = options.appId;
   }
 }
 

--- a/src/core/config/runtime.ts
+++ b/src/core/config/runtime.ts
@@ -9,6 +9,9 @@ import { isBrowser } from '../../utils/platform';
  */
 export type MetaTagConfig = PartialUiPathConfig & { folderKey?: string };
 
+/** Value of `uipath:runtime-auth-mode` that switches the SDK into public (application-identity) mode. */
+export const RUNTIME_AUTH_MODE_APPLICATION = 'application';
+
 /**
  * Get the content of a meta tag by name.
  * Returns undefined if not in browser environment or meta tag is not found.
@@ -36,6 +39,8 @@ export function loadFromMetaTags(): MetaTagConfig | null {
     baseUrl: getMetaTagContent(UiPathMetaTags.BASE_URL),
     redirectUri: getMetaTagContent(UiPathMetaTags.REDIRECT_URI),
     folderKey: getMetaTagContent(UiPathMetaTags.FOLDER_KEY),
+    runtimeAuthMode: getMetaTagContent(UiPathMetaTags.RUNTIME_AUTH_MODE),
+    appId: getMetaTagContent(UiPathMetaTags.APP_ID),
   };
 
   const hasAnyValue = Object.values(config).some(Boolean);

--- a/src/core/config/runtime.ts
+++ b/src/core/config/runtime.ts
@@ -9,6 +9,9 @@ import { isBrowser } from '../../utils/platform';
  */
 export type MetaTagConfig = PartialUiPathConfig & { folderKey?: string };
 
+/** Value of `uipath:runtime-auth-mode` that switches the SDK into public (anonymous) mode. */
+export const RUNTIME_AUTH_MODE_ANONYMOUS = 'anonymous';
+
 /**
  * Get the content of a meta tag by name.
  * Returns undefined if not in browser environment or meta tag is not found.
@@ -36,6 +39,8 @@ export function loadFromMetaTags(): MetaTagConfig | null {
     baseUrl: getMetaTagContent(UiPathMetaTags.BASE_URL),
     redirectUri: getMetaTagContent(UiPathMetaTags.REDIRECT_URI),
     folderKey: getMetaTagContent(UiPathMetaTags.FOLDER_KEY),
+    runtimeAuthMode: getMetaTagContent(UiPathMetaTags.RUNTIME_AUTH_MODE),
+    appId: getMetaTagContent(UiPathMetaTags.APP_ID),
   };
 
   const hasAnyValue = Object.values(config).some(Boolean);

--- a/src/core/config/sdk-config.ts
+++ b/src/core/config/sdk-config.ts
@@ -12,6 +12,15 @@ export interface OAuthFields {
   scope: string;
 }
 
+// Public (anonymous) coded-app fields. Injected via meta tags at deploy — the app
+// runs as its own identity through the Apps gateway, so it carries no OAuth creds.
+export interface PublicModeFields {
+  /** 'application' switches the SDK into public mode; absent/'user' keeps PKCE. */
+  runtimeAuthMode?: string;
+  /** Deployment id used to build the Apps-gateway routes in public mode. */
+  appId?: string;
+}
+
 // Configuration type that enforces either secret or complete OAuth fields
 export type UiPathSDKConfig = BaseConfig & (
   | { secret: string; clientId?: never; redirectUri?: never; scope?: never }
@@ -20,7 +29,13 @@ export type UiPathSDKConfig = BaseConfig & (
 
 // Flexible partial type for constructor input (allows any combination of fields)
 // The isCompleteConfig function validates the final merged config
-export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string }>;
+export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string } & PublicModeFields>;
+
+// Type guard: is the app running in public (anonymous) mode? Requires the appId
+// the gateway routes are keyed on, so a bare mode flag can't half-enable it.
+export function isPublicMode(config: { runtimeAuthMode?: string; appId?: string }): config is { runtimeAuthMode: string; appId: string } {
+  return config.runtimeAuthMode === 'application' && Boolean(config.appId);
+}
 
 // Type guard to check if config has OAuth credentials
 export function hasOAuthConfig(config: { clientId?: string; redirectUri?: string; scope?: string }): config is { clientId: string; redirectUri: string; scope: string } {

--- a/src/core/config/sdk-config.ts
+++ b/src/core/config/sdk-config.ts
@@ -12,6 +12,15 @@ export interface OAuthFields {
   scope: string;
 }
 
+// Public (anonymous) coded-app fields. Injected via meta tags at deploy — the app
+// runs as its own identity through the Apps gateway, so it carries no OAuth creds.
+export interface PublicModeFields {
+  /** 'anonymous' switches the SDK into public mode; absent/'user' keeps PKCE. */
+  runtimeAuthMode?: string;
+  /** Deployment id used to build the Apps-gateway routes in public mode. */
+  appId?: string;
+}
+
 // Configuration type that enforces either secret or complete OAuth fields
 export type UiPathSDKConfig = BaseConfig & (
   | { secret: string; clientId?: never; redirectUri?: never; scope?: never }
@@ -20,7 +29,13 @@ export type UiPathSDKConfig = BaseConfig & (
 
 // Flexible partial type for constructor input (allows any combination of fields)
 // The isCompleteConfig function validates the final merged config
-export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string }>;
+export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string } & PublicModeFields>;
+
+// Type guard: is the app running in public (anonymous) mode? Requires the appId
+// the gateway routes are keyed on, so a bare mode flag can't half-enable it.
+export function isPublicMode(config: { runtimeAuthMode?: string; appId?: string }): config is { runtimeAuthMode: string; appId: string } {
+  return config.runtimeAuthMode === 'anonymous' && Boolean(config.appId);
+}
 
 // Type guard to check if config has OAuth credentials
 export function hasOAuthConfig(config: { clientId?: string; redirectUri?: string; scope?: string }): config is { clientId: string; redirectUri: string; scope: string } {

--- a/src/core/http/public-app-client.ts
+++ b/src/core/http/public-app-client.ts
@@ -1,0 +1,98 @@
+import { ErrorFactory } from '../errors/error-factory';
+import { errorResponseParser } from '../errors/parser';
+import { CONTENT_TYPES } from '../../utils/constants/headers';
+
+/**
+ * HTTP client for **public (anonymous) coded apps**.
+ *
+ * In public mode the browser holds no token — the visitor is identified only by an
+ * opaque, HttpOnly session cookie, and the app's own identity is minted server-side
+ * by the Apps gateway. So this client is deliberately separate from {@link ApiClient}
+ * (which always attaches a PKCE Bearer): it sends `credentials: 'include'`, never an
+ * Authorization header, and talks to the gateway's REST surface rather than raw OData.
+ *
+ * All requests are same-origin, routed by the edge to the Apps service:
+ *   `{baseUrl}/{orgName}/apps_/integrations/codedapp/{appId}/...`
+ *
+ * Session lifecycle: the first call may 401 (no cookie yet, or the Redis session
+ * expired/was evicted). On a 401 the client bootstraps a session via `POST /session`
+ * (which Set-Cookies) and retries the original request once. Bootstrap is single-flight
+ * so concurrent calls share one `/session` round-trip.
+ */
+export class PublicAppClient {
+  private readonly gatewayBase: string;
+  // In-flight session bootstrap, shared so N concurrent 401s trigger one /session call.
+  private sessionBootstrap: Promise<void> | null = null;
+
+  constructor(baseUrl: string, orgName: string, appId: string) {
+    const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    this.gatewayBase = `${base}/${orgName}/apps_/integrations/codedapp/${appId}`;
+  }
+
+  /** Starts a process and returns the created job. The gateway records it in this session's owned-set. */
+  async startProcess(processKey: string, inputArguments?: unknown): Promise<unknown> {
+    return this.request('POST', `/orchestrator/processes/${encodeURIComponent(processKey)}/jobs`, { inputArguments });
+  }
+
+  /** Reads a job's output. Returns 404 (→ error) if this session doesn't own the job. */
+  async getJobOutput(jobId: string): Promise<unknown> {
+    return this.request('GET', `/orchestrator/jobs/${encodeURIComponent(jobId)}/output`);
+  }
+
+  /**
+   * Bootstraps the anonymous session. Idempotent and single-flight: the gateway
+   * responds 204 with a `Set-Cookie`. A non-2xx here is terminal (the app is not
+   * public/open, or the feature is off) and surfaces as an error.
+   */
+  private async ensureSession(): Promise<void> {
+    if (!this.sessionBootstrap) {
+      this.sessionBootstrap = (async () => {
+        const response = await fetch(`${this.gatewayBase}/session`, {
+          method: 'POST',
+          credentials: 'include',
+        });
+        if (!response.ok) {
+          const errorInfo = await errorResponseParser.parse(response);
+          throw ErrorFactory.createFromHttpStatus(response.status, errorInfo);
+        }
+      })();
+      // Clear on settle so a later expiry can bootstrap again.
+      this.sessionBootstrap.catch(() => undefined).finally(() => {
+        this.sessionBootstrap = null;
+      });
+    }
+    return this.sessionBootstrap;
+  }
+
+  private async request(method: string, subPath: string, body?: unknown): Promise<unknown> {
+    const doFetch = () =>
+      fetch(`${this.gatewayBase}${subPath}`, {
+        method,
+        credentials: 'include',
+        headers: body === undefined ? undefined : { 'Content-Type': CONTENT_TYPES.JSON },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+
+    let response: Response;
+    try {
+      response = await doFetch();
+      // No session yet, or it expired/was revoked — bootstrap once and retry.
+      if (response.status === 401) {
+        await this.ensureSession();
+        response = await doFetch();
+      }
+    } catch (error) {
+      throw ErrorFactory.createNetworkError(error);
+    }
+
+    if (!response.ok) {
+      const errorInfo = await errorResponseParser.parse(response);
+      throw ErrorFactory.createFromHttpStatus(response.status, errorInfo);
+    }
+    if (response.status === 204) {
+      return undefined;
+    }
+    const text = await response.text();
+    return text ? JSON.parse(text) : undefined;
+  }
+}

--- a/src/core/internals/types.ts
+++ b/src/core/internals/types.ts
@@ -6,6 +6,7 @@
 import { UiPathConfig } from '../config/config';
 import { ExecutionContext } from '../context/execution';
 import { TokenManager } from '../auth/token-manager';
+import { PublicAppClient } from '../http/public-app-client';
 
 /**
  * Private SDK components used by services.
@@ -25,4 +26,10 @@ export interface PrivateSDK {
    * Not user-settable via the SDK constructor.
    */
   folderKey?: string;
+  /**
+   * Present only in public (anonymous) coded-app mode. Routes supported calls
+   * through the Apps gateway with a session cookie instead of a user token.
+   * @internal
+   */
+  publicAppClient?: PublicAppClient;
 }

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -2,8 +2,9 @@ import { UiPathConfig } from './config/config';
 import { ExecutionContext } from './context/execution';
 import { AuthService } from './auth/service';
 import { TokenInfo } from './auth/types';
-import { UiPathSDKConfig, PartialUiPathConfig, BaseConfig, hasOAuthConfig, hasSecretConfig } from './config/sdk-config';
-import { validateConfig, normalizeBaseUrl, isCompleteConfig } from './config/config-utils';
+import { UiPathSDKConfig, PartialUiPathConfig, BaseConfig, hasOAuthConfig, hasSecretConfig, isPublicMode } from './config/sdk-config';
+import { validateConfig, normalizeBaseUrl, isCompleteConfig, hasRequiredBaseFields } from './config/config-utils';
+import { PublicAppClient } from './http/public-app-client';
 import { telemetryClient, trackEvent } from './telemetry';
 import { SDKInternalsRegistry } from './internals';
 import { loadFromMetaTags } from './config/runtime';
@@ -74,37 +75,54 @@ export class UiPath implements IUiPath {
     // Merge configuration: constructor config overrides meta tags
     const mergedConfig = config ? { ...configFromMetaTags, ...config } : configFromMetaTags;
 
-    if (mergedConfig && isCompleteConfig(mergedConfig)) {
+    // Public (anonymous) mode is complete without OAuth/secret: the app carries no
+    // creds — the Apps gateway holds its identity. Base fields (baseUrl/org/tenant)
+    // still come from meta tags/config.
+    if (mergedConfig && (isCompleteConfig(mergedConfig) || (isPublicMode(mergedConfig) && hasRequiredBaseFields(mergedConfig)))) {
       this.#initializeWithConfig(mergedConfig);
     } else if (config) {
       this.#partialConfig = config;
     }
   }
 
-  #initializeWithConfig(config: UiPathSDKConfig): void {
-    // Validate and normalize the configuration
-    validateConfig(config);
+  #initializeWithConfig(config: PartialUiPathConfig): void {
+    const publicMode = isPublicMode(config);
+
+    // Public mode carries no OAuth/secret — skip auth validation. Base fields are
+    // already guaranteed by the caller's gate.
+    if (!publicMode) {
+      validateConfig(config as UiPathSDKConfig);
+    }
 
     const hasSecretAuth = hasSecretConfig(config);
     const hasOAuthAuth = hasOAuthConfig(config);
 
     // Initialize core components
     const internalConfig = new UiPathConfig({
-      baseUrl: normalizeBaseUrl(config.baseUrl),
-      orgName: config.orgName,
-      tenantName: config.tenantName,
+      baseUrl: normalizeBaseUrl(config.baseUrl!),
+      orgName: config.orgName!,
+      tenantName: config.tenantName!,
       secret: hasSecretAuth ? config.secret : undefined,
       clientId: hasOAuthAuth ? config.clientId : undefined,
       redirectUri: hasOAuthAuth ? config.redirectUri : undefined,
       scope: hasOAuthAuth ? config.scope : undefined,
+      runtimeAuthMode: config.runtimeAuthMode,
+      appId: config.appId,
     });
 
     const executionContext = new ExecutionContext();
+    // AuthService is safe without creds (no token manager work happens until a call
+    // needs one, which public-mode services never do — they route through the gateway).
     this.#authService = new AuthService(internalConfig, executionContext);
     if (this.#multiLogin) {
       this.#authService.setMultiLogin();
     }
     this.#config = internalConfig;
+
+    // In public mode, build the gateway client the supported services route through.
+    const publicAppClient = publicMode
+      ? new PublicAppClient(internalConfig.baseUrl, internalConfig.orgName, internalConfig.appId!)
+      : undefined;
 
     // Store internals in SDKInternalsRegistry (not visible on instance).
     // `folderKey` is meta-tag-only — kept off `UiPathConfig` (which mirrors
@@ -114,6 +132,7 @@ export class UiPath implements IUiPath {
       context: executionContext,
       tokenManager: this.#authService.getTokenManager(),
       folderKey: this.#metaFolderKey,
+      publicAppClient,
     });
 
     // Expose read-only config for user convenience

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -1,4 +1,5 @@
 import { ApiClient } from '../core/http/api-client';
+import { PublicAppClient } from '../core/http/public-app-client';
 import { RequestSpec } from '../models/common/request-spec';
 import { PaginatedResponse, PaginationOptions } from '../utils/pagination/types';
 import {
@@ -76,10 +77,18 @@ export class BaseService {
    * const entities = new Entities(sdk);
    * ```
    */
+  /**
+   * Apps-gateway client, present only when the SDK runs in public (anonymous) mode.
+   * Services that support public mode route through this instead of the token-based
+   * ApiClient. Shared across services so the anonymous session is bootstrapped once.
+   */
+  protected readonly publicApp?: PublicAppClient;
+
   constructor(instance: IUiPath, headers?: Record<string, string>) {
-    const { config, context, tokenManager, folderKey } = SDKInternalsRegistry.get(instance);
+    const { config, context, tokenManager, folderKey, publicAppClient } = SDKInternalsRegistry.get(instance);
     this.#apiClient = new ApiClient(config, context, tokenManager, headers ? { headers } : {});
     this.config = { folderKey };
+    this.publicApp = publicAppClient;
   }
 
   /**

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -96,9 +96,20 @@ export class JobService extends FolderScopedService implements JobServiceModel {
   }
 
   @track('Jobs.GetOutput')
-  async getOutput(jobKey: string, folderId: number): Promise<Record<string, unknown> | null> {
+  async getOutput(jobKey: string, folderId?: number): Promise<Record<string, unknown> | null> {
     if (!jobKey) {
       throw new ValidationError({ message: 'jobKey is required for getOutput' });
+    }
+
+    // Public (anonymous) mode: the gateway checks this session owns the job (404 if
+    // not), mints the app token, and returns the output — no folderId, no user token.
+    if (this.publicApp) {
+      const result = await this.publicApp.getJobOutput(jobKey) as { output?: Record<string, unknown> | null } | null;
+      return result?.output ?? null;
+    }
+
+    if (folderId === undefined) {
+      throw new ValidationError({ message: 'folderId is required for getOutput' });
     }
 
     const job = await this.getById(jobKey, folderId, { select: 'outputArguments,outputFile' });

--- a/src/services/orchestrator/processes/processes.ts
+++ b/src/services/orchestrator/processes/processes.ts
@@ -21,6 +21,7 @@ import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
 import { track } from '../../../core/telemetry';
 import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
+import { ValidationError } from '../../../core/errors';
 
 /**
  * Service for interacting with UiPath Orchestrator Processes API
@@ -69,6 +70,17 @@ export class ProcessService extends FolderScopedService implements ProcessServic
     optionsOrFolderId?: ProcessStartOptions | number,
     legacyOptions?: RequestOptions,
   ): Promise<ProcessStartResponse[]> {
+    // Public (anonymous) mode: the gateway resolves folder + identity from the
+    // deployment, so folder context and the OData shape don't apply here — send the
+    // process key + inputs and let the gateway forward StartJobs as the app.
+    if (this.publicApp) {
+      if (!request.processKey) {
+        throw new ValidationError({ message: 'processKey is required to start a process in public mode' });
+      }
+      const job = await this.publicApp.startProcess(request.processKey, request.inputArguments);
+      return (job ? [job] : []) as ProcessStartResponse[];
+    }
+
     // Normalize the two overload forms into a single internal shape.
     let folderId: number | undefined;
     let folderKey: string | undefined;

--- a/src/utils/runtime/constants.ts
+++ b/src/utils/runtime/constants.ts
@@ -20,4 +20,10 @@ export enum UiPathMetaTags {
   // Folder context (injected during coded-app deployment)
   FOLDER_KEY = 'uipath:folder-key',
 
+  // Public (anonymous) coded-app runtime mode. Injected at deploy when the app
+  // runs as its own identity (no user login). RUNTIME_AUTH_MODE = 'application'
+  // switches the SDK into public mode; APP_ID keys the Apps-gateway routes.
+  RUNTIME_AUTH_MODE = 'uipath:runtime-auth-mode',
+  APP_ID = 'uipath:app-id',
+
 }

--- a/src/utils/runtime/constants.ts
+++ b/src/utils/runtime/constants.ts
@@ -20,4 +20,10 @@ export enum UiPathMetaTags {
   // Folder context (injected during coded-app deployment)
   FOLDER_KEY = 'uipath:folder-key',
 
+  // Public (anonymous) coded-app runtime mode. Injected at deploy when the app
+  // runs as its own identity (no user login). RUNTIME_AUTH_MODE = 'anonymous'
+  // switches the SDK into public mode; APP_ID keys the Apps-gateway routes.
+  RUNTIME_AUTH_MODE = 'uipath:runtime-auth-mode',
+  APP_ID = 'uipath:app-id',
+
 }

--- a/tests/unit/core/public-app-client.test.ts
+++ b/tests/unit/core/public-app-client.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PublicAppClient } from '@/core/http/public-app-client';
+
+/**
+ * PublicAppClient: same-origin, cookie-credentialed calls to the Apps gateway for
+ * anonymous coded apps, with single-flight session bootstrap on 401.
+ */
+describe('PublicAppClient', () => {
+  const base = 'https://cloud.uipath.com';
+  const gateway = `${base}/my_org/apps_/integrations/codedapp/app-123`;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: PublicAppClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    (globalThis as any).fetch = fetchMock;
+    client = new PublicAppClient(base, 'my_org', 'app-123');
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+  it('startProcess POSTs to the gateway route with credentials and returns the job', async () => {
+    fetchMock.mockResolvedValueOnce(json(201, { jobKey: 'J-1', state: 'Pending' }));
+
+    const job = await client.startProcess('proc-1', { amount: 5 });
+
+    expect(job).toEqual({ jobKey: 'J-1', state: 'Pending' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${gateway}/orchestrator/processes/proc-1/jobs`);
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+    expect(JSON.parse(init.body)).toEqual({ inputArguments: { amount: 5 } });
+  });
+
+  it('getJobOutput GETs the output route', async () => {
+    fetchMock.mockResolvedValueOnce(json(200, { output: { result: 42 } }));
+
+    const out = await client.getJobOutput('J-1');
+
+    expect(out).toEqual({ output: { result: 42 } });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${gateway}/orchestrator/jobs/J-1/output`);
+    expect(init.method).toBe('GET');
+    expect(init.credentials).toBe('include');
+  });
+
+  it('on 401 it bootstraps a session then retries the original request once', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 })) // first call: no session
+      .mockResolvedValueOnce(new Response(null, { status: 204 })) // POST /session
+      .mockResolvedValueOnce(json(201, { jobKey: 'J-2' }));        // retry
+
+    const job = await client.startProcess('proc-1');
+
+    expect(job).toEqual({ jobKey: 'J-2' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1][0]).toBe(`${gateway}/session`);
+    expect(fetchMock.mock.calls[1][1].method).toBe('POST');
+  });
+
+  it('throws if session bootstrap fails (app not public / feature off)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 })); // /session denied
+
+    await expect(client.startProcess('proc-1')).rejects.toBeTruthy();
+  });
+
+  it('surfaces a 404 on job output (session does not own the job)', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }));
+    await expect(client.getJobOutput('someone-elses-job')).rejects.toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Draft — the SDK half of public (anonymous) coded apps.** Pairs with the server-side session + integration and the edge-forwarding change (separate repos). Not for merge yet.

## Why
A public coded app serves anonymous visitors with no UiPath login. The SDK can't do PKCE and holds no token. Instead, in **public mode** the SDK calls its own backend same-origin through the Apps gateway, which resolves the visitor's session, mints the app's identity server-side, and forwards downstream. The token never touches the browser.

## What this adds
- **Config / meta tags** — reads `uipath:runtime-auth-mode` (`anonymous`) and `uipath:app-id`, injected at deploy. `isPublicMode()` gates the behavior; public mode is a complete config even without OAuth/secret (there are none).
- **`PublicAppClient`** — same-origin, cookie-credentialed (`credentials: 'include'`, no `Authorization`) calls to `{baseUrl}/{org}/apps_/integrations/codedapp/{appId}/...`. On a `401` it bootstraps a session (`POST /session`, single-flight) and retries once. This mirrors the design's "browser holds only the cookie" model.
- **Service wiring** — `Processes.start` and `Jobs.getOutput` route through the gateway in public mode; the existing token-based path is untouched otherwise.

## Scope / follow-ups
- Covers the two integration methods that match the current server routes (start-process, read-output). Each additional method is a one-line delegation to `PublicAppClient` — deliberately not done here.
- `inputArguments`: the SDK models it as a JSON string while the gateway currently expects an object — the two need to agree (flagging, not fixed here).
- Depends on deploy injecting the `uipath:app-id` + `uipath:runtime-auth-mode` meta tags, and on Gate 1 (resource fence) landing server-side.

## Tests
`tests/unit/core/public-app-client.test.ts` — URL shape, credentialed fetch, 401→bootstrap→retry, and fail-closed on denied session / unowned job (5 passing). Existing core/base/orchestrator suites still green (162 tests).