### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,15 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -28,7 +28,7 @@ jobs:
         run: npm run lint
 
   lint-packages:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     strategy:
@@ -42,10 +42,10 @@ jobs:
         working-directory: packages/${{ matrix.package }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -58,15 +58,15 @@ jobs:
         run: npm run lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -78,7 +78,7 @@ jobs:
         run: npm run test:coverage -- --run
 
   test-packages:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     strategy:
@@ -91,10 +91,10 @@ jobs:
         working-directory: packages/${{ matrix.package }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
@@ -32,13 +32,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8 # v1
+        uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'claude,github-actions[bot]'

--- a/.github/workflows/claude-docs-update.yml
+++ b/.github/workflows/claude-docs-update.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   enhance-docs:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Enhance Claude docs
         id: claude
-        uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1
+        uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pr-description:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     if: |
@@ -29,7 +29,7 @@ jobs:
           echo "PR description is present."
 
   commitlint:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: read
@@ -37,12 +37,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "24.x"
           cache: "npm"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,10 @@ permissions:
 jobs:
   coverage:
     runs-on: uipath-ubuntu-latest
+    env:
+      # uipath-ubuntu-* runners have less RAM than ubuntu-latest, so Node
+      # auto-sizes its heap to ~2 GB and the rollup build OOMs (exit 134).
+      NODE_OPTIONS: --max-old-space-size=6144
 
     steps:
       - name: Checkout

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,16 +18,16 @@ permissions:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
         run: npm run test:coverage -- --run
 
       - name: Upload unit test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: unit-coverage
           path: coverage/lcov.info
@@ -115,14 +115,14 @@ jobs:
         run: npm run test:integration:coverage -- --run
 
       - name: Upload integration test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: integration-coverage
           path: coverage-integration/lcov.info
 
       - name: SonarCloud Scan
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
+        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d  # v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -34,20 +34,20 @@ concurrency:
 
 jobs:
   build-and-preview:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
         if: github.event.action != 'closed'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
 
       - name: Setup Python
         if: github.event.action != 'closed'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -97,7 +97,7 @@ jobs:
       - name: Deploy / update / remove PR preview
         # Same-repo PRs only — fork PRs get a read-only token and can't publish.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1.8.1
         with:
           source-dir: site
           preview-branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,18 +12,18 @@ permissions:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '18'
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
@@ -56,7 +56,7 @@ jobs:
         # clean-exclude keeps `pr-preview/` intact while still removing stale
         # docs pages; force: false rebases instead of clobbering concurrent
         # preview deployments.
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4.8.0
         with:
           branch: gh-pages
           folder: site

--- a/.github/workflows/export-airgap-bundle.yml
+++ b/.github/workflows/export-airgap-bundle.yml
@@ -28,7 +28,7 @@ permissions: {}
 jobs:
   build:
     name: Build bundle
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -37,12 +37,12 @@ jobs:
       bundle_name: ${{ steps.meta.outputs.bundle_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
 
@@ -69,7 +69,7 @@ jobs:
           jq -r '"- Tarballs: \(.packages | length)"' airgap-bundle/manifest.json >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{ steps.meta.outputs.bundle_name }}
           if-no-files-found: error
@@ -79,16 +79,16 @@ jobs:
   verify:
     name: Verify bundle installs offline
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions: {}
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
 
       - name: Download bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ needs.build.outputs.bundle_name }}
           path: airgap-bundle
@@ -149,12 +149,12 @@ jobs:
   attach:
     name: Attach assets to release
     needs: [build, verify]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Download bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ needs.build.outputs.bundle_name }}
           path: airgap-bundle

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,7 +33,7 @@ jobs:
     # coverage workflow did not succeed.
     needs: coverage
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Check coverage result
         if: needs.coverage.result != 'success'
@@ -42,7 +42,7 @@ jobs:
           exit 1
 
   test-packages:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     strategy:
@@ -55,10 +55,10 @@ jobs:
         working-directory: packages/${{ matrix.package }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -76,17 +76,17 @@ jobs:
     # enforced the next time it is changed). Not an oxlint rule — these are
     # filesystem/structural checks (file presence, README media, favicon) that a
     # source-code linter can't express, so they live as a script + this job.
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ on:
 
 permissions: {}
 
+env:
+  # uipath-ubuntu-* runners have less RAM than ubuntu-latest, so Node
+  # auto-sizes its heap to ~2 GB and the rollup build OOMs (exit 134).
+  NODE_OPTIONS: --max-old-space-size=6144
+
 jobs:
   publish-sdk:
     if: github.event.inputs.package == 'ts-sdk'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ permissions: {}
 jobs:
   publish-sdk:
     if: github.event.inputs.package == 'ts-sdk'
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: ${{ inputs.github_packages_only && 'github-packages-dev' || 'production' }}
     permissions:
       contents: read
@@ -31,12 +31,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
 
@@ -66,7 +66,7 @@ jobs:
         run: npm run build
 
       - name: Setup registry for npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -122,7 +122,7 @@ jobs:
   trigger-cf-worker:
     if: ${{ !inputs.github_packages_only }}
     needs: publish-sdk
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions: {}
     steps:
       - name: Trigger API CORS Worker deploy (staging + production)
@@ -140,7 +140,7 @@ jobs:
           
   publish-coded-action-app-sdk:
     if: github.event.inputs.package == 'coded-action-app-sdk'
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: ${{ inputs.github_packages_only && 'github-packages-dev' || 'production' }}
     permissions:
       contents: read
@@ -151,12 +151,12 @@ jobs:
         working-directory: packages/coded-action-app
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
 
@@ -186,7 +186,7 @@ jobs:
         run: npm run build
 
       - name: Setup registry for npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -231,7 +231,7 @@ jobs:
 
   publish-telemetry:
     if: github.event.inputs.package == 'telemetry'
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: ${{ inputs.github_packages_only && 'github-packages-dev' || 'production' }}
     permissions:
       contents: read
@@ -242,12 +242,12 @@ jobs:
         working-directory: packages/telemetry
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
 
@@ -279,7 +279,7 @@ jobs:
         run: npm test
 
       - name: Setup registry for npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-metadata-gen.yml
+++ b/.github/workflows/release-metadata-gen.yml
@@ -20,7 +20,7 @@ jobs:
   regen:
     # Only same-repo PRs get a writable token; fork PRs cannot push back.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: write
     env:
@@ -28,13 +28,13 @@ jobs:
       HEAD_REF: ${{ github.head_ref }}
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.