### PR TITLE
feat(telemetry): let a consumer supply its own connection string

### DIFF
--- a/packages/telemetry/src/client.ts
+++ b/packages/telemetry/src/client.ts
@@ -185,8 +185,9 @@ class ApplicationInsightsEventExporter implements LogRecordExporter {
  * Action Apps package). Each consumer instantiates its own client so that
  * its identity (`cloudRoleName`, `serviceName`, `sdkVersion`, …) and tenant
  * context flow through to its own `Logger` and exporter pipeline. Two
- * consumers running in the same process emit independent events — they
- * share the Application Insights connection string but nothing else.
+ * consumers running in the same process emit independent events — they share
+ * the Application Insights connection string, unless one supplies its own via
+ * `TelemetryClientInitOptions.connectionString`, but nothing else.
  *
  * Records are emitted via `Logger.emit` and batched by
  * `BatchLogRecordProcessor` before being handed to the Application Insights
@@ -211,11 +212,16 @@ export class TelemetryClient {
         this.telemetryContext = options.context;
 
         try {
-            if (!this.isValidConnectionString(CONNECTION_STRING)) {
+            // A consumer pointing at its own Application Insights resource
+            // supplies its own string; the shared one is the default.
+            const connectionString =
+                options.connectionString ?? CONNECTION_STRING;
+
+            if (!this.isValidConnectionString(connectionString)) {
                 return;
             }
 
-            this.setupTelemetryProvider(CONNECTION_STRING);
+            this.setupTelemetryProvider(connectionString);
         } catch (error) {
             console.debug('Failed to initialize telemetry:', error);
         }

--- a/packages/telemetry/src/client.ts
+++ b/packages/telemetry/src/client.ts
@@ -99,6 +99,15 @@ class ApplicationInsightsEventExporter implements LogRecordExporter {
         return Promise.resolve();
     }
 
+    /**
+     * Required by `LogRecordExporter`. A no-op like `shutdown`: records are
+     * posted fire-and-forget in `sendAsCustomEvent`, so there is no queue of
+     * in-flight requests here to await.
+     */
+    public forceFlush(): Promise<void> {
+        return Promise.resolve();
+    }
+
     private sendAsCustomEvent(logRecord: ReadableLogRecord): void {
         const eventName = String(logRecord.body);
 

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -38,6 +38,17 @@ export interface TelemetryClientInitOptions {
     loggerName: string;
     /** Default event display name used when none is supplied to `track`. */
     defaultEventName: string;
+    /**
+     * Application Insights connection string. Omit it to use the shared one
+     * patched into this package at publish time, which is what every consumer
+     * did before this option existed. Supply one to send a consumer's events to
+     * its own resource instead.
+     *
+     * An empty string disables telemetry rather than falling back, so a
+     * consumer whose own value is unset emits nothing instead of silently
+     * reporting to the shared resource.
+     */
+    connectionString?: string;
     /** Optional per-tenant context applied to every event. */
     context?: TelemetryContext;
 }

--- a/packages/telemetry/tests/client.test.ts
+++ b/packages/telemetry/tests/client.test.ts
@@ -134,6 +134,7 @@ describe('TelemetryClient.initialize', () => {
         });
 
         expect(mocks.LoggerProvider).not.toHaveBeenCalled();
+        expect(mocks.getLogger).not.toHaveBeenCalled();
     });
 
     it('ignores subsequent initialize calls on the same instance — first init wins', async () => {

--- a/packages/telemetry/tests/client.test.ts
+++ b/packages/telemetry/tests/client.test.ts
@@ -90,6 +90,52 @@ describe('TelemetryClient.initialize', () => {
         expect(mocks.getLogger).not.toHaveBeenCalled();
     });
 
+    it('prefers a connection string supplied by the consumer over the shared one', async () => {
+        // The point of the option: a consumer reports to its own Application
+        // Insights resource without this package being republished for it.
+        const client = await clientWithConnectionString('');
+
+        client.initialize({
+            ...VALID_OPTIONS,
+            connectionString: VALID_CONNECTION_STRING,
+        });
+
+        // The shared string is empty here, so reaching the provider at all
+        // proves the supplied one was the value used.
+        expect(mocks.LoggerProvider).toHaveBeenCalledTimes(1);
+        expect(mocks.getLogger).toHaveBeenCalledWith('test-logger');
+    });
+
+    it('falls back to the shared connection string when the consumer omits one', async () => {
+        const client = await clientWithConnectionString(VALID_CONNECTION_STRING);
+
+        client.initialize(VALID_OPTIONS);
+
+        expect(mocks.LoggerProvider).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-ops on an empty supplied string rather than falling back to the shared one', async () => {
+        // A consumer whose own value is unset must emit nothing, not report to
+        // the shared resource by accident.
+        const client = await clientWithConnectionString(VALID_CONNECTION_STRING);
+
+        client.initialize({ ...VALID_OPTIONS, connectionString: '' });
+
+        expect(mocks.LoggerProvider).not.toHaveBeenCalled();
+        expect(mocks.getLogger).not.toHaveBeenCalled();
+    });
+
+    it('no-ops on a supplied string that is still an unsubstituted placeholder', async () => {
+        const client = await clientWithConnectionString(VALID_CONNECTION_STRING);
+
+        client.initialize({
+            ...VALID_OPTIONS,
+            connectionString: '$MY_CONNECTION_STRING',
+        });
+
+        expect(mocks.LoggerProvider).not.toHaveBeenCalled();
+    });
+
     it('ignores subsequent initialize calls on the same instance — first init wins', async () => {
         const client = await clientWithConnectionString(VALID_CONNECTION_STRING);
 


### PR DESCRIPTION
Requested and approved in [#feat-codedapps](https://uipath.enterprise.slack.com/archives/C092C80PJV7/p1786521172198069) — "Sounds good to me, raise the PR."

## What

Adds an optional `connectionString` to `TelemetryClientInitOptions` in `packages/telemetry`, so a consumer can send its events to its own Application Insights resource.

```ts
connectionString?: string;   // omit → the packaged default
                             // empty string → telemetry off, no fallback
```

## Why

The connection string is a module-level constant `sed`-patched at publish time, `initialize()` accepted no override, and `setupTelemetryProvider` is private — so every consumer was pinned to one destination. That is a gap in a package whose design is "each consumer builds its own client": a consumer could already set its own `cloudRoleName`, `serviceName`, `sdkVersion` and tenant context, but not where its events land.

The Coded Action App SDK telemetry design doc already lists this as a property of this option — *"Custom connection string support: Yes — passed to provider constructor"* — and that is true internally, since `setupTelemetryProvider(connectionString)` and the exporter constructor both take it as a parameter. It was simply never surfaced on the public `initialize()`. This exposes it rather than adding anything new.

The immediate consumer is Maestro Business Apps, which needs its own resource rather than sharing the SDK's.

## Behaviour

| Caller passes | Result |
| --- | --- |
| nothing | Packaged default — **unchanged for every existing consumer** |
| a valid string | That resource is used |
| `''` | Telemetry off. **No fallback** |
| `'$SOMETHING'` | Telemetry off (existing placeholder guard) |

The empty-string rule is deliberate: a consumer whose own value is unconfigured should emit nothing, rather than silently reporting into the shared resource. Falling back would make a misconfiguration invisible and pollute the shared data.

Backwards compatible — the field is optional and defaults to the current value, so the root SDK and `coded-action-app` are unaffected.

## Second commit: an unrelated pre-existing fix

`3a9fc4b` is separate and can be dropped independently if you'd rather it went on its own.

`ApplicationInsightsEventExporter implements LogRecordExporter` but never declared `forceFlush`, which that interface requires at the pinned `@opentelemetry/sdk-logs`. **`npm run typecheck` fails on `main` today** — TS2420 and TS2345, reproduced on a clean `c7a56c9`. I fixed it because the repo's own pre-commit checklist requires a clean typecheck and I could not satisfy that otherwise.

It is a no-op, matching the existing `shutdown`: records are posted fire-and-forget in `sendAsCustomEvent`, so there is no queue of in-flight requests to await. Making it flush for real would mean tracking those promises — a behaviour change, deliberately not done here.

## Verification

Run in `packages/telemetry`:

| Check | Result |
| --- | --- |
| `npm run typecheck` | exit 0 — also fixes the pre-existing failure above |
| `npm run lint` | exit 0 |
| `npx vitest run` | 41 pass (4 new) |
| `npm run build` | exit 0; `connectionString` present in `dist/index.d.ts` |

Each new test was mutation-checked: reverting the resolution to `CONNECTION_STRING` fails exactly the three that assert the new behaviour, and the fallback test keeps passing — confirming they test the option rather than the surroundings.

Not run: the **root** SDK's `typecheck` / `test:unit` / `build`. Those resolve `@uipath/core-telemetry` from the published package rather than this workspace, so an added optional field cannot affect them, but CI will confirm.

## Not included

- **No version bump** — a separate PR per the release workflow.
- No docs changes. This package has no README or docs page, and the `docs/oauth-scopes.md` / `mkdocs.yml` / `docs/pagination.md` checklist items apply to SDK service methods, not to a client option. The option is documented in JSDoc, which is what `.d.ts` consumers and IDE hovers read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwgxkTUnqbWRN3xUwr6B46)_