### PR TITLE
feat(data-fabric): add havingFilter to entity record queries [DS-9078]

### DIFF
--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -429,12 +429,12 @@ export interface EntityServiceModel {
    * for constraints and the result-row key format.
    *
    * @param id - UUID of the entity
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, joins, and pagination The `folderKey` property is **experimental**.
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, joins, havingFilter, and pagination The `folderKey` property is **experimental**.
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    * @example
    * ```typescript
-   * import { Entities, LogicalOperator, QueryFilterOperator, EntityAggregateFunction, JoinType } from '@uipath/uipath-typescript/entities';
+   * import { Entities, LogicalOperator, QueryFilterOperator, EntityAggregateFunction, EntityHavingOperator, JoinType } from '@uipath/uipath-typescript/entities';
    *
    * const entities = new Entities(sdk);
    *
@@ -461,6 +461,18 @@ export interface EntityServiceModel {
    *   aggregates: [
    *     { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
    *   ],
+   * });
+   *
+   * // Post-aggregation filter (HAVING): only statuses with more than 5 records
+   * await entities.queryRecordsById(<id>, {
+   *   selectedFields: ["status"],
+   *   groupBy: ["status"],
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
+   *   ],
+   *   havingFilter: {
+   *     aggregateFilters: [{ aggregateAlias: "total", operator: EntityHavingOperator.GreaterThan, value: "5" }],
+   *   },
    * });
    *
    * // Folder-scoped entity: pass the entity's folder key
@@ -920,12 +932,12 @@ export interface EntityMethods {
    * Cross-entity joins are supported via the `joins` option — see {@link EntityJoin}
    * for constraints and the result-row key format.
    *
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, joins, and pagination
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, joins, havingFilter, and pagination
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    * @example
    * ```typescript
-   * import { Entities, LogicalOperator, QueryFilterOperator, EntityAggregateFunction, JoinType } from '@uipath/uipath-typescript/entities';
+   * import { Entities, LogicalOperator, QueryFilterOperator, EntityAggregateFunction, EntityHavingOperator, JoinType } from '@uipath/uipath-typescript/entities';
    *
    * const entities = new Entities(sdk);
    *
@@ -946,6 +958,18 @@ export interface EntityMethods {
    *   aggregates: [
    *     { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
    *   ],
+   * });
+   *
+   * // Post-aggregation filter (HAVING): only statuses with more than 5 records
+   * await entity.queryRecords({
+   *   selectedFields: ["status"],
+   *   groupBy: ["status"],
+   *   aggregates: [
+   *     { function: EntityAggregateFunction.Count, field: "Id", alias: "total" },
+   *   ],
+   *   havingFilter: {
+   *     aggregateFilters: [{ aggregateAlias: "total", operator: EntityHavingOperator.GreaterThan, value: "5" }],
+   *   },
    * });
    *
    * // Aggregate: total sum and average across all records (no grouping)

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -238,7 +238,14 @@ export interface EntityAggregate {
 }
 
 /** Comparison operators supported in a {@link EntityHavingFilter} condition. */
-export type EntityHavingOperator = "=" | "!=" | "<>" | ">" | ">=" | "<" | "<=";
+export enum EntityHavingOperator {
+  Equals = '=',
+  NotEquals = '!=',
+  GreaterThan = '>',
+  GreaterThanOrEqual = '>=',
+  LessThan = '<',
+  LessThanOrEqual = '<=',
+}
 
 /**
  * One `HAVING` condition over a declared aggregate's result.

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -270,8 +270,8 @@ export interface EntityHavingCondition {
 /**
  * Post-aggregation filter (SQL `HAVING`) applied to grouped aggregate results.
  *
- * Requires `aggregates` and `groupBy` on the query. Supported for native (LDO)
- * entities only, and gated by the tenant's `enable-having-on-query` feature
+ * Requires `aggregates` and `groupBy` on the query. Supported for native entities
+ * only; gated by the tenant's `enable-having-on-query` feature
  * flag — the server responds 400 when either doesn't hold. Maximum 5 conditions.
  */
 export interface EntityHavingFilter {

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -237,6 +237,43 @@ export interface EntityAggregate {
   alias?: string;
 }
 
+/** Comparison operators supported in a {@link EntityHavingFilter} condition. */
+export type EntityHavingOperator = "=" | "!=" | "<>" | ">" | ">=" | "<" | "<=";
+
+/**
+ * One `HAVING` condition over a declared aggregate's result.
+ *
+ * Conditions reference aggregates by alias (aggregates-only): `aggregateAlias`
+ * must match the `alias` of an entry in
+ * {@link EntityQueryRecordsOptions.aggregates}. Row-level conditions belong in
+ * `filterGroup`, which filters before grouping.
+ */
+export interface EntityHavingCondition {
+  /** Alias of the declared aggregate this condition applies to. */
+  aggregateAlias: string;
+  /** Comparison operator. */
+  operator: EntityHavingOperator;
+  /**
+   * Comparison value, as a string. Must parse as an integer for `COUNT` and as
+   * a number for `SUM`/`AVG`; `MIN`/`MAX` values follow the aggregated field's type.
+   */
+  value: string;
+}
+
+/**
+ * Post-aggregation filter (SQL `HAVING`) applied to grouped aggregate results.
+ *
+ * Requires `aggregates` and `groupBy` on the query. Supported for native (LDO)
+ * entities only, and gated by the tenant's `enable-having-on-query` feature
+ * flag — the server responds 400 when either doesn't hold. Maximum 5 conditions.
+ */
+export interface EntityHavingFilter {
+  /** Logical operator between conditions (default: {@link LogicalOperator.And}). */
+  logicalOperator?: LogicalOperator;
+  /** Conditions over declared aggregate aliases. */
+  aggregateFilters: EntityHavingCondition[];
+}
+
 /**
  * A single cross-entity JOIN clause for a structured query.
  *
@@ -300,6 +337,12 @@ export type EntityQueryRecordsOptions = {
   aggregates?: EntityAggregate[];
   /** Field names to group aggregate results by. */
   groupBy?: string[];
+  /**
+   * Post-aggregation filter on grouped results (SQL `HAVING`). Conditions
+   * reference declared aggregate aliases; requires `aggregates` and `groupBy`.
+   * See {@link EntityHavingFilter} for constraints.
+   */
+  havingFilter?: EntityHavingFilter;
   /**
    * Cross-entity joins. Each entry joins one related entity into the query;
    * supply several for a multi-join query. Requires `selectedFields` or

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -307,6 +307,13 @@ export class EntityService extends BaseService implements EntityServiceModel {
         message: 'Join queries require selectedFields or aggregates — reference fields as "<EntityName>.<FieldName>" (e.g. "Customer.name")',
       });
     }
+    // The server's aggregates-only HAVING contract requires aggregates + groupBy;
+    // surface that requirement client-side with an actionable message.
+    if (options?.havingFilter && (!options.aggregates?.length || !options.groupBy?.length)) {
+      throw new ValidationError({
+        message: 'havingFilter requires aggregates and groupBy — conditions reference declared aggregate aliases; use filterGroup for row-level conditions',
+      });
+    }
     // folderKey is header-only; expansionLevel must be sent as a query param by PaginationHelpers.
     const { folderKey, expansionLevel, ...rest } = options ?? {};
     // The multi-entity (joins) contract only exists on the name-based query route —
@@ -335,7 +342,7 @@ export class EntityService extends BaseService implements EntityServiceModel {
           countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
         }
       },
-      excludeFromPrefix: ['filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy', 'joins']
+      excludeFromPrefix: ['filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy', 'joins', 'havingFilter']
     }, downstreamOptions);
   }
 

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -844,13 +844,11 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       if (!entityId) {
         throw new Error('No entity ID available for testing');
       }
-      if (!config.dataFabricTestJoinFieldName) {
-        throw new Error('DATA_FABRIC_TEST_JOIN_FIELD_NAME env var is required for the havingFilter test (used as the groupBy field)');
-      }
-      const groupField = config.dataFabricTestJoinFieldName;
+      // Group by Id: always present on every entity, no fixture coupling — one
+      // group per record, each with cnt = 1, which keeps both assertions meaningful.
       const base = {
-        selectedFields: [groupField],
-        groupBy: [groupField],
+        selectedFields: ['Id'],
+        groupBy: ['Id'],
         aggregates: [
           { function: EntityAggregateFunction.Count, field: 'Id', alias: 'cnt' },
         ],
@@ -867,7 +865,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       });
       expect(all.items.length).toBeGreaterThan(0);
       all.items.forEach(item => {
-        expect((item as Record<string, any>).cnt).toBeGreaterThanOrEqual(1);
+        expect((item as Record<string, unknown>).cnt).toBeGreaterThanOrEqual(1);
       });
 
       // An unsatisfiable threshold must return no groups. A backend that ignores

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -878,7 +878,7 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
           ],
         },
       });
-      expect(none.items.length).toBe(0);
+      expect(none.items).toHaveLength(0);
     });
 
     // Regression guard: DF reads `expansionLevel` only from the URL on POST record endpoints.

--- a/tests/integration/shared/data-fabric/entities.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities.integration.test.ts
@@ -11,6 +11,7 @@ import { generateRandomString, generateRandomInt, generateRandomFloat, hasValidP
 import {
   EntityAggregateFunction,
   EntityFieldDataType,
+  EntityHavingOperator,
   EntityRecord,
   FieldDisplayType,
   FieldMetaData,
@@ -831,6 +832,55 @@ describe.each(modes)('Data Fabric Entities - Integration Tests [%s]', (mode) => 
       expect(row.total).toBeDefined();
       expect(typeof row.total).toBe('number');
       expect(row.total).toBeGreaterThanOrEqual(0);
+    });
+
+    // The tenant must have the `enable-having-on-query` feature flag; without it the
+    // server rejects havingFilter with a 400 naming the flag, which fails this test
+    // loudly rather than letting the coverage be silently absent.
+    it('should filter grouped results with havingFilter (HAVING)', async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for testing');
+      }
+      if (!config.dataFabricTestJoinFieldName) {
+        throw new Error('DATA_FABRIC_TEST_JOIN_FIELD_NAME env var is required for the havingFilter test (used as the groupBy field)');
+      }
+      const groupField = config.dataFabricTestJoinFieldName;
+      const base = {
+        selectedFields: [groupField],
+        groupBy: [groupField],
+        aggregates: [
+          { function: EntityAggregateFunction.Count, field: 'Id', alias: 'cnt' },
+        ],
+      };
+
+      // Every group has at least one record, so `cnt >= 1` must return every group.
+      const all = await entities.queryRecordsById(entityId, {
+        ...base,
+        havingFilter: {
+          aggregateFilters: [
+            { aggregateAlias: 'cnt', operator: EntityHavingOperator.GreaterThanOrEqual, value: '1' },
+          ],
+        },
+      });
+      expect(all.items.length).toBeGreaterThan(0);
+      all.items.forEach(item => {
+        expect((item as Record<string, any>).cnt).toBeGreaterThanOrEqual(1);
+      });
+
+      // An unsatisfiable threshold must return no groups. A backend that ignores
+      // havingFilter returns every group here — that is the failing signal.
+      const none = await entities.queryRecordsById(entityId, {
+        ...base,
+        havingFilter: {
+          aggregateFilters: [
+            { aggregateAlias: 'cnt', operator: EntityHavingOperator.GreaterThan, value: '1000000000' },
+          ],
+        },
+      });
+      expect(none.items.length).toBe(0);
     });
 
     // Regression guard: DF reads `expansionLevel` only from the URL on POST record endpoints.

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -40,6 +40,7 @@ import {
   ExternalField,
   FieldDisplayType,
   JoinType,
+  LogicalOperator,
   QueryFilterOperator,
   RawEntityGetResponse,
 } from "../../../../src/models/data-fabric/entities.types";
@@ -1932,6 +1933,65 @@ describe("EntityService Unit Tests", () => {
       ).rejects.toThrow(/Join queries require selectedFields or aggregates/);
       expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
       expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
+    it("should forward havingFilter verbatim and include it in excludeFromPrefix", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+        aggregates: [
+          { function: EntityAggregateFunction.Count, field: "Id", alias: "cnt" },
+        ],
+        groupBy: ["region"],
+        havingFilter: {
+          logicalOperator: LogicalOperator.Or,
+          aggregateFilters: [
+            { aggregateAlias: "cnt", operator: ">", value: "5" },
+            { aggregateAlias: "cnt", operator: "<=", value: "100" },
+          ],
+        },
+      });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeFromPrefix: expect.arrayContaining(["havingFilter"]),
+        }),
+        expect.objectContaining({
+          havingFilter: {
+            logicalOperator: LogicalOperator.Or,
+            aggregateFilters: [
+              { aggregateAlias: "cnt", operator: ">", value: "5" },
+              { aggregateAlias: "cnt", operator: "<=", value: "100" },
+            ],
+          },
+        }),
+      );
+    });
+
+    it("should throw ValidationError when havingFilter is supplied without aggregates", async () => {
+      await expect(
+        entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          groupBy: ["region"],
+          havingFilter: {
+            aggregateFilters: [{ aggregateAlias: "cnt", operator: ">", value: "5" }],
+          },
+        }),
+      ).rejects.toThrow(/havingFilter requires aggregates and groupBy/);
+      expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
+    });
+
+    it("should throw ValidationError when havingFilter is supplied without groupBy", async () => {
+      await expect(
+        entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
+          aggregates: [
+            { function: EntityAggregateFunction.Count, field: "Id", alias: "cnt" },
+          ],
+          havingFilter: {
+            aggregateFilters: [{ aggregateAlias: "cnt", operator: ">", value: "5" }],
+          },
+        }),
+      ).rejects.toThrow(/havingFilter requires aggregates and groupBy/);
+      expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
     });
 
     it("should accept joins with aggregates and no selectedFields", async () => {

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -36,6 +36,7 @@ import type {
 import {
   EntityFieldDataType,
   EntityAggregateFunction,
+  EntityHavingOperator,
   EntityType,
   ExternalField,
   FieldDisplayType,
@@ -1946,8 +1947,8 @@ describe("EntityService Unit Tests", () => {
         havingFilter: {
           logicalOperator: LogicalOperator.Or,
           aggregateFilters: [
-            { aggregateAlias: "cnt", operator: ">", value: "5" },
-            { aggregateAlias: "cnt", operator: "<=", value: "100" },
+            { aggregateAlias: "cnt", operator: EntityHavingOperator.GreaterThan, value: "5" },
+            { aggregateAlias: "cnt", operator: EntityHavingOperator.LessThanOrEqual, value: "100" },
           ],
         },
       });
@@ -1960,8 +1961,8 @@ describe("EntityService Unit Tests", () => {
           havingFilter: {
             logicalOperator: LogicalOperator.Or,
             aggregateFilters: [
-              { aggregateAlias: "cnt", operator: ">", value: "5" },
-              { aggregateAlias: "cnt", operator: "<=", value: "100" },
+              { aggregateAlias: "cnt", operator: EntityHavingOperator.GreaterThan, value: "5" },
+              { aggregateAlias: "cnt", operator: EntityHavingOperator.LessThanOrEqual, value: "100" },
             ],
           },
         }),
@@ -1973,7 +1974,7 @@ describe("EntityService Unit Tests", () => {
         entityService.queryRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, {
           groupBy: ["region"],
           havingFilter: {
-            aggregateFilters: [{ aggregateAlias: "cnt", operator: ">", value: "5" }],
+            aggregateFilters: [{ aggregateAlias: "cnt", operator: EntityHavingOperator.GreaterThan, value: "5" }],
           },
         }),
       ).rejects.toThrow(/havingFilter requires aggregates and groupBy/);
@@ -1987,7 +1988,7 @@ describe("EntityService Unit Tests", () => {
             { function: EntityAggregateFunction.Count, field: "Id", alias: "cnt" },
           ],
           havingFilter: {
-            aggregateFilters: [{ aggregateAlias: "cnt", operator: ">", value: "5" }],
+            aggregateFilters: [{ aggregateAlias: "cnt", operator: EntityHavingOperator.GreaterThan, value: "5" }],
           },
         }),
       ).rejects.toThrow(/havingFilter requires aggregates and groupBy/);


### PR DESCRIPTION
## What
Adds `havingFilter` to `EntityQueryRecordsOptions`: a post-aggregation filter (SQL HAVING) over grouped aggregate results. Conditions reference declared aggregate aliases (`{ aggregateAlias, operator, value }`), combined with AND/OR.

## How
- New types: `EntityHavingFilter`, `EntityHavingCondition`, `EntityHavingOperator` (wire-shape 1:1 with the Data Service contract from [CommonEntityPlatform#5832](https://github.com/UiPath/CommonEntityPlatform/pull/5832))
- `queryRecordsById`: client-side ValidationError when `havingFilter` is supplied without `aggregates` + `groupBy` (mirrors the join validations)
- `havingFilter` added to `excludeFromPrefix` - without this the pagination helper OData-prefixes the key to `$havingFilter` and it silently never reaches the server
- Works on both the ID-based route and the name-based multi-entity (joins) route

## Server contract notes
- Aggregates-only: conditions must reference declared aggregate aliases; row-level conditions stay in `filterGroup`
- Native (LDO) entities only; federated entities and FQS-routed queries return 400
- Tenant must have the `enable-having-on-query` feature flag (rolling out ring-by-ring, alpha first)

## Tests
3 new unit tests (verbatim forwarding + excludeFromPrefix, missing-aggregates rejection, missing-groupBy rejection). Full suite: 2153 passed, lint and build clean.

Consumer-rollout ticket: DS-9078. The uip CLI's `df records query` pass-through depends on this change + a version bump (its body keys are gated by this SDK's excludeFromPrefix allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)