### PR TITLE
fix: oauth scope docs for Connections

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -2,44 +2,6 @@
 
 This page lists the specific OAuth scopes required in external app for each SDK method.
 
-## Integration Service — Connectors
-
-| Method | OAuth Scope |
-|--------|-------------|
-| `getAll()` | `IS.Connectors.Read` |
-| `getById()` | `IS.Connectors.Read` |
-| `getDefaultConnection()` | `IS.Connectors.Read` |
-| `getConnections()` | `IS.Connectors.Read` |
-
-## Integration Service — Connections
-
-| Method | OAuth Scope |
-|--------|-------------|
-| `getAll()` | `IS.Connections.Read` |
-| `getById()` | `IS.Connections.Read` |
-| `ping()` | `IS.Connections.Read` |
-| `reauthenticate()` | `IS.Connections.Read` |
-
-## Integration Service — Elements
-
-| Method | OAuth Scope |
-|--------|-------------|
-| `getObjects()` | `IS.Connector.Export` |
-| `getActivities()` | `IS.Connector.Export` |
-| `getObjectMetadata()` | `IS.Connector.Export` |
-| `getEventObjects()` | `IS.Connector.Export` |
-| `getEventObjectMetadata()` | `IS.Connector.Export` |
-| `getInstanceObjects()` | `IS.Connector.Export` |
-| `getInstanceObjectMetadata()` | `IS.Connector.Export` |
-| `getInstanceEventObjects()` | `IS.Connector.Export` |
-| `getInstanceEventObjectMetadata()` | `IS.Connector.Export` |
-
-## Integration Service — Execution
-
-| Function | OAuth Scope |
-|----------|-------------|
-| `execute()` | `IS.Connections.Read` (plus any third-party scopes required by the underlying connection) |
-
 ## Assets
 
 | Method | OAuth Scope |
@@ -338,3 +300,43 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getSpansByReference()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 | `getGovernanceDecisions()` | `Traces.Api Insights.RealTimeData Insights OR.Folders.Read` |
 | `getGovernanceSummary()` | `Traces.Api Insights.RealTimeData Insights OR.Folders.Read` |
+
+## Connections
+
+### Connectors
+
+| Method | OAuth Scope |
+|--------|-------------|
+| `getAll()` | `IS.Connectors.Read` |
+| `getById()` | `IS.Connectors.Read` |
+| `getDefaultConnection()` | `IS.Connectors.Read` |
+| `getConnections()` | `IS.Connectors.Read` |
+
+### Connections
+
+| Method | OAuth Scope |
+|--------|-------------|
+| `getAll()` | `IS.Connections.Read` |
+| `getById()` | `IS.Connections.Read` |
+| `ping()` | `IS.Connections.Read` |
+| `reauthenticate()` | `IS.Connections.Read` |
+
+### Elements
+
+| Method | OAuth Scope |
+|--------|-------------|
+| `getObjects()` | `IS.Connector.Export` |
+| `getActivities()` | `IS.Connector.Export` |
+| `getObjectMetadata()` | `IS.Connector.Export` |
+| `getEventObjects()` | `IS.Connector.Export` |
+| `getEventObjectMetadata()` | `IS.Connector.Export` |
+| `getInstanceObjects()` | `IS.Connector.Export` |
+| `getInstanceObjectMetadata()` | `IS.Connector.Export` |
+| `getInstanceEventObjects()` | `IS.Connector.Export` |
+| `getInstanceEventObjectMetadata()` | `IS.Connector.Export` |
+
+### Execution
+
+| Function | OAuth Scope |
+|----------|-------------|
+| `execute()` | `IS.Connections.Read` (plus any third-party scopes required by the underlying connection) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,15 +196,15 @@ nav:
             - api/interfaces/attachments/index.md
           - Assets: api/interfaces/AssetServiceModel.md
           - Buckets: api/interfaces/BucketServiceModel.md
+          - Connections:
+            - Connectors: api/interfaces/ConnectorsServiceModel.md
+            - Connections: api/interfaces/ConnectionsServiceModel.md
+            - Elements: api/interfaces/ElementsServiceModel.md
           - Entities:
             - api/interfaces/entity/index.md
             - Choice Sets: api/interfaces/ChoiceSetServiceModel.md
           - Functions: api/interfaces/FunctionServiceModel.md
           - Governance: api/interfaces/GovernanceServiceModel.md
-          - Integration Service:
-            - Connectors: api/interfaces/ConnectorsServiceModel.md
-            - Connections: api/interfaces/ConnectionsServiceModel.md
-            - Elements: api/interfaces/ElementsServiceModel.md
           - Maestro:
             - Processes: api/interfaces/MaestroProcessesServiceModel.md
             - Process Instances: api/interfaces/ProcessInstancesServiceModel.md


### PR DESCRIPTION
## What Changed

Documentation-only change. No SDK code, types, endpoints, or tests were touched.

"Integration Service" is a product area, not a resource name — the resource is **Connections**. Both the OAuth scopes page and the API Reference nav are renamed accordingly.

### `docs/oauth-scopes.md`

The four flat `## Integration Service — *` headings become one `## Connections` section with subheadings, matching the existing `## Conversational Agent` layout.

| Before | After |
|--------|-------|
| `## Integration Service — Connectors` | `## Connections` → `### Connectors` |
| `## Integration Service — Connections` | `## Connections` → `### Connections` |
| `## Integration Service — Elements` | `## Connections` → `### Elements` |
| `## Integration Service — Execution` | `## Connections` → `### Execution` |

The section also moves from the top of the page to the end, after `## Agent Traces`, so the page opens with `## Assets`.

### `mkdocs.yml`

The API Reference nav group `Integration Service:` is renamed to `Connections:` with the same `Connectors` / `Connections` / `Elements` children. It also moves to its alphabetical slot after `Buckets` (previously between `Governance` and `Maestro`), consistent with the rest of the nav.

## Scope Table Contents

Unchanged — all 18 method-to-scope rows are preserved verbatim. This is a pure heading restructure and reorder.

## Files

| Area | Files |
|------|-------|
| Docs | `docs/oauth-scopes.md` |
| Docs nav | `mkdocs.yml` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
