### PR TITLE
chore: Add stale issue and PR monitoring workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,9 @@ jobs:
   label:
     runs-on: uipath-ubuntu-latest
     name: Determine PR Labels
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/stale@5bef64f19d7facfed25b8b884e6374bb33e9bd7d # v9.1.0
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     name: Determine PR Labels
     steps:
       - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4.1.1
-        with:
+      - uses: actions/stale@5bef64f19d7facfed25b8b884e6374bb33e9bd7d # v9.1.0
           # stale-issue-message not provided so that *issues* do not expire
           stale-pr-message: >
             *🤖 Bleep bloop!*

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   label:
-    if: ${{ !contains(github.head_ref, 'localization_sync/') }}
+    runs-on: uipath-ubuntu-latest
     runs-on: uipath-ubuntu-latest
     name: Determine PR Labels
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
     name: Determine PR Labels
     steps:
       - uses: actions/stale@5bef64f19d7facfed25b8b884e6374bb33e9bd7d # v9.1.0
+        with:
           # stale-issue-message not provided so that *issues* do not expire
           stale-pr-message: >
             *🤖 Bleep bloop!*

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# Adds stale labels for PR's with no commits in
+# the past 14 days.
+# Deletes stale PR's
+name: Monitor for stale issues and pull requests.
+on:
+  schedule:
+    - cron: '30 18 * * *' # IST Midnight
+  workflow_dispatch:
+
+jobs:
+  label:
+    if: ${{ !contains(github.head_ref, 'localization_sync/') }}
+    runs-on: uipath-ubuntu-latest
+    name: Determine PR Labels
+    steps:
+      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4.1.1
+        with:
+          # stale-issue-message not provided so that *issues* do not expire
+          stale-pr-message: >
+            *🤖 Bleep bloop!*
+            This PR has not seen any activity in the last week and will be closed automatically in **14 days**. Please push a commit or leave a comment to keep this PR open.
+          close-pr-message: >
+            *🤖 Bleep bloop!*
+            This PR was closed because it has not seen any activity since the last bi-weekly review.
+          days-before-stale: 5 # once something becomes 'active' (not draft) it should keep progressing
+          days-before-close: 14 # the bi-weekly interval
+          exempt-pr-labels: draft
+          operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: uipath-ubuntu-latest
     name: Determine PR Labels
     steps:
-      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4.1.1
       - uses: actions/stale@5bef64f19d7facfed25b8b884e6374bb33e9bd7d # v9.1.0
           # stale-issue-message not provided so that *issues* do not expire
           stale-pr-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   label:
     runs-on: uipath-ubuntu-latest
-    runs-on: uipath-ubuntu-latest
     name: Determine PR Labels
     steps:
       - uses: actions/stale@5bef64f19d7facfed25b8b884e6374bb33e9bd7d # v9.1.0


### PR DESCRIPTION
This workflow monitors pull requests for inactivity and applies stale labels, closing them if no activity occurs within 14 days.