### PR TITLE
fix(ci): raise Node heap for the release-metadata regen build

### DIFF
--- a/.github/workflows/release-metadata-gen.yml
+++ b/.github/workflows/release-metadata-gen.yml
@@ -26,6 +26,9 @@ jobs:
     env:
       BASE_REF: ${{ github.base_ref }}
       HEAD_REF: ${{ github.head_ref }}
+      # uipath-ubuntu-* runners have less RAM than ubuntu-latest, so Node
+      # auto-sizes its heap to ~2 GB and the rollup build OOMs (exit 134).
+      NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout PR head
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1


### PR DESCRIPTION
## Summary

Completes the runner migration from #648. That PR moved CI to the managed `uipath-ubuntu-*` pool (which has less RAM than `ubuntu-latest`) and raised the Node heap on the build-running workflows — but it covered only **2 of the 3**:

| Workflow that runs `npm run build` | Heap raise (`NODE_OPTIONS`) |
|---|---|
| `coverage.yml` | ✅ already set in #648 |
| `publish.yml` | ✅ already set in #648 |
| `release-metadata-gen.yml` | ❌ **missing** → fixed here |

On the managed runners Node auto-sizes its heap to ~2 GB, so the rollup build in the regen workflow aborts with `FATAL ERROR: ... JavaScript heap out of memory` (exit 134). As a result, `release-metadata.json` is never regenerated/committed onto version-bump PRs.

## Change

Add the same `NODE_OPTIONS: --max-old-space-size=6144` (and the identical explanatory comment) the sibling workflows already use, to the `regen` job in `release-metadata-gen.yml`.

```yaml
    env:
      BASE_REF: ${{ github.base_ref }}
      HEAD_REF: ${{ github.head_ref }}
      # uipath-ubuntu-* runners have less RAM than ubuntu-latest, so Node
      # auto-sizes its heap to ~2 GB and the rollup build OOMs (exit 134).
      NODE_OPTIONS: --max-old-space-size=6144
```

## Impact

- Releases were **not** affected — `publish.yml` already had the heap raise.
- Only the auto-regen on version-bump PRs was broken. Observed failing on the current 1.6.1 bump PR (#657); merging this unblocks it.

## Verification

One-line env addition mirroring the proven fix already live in `coverage.yml`/`publish.yml`. The regen workflow re-runs on the bump PR after this lands and should build within the raised heap and commit the regenerated metadata.
