### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.6.0",
+  "sdkVersion": "1.7.0",
   "services": [
     {
       "name": "AgentMemory",
@@ -212,6 +212,10 @@
         {
           "name": "getStagesSlaSummary",
           "since": null
+        },
+        {
+          "name": "getVariables",
+          "since": "1.6.0"
         },
         {
           "name": "pause",
@@ -450,6 +454,21 @@
       ]
     },
     {
+      "name": "Functions",
+      "subpath": "@uipath/uipath-typescript/functions",
+      "since": "1.7.0",
+      "methods": [
+        {
+          "name": "getAll",
+          "since": "1.7.0"
+        },
+        {
+          "name": "invoke",
+          "since": "1.7.0"
+        }
+      ]
+    },
+    {
       "name": "Governance",
       "subpath": "@uipath/uipath-typescript/governance",
       "since": "1.4.1",
@@ -654,6 +673,37 @@
       ]
     },
     {
+      "name": "TaskCatalogs",
+      "subpath": "@uipath/uipath-typescript/tasks",
+      "since": "1.7.0",
+      "methods": [
+        {
+          "name": "create",
+          "since": "1.7.0"
+        },
+        {
+          "name": "getAll",
+          "since": "1.7.0"
+        },
+        {
+          "name": "getById",
+          "since": "1.7.0"
+        },
+        {
+          "name": "getByName",
+          "since": "1.7.0"
+        },
+        {
+          "name": "updateById",
+          "since": "1.7.0"
+        },
+        {
+          "name": "updateByName",
+          "since": "1.7.0"
+        }
+      ]
+    },
+    {
       "name": "Tasks",
       "subpath": "@uipath/uipath-typescript/tasks",
       "since": null,
@@ -671,6 +721,14 @@
           "since": null
         },
         {
+          "name": "createComment",
+          "since": "1.7.0"
+        },
+        {
+          "name": "editMetadata",
+          "since": "1.7.0"
+        },
+        {
           "name": "getAll",
           "since": null
         },
@@ -679,12 +737,32 @@
           "since": null
         },
         {
+          "name": "getComments",
+          "since": "1.7.0"
+        },
+        {
+          "name": "getDataById",
+          "since": "1.7.0"
+        },
+        {
+          "name": "getDataByKey",
+          "since": "1.7.0"
+        },
+        {
           "name": "getUsers",
           "since": null
         },
         {
           "name": "reassign",
           "since": null
+        },
+        {
+          "name": "saveData",
+          "since": "1.7.0"
+        },
+        {
+          "name": "saveTags",
+          "since": "1.7.0"
         },
         {
           "name": "unassign",


### PR DESCRIPTION
## Summary

Version bump `1.6.0` → `1.6.1` for today's release.

**Why patch, not minor:** per this repo's convention, minor bumps are reserved for releases that carry **breaking changes** (e.g. 1.6.0 went minor specifically for the Data Fabric field renames); additive, backward-compatible features ship in patch releases (e.g. 1.5.1 introduced the Notifications service foundation as a patch; 1.5.5 added new methods as a patch). This release adds new functionality but **no breaking changes**, so it's a patch.

#608 removed only the `@internal`, undocumented `setMultiLogin()` — an interim workaround that had already become a no-op and never appeared in any published surface (absent from `release-metadata.json`, the generated docs, and `oauth-scopes.md`; `excludeInternal` keeps `@internal` out of TypeDoc). No documented consumer is affected.

`release-metadata.json` regenerates automatically on this PR. Note: `CaseInstances.getVariables` shipped in 1.6.0 (#626) but was never recorded in the 1.6.0 metadata (that bump only updated the `sdkVersion` string), so the deterministic regen would have stamped it `1.6.1`; its `since` is corrected to `1.6.0` in this PR.

## Draft release notes (1.6.1)

Copy-paste content for the draft release, following the 1.5.1/1.5.5 format:

````markdown
### New Features & Improvements

- Added a new `Functions` service (`@uipath/uipath-typescript/functions`) for discovering and invoking coded functions directly. Supports `getAll()` (paginated) and `invoke()`, plus a bound `fn.invoke()` on listed functions (#614)
- Added a new `TaskCatalogs` service for managing task catalogs — `getAll`, `getById`, `getByName`, `create`, `updateById`, and `updateByName` (#632)
- Added task comments, data, tags, and metadata to the `Tasks` service — `getComments`/`createComment`, `getDataById`/`getDataByKey`/`saveData`, `saveTags`, and `editMetadata`. `saveData` routes to the correct endpoint per task type, so Form and App tasks save correctly (#632, #652)

---

### Bug Fixes

- Fixed OAuth login for Basic Auth users in mixed-auth organizations. The SDK no longer appends `acr_values` to the authorize request, so login no longer forces the org's SSO/SAML identity provider — the correct organization is resolved from the client ID and every login method works (Basic Auth, SSO/SAML, MS Entra silent login, directory-only SSO, and mixed-auth orgs) (#608)

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.6.0...1.6.1
````

Excluded as not user-facing: #612 (exports `@internal`-tagged Data Fabric roles/directory types — kept out of docs), #628/#638/#640/#648 (CI/publishing), #630/#649/#631/#634 (docs & sample GIFs).
