### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -132,6 +132,10 @@
       "since": null,
       "methods": [
         {
+          "name": "create",
+          "since": "1.6.1"
+        },
+        {
           "name": "getById",
           "since": null
         }
@@ -493,12 +497,20 @@
           "since": null
         },
         {
+          "name": "getAttachments",
+          "since": "1.6.1"
+        },
+        {
           "name": "getById",
           "since": null
         },
         {
           "name": "getOutput",
           "since": null
+        },
+        {
+          "name": "linkAttachment",
+          "since": "1.6.1"
         },
         {
           "name": "restart",

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -215,7 +215,7 @@
         },
         {
           "name": "getVariables",
-          "since": "1.6.1"
+          "since": "1.6.0"
         },
         {
           "name": "pause",

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.6.0",
+  "sdkVersion": "1.6.1",
   "services": [
     {
       "name": "AgentMemory",
@@ -212,6 +212,10 @@
         {
           "name": "getStagesSlaSummary",
           "since": null
+        },
+        {
+          "name": "getVariables",
+          "since": "1.6.1"
         },
         {
           "name": "pause",
@@ -450,6 +454,21 @@
       ]
     },
     {
+      "name": "Functions",
+      "subpath": "@uipath/uipath-typescript/functions",
+      "since": "1.6.1",
+      "methods": [
+        {
+          "name": "getAll",
+          "since": "1.6.1"
+        },
+        {
+          "name": "invoke",
+          "since": "1.6.1"
+        }
+      ]
+    },
+    {
       "name": "Governance",
       "subpath": "@uipath/uipath-typescript/governance",
       "since": "1.4.1",
@@ -558,6 +577,21 @@
       ]
     },
     {
+      "name": "Platform",
+      "subpath": "@uipath/uipath-typescript/platform",
+      "since": "1.6.1",
+      "methods": [
+        {
+          "name": "getUserSettings",
+          "since": "1.6.1"
+        },
+        {
+          "name": "updateUserSettings",
+          "since": "1.6.1"
+        }
+      ]
+    },
+    {
       "name": "Processes",
       "subpath": "@uipath/uipath-typescript/processes",
       "since": null,
@@ -654,6 +688,37 @@
       ]
     },
     {
+      "name": "TaskCatalogs",
+      "subpath": "@uipath/uipath-typescript/tasks",
+      "since": "1.6.1",
+      "methods": [
+        {
+          "name": "create",
+          "since": "1.6.1"
+        },
+        {
+          "name": "getAll",
+          "since": "1.6.1"
+        },
+        {
+          "name": "getById",
+          "since": "1.6.1"
+        },
+        {
+          "name": "getByName",
+          "since": "1.6.1"
+        },
+        {
+          "name": "updateById",
+          "since": "1.6.1"
+        },
+        {
+          "name": "updateByName",
+          "since": "1.6.1"
+        }
+      ]
+    },
+    {
       "name": "Tasks",
       "subpath": "@uipath/uipath-typescript/tasks",
       "since": null,
@@ -671,6 +736,14 @@
           "since": null
         },
         {
+          "name": "createComment",
+          "since": "1.6.1"
+        },
+        {
+          "name": "editMetadata",
+          "since": "1.6.1"
+        },
+        {
           "name": "getAll",
           "since": null
         },
@@ -679,12 +752,32 @@
           "since": null
         },
         {
+          "name": "getComments",
+          "since": "1.6.1"
+        },
+        {
+          "name": "getDataById",
+          "since": "1.6.1"
+        },
+        {
+          "name": "getDataByKey",
+          "since": "1.6.1"
+        },
+        {
           "name": "getUsers",
           "since": null
         },
         {
           "name": "reassign",
           "since": null
+        },
+        {
+          "name": "saveData",
+          "since": "1.6.1"
+        },
+        {
+          "name": "saveTags",
+          "since": "1.6.1"
         },
         {
           "name": "unassign",


### PR DESCRIPTION
## Summary

Version bump `1.6.0` → `1.6.1` for today's release. Changes only `package.json` and `package-lock.json`; `release-metadata.json` is regenerated and committed onto this branch automatically by the `Regenerate release-metadata` workflow.

**Why patch, not minor:** per this repo's convention, minor bumps are reserved for releases that carry **breaking changes** (e.g. 1.6.0 went minor specifically for the Data Fabric field renames); additive, backward-compatible features ship in patch releases (e.g. 1.5.1 introduced the Notifications service foundation as a patch; 1.5.5 added new methods as a patch). This release adds new functionality but **no breaking changes**, so it's a patch.

#608 removed only the `@internal`, undocumented `setMultiLogin()` — an interim workaround that had already become a no-op and never appeared in any published surface (absent from `release-metadata.json`, the generated docs, and `oauth-scopes.md`; `excludeInternal` keeps `@internal` out of TypeDoc). No documented consumer is affected.

## Draft release notes (1.6.1)

````markdown
### New Features & Improvements

- Introduced a Platform service for user-scoped platform settings (#629)
- Introduced a Functions service for invoking coded functions (#614)
- Added attachment upload and job attachment APIs via `Attachments.create()`, `Jobs.getAttachments()`, and `Jobs.linkAttachment()` (#646)
- Added Task Catalogs, notes, and task data/tags/metadata to the Tasks service (#632, #652)
- Made client-side tools public in the Conversational Agent service (#637)

---

### Bug Fixes

- Dropped `acr_values` from the OAuth flow and made no-acr the default, fixing login for Basic Auth users in mixed-auth organizations (#608)

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.6.0...1.6.1
````

Excluded as not user-facing: #612 (exports `@internal`-tagged Data Fabric roles/directory types — kept out of docs), #628/#638/#640/#648 (CI/publishing), #630/#649/#631/#634 (docs & sample GIFs).

---

> **`CaseInstances.getVariables` `since` corrected to `1.6.0`:** it shipped in 1.6.0 (#626) but was never recorded in `release-metadata.json` — that bump regenerated against an earlier (1.5.6) branch state before #626 landed, then only the `sdkVersion` string was updated. The auto-regen therefore stamped it `1.6.1`; the follow-up commit here sets it back to `1.6.0`. The generator carries this value forward on future regens.
