### PR TITLE
docs(functions): mark the coded Functions service as preview

### DIFF
--- a/src/models/orchestrator/functions.models.ts
+++ b/src/models/orchestrator/functions.models.ts
@@ -6,6 +6,13 @@ import { ValidationError } from '../../core/errors/validation';
 export type FunctionGetResponse = RawFunctionGetResponse & FunctionMethods;
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+ * Preview: This service is experimental and may change or be removed in future releases.
+ * ///
+ *
  * Service for invoking UiPath Coded Functions.
  *
  * Coded functions are lightweight units of TypeScript/JavaScript or Python code
@@ -28,6 +35,12 @@ export type FunctionGetResponse = RawFunctionGetResponse & FunctionMethods;
 export interface FunctionServiceModel {
   /**
    * Gets all functions in a folder with optional filtering and pagination.
+   *
+   * @experimental
+   *
+   * /// warning
+   * Preview: This method is experimental and may change or be removed in future releases.
+   * ///
    *
    * Returns each function's identity (name, slug, HTTP method), state, and
    * packaging details, with an {@link FunctionMethods.invoke | invoke} method
@@ -81,6 +94,12 @@ export interface FunctionServiceModel {
   /**
    * Invokes a function and returns its output.
    *
+   * @experimental
+   *
+   * /// warning
+   * Preview: This method is experimental and may change or be removed in future releases.
+   * ///
+   *
    * The call is synchronous — it resolves with the function's output.
    *
    * Type the input and output by supplying the generics — they should match the
@@ -130,6 +149,12 @@ export interface FunctionServiceModel {
 export interface FunctionMethods {
   /**
    * Invokes this function and returns its output.
+   *
+   * @experimental
+   *
+   * /// warning
+   * Preview: This method is experimental and may change or be removed in future releases.
+   * ///
    *
    * @param input - Input for the function, sent as the request body (or as query
    *   parameters for functions declared with the `Get` method). Defaults to an empty object.

--- a/src/models/orchestrator/functions.models.ts
+++ b/src/models/orchestrator/functions.models.ts
@@ -143,6 +143,13 @@ export interface FunctionServiceModel {
 }
 
 /**
+ *
+ * @experimental
+ *
+ * /// warning
+ * Preview: This service is experimental and may change or be removed in future releases.
+ * ///
+ *
  * Methods available on function response objects.
  * These are bound to the function data and delegate to the service.
  */

--- a/src/models/orchestrator/index.ts
+++ b/src/models/orchestrator/index.ts
@@ -4,6 +4,8 @@ export * from './assets.types';
 export * from './assets.models';
 export * from './buckets.types';
 export * from './buckets.models';
+export * from './functions.types';
+export * from './functions.models';
 // export * from './folder';
 export * from './jobs.types';
 export * from './jobs.models';


### PR DESCRIPTION
## Summary

Marks the entire **coded Functions** service as **preview / experimental**, following the same pattern used for Governance and Agent Memory (and the `@experimental` + Preview-warning convention introduced in #328).

`@experimental` + a `/// warning` Preview admonition is applied to every public layer of Functions:

- The service-level `FunctionServiceModel` JSDoc — "This service is experimental…"
- `FunctionServiceModel.getAll()` and `FunctionServiceModel.invoke()` — "This method is experimental…"
- The bound `FunctionMethods.invoke()`

## Notes

- **Service class not tagged.** Functions is modular-only — no `UiPath`-class wrapper, and the service class isn't a TypeDoc entry point (`typedoc.json` runs on `src/index.ts` only). This matches `GovernanceService`, whose class is likewise untagged; the interface is the rendered/documented surface.
- **Still a released, public API.** `@experimental` does not remove Functions from `release-metadata.json` — the generator excludes only `@internal`. Coded functions continues to ship and is documented, just flagged as preview.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- JSDoc-only change; format copied verbatim from `governance.models.ts` / `memory.models.ts`, which already render correctly.

## Sequencing

Coded functions is new in the upcoming **1.6.1** release (bump PR #657). Merging this before 1.6.1 publishes ensures the service ships marked as preview from its first release. After merge, #657 can be rebased so the release includes it.
