### PR TITLE
feat: onboard attachment upload and job attachment APIs

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -21,6 +21,8 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 | `stop()` | `OR.Jobs` |
 | `resume()` | `OR.Jobs` or `OR.Jobs.Write` |
 | `restart()` | `OR.Jobs` |
+| `getAttachments()` | `OR.Jobs` or `OR.Jobs.Read` |
+| `linkAttachment()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ## Functions
 
@@ -36,6 +38,7 @@ Coded functions are invoked through their HTTP endpoint, which requires the [`OR
 | Method | OAuth Scope |
 |--------|-------------|
 | `getById()` | `OR.Folders` or `OR.Folders.Read` |
+| `create()` | `OR.Folders` or `OR.Folders.Write` |
 
 ## Buckets
 

--- a/src/core/errors/parser.ts
+++ b/src/core/errors/parser.ts
@@ -153,7 +153,9 @@ export class ErrorResponseParser {
    */
   async parse(response: Response): Promise<ParsedErrorInfo> {
     try {
-      const errorBody = await response.json();
+      // Parse a clone so the body stays readable — a non-JSON error (e.g. the XML
+      // Azure Storage returns) must still be recoverable in the fallback below.
+      const errorBody = await response.clone().json();
       
       // Find the first strategy that can parse this error format
       const strategy = this.strategies.find(s => s.canParse(errorBody));

--- a/src/models/orchestrator/attachments.models.ts
+++ b/src/models/orchestrator/attachments.models.ts
@@ -1,6 +1,8 @@
 import {
   AttachmentResponse,
   AttachmentGetByIdOptions,
+  AttachmentCreateOptions,
+  AttachmentCreateResponse,
 } from './attachments.types';
 
 /**
@@ -25,4 +27,44 @@ export interface AttachmentServiceModel {
    * ```
    */
   getById(id: string, options?: AttachmentGetByIdOptions): Promise<AttachmentResponse>;
+
+  /**
+   * Creates an attachment and uploads its content.
+   *
+   * The upload is handled for you — the attachment record and its file are both
+   * in place once this resolves. Returns the stored attachment, whose `id` is
+   * the handle to use everywhere else (for example as the value of a `file`
+   * field in an action's output data).
+   *
+   * Pass `jobKey` to link the attachment to a job as part of the same call;
+   * `jobs.linkAttachment()` is only needed to attach it to a further job later.
+   *
+   * @param name - File name to store the attachment under, including its extension
+   * @param content - File content to upload
+   * @param options - Optional job to link to, its category, and the folder to create the attachment in
+   * @returns Promise resolving to the created {@link AttachmentCreateResponse}
+   * @example
+   * ```typescript
+   * import { Attachments } from '@uipath/uipath-typescript/attachments';
+   *
+   * const attachments = new Attachments(sdk);
+   *
+   * // Upload a file picked in the browser
+   * const attachment = await attachments.create(file.name, file);
+   * console.log(attachment.id);
+   * ```
+   * @example
+   * ```typescript
+   * // Upload and link it to a job in one call
+   * const attachment = await attachments.create('invoice.pdf', file, {
+   *   jobKey: <jobKey>,
+   *   category: 'Invoice',
+   * });
+   * ```
+   */
+  create(
+    name: string,
+    content: Blob | Uint8Array<ArrayBuffer> | File,
+    options?: AttachmentCreateOptions
+  ): Promise<AttachmentCreateResponse>;
 }

--- a/src/models/orchestrator/attachments.types.ts
+++ b/src/models/orchestrator/attachments.types.ts
@@ -52,3 +52,36 @@ export interface AttachmentResponse {
  * Options for getting an attachment by ID
  */
 export interface AttachmentGetByIdOptions extends BaseOptions {};
+
+/**
+ * Attachment returned when a new attachment is created.
+ *
+ * The upload URI is deliberately not exposed — the SDK uploads the content
+ * before returning, so the short-lived write credential serves no further
+ * purpose to the caller.
+ */
+export interface AttachmentCreateResponse extends Omit<AttachmentResponse, 'blobFileAccess'> {};
+
+/**
+ * Options for creating an attachment
+ */
+export interface AttachmentCreateOptions {
+  /**
+   * Key of a job to link the new attachment to. When set, the attachment is
+   * created and linked in a single call — no separate `jobs.linkAttachment()`
+   * is needed.
+   */
+  jobKey?: string;
+
+  /**
+   * Label that groups the attachment within the job. Only meaningful together
+   * with `jobKey`.
+   */
+  category?: string;
+
+  /**
+   * ID of the folder to create the attachment in. Defaults to the tenant's
+   * default folder context when omitted.
+   */
+  folderId?: number;
+}

--- a/src/models/orchestrator/jobs.models.ts
+++ b/src/models/orchestrator/jobs.models.ts
@@ -1,4 +1,4 @@
-import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions, JobResumeOptions } from './jobs.types';
+import { JobGetAllOptions, JobGetByIdOptions, RawJobGetResponse, JobStopOptions, JobResumeOptions, JobAttachmentGetResponse, JobLinkAttachmentOptions } from './jobs.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 
 /** Combined response type for job data with bound methods. */
@@ -216,6 +216,69 @@ export interface JobServiceModel {
    * ```
    */
   restart(jobKey: string, folderId: number): Promise<JobGetResponse>;
+
+  /**
+   * Gets all attachments linked to a job.
+   *
+   * @param jobKey - The unique key (GUID) of the job whose attachments to retrieve
+   * @param folderId - The folder ID where the job resides
+   * @returns Promise resolving to an array of {@link JobAttachmentGetResponse} links, empty when the job has none
+   *
+   * @example
+   * ```typescript
+   * const attachments = await jobs.getAttachments(<jobKey>, <folderId>);
+   * ```
+   *
+   * @example
+   * ```typescript
+   * import { Attachments } from '@uipath/uipath-typescript/attachments';
+   *
+   * // Read the underlying file of each attachment linked to a job
+   * const attachmentsService = new Attachments(sdk);
+   * const links = await jobs.getAttachments(<jobKey>, <folderId>);
+   *
+   * for (const link of links) {
+   *   const attachment = await attachmentsService.getById(link.attachmentId);
+   *   console.log(link.category, attachment.blobFileAccess.uri);
+   * }
+   * ```
+   */
+  getAttachments(jobKey: string, folderId: number): Promise<JobAttachmentGetResponse[]>;
+
+  /**
+   * Links an existing attachment to a job.
+   *
+   * This does not upload a file — it associates an attachment that already
+   * exists in Orchestrator with a job.
+   *
+   * The returned link does not carry `attachmentName` or `creatorUserId` yet —
+   * read them back with {@link getAttachments}.
+   *
+   * @param attachmentId - The unique ID (GUID) of the attachment to link
+   * @param jobKey - The unique key (GUID) of the job to link the attachment to
+   * @param folderId - The folder ID where the job resides
+   * @param options - Optional settings for the link, such as its category
+   * @returns Promise resolving to the created {@link JobAttachmentGetResponse} link
+   *
+   * @example
+   * ```typescript
+   * const link = await jobs.linkAttachment(<attachmentId>, <jobKey>, <folderId>);
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Group the attachment under a category of your choosing
+   * const link = await jobs.linkAttachment(<attachmentId>, <jobKey>, <folderId>, {
+   *   category: 'Invoice',
+   * });
+   * ```
+   */
+  linkAttachment(
+    attachmentId: string,
+    jobKey: string,
+    folderId: number,
+    options?: JobLinkAttachmentOptions
+  ): Promise<JobAttachmentGetResponse>;
 }
 
 /**
@@ -278,6 +341,37 @@ export interface JobMethods {
    * @returns Promise resolving to the new {@link JobGetResponse} with full job details
    */
   restart(): Promise<JobGetResponse>;
+
+  /**
+   * Gets all attachments linked to this job.
+   *
+   * @returns Promise resolving to an array of {@link JobAttachmentGetResponse} links, empty when the job has none
+   *
+   * @example
+   * ```typescript
+   * const job = await jobs.getById(<jobKey>, <folderId>);
+   * const attachments = await job.getAttachments();
+   * ```
+   */
+  getAttachments(): Promise<JobAttachmentGetResponse[]>;
+
+  /**
+   * Links an existing attachment to this job.
+   *
+   * @param attachmentId - The unique ID (GUID) of the attachment to link
+   * @param options - Optional settings for the link, such as its category
+   * @returns Promise resolving to the created {@link JobAttachmentGetResponse} link
+   *
+   * @example
+   * ```typescript
+   * const job = await jobs.getById(<jobKey>, <folderId>);
+   * const link = await job.linkAttachment(<attachmentId>, { category: 'Invoice' });
+   * ```
+   */
+  linkAttachment(
+    attachmentId: string,
+    options?: JobLinkAttachmentOptions
+  ): Promise<JobAttachmentGetResponse>;
 }
 
 /**
@@ -308,6 +402,19 @@ function createJobMethods(jobData: RawJobGetResponse, service: JobServiceModel):
       if (!jobData.key) throw new Error('Job key is undefined');
       if (!jobData.folderId) throw new Error('Job folderId is undefined');
       return service.restart(jobData.key, jobData.folderId);
+    },
+    async getAttachments(): Promise<JobAttachmentGetResponse[]> {
+      if (!jobData.key) throw new Error('Job key is undefined');
+      if (!jobData.folderId) throw new Error('Job folderId is undefined');
+      return service.getAttachments(jobData.key, jobData.folderId);
+    },
+    async linkAttachment(
+      attachmentId: string,
+      options?: JobLinkAttachmentOptions
+    ): Promise<JobAttachmentGetResponse> {
+      if (!jobData.key) throw new Error('Job key is undefined');
+      if (!jobData.folderId) throw new Error('Job folderId is undefined');
+      return service.linkAttachment(attachmentId, jobData.key, jobData.folderId, options);
     },
   };
 }

--- a/src/models/orchestrator/jobs.types.ts
+++ b/src/models/orchestrator/jobs.types.ts
@@ -194,3 +194,69 @@ export interface JobStopOptions {
   strategy?: StopStrategy;
 }
 
+
+/**
+ * Interface for an attachment linked to a job
+ */
+export interface JobAttachmentGetResponse {
+  /**
+   * Unique identifier of the link between the job and the attachment
+   */
+  id: string;
+
+  /**
+   * Identifier of the linked attachment. Pass this to `attachments.getById()`
+   * to read the attachment's metadata and download URI.
+   */
+  attachmentId: string;
+
+  /**
+   * Key of the job the attachment is linked to
+   */
+  jobKey: string;
+
+  /**
+   * Caller-defined label that groups attachments within a job. Attachments
+   * uploaded by a running automation carry the category `JobAttachment`.
+   * Null when the link was created without a category.
+   */
+  category: string | null;
+
+  /**
+   * File name of the linked attachment. Null on the response returned when the
+   * link is first created — read it back with {@link JobServiceModel.getAttachments}.
+   */
+  attachmentName: string | null;
+
+  /**
+   * When the link was last modified
+   */
+  lastModifiedTime: string | null;
+
+  /**
+   * ID of the user who last modified the link
+   */
+  lastModifierUserId: number | null;
+
+  /**
+   * When the link was created
+   */
+  createdTime: string;
+
+  /**
+   * ID of the user who created the link
+   */
+  creatorUserId: number | null;
+}
+
+/**
+ * Options for linking an attachment to a job
+ */
+export interface JobLinkAttachmentOptions {
+  /**
+   * Label that groups the attachment within the job. Free-form — any string the
+   * calling application uses to distinguish attachments (e.g. `Input`,
+   * `Output`, `Invoice`). Defaults to null when omitted.
+   */
+  category?: string;
+}

--- a/src/services/orchestrator/attachments/attachments.ts
+++ b/src/services/orchestrator/attachments/attachments.ts
@@ -1,15 +1,29 @@
-import { ValidationError } from '../../../core/errors';
+import { ValidationError, ServerError } from '../../../core/errors';
+import { ErrorFactory } from '../../../core/errors/error-factory';
+import { errorResponseParser } from '../../../core/errors/parser';
 import {
   AttachmentResponse,
   AttachmentGetByIdOptions,
+  AttachmentCreateOptions,
+  AttachmentCreateResponse,
 } from '../../../models/orchestrator/attachments.types';
+import { BucketGetUriResponse } from '../../../models/orchestrator/buckets.types';
 import { AttachmentServiceModel } from '../../../models/orchestrator/attachments.models';
-import { pascalToCamelCaseKeys, addPrefixToKeys, transformData, transformOptions } from '../../../utils/transform';
+import {
+  pascalToCamelCaseKeys,
+  camelToPascalCaseKeys,
+  addPrefixToKeys,
+  transformData,
+  transformOptions,
+  arrayDictionaryToRecord,
+} from '../../../utils/transform';
 import { ORCHESTRATOR_ATTACHMENT_ENDPOINTS } from '../../../utils/constants/endpoints';
 import { ODATA_PREFIX } from '../../../utils/constants/common';
+import { createHeaders } from '../../../utils/http/headers';
+import { FOLDER_ID } from '../../../utils/constants/headers';
 import { track } from '../../../core/telemetry';
 import { AttachmentsMap } from '../../../models/orchestrator/attachments.constants';
-import { BaseService } from '../../..//services/base';
+import { BaseService } from '../../../services/base';
 import { BucketMap } from '../../../models/orchestrator/buckets.constants';
 
 export class AttachmentService extends BaseService implements AttachmentServiceModel {
@@ -35,5 +49,85 @@ export class AttachmentService extends BaseService implements AttachmentServiceM
     const camelCased = pascalToCamelCaseKeys(response.data) as AttachmentResponse;
     camelCased.blobFileAccess = transformData(camelCased.blobFileAccess, BucketMap);
     return transformData(camelCased, AttachmentsMap);
+  }
+
+  @track('Attachments.Create')
+  async create(
+    name: string,
+    content: Blob | Uint8Array<ArrayBuffer> | File,
+    options?: AttachmentCreateOptions
+  ): Promise<AttachmentCreateResponse> {
+    if (!name) {
+      throw new ValidationError({ message: 'name is required for create' });
+    }
+    if (!content) {
+      throw new ValidationError({ message: 'content is required for create' });
+    }
+
+    // Built with the API's own field names — AttachmentsMap only covers the two
+    // timestamp renames, so running this through it would be a no-op.
+    // Passing jobKey links the attachment to the job as part of creation.
+    const response = await this.post<Record<string, unknown>>(
+      ORCHESTRATOR_ATTACHMENT_ENDPOINTS.CREATE,
+      camelToPascalCaseKeys({
+        name,
+        jobKey: options?.jobKey,
+        attachmentCategory: options?.category,
+      }),
+      { headers: createHeaders({ [FOLDER_ID]: options?.folderId }) }
+    );
+
+    const camelCased = pascalToCamelCaseKeys(response.data) as AttachmentResponse;
+    camelCased.blobFileAccess = transformData(camelCased.blobFileAccess, BucketMap);
+    const attachment = transformData(camelCased, AttachmentsMap);
+
+    await this.uploadContent(attachment.blobFileAccess, content);
+
+    // The write URI is a short-lived credential and is spent by this point;
+    // the OData context is transport metadata that callers never need.
+    const {
+      blobFileAccess: _blobFileAccess,
+      '@odata.context': _odataContext,
+      ...created
+    } = attachment as AttachmentResponse & { '@odata.context'?: string };
+    return created;
+  }
+
+  /**
+   * Uploads content to the short-lived URI returned alongside a new attachment.
+   * The URI carries its own credential, so no SDK auth header is added unless
+   * the response explicitly asks for one.
+   */
+  private async uploadContent(
+    blobFileAccess: BucketGetUriResponse,
+    content: Blob | Uint8Array<ArrayBuffer> | File
+  ): Promise<void> {
+    if (!blobFileAccess?.uri) {
+      throw new ServerError({ message: 'Attachment upload URI missing from the create response' });
+    }
+
+    // Storage returns its required headers (e.g. x-ms-blob-type) as parallel
+    // key/value arrays; sending them unconverted drops them and the PUT is rejected.
+    const rawHeaders = blobFileAccess.headers;
+    const requestHeaders: Record<string, string> =
+      rawHeaders && 'keys' in rawHeaders && 'values' in rawHeaders
+        ? arrayDictionaryToRecord(rawHeaders as unknown as { keys: string[]; values: string[] })
+        : { ...rawHeaders };
+
+    if (blobFileAccess.requiresAuth) {
+      requestHeaders['Authorization'] = `Bearer ${await this.getValidAuthToken()}`;
+    }
+
+    const response = await fetch(blobFileAccess.uri, {
+      method: 'PUT',
+      body: content,
+      headers: createHeaders(requestHeaders),
+    });
+
+    if (!response.ok) {
+      // Reported from the response body — the URI itself is a credential and is never echoed.
+      const errorInfo = await errorResponseParser.parse(response);
+      throw ErrorFactory.createFromHttpStatus(response.status, errorInfo);
+    }
   }
 }

--- a/src/services/orchestrator/jobs/jobs.ts
+++ b/src/services/orchestrator/jobs/jobs.ts
@@ -1,5 +1,5 @@
 import { FolderScopedService } from '../../folder-scoped';
-import { RawJobGetResponse, JobGetAllOptions, JobGetByIdOptions, JobStopOptions, JobResumeOptions } from '../../../models/orchestrator/jobs.types';
+import { RawJobGetResponse, JobGetAllOptions, JobGetByIdOptions, JobStopOptions, JobResumeOptions, JobAttachmentGetResponse, JobLinkAttachmentOptions } from '../../../models/orchestrator/jobs.types';
 import { JobServiceModel, JobGetResponse, createJobWithMethods } from '../../../models/orchestrator/jobs.models';
 import { addPrefixToKeys, pascalToCamelCaseKeys, transformOptions, transformData } from '../../../utils/transform';
 import { JOB_ENDPOINTS } from '../../../utils/constants/endpoints';
@@ -185,6 +185,64 @@ export class JobService extends FolderScopedService implements JobServiceModel {
 
     const rawJob = transformData(pascalToCamelCaseKeys(response.data) as RawJobGetResponse, JobMap);
     return createJobWithMethods(rawJob, this);
+  }
+
+  @track('Jobs.GetAttachments')
+  async getAttachments(jobKey: string, folderId: number): Promise<JobAttachmentGetResponse[]> {
+    if (!jobKey) {
+      throw new ValidationError({ message: 'jobKey is required for getAttachments' });
+    }
+
+    if (!folderId) {
+      throw new ValidationError({ message: 'folderId is required for getAttachments' });
+    }
+
+    const response = await this.get<Record<string, unknown>[]>(
+      JOB_ENDPOINTS.ATTACHMENTS.GET_BY_JOB_KEY,
+      {
+        params: { jobKey },
+        headers: createHeaders({ [FOLDER_ID]: folderId }),
+      }
+    );
+
+    // The endpoint answers in camelCase already, so only JobMap's semantic
+    // renames (creationTime, lastModificationTime) apply here.
+    return transformData(response.data, JobMap) as unknown as JobAttachmentGetResponse[];
+  }
+
+  @track('Jobs.LinkAttachment')
+  async linkAttachment(
+    attachmentId: string,
+    jobKey: string,
+    folderId: number,
+    options?: JobLinkAttachmentOptions
+  ): Promise<JobAttachmentGetResponse> {
+    if (!attachmentId) {
+      throw new ValidationError({ message: 'attachmentId is required for linkAttachment' });
+    }
+
+    if (!jobKey) {
+      throw new ValidationError({ message: 'jobKey is required for linkAttachment' });
+    }
+
+    if (!folderId) {
+      throw new ValidationError({ message: 'folderId is required for linkAttachment' });
+    }
+
+    // Request field names match the API's, so no outbound field map is needed.
+    const response = await this.post<Record<string, unknown>>(
+      JOB_ENDPOINTS.ATTACHMENTS.LINK,
+      {
+        attachmentId,
+        jobKey,
+        category: options?.category,
+      },
+      {
+        headers: createHeaders({ [FOLDER_ID]: folderId }),
+      }
+    );
+
+    return transformData(response.data, JobMap) as unknown as JobAttachmentGetResponse;
   }
 
   /**

--- a/src/utils/constants/endpoints/orchestrator.ts
+++ b/src/utils/constants/endpoints/orchestrator.ts
@@ -65,6 +65,12 @@ export const JOB_ENDPOINTS = {
   STOP: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.StopJobs`,
   RESUME: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.ResumeJob`,
   RESTART: `${ORCHESTRATOR_BASE}/odata/Jobs/UiPath.Server.Configuration.OData.RestartJob`,
+  ATTACHMENTS: {
+    /** Attachments linked to a job; the job is addressed by the `jobKey` query param. */
+    GET_BY_JOB_KEY: `${ORCHESTRATOR_BASE}/api/JobAttachments/GetByJobKey`,
+    /** Links an existing attachment to a job. */
+    LINK: `${ORCHESTRATOR_BASE}/api/JobAttachments/Post`,
+  },
 } as const;
 
 /**
@@ -81,6 +87,8 @@ export const ASSET_ENDPOINTS = {
  */
 export const ORCHESTRATOR_ATTACHMENT_ENDPOINTS = {
   GET_BY_ID: (id: string) => `${ORCHESTRATOR_BASE}/odata/Attachments(${id})`,
+  /** Creates an attachment record and returns a short-lived URI to upload its content to. */
+  CREATE: `${ORCHESTRATOR_BASE}/odata/Attachments`,
 } as const;
 
 /**

--- a/tests/integration/shared/orchestrator/attachments.integration.test.ts
+++ b/tests/integration/shared/orchestrator/attachments.integration.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
 import { AttachmentService } from '../../../../src/services/orchestrator/attachments';
+import { generateRandomString } from '../../utils/helpers';
 
 /**
  * Integration tests for the Orchestrator Attachment service.
@@ -91,6 +92,101 @@ describe.each(modes)(
         const attachments = new AttachmentService(sdk);
 
         await expect(attachments.getById('')).rejects.toThrow('id is required for getById');
+      });
+    });
+
+    describe('create', () => {
+      /**
+       * Each test creates a real attachment; they are deleted afterwards via the
+       * API since the SDK exposes no delete for attachments.
+       */
+      const createdAttachmentIds: string[] = [];
+
+      afterAll(async () => {
+        const config = getTestConfig();
+        const base = `${config.baseUrl}/${config.orgName}/${config.tenantName}/orchestrator_`;
+
+        for (const id of createdAttachmentIds) {
+          await fetch(`${base}/odata/Attachments(${id})`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${config.secret}` },
+          });
+        }
+      });
+
+      it('should create an attachment and upload its content', async () => {
+        const { sdk } = getServices();
+        const attachments = new AttachmentService(sdk);
+        const name = `IntegrationTest_Attachment_${generateRandomString()}.txt`;
+        const content = `uploaded at ${new Date().toISOString()}`;
+
+        const result = await attachments.create(name, new Blob([content]));
+        createdAttachmentIds.push(result.id);
+
+        expect(result.id).toBeDefined();
+        expect(result.name).toBe(name);
+        // The write URI is spent during upload and must not reach the caller
+        expect((result as any).blobFileAccess).toBeUndefined();
+
+        // Read it back and confirm the content actually landed in storage
+        const stored = await attachments.getById(result.id);
+        expect(stored.name).toBe(name);
+        expect(stored.blobFileAccess.uri).toBeDefined();
+
+        const download = await fetch(stored.blobFileAccess.uri);
+        expect(download.ok).toBe(true);
+        expect(await download.text()).toBe(content);
+      });
+
+      it('should validate transform: camelCase fields present, PascalCase absent', async () => {
+        const { sdk } = getServices();
+        const attachments = new AttachmentService(sdk);
+        const name = `IntegrationTest_Attachment_${generateRandomString()}.txt`;
+
+        const result = await attachments.create(name, new Blob(['transform check']));
+        createdAttachmentIds.push(result.id);
+
+        expect(typeof result.createdTime).toBe('string');
+        expect((result as any).CreationTime).toBeUndefined();
+        expect((result as any).Name).toBeUndefined();
+        expect((result as any).Id).toBeUndefined();
+      });
+
+      it('should link the attachment to a job when jobKey is supplied', async () => {
+        const { sdk, jobs } = getServices();
+        const config = getTestConfig();
+        const attachments = new AttachmentService(sdk);
+
+        if (!jobs) {
+          throw new Error('Jobs service not available in test services');
+        }
+
+        const folderId = Number(config.jobsTestFolderId ?? config.folderId);
+        if (!folderId) {
+          throw new Error('JOBS_TEST_FOLDER_ID or INTEGRATION_TEST_FOLDER_ID is required for this test');
+        }
+
+        const jobList = await jobs.getAll({ folderId, pageSize: 1 });
+        if (!jobList.items.length) {
+          throw new Error(`No jobs found in folder ${folderId} to link an attachment to`);
+        }
+        const jobKey = jobList.items[0].key;
+
+        const name = `IntegrationTest_Attachment_${generateRandomString()}.txt`;
+        const result = await attachments.create(name, new Blob(['linked on create']), {
+          jobKey,
+          category: 'IntegrationTest',
+          folderId,
+        });
+        createdAttachmentIds.push(result.id);
+
+        // Creating with a jobKey links it, so no separate linkAttachment call is needed
+        const links = await jobs.getAttachments(jobKey, folderId);
+        const linked = links.find(link => link.attachmentId === result.id);
+
+        expect(linked).toBeDefined();
+        expect(linked!.category).toBe('IntegrationTest');
+        expect(linked!.attachmentName).toBe(name);
       });
     });
   }

--- a/tests/integration/shared/orchestrator/jobs.integration.test.ts
+++ b/tests/integration/shared/orchestrator/jobs.integration.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { getServices, getTestConfig, setupUnifiedTests, InitMode } from '../../config/unified-setup';
+import { generateRandomString } from '../../utils/helpers';
 import type { JobGetResponse } from '../../../../src/models/orchestrator/jobs.models';
 
 const modes: InitMode[] = ['v1'];
@@ -338,6 +339,186 @@ describe.each(modes)('Orchestrator Jobs - Integration Tests [%s]', (mode) => {
       expect(typeof job.id).toBe('number');
       expect(typeof job.key).toBe('string');
       expect(typeof job.state).toBe('string');
+    });
+  });
+
+  /**
+   * Orchestrator exposes no endpoint for unlinking a job attachment, so each
+   * test links a throwaway attachment created for the purpose and deletes that
+   * attachment afterwards — removing the link with it. Creating and deleting
+   * the attachment itself is not part of the SDK surface, so those two calls
+   * go straight to the API.
+   */
+  describe('job attachments', () => {
+    /** How many jobs to check when looking for one without attachments. */
+    const MAX_EMPTY_JOB_SCAN = 10;
+
+    let jobKey!: string;
+    let attachmentFolderId!: number;
+    let seededAttachmentId!: string;
+
+    /** Attachment IDs to delete once the suite finishes. */
+    const createdAttachmentIds: string[] = [];
+
+    function orchestratorBaseUrl(): string {
+      const config = getTestConfig();
+      return `${config.baseUrl}/${config.orgName}/${config.tenantName}/orchestrator_`;
+    }
+
+    function apiHeaders(): Record<string, string> {
+      const config = getTestConfig();
+      return {
+        Authorization: `Bearer ${config.secret}`,
+        'Content-Type': 'application/json',
+        'X-UIPATH-OrganizationUnitId': String(attachmentFolderId),
+      };
+    }
+
+    /** Creates an empty attachment to link, and registers it for cleanup. */
+    async function createThrowawayAttachment(): Promise<string> {
+      const response = await fetch(`${orchestratorBaseUrl()}/odata/Attachments`, {
+        method: 'POST',
+        headers: apiHeaders(),
+        body: JSON.stringify({ Name: `IntegrationTest_JobAttachment_${generateRandomString()}.txt` }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to create test attachment: ${response.status} ${await response.text()}`);
+      }
+
+      const attachment = await response.json() as { Id: string };
+      createdAttachmentIds.push(attachment.Id);
+      return attachment.Id;
+    }
+
+    beforeAll(async () => {
+      const { jobs, folderId } = getJobsService();
+
+      if (!folderId) {
+        throw new Error('INTEGRATION_TEST_FOLDER_ID is required for job attachment tests');
+      }
+      attachmentFolderId = folderId;
+
+      // Any job in the folder will do — the link is what the tests exercise.
+      const result = await jobs.getAll({ folderId, pageSize: 1 });
+      if (!result.items.length) {
+        throw new Error(`No jobs found in folder ${folderId} to attach test attachments to`);
+      }
+      jobKey = result.items[0].key;
+
+      // Seed one link so getAttachments always has something to return.
+      seededAttachmentId = await createThrowawayAttachment();
+      await jobs.linkAttachment(seededAttachmentId, jobKey, folderId, { category: 'IntegrationTest' });
+    });
+
+    afterAll(async () => {
+      // Deleting the attachment removes the job link along with it.
+      for (const attachmentId of createdAttachmentIds) {
+        await fetch(`${orchestratorBaseUrl()}/odata/Attachments(${attachmentId})`, {
+          method: 'DELETE',
+          headers: apiHeaders(),
+        });
+      }
+    });
+
+    it('should retrieve the attachments linked to a job', async () => {
+      const { jobs } = getJobsService();
+
+      const result = await jobs.getAttachments(jobKey, attachmentFolderId);
+
+      expect(Array.isArray(result)).toBe(true);
+
+      const seeded = result.find(link => link.attachmentId === seededAttachmentId);
+      expect(seeded).toBeDefined();
+      expect(seeded!.jobKey).toBe(jobKey);
+      expect(seeded!.category).toBe('IntegrationTest');
+      expect(typeof seeded!.id).toBe('string');
+      expect(typeof seeded!.attachmentName).toBe('string');
+    });
+
+    it('should validate transform: renamed fields present, raw API names absent', async () => {
+      const { jobs } = getJobsService();
+
+      const result = await jobs.getAttachments(jobKey, attachmentFolderId);
+      const seeded = result.find(link => link.attachmentId === seededAttachmentId);
+
+      expect(seeded).toBeDefined();
+
+      // creationTime -> createdTime
+      expect(typeof seeded!.createdTime).toBe('string');
+      expect((seeded as any).creationTime).toBeUndefined();
+
+      // lastModificationTime -> lastModifiedTime
+      expect((seeded as any).lastModificationTime).toBeUndefined();
+    });
+
+    it('should return an empty array for a job with no attachments', async () => {
+      const { jobs } = getJobsService();
+
+      // Bounded scan — most jobs carry no attachments, so a short sweep suffices
+      // and keeps the suite from firing one request per job in the folder.
+      const candidates = await jobs.getAll({ folderId: attachmentFolderId, pageSize: MAX_EMPTY_JOB_SCAN });
+
+      let jobWithoutAttachments: string | undefined;
+      for (const job of candidates.items) {
+        if (job.key === jobKey) continue;
+        const links = await jobs.getAttachments(job.key, attachmentFolderId);
+        if (!links.length) {
+          jobWithoutAttachments = job.key;
+          break;
+        }
+      }
+
+      if (!jobWithoutAttachments) {
+        throw new Error(
+          `All ${MAX_EMPTY_JOB_SCAN} scanned jobs in folder ${attachmentFolderId} have attachments; cannot verify the empty case`
+        );
+      }
+
+      const result = await jobs.getAttachments(jobWithoutAttachments, attachmentFolderId);
+      expect(result).toEqual([]);
+    });
+
+    it('should link an attachment to a job with a category', async () => {
+      const { jobs } = getJobsService();
+      const attachmentId = await createThrowawayAttachment();
+
+      const result = await jobs.linkAttachment(attachmentId, jobKey, attachmentFolderId, {
+        category: 'IntegrationTestCategory',
+      });
+
+      expect(result).toBeDefined();
+      expect(result.attachmentId).toBe(attachmentId);
+      expect(result.jobKey).toBe(jobKey);
+      expect(result.category).toBe('IntegrationTestCategory');
+      expect(typeof result.id).toBe('string');
+      expect(typeof result.createdTime).toBe('string');
+      expect((result as any).creationTime).toBeUndefined();
+    });
+
+    it('should link an attachment without a category', async () => {
+      const { jobs } = getJobsService();
+      const attachmentId = await createThrowawayAttachment();
+
+      const result = await jobs.linkAttachment(attachmentId, jobKey, attachmentFolderId);
+
+      expect(result.attachmentId).toBe(attachmentId);
+      expect(result.category).toBeNull();
+    });
+
+    it('should make the new link visible to getAttachments', async () => {
+      const { jobs } = getJobsService();
+      const attachmentId = await createThrowawayAttachment();
+
+      await jobs.linkAttachment(attachmentId, jobKey, attachmentFolderId, { category: 'RoundTrip' });
+
+      const links = await jobs.getAttachments(jobKey, attachmentFolderId);
+      const created = links.find(link => link.attachmentId === attachmentId);
+
+      expect(created).toBeDefined();
+      expect(created!.category).toBe('RoundTrip');
+      // The name is absent on the link response but populated when read back.
+      expect(typeof created!.attachmentName).toBe('string');
     });
   });
 });

--- a/tests/unit/core/errors/parser.test.ts
+++ b/tests/unit/core/errors/parser.test.ts
@@ -1,0 +1,64 @@
+// ===== IMPORTS =====
+import { describe, it, expect } from 'vitest';
+import { errorResponseParser } from '../../../../src/core/errors/parser';
+import { ERROR_PARSER_TEST_CONSTANTS } from '../../../utils/constants/errors';
+
+// ===== TEST SUITE =====
+describe('ErrorResponseParser Unit Tests', () => {
+  describe('parse', () => {
+    it('should parse an Orchestrator JSON error body', async () => {
+      const response = new Response(
+        JSON.stringify({
+          message: ERROR_PARSER_TEST_CONSTANTS.ORCHESTRATOR_ERROR_MESSAGE,
+          errorCode: ERROR_PARSER_TEST_CONSTANTS.ORCHESTRATOR_ERROR_CODE,
+          traceId: ERROR_PARSER_TEST_CONSTANTS.ORCHESTRATOR_TRACE_ID,
+        }),
+        { status: 400, statusText: 'Bad Request', headers: { 'content-type': 'application/json' } }
+      );
+
+      const result = await errorResponseParser.parse(response);
+
+      expect(result.message).toBe(ERROR_PARSER_TEST_CONSTANTS.ORCHESTRATOR_ERROR_MESSAGE);
+      expect(result.code).toBe('400');
+      expect(result.requestId).toBe(ERROR_PARSER_TEST_CONSTANTS.ORCHESTRATOR_TRACE_ID);
+    });
+
+    it('should preserve a non-JSON error body in responseText', async () => {
+      // Blob storage answers with XML, not JSON. Parsing the response directly
+      // consumes the body, leaving nothing for the fallback to read — so the
+      // provider's own error code would be lost to anyone debugging an upload.
+      const response = new Response(ERROR_PARSER_TEST_CONSTANTS.XML_ERROR_BODY, {
+        status: 403,
+        statusText: ERROR_PARSER_TEST_CONSTANTS.XML_ERROR_STATUS_TEXT,
+        headers: { 'content-type': 'application/xml' },
+      });
+
+      const result = await errorResponseParser.parse(response);
+
+      expect(result.details.responseText).toBe(ERROR_PARSER_TEST_CONSTANTS.XML_ERROR_BODY);
+      expect(result.details.parseError).toBeDefined();
+    });
+
+    it('should fall back to statusText as the message for a non-JSON body', async () => {
+      const response = new Response(ERROR_PARSER_TEST_CONSTANTS.XML_ERROR_BODY, {
+        status: 403,
+        statusText: ERROR_PARSER_TEST_CONSTANTS.XML_ERROR_STATUS_TEXT,
+        headers: { 'content-type': 'application/xml' },
+      });
+
+      const result = await errorResponseParser.parse(response);
+
+      expect(result.message).toBe(ERROR_PARSER_TEST_CONSTANTS.XML_ERROR_STATUS_TEXT);
+      expect(result.code).toBe('403');
+    });
+
+    it('should handle an empty body', async () => {
+      const response = new Response('', { status: 500, statusText: 'Internal Server Error' });
+
+      const result = await errorResponseParser.parse(response);
+
+      expect(result.message).toBe('Internal Server Error');
+      expect(result.details.responseText).toBe('');
+    });
+  });
+});

--- a/tests/unit/models/orchestrator/jobs.test.ts
+++ b/tests/unit/models/orchestrator/jobs.test.ts
@@ -3,7 +3,7 @@ import {
   createJobWithMethods,
   JobServiceModel
 } from '../../../../src/models/orchestrator/jobs.models';
-import { createBasicJob } from '../../../utils/mocks/jobs';
+import { createBasicJob, createMockRawJobAttachment } from '../../../utils/mocks/jobs';
 import { JOB_TEST_CONSTANTS } from '../../../utils/constants/jobs';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
 import { StopStrategy } from '../../../../src/models/orchestrator/processes.types';
@@ -20,6 +20,8 @@ describe('Job Models', () => {
       stop: vi.fn(),
       resume: vi.fn(),
       restart: vi.fn(),
+      getAttachments: vi.fn(),
+      linkAttachment: vi.fn(),
     } as any;
   });
 
@@ -187,5 +189,87 @@ describe('Job Models', () => {
         await expect(job.restart()).rejects.toThrow('Job folderId is undefined');
       });
     });
+    describe('job.getAttachments()', () => {
+      it('should call service.getAttachments with the job key and folder ID', async () => {
+        const job = createJobWithMethods(createBasicJob(), mockService);
+        const links = [createMockRawJobAttachment()] as any;
+        vi.mocked(mockService.getAttachments).mockResolvedValue(links);
+
+        const result = await job.getAttachments();
+
+        expect(mockService.getAttachments).toHaveBeenCalledWith(
+          JOB_TEST_CONSTANTS.JOB_KEY,
+          TEST_CONSTANTS.FOLDER_ID
+        );
+        expect(result).toEqual(links);
+      });
+
+      it('should throw when the job key is undefined', async () => {
+        const job = createJobWithMethods(createBasicJob({ key: undefined as any }), mockService);
+
+        await expect(job.getAttachments()).rejects.toThrow('Job key is undefined');
+        expect(mockService.getAttachments).not.toHaveBeenCalled();
+      });
+
+      it('should throw when the job folderId is undefined', async () => {
+        const job = createJobWithMethods(createBasicJob({ folderId: undefined as any }), mockService);
+
+        await expect(job.getAttachments()).rejects.toThrow('Job folderId is undefined');
+        expect(mockService.getAttachments).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('job.linkAttachment()', () => {
+      it('should call service.linkAttachment with the captured job key and folder ID', async () => {
+        const job = createJobWithMethods(createBasicJob(), mockService);
+        const link = createMockRawJobAttachment() as any;
+        vi.mocked(mockService.linkAttachment).mockResolvedValue(link);
+
+        const result = await job.linkAttachment(JOB_TEST_CONSTANTS.ATTACHMENT_ID, {
+          category: JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY,
+        });
+
+        expect(mockService.linkAttachment).toHaveBeenCalledWith(
+          JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+          JOB_TEST_CONSTANTS.JOB_KEY,
+          TEST_CONSTANTS.FOLDER_ID,
+          { category: JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY }
+        );
+        expect(result).toEqual(link);
+      });
+
+      it('should forward undefined options when none are supplied', async () => {
+        const job = createJobWithMethods(createBasicJob(), mockService);
+        vi.mocked(mockService.linkAttachment).mockResolvedValue(createMockRawJobAttachment() as any);
+
+        await job.linkAttachment(JOB_TEST_CONSTANTS.ATTACHMENT_ID);
+
+        expect(mockService.linkAttachment).toHaveBeenCalledWith(
+          JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+          JOB_TEST_CONSTANTS.JOB_KEY,
+          TEST_CONSTANTS.FOLDER_ID,
+          undefined
+        );
+      });
+
+      it('should throw when the job key is undefined', async () => {
+        const job = createJobWithMethods(createBasicJob({ key: undefined as any }), mockService);
+
+        await expect(
+          job.linkAttachment(JOB_TEST_CONSTANTS.ATTACHMENT_ID)
+        ).rejects.toThrow('Job key is undefined');
+        expect(mockService.linkAttachment).not.toHaveBeenCalled();
+      });
+
+      it('should throw when the job folderId is undefined', async () => {
+        const job = createJobWithMethods(createBasicJob({ folderId: undefined as any }), mockService);
+
+        await expect(
+          job.linkAttachment(JOB_TEST_CONSTANTS.ATTACHMENT_ID)
+        ).rejects.toThrow('Job folderId is undefined');
+        expect(mockService.linkAttachment).not.toHaveBeenCalled();
+      });
+    });
+
   });
 });

--- a/tests/unit/services/conversational-agent/conversational-agent.test.ts
+++ b/tests/unit/services/conversational-agent/conversational-agent.test.ts
@@ -36,13 +36,12 @@ vi.mock('@/services/conversational-agent/conversations/session/session-manager',
   }); })
 }));
 
-// Minimal non-OK Response stub for the error-mapping tests.
-const errorResponse = (status: number, statusText: string) => ({
-  ok: false,
-  status,
-  statusText,
-  json: async () => ({ message: statusText }),
-});
+// Real Response for the error-mapping tests — the parser reads the body via
+// clone(), which a plain object literal cannot model.
+const errorResponse = (status: number, statusText: string) => new Response(
+  JSON.stringify({ message: statusText }),
+  { status, statusText, headers: { 'content-type': 'application/json' } },
+);
 
 // ===== TEST SUITE =====
 describe('ConversationalAgentService Unit Tests', () => {

--- a/tests/unit/services/orchestrator/attachments.test.ts
+++ b/tests/unit/services/orchestrator/attachments.test.ts
@@ -7,7 +7,10 @@ import { createServiceTestDependencies, createMockApiClient } from '../../../uti
 import { createMockError } from '../../../utils/mocks/core';
 import { AttachmentGetByIdOptions } from '../../../../src/models/orchestrator/attachments.types';
 import { ATTACHMENT_TEST_CONSTANTS } from '../../../utils/constants/attachments';
+import { TEST_CONSTANTS } from '../../../utils/constants/common';
 import { ORCHESTRATOR_ATTACHMENT_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import { FOLDER_ID } from '../../../../src/utils/constants/headers';
+import { ValidationError, ServerError, AuthorizationError } from '../../../../src/core/errors';
 
 // ===== MOCKING =====
 vi.mock('../../../../src/core/http/api-client');
@@ -151,6 +154,214 @@ describe('AttachmentService Unit Tests', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('create', () => {
+    const uploadBody = new Blob([ATTACHMENT_TEST_CONSTANTS.UPLOAD_CONTENT]);
+    let fetchMock: any;
+
+    beforeEach(() => {
+      fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+      vi.stubGlobal('fetch', fetchMock);
+      mockApiClient.post.mockResolvedValue(createMockRawAttachment());
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('should create the attachment and upload its content', async () => {
+      const result = await attachmentService.create(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+        uploadBody
+      );
+
+      expect(result.id).toBe(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_ID);
+      expect(result.name).toBe(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME);
+
+      // The content is PUT to the URI returned by the create call
+      expect(fetchMock).toHaveBeenCalledWith(
+        ATTACHMENT_TEST_CONSTANTS.BLOB_URI,
+        expect.objectContaining({
+          method: 'PUT',
+          body: uploadBody,
+        })
+      );
+    });
+
+    it('should send a PascalCase body to the OData endpoint', async () => {
+      await attachmentService.create(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+        uploadBody
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ORCHESTRATOR_ATTACHMENT_ENDPOINTS.CREATE,
+        expect.objectContaining({ Name: ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME }),
+        expect.any(Object)
+      );
+    });
+
+    it('should link to a job when jobKey is supplied', async () => {
+      await attachmentService.create(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+        uploadBody,
+        {
+          jobKey: ATTACHMENT_TEST_CONSTANTS.JOB_KEY,
+          category: ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_CATEGORY,
+          folderId: TEST_CONSTANTS.FOLDER_ID,
+        }
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ORCHESTRATOR_ATTACHMENT_ENDPOINTS.CREATE,
+        expect.objectContaining({
+          Name: ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+          JobKey: ATTACHMENT_TEST_CONSTANTS.JOB_KEY,
+          AttachmentCategory: ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_CATEGORY,
+        }),
+        expect.objectContaining({
+          headers: { [FOLDER_ID]: String(TEST_CONSTANTS.FOLDER_ID) },
+        })
+      );
+    });
+
+    it('should convert storage headers from key/value arrays before uploading', async () => {
+      // Storage returns required headers as parallel arrays; sending them
+      // unconverted drops x-ms-blob-type and the PUT is rejected.
+      mockApiClient.post.mockResolvedValue(
+        createMockRawAttachment({
+          BlobFileAccess: {
+            Uri: ATTACHMENT_TEST_CONSTANTS.BLOB_URI,
+            Verb: 'PUT',
+            RequiresAuth: false,
+            Headers: { Keys: ['x-ms-blob-type'], Values: ['BlockBlob'] },
+          },
+        })
+      );
+
+      await attachmentService.create(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+        uploadBody
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        ATTACHMENT_TEST_CONSTANTS.BLOB_URI,
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-ms-blob-type': 'BlockBlob' }),
+        })
+      );
+    });
+
+    it('should not send a folder header when no folderId is supplied', async () => {
+      await attachmentService.create(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME, uploadBody);
+
+      // The attachment then lands in the tenant's default folder. Sending the
+      // header with an undefined value would target a folder that doesn't exist.
+      const [, , config] = mockApiClient.post.mock.calls[0];
+      expect(config.headers).not.toHaveProperty(FOLDER_ID);
+    });
+
+    it('should not expose the upload URI on the response', async () => {
+      const result = await attachmentService.create(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+        uploadBody
+      );
+
+      // The write URI is a short-lived credential and must not leak to callers
+      expect((result as any).blobFileAccess).toBeUndefined();
+    });
+
+    it('should not leak OData transport metadata on the response', async () => {
+      mockApiClient.post.mockResolvedValue(
+        createMockRawAttachment({ '@odata.context': 'https://tenant/odata/$metadata#Attachments/$entity' })
+      );
+
+      const result = await attachmentService.create(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+        uploadBody
+      );
+
+      expect((result as any)['@odata.context']).toBeUndefined();
+    });
+
+    it('should apply the transform pipeline to the created attachment', async () => {
+      const result = await attachmentService.create(
+        ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+        uploadBody
+      );
+
+      expect(result.createdTime).toBe(ATTACHMENT_TEST_CONSTANTS.CREATED_TIME);
+      expect((result as any).CreationTime).toBeUndefined();
+      expect(result.lastModifiedTime).toBe(ATTACHMENT_TEST_CONSTANTS.LAST_MODIFIED_TIME);
+      expect((result as any).LastModificationTime).toBeUndefined();
+    });
+
+    it('should throw ValidationError when name is empty string', async () => {
+      await expect(
+        attachmentService.create('', uploadBody)
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when content is missing', async () => {
+      await expect(
+        attachmentService.create(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME, undefined as any)
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw ServerError when the create response has no upload URI', async () => {
+      mockApiClient.post.mockResolvedValue(
+        createMockRawAttachment({ BlobFileAccess: { Uri: undefined } })
+      );
+
+      await expect(
+        attachmentService.create(
+          ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+          uploadBody
+        )
+      ).rejects.toBeInstanceOf(ServerError);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the content upload fails', async () => {
+      // Real Response — the parser reads the body via clone(), which a plain
+      // object literal cannot model, so a stub would route to the fallback path
+      // and never exercise parsing.
+      fetchMock.mockResolvedValue(
+        new Response(ATTACHMENT_TEST_CONSTANTS.XML_UPLOAD_ERROR_BODY, {
+          status: 403,
+          statusText: ATTACHMENT_TEST_CONSTANTS.ERROR_UPLOAD_FAILED,
+          headers: { 'content-type': 'application/xml' },
+        })
+      );
+
+      const error = await attachmentService
+        .create(ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME, uploadBody)
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(AuthorizationError);
+      // Storage's own body reaches the caller, so a failed upload is diagnosable
+      expect((error as AuthorizationError).message).toBe(
+        ATTACHMENT_TEST_CONSTANTS.ERROR_UPLOAD_FAILED
+      );
+    });
+
+    it('should handle API errors from the create call', async () => {
+      const error = createMockError(ATTACHMENT_TEST_CONSTANTS.ERROR_ATTACHMENT_NOT_FOUND);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        attachmentService.create(
+          ATTACHMENT_TEST_CONSTANTS.ATTACHMENT_NAME,
+          uploadBody
+        )
+      ).rejects.toThrow(ATTACHMENT_TEST_CONSTANTS.ERROR_ATTACHMENT_NOT_FOUND);
     });
   });
 });

--- a/tests/unit/services/orchestrator/jobs.test.ts
+++ b/tests/unit/services/orchestrator/jobs.test.ts
@@ -6,6 +6,7 @@ import { PaginationHelpers } from '../../../../src/utils/pagination/helpers';
 import {
   createMockTransformedJobCollection,
   createMockRawJob,
+  createMockRawJobAttachment,
 } from '../../../utils/mocks/jobs';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
 import { createMockError } from '../../../utils/mocks/core';
@@ -20,6 +21,8 @@ import { JOB_TEST_CONSTANTS } from '../../../utils/constants/jobs';
 import { JOB_ENDPOINTS, ORCHESTRATOR_ATTACHMENT_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { StopStrategy } from '../../../../src/models/orchestrator/processes.types';
 import { JOB_KEY_RESOLUTION_CHUNK_SIZE } from '../../../../src/models/orchestrator/jobs.constants';
+import { FOLDER_ID } from '../../../../src/utils/constants/headers';
+import { ValidationError } from '../../../../src/core/errors';
 
 // ===== MOCKING =====
 vi.mock('../../../../src/core/http/api-client');
@@ -818,6 +821,222 @@ describe('JobService Unit Tests', () => {
       await expect(
         jobService.restart(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID)
       ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_NOT_FOUND);
+    });
+  });
+
+  describe('getAttachments', () => {
+    it('should get job attachments successfully with all fields mapped correctly', async () => {
+      mockApiClient.get.mockResolvedValue([createMockRawJobAttachment()]);
+
+      const result = await jobService.getAttachments(
+        JOB_TEST_CONSTANTS.JOB_KEY,
+        TEST_CONSTANTS.FOLDER_ID
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_LINK_ID);
+      expect(result[0].attachmentId).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_ID);
+      expect(result[0].jobKey).toBe(JOB_TEST_CONSTANTS.JOB_KEY);
+      expect(result[0].category).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_CATEGORY);
+      expect(result[0].attachmentName).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_NAME);
+      expect(result[0].creatorUserId).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_CREATOR_USER_ID);
+      expect(result[0].lastModifierUserId).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_LAST_MODIFIER_USER_ID);
+    });
+
+    it('should send the job key as a query param and the folder ID as a header', async () => {
+      mockApiClient.get.mockResolvedValue([createMockRawJobAttachment()]);
+
+      await jobService.getAttachments(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.ATTACHMENTS.GET_BY_JOB_KEY,
+        expect.objectContaining({
+          params: { jobKey: JOB_TEST_CONSTANTS.JOB_KEY },
+          headers: { [FOLDER_ID]: String(TEST_CONSTANTS.FOLDER_ID) },
+        })
+      );
+    });
+
+    it('should apply semantic renames and drop the raw API field names', async () => {
+      mockApiClient.get.mockResolvedValue([createMockRawJobAttachment()]);
+
+      const result = await jobService.getAttachments(
+        JOB_TEST_CONSTANTS.JOB_KEY,
+        TEST_CONSTANTS.FOLDER_ID
+      );
+
+      // creationTime -> createdTime
+      expect(result[0].createdTime).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_CREATED_TIME);
+      expect((result[0] as any).creationTime).toBeUndefined();
+
+      // lastModificationTime -> lastModifiedTime
+      expect(result[0].lastModifiedTime).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_LAST_MODIFIED_TIME);
+      expect((result[0] as any).lastModificationTime).toBeUndefined();
+    });
+
+    it('should transform every item when the job has multiple attachments', async () => {
+      mockApiClient.get.mockResolvedValue([
+        createMockRawJobAttachment(),
+        createMockRawJobAttachment({
+          id: 'second-link-id',
+          category: JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY,
+        }),
+      ]);
+
+      const result = await jobService.getAttachments(
+        JOB_TEST_CONSTANTS.JOB_KEY,
+        TEST_CONSTANTS.FOLDER_ID
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[1].category).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY);
+      // The rename must apply to every element, not just the first
+      expect(result[1].createdTime).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_CREATED_TIME);
+      expect((result[1] as any).creationTime).toBeUndefined();
+    });
+
+    it('should return an empty array when the job has no attachments', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      const result = await jobService.getAttachments(
+        JOB_TEST_CONSTANTS.JOB_KEY,
+        TEST_CONSTANTS.FOLDER_ID
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw ValidationError when jobKey is empty string', async () => {
+      await expect(
+        jobService.getAttachments('', TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when folderId is missing', async () => {
+      await expect(
+        jobService.getAttachments(JOB_TEST_CONSTANTS.JOB_KEY, 0)
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(JOB_TEST_CONSTANTS.ERROR_JOB_ATTACHMENT_NOT_FOUND);
+      mockApiClient.get.mockRejectedValue(error);
+
+      await expect(
+        jobService.getAttachments(JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_ATTACHMENT_NOT_FOUND);
+    });
+  });
+
+  describe('linkAttachment', () => {
+    it('should link an attachment to a job and return the transformed link', async () => {
+      mockApiClient.post.mockResolvedValue(
+        createMockRawJobAttachment({ category: JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY })
+      );
+
+      const result = await jobService.linkAttachment(
+        JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+        JOB_TEST_CONSTANTS.JOB_KEY,
+        TEST_CONSTANTS.FOLDER_ID,
+        { category: JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY }
+      );
+
+      expect(result.id).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_LINK_ID);
+      expect(result.attachmentId).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_ID);
+      expect(result.category).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY);
+
+      // creationTime -> createdTime on the link path too
+      expect(result.createdTime).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_CREATED_TIME);
+      expect((result as any).creationTime).toBeUndefined();
+      expect(result.lastModifiedTime).toBe(JOB_TEST_CONSTANTS.ATTACHMENT_LAST_MODIFIED_TIME);
+      expect((result as any).lastModificationTime).toBeUndefined();
+    });
+
+    it('should send the link payload as-is with the folder ID as a header', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawJobAttachment());
+
+      await jobService.linkAttachment(
+        JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+        JOB_TEST_CONSTANTS.JOB_KEY,
+        TEST_CONSTANTS.FOLDER_ID,
+        { category: JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY }
+      );
+
+      // The API takes camelCase field names, so the body is sent unmapped
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.ATTACHMENTS.LINK,
+        {
+          attachmentId: JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+          jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
+          category: JOB_TEST_CONSTANTS.ATTACHMENT_CUSTOM_CATEGORY,
+        },
+        expect.objectContaining({
+          headers: { [FOLDER_ID]: String(TEST_CONSTANTS.FOLDER_ID) },
+        })
+      );
+    });
+
+    it('should omit the category when no options are supplied', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawJobAttachment({ category: null }));
+
+      const result = await jobService.linkAttachment(
+        JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+        JOB_TEST_CONSTANTS.JOB_KEY,
+        TEST_CONSTANTS.FOLDER_ID
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        JOB_ENDPOINTS.ATTACHMENTS.LINK,
+        expect.objectContaining({ category: undefined }),
+        expect.any(Object)
+      );
+      // The API answers with a null category when none was sent
+      expect(result.category).toBeNull();
+    });
+
+    it('should throw ValidationError when attachmentId is empty string', async () => {
+      await expect(
+        jobService.linkAttachment('', JOB_TEST_CONSTANTS.JOB_KEY, TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when jobKey is empty string', async () => {
+      await expect(
+        jobService.linkAttachment(JOB_TEST_CONSTANTS.ATTACHMENT_ID, '', TEST_CONSTANTS.FOLDER_ID)
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when folderId is missing', async () => {
+      await expect(
+        jobService.linkAttachment(
+          JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+          JOB_TEST_CONSTANTS.JOB_KEY,
+          0
+        )
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      const error = createMockError(JOB_TEST_CONSTANTS.ERROR_JOB_ATTACHMENT_NOT_FOUND);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        jobService.linkAttachment(
+          JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+          JOB_TEST_CONSTANTS.JOB_KEY,
+          TEST_CONSTANTS.FOLDER_ID
+        )
+      ).rejects.toThrow(JOB_TEST_CONSTANTS.ERROR_JOB_ATTACHMENT_NOT_FOUND);
     });
   });
 });

--- a/tests/utils/constants/attachments.ts
+++ b/tests/utils/constants/attachments.ts
@@ -30,4 +30,13 @@ export const ATTACHMENT_TEST_CONSTANTS = {
 
   // OData Parameters
   ODATA_SELECT_FIELDS: 'id,name,blobFileAccess',
+
+  // Create
+  UPLOAD_CONTENT: 'file body',
+  ERROR_NAME_REQUIRED: 'name is required for create',
+  ERROR_CONTENT_REQUIRED: 'content is required for create',
+  ERROR_UPLOAD_FAILED: 'Server failed to authenticate the request.',
+  // Blob storage answers in XML, not JSON — the upload failure path must cope.
+  XML_UPLOAD_ERROR_BODY:
+    '<?xml version=\'1.0\' encoding=\'utf-8\'?><Error><Code>AuthenticationFailed</Code></Error>',
 } as const;

--- a/tests/utils/constants/errors.ts
+++ b/tests/utils/constants/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Error parser test constants
+ * Error-parsing-specific constants only
+ */
+
+export const ERROR_PARSER_TEST_CONSTANTS = {
+  // Shape Orchestrator actually returns: message + numeric errorCode + traceId.
+  ORCHESTRATOR_ERROR_MESSAGE: 'A folder is required for this action.',
+  ORCHESTRATOR_ERROR_CODE: 1101,
+  ORCHESTRATOR_TRACE_ID: '00-d0c08db7f3eeac1477da0882ffc7-35f88125b7e01d82-01',
+
+  // A representative non-JSON error body — Azure Storage answers in XML, which
+  // is what a failed attachment or bucket upload surfaces.
+  XML_ERROR_BODY:
+    '<?xml version="1.0" encoding="utf-8"?><Error><Code>AuthenticationFailed</Code>' +
+    '<Message>Signature not valid in the specified time frame</Message></Error>',
+  XML_ERROR_STATUS_TEXT: 'Server failed to authenticate the request.',
+} as const;

--- a/tests/utils/constants/jobs.ts
+++ b/tests/utils/constants/jobs.ts
@@ -36,4 +36,17 @@ export const JOB_TEST_CONSTANTS = {
   ERROR_JOB_NOT_FOUND: 'Job not found',
   ERROR_JOBS_NOT_FOUND_FOR_KEYS: 'Jobs not found for keys',
   ERROR_JOB_RESUME_FAILED: 'Job resume failed',
+
+  // Job attachments
+  ATTACHMENT_LINK_ID: 'd7cd7a5f-f23d-4024-a9b7-08def2f24b42',
+  ATTACHMENT_ID: '5a1f66bd-7ed8-43f1-6506-08def2f09aaf',
+  ATTACHMENT_NAME: 'invoice-2026-08.pdf',
+  ATTACHMENT_CATEGORY: 'JobAttachment',
+  ATTACHMENT_CUSTOM_CATEGORY: 'Invoice',
+  ATTACHMENT_CREATOR_USER_ID: 3495860,
+  ATTACHMENT_LAST_MODIFIER_USER_ID: 3495861,
+  // Distinctive values so the semantic renames are verifiable
+  ATTACHMENT_CREATED_TIME: '2000-01-01T00:00:00.000Z',
+  ATTACHMENT_LAST_MODIFIED_TIME: '2000-06-15T12:30:00.000Z',
+  ERROR_JOB_ATTACHMENT_NOT_FOUND: 'Job attachment not found',
 } as const;

--- a/tests/utils/mocks/jobs.ts
+++ b/tests/utils/mocks/jobs.ts
@@ -168,3 +168,29 @@ export const createMockTransformedJobCollection = (
     ...(options?.totalPages !== undefined && { totalPages: options.totalPages }),
   });
 };
+
+/**
+ * Creates a mock job attachment in RAW API format (before transformation).
+ *
+ * The endpoint answers in camelCase, so only the two semantically renamed
+ * fields (`creationTime`, `lastModificationTime`) differ from the SDK shape.
+ *
+ * @param overrides - Optional overrides for specific fields
+ * @returns Raw job attachment data as it comes from the API
+ */
+export const createMockRawJobAttachment = (
+  overrides: Partial<Record<string, unknown>> = {}
+): Record<string, unknown> => {
+  return createMockBaseResponse<Record<string, unknown>>({
+    id: JOB_TEST_CONSTANTS.ATTACHMENT_LINK_ID,
+    attachmentId: JOB_TEST_CONSTANTS.ATTACHMENT_ID,
+    jobKey: JOB_TEST_CONSTANTS.JOB_KEY,
+    category: JOB_TEST_CONSTANTS.ATTACHMENT_CATEGORY,
+    attachmentName: JOB_TEST_CONSTANTS.ATTACHMENT_NAME,
+    creatorUserId: JOB_TEST_CONSTANTS.ATTACHMENT_CREATOR_USER_ID,
+    lastModifierUserId: JOB_TEST_CONSTANTS.ATTACHMENT_LAST_MODIFIER_USER_ID,
+    // Raw API field names that the transform pipeline renames
+    creationTime: JOB_TEST_CONSTANTS.ATTACHMENT_CREATED_TIME,
+    lastModificationTime: JOB_TEST_CONSTANTS.ATTACHMENT_LAST_MODIFIED_TIME,
+  }, overrides);
+};


### PR DESCRIPTION
Onboards the attachment APIs so a coded app can upload a file and attach it to a job.

Related: [APPS-35700](https://uipath.atlassian.net/browse/APPS-35700)

### What you can do now

```ts
// Upload a file the user picked
const attachment = await attachments.create(file.name, file);

// Or upload and attach it to a job in one call
const attachment = await attachments.create(file.name, file, {
  jobKey: <jobKey>,
  category: 'Invoice',
});

// List what's attached to a job
const links = await jobs.getAttachments(<jobKey>, <folderId>);

// Attach an existing attachment to another job
await jobs.linkAttachment(<attachmentId>, <jobKey>, <folderId>);
```

`getAttachments()` and `linkAttachment()` are also available on a job you've already fetched, so you don't have to pass the key and folder again:

```ts
const job = await jobs.getById(<jobKey>, <folderId>);
await job.getAttachments();
```

### Notes

- `attachments.create()` does the upload for you. Orchestrator hands back a short-lived write URL, the SDK PUTs the file to it, and that URL is deliberately left off the response — it's spent, and it's a credential.
- The `id` on the returned attachment is the handle to pass around, e.g. as the value of a `file` field in an action's output data.
- Orchestrator has no API to unlink an attachment from a job, so integration tests clean up by deleting the attachment itself.

### Testing

- Unit tests for both services, including that the write URL and OData metadata never reach the caller
- Integration tests against a live tenant, including downloading an uploaded file back and checking the bytes match
- Verified end to end against the built bundle: upload → attach → read back → clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPS-35700]: https://uipath.atlassian.net/browse/APPS-35700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ