### PR TITLE
feat(functions): acquire a Studio Web license before invoking [APPS-37123]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -28,6 +28,8 @@ This page lists the specific OAuth scopes required in external app for each SDK 
 
 Coded functions are invoked through their HTTP endpoint, which requires the [`OR.Default`](https://docs.uipath.com/automation-cloud/automation-cloud/latest/api-guide/accessing-uipath-resources-using-external-applications#declaring-scopes) scope. It acts as a wildcard granting fine-grained access based on the app's assigned role, and must appear explicitly in the app's scope string.
 
+Before running the function, `invoke()` also acquires a Studio Web license for the calling user. That call requires a valid Orchestrator token but no scope of its own, so it adds nothing to the table below.
+
 | Method | OAuth Scope |
 |--------|-------------|
 | `getAll()` | `OR.Default` |

--- a/src/models/orchestrator/functions.internal-types.ts
+++ b/src/models/orchestrator/functions.internal-types.ts
@@ -64,10 +64,12 @@ export interface RawStudioWebLicenseResponse {
   /** Last update of the licensed user session (ISO 8601). */
   lastUpdated: string;
   /**
-   * Unsigned JWT carrying the granted licence units and its own validity
-   * window. Its `exp` claim drives the SDK's cache TTL.
+   * Unsigned JWT carrying the granted license units and its own validity
+   * window; its `exp` claim is what the SDK reuses the license against. Null
+   * when the platform issues no token, in which case the SDK holds the license
+   * only for the fallback lifetime.
    */
-  licenseToken: string;
+  licenseToken: string | null;
 }
 
 /** Claims the SDK reads from the unsigned license token. Never verified. */

--- a/src/models/orchestrator/functions.internal-types.ts
+++ b/src/models/orchestrator/functions.internal-types.ts
@@ -3,6 +3,7 @@
  * transformation. Not exported through the public barrel.
  */
 
+
 /**
  * Raw HTTP trigger row from `GET /odata/HttpTriggers` after
  * `pascalToCamelCaseKeys()`. Only the fields consumed by the service are
@@ -44,3 +45,84 @@ export interface RawFolderResponse {
   /** Folder key (GUID) — the `t/{key}` segment of the function invoke URL. */
   Key: string;
 }
+
+/**
+ * Raw response from `POST /api/StudioWeb/AcquireLicense`. The endpoint already
+ * answers in camelCase, so no key transform is applied.
+ */
+export interface RawStudioWebLicenseResponse {
+  /** Robot type the license was granted for, e.g. `StudioX`. */
+  robotType: string;
+  /** Every robot type the acquired license covers. */
+  robotTypes: string[];
+  /** Whether the license came from an external provider. */
+  externalLicense: boolean;
+  /** Whether the caller ended up licensed. */
+  isLicensed: boolean;
+  /** Start of the licensed user session (ISO 8601). Refreshed on every call. */
+  started: string;
+  /** Last update of the licensed user session (ISO 8601). */
+  lastUpdated: string;
+  /**
+   * Unsigned JWT carrying the granted licence units and its own validity
+   * window. Its `exp` claim drives the SDK's cache TTL.
+   */
+  licenseToken: string;
+}
+
+/** Claims the SDK reads from the unsigned license token. Never verified. */
+export interface StudioWebLicenseTokenClaims {
+  /** Expiry, seconds since the Unix epoch. Drives the cache lifetime. */
+  exp?: number;
+  /** Not-before, seconds since the Unix epoch. */
+  nbf?: number;
+  /** User's base license tier, e.g. `BASICNU`. Absent for an unlicensed user. */
+  ubl?: string;
+  /** Licensed units granted, e.g. `['APPS', 'STDW', 'AGENT']`. */
+  lu?: string[];
+  /** Validity of the token, e.g. `VALID`. */
+  status?: string;
+}
+
+/** A license acquired for the calling user. */
+export interface StudioWebLicense {
+  /** Robot type the license was granted for, e.g. `StudioX`. */
+  robotType: string;
+  /** Every robot type the acquired license covers. */
+  robotTypes: string[];
+  /** Whether the caller ended up licensed. */
+  isLicensed: boolean;
+  /** Start of the licensed user session (ISO 8601). Refreshed on every acquisition. */
+  startedTime: string;
+  /** When the license stops being valid (ISO 8601), read from the token. */
+  expiresTime?: string;
+  /** The user's base license tier, e.g. `BASICNU`. Absent for an unlicensed user. */
+  licenseTier?: string;
+  /** Licensed units the token grants. */
+  licensedUnits?: string[];
+}
+
+/**
+ * Options for acquiring a license directly.
+ *
+ * @internal
+ */
+export interface FunctionAcquireLicenseOptions {
+  /**
+   * Acquires a fresh license instead of returning the one already held.
+   * Defaults to `false`.
+   */
+  refresh?: boolean;
+}
+
+/** A resolved or in-flight license acquisition held in the service's cache. */
+export interface LicenseCacheEntry {
+  /**
+   * The acquisition. Stored while still pending so concurrent invokes share one
+   * round trip.
+   */
+  acquisition: Promise<StudioWebLicense>;
+  /** Epoch milliseconds after which the entry is stale. */
+  expiresAtMs: number;
+}
+

--- a/src/models/orchestrator/functions.models.ts
+++ b/src/models/orchestrator/functions.models.ts
@@ -1,4 +1,10 @@
-import { FunctionGetAllOptions, FunctionInvokeOptions, FunctionRef, RawFunctionGetResponse } from './functions.types';
+import {
+  FunctionGetAllOptions,
+  FunctionInvokeOptions,
+  FunctionRef,
+  RawFunctionGetResponse,
+} from './functions.types';
+import { FunctionAcquireLicenseOptions, StudioWebLicense } from './functions.internal-types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination';
 import { ValidationError } from '../../core/errors/validation';
 
@@ -107,18 +113,36 @@ export interface FunctionServiceModel {
    * one of `folderId`, `folderKey`, or `folderPath` in the options, or initialize
    * the SDK with a folder context.
    *
+   * Before invoking, the SDK acquires a license for the calling user — their own
+   * if they hold one, otherwise the free Attended Studio Web license — and
+   * reuses it while it stays valid, so a burst of invocations costs one
+   * acquisition. Acquiring is a precondition rather than bookkeeping: it
+   * provisions the robot the function runs on, so an invocation whose license
+   * cannot be acquired fails with that error rather than proceeding.
+   *
    * @param func - Function to invoke. Currently identified by `name` (unique within
    *   a folder); additional identifiers may be added in future releases.
    * @param input - Input for the function, sent as the request body (or as query
    *   parameters for functions declared with the `Get` method). Defaults to an empty object.
-   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`) and
-   *   parent job attribution (`jobKey`)
+   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`),
+   *   parent job attribution (`jobKey`), and `refreshLicense` to force a fresh
+   *   license acquisition
    * @returns Promise resolving to the function's output
    *
    * @example
    * ```typescript
    * // Invoke a function
    * const result = await functions.invoke({ name: 'hello' }, { name: 'Alice' }, { folderId: <folderId> });
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Force a fresh license, e.g. just after the user's licensing changed
+   * const result = await functions.invoke(
+   *   { name: 'hello' },
+   *   { name: 'Alice' },
+   *   { folderKey: '<folderKey>', refreshLicense: true }
+   * );
    * ```
    *
    * @example
@@ -140,6 +164,19 @@ export interface FunctionServiceModel {
     input?: TInput,
     options?: FunctionInvokeOptions
   ): Promise<TOutput>;
+
+  /**
+   * Acquires a license for the calling user without invoking anything.
+   *
+   * {@link FunctionServiceModel.invoke | invoke} already does this, so callers
+   * do not need to.
+   *
+   * @internal
+   *
+   * @param options - Whether to force a fresh acquisition rather than reusing the license already held
+   * @returns Promise resolving to the acquired license
+   */
+  acquireLicense(options?: FunctionAcquireLicenseOptions): Promise<StudioWebLicense>;
 }
 
 /**

--- a/src/models/orchestrator/functions.types.ts
+++ b/src/models/orchestrator/functions.types.ts
@@ -63,6 +63,16 @@ export type FunctionGetAllOptions = RequestOptions & PaginationOptions & FolderS
 export interface FunctionInvokeOptions extends FolderScopedOptions {
   /** Key (GUID) of the job this invocation belongs to, so the run is attributed to it. */
   jobKey?: string;
+  /**
+   * Acquires a fresh license instead of reusing the one already held for this
+   * user. Defaults to `false`.
+   *
+   * A license is cached for as long as the platform says it is valid — currently
+   * two hours, read from the license itself rather than assumed — so a burst of
+   * invocations costs one acquisition. Set this when the user's licensing may
+   * have changed and the invocation must reflect it before that lapses.
+   */
+  refreshLicense?: boolean;
 }
 
 /**

--- a/src/models/orchestrator/functions.types.ts
+++ b/src/models/orchestrator/functions.types.ts
@@ -69,7 +69,9 @@ export interface FunctionInvokeOptions extends FolderScopedOptions {
    *
    * A license is reused for as long as it says it is valid, read from the
    * license rather than assumed, so a burst of invocations costs one
-   * acquisition. A license that states no validity window is held only briefly.
+   * acquisition. A license that states no validity window — as the free tier's
+   * does not — is reused for five minutes and then re-acquired.
+   *
    * Set this when the user's licensing may have changed and the invocation must
    * reflect it before that lapses.
    */

--- a/src/models/orchestrator/functions.types.ts
+++ b/src/models/orchestrator/functions.types.ts
@@ -67,10 +67,11 @@ export interface FunctionInvokeOptions extends FolderScopedOptions {
    * Acquires a fresh license instead of reusing the one already held for this
    * user. Defaults to `false`.
    *
-   * A license is cached for as long as the platform says it is valid — currently
-   * two hours, read from the license itself rather than assumed — so a burst of
-   * invocations costs one acquisition. Set this when the user's licensing may
-   * have changed and the invocation must reflect it before that lapses.
+   * A license is reused for as long as it says it is valid, read from the
+   * license rather than assumed, so a burst of invocations costs one
+   * acquisition. A license that states no validity window is held only briefly.
+   * Set this when the user's licensing may have changed and the invocation must
+   * reflect it before that lapses.
    */
   refreshLicense?: boolean;
 }

--- a/src/services/orchestrator/functions/functions.ts
+++ b/src/services/orchestrator/functions/functions.ts
@@ -43,12 +43,16 @@ import type { IUiPath } from '../../../core/types';
 const MAX_SUGGESTED_NAMES = 20;
 
 /**
- * How long a license is reused when it states no expiry of its own — not every
- * grant carries a token to read one from. Short, so a license the SDK cannot
- * reason about is re-checked soon; long enough that a burst still costs one
- * acquisition.
+ * How long a license is reused when it states no expiry of its own — the free
+ * grant carries no token to read one from.
+ *
+ * Deliberately short. Where a license states a window the SDK follows it; where
+ * the platform states none, re-checking soon keeps the SDK from honouring a
+ * licensing change later than it happens. Re-checking costs almost nothing: the
+ * acquisition runs in parallel with the name lookup, so it hides inside a leg
+ * the invocation already pays for.
  */
-const DEFAULT_LICENSE_TTL_MS = 5 * 60 * 1000;
+const FALLBACK_LICENSE_TTL_MS = 5 * 60 * 1000;
 
 /** Renew slightly early so an invoke never races the expiry boundary. */
 const LICENSE_EXPIRY_SKEW_MS = 30 * 1000;
@@ -228,9 +232,12 @@ export class FunctionService extends FolderScopedService implements FunctionServ
 
     const entry: LicenseCacheEntry = {
       acquisition: this.requestLicense(),
-      // Optimistic until the real expiry arrives, so a pending entry is never
-      // read as stale by a concurrent caller.
-      expiresAtMs: now + DEFAULT_LICENSE_TTL_MS,
+      // Stands in until the real expiry arrives, and earns its keep twice: a
+      // pending entry is never read as stale by a concurrent caller, and an
+      // acquisition that never settles stops capturing new callers once this
+      // lapses. Eviction reads the expiry synchronously, so it lives on the
+      // entry rather than inside the promise.
+      expiresAtMs: now + FALLBACK_LICENSE_TTL_MS,
     };
     // Replacing an existing key does not grow the map, so no room is needed —
     // evicting there would drop another caller's license for nothing.
@@ -239,7 +246,7 @@ export class FunctionService extends FolderScopedService implements FunctionServ
 
     try {
       const license = await entry.acquisition;
-      entry.expiresAtMs = licenseExpiryMs(license.expiresTime) ?? now + DEFAULT_LICENSE_TTL_MS;
+      entry.expiresAtMs = licenseExpiryMs(license.expiresTime) ?? now + FALLBACK_LICENSE_TTL_MS;
       return license;
     } catch (error) {
       // Never cache a rejection — the next call must retry, not replay it.

--- a/src/services/orchestrator/functions/functions.ts
+++ b/src/services/orchestrator/functions/functions.ts
@@ -6,7 +6,15 @@ import {
   FunctionRef,
   RawFunctionGetResponse,
 } from '../../../models/orchestrator/functions.types';
-import { RawFolderResponse, RawFunctionTrigger } from '../../../models/orchestrator/functions.internal-types';
+import {
+  FunctionAcquireLicenseOptions,
+  LicenseCacheEntry,
+  RawFolderResponse,
+  RawFunctionTrigger,
+  RawStudioWebLicenseResponse,
+  StudioWebLicense,
+  StudioWebLicenseTokenClaims,
+} from '../../../models/orchestrator/functions.internal-types';
 import { CollectionResponse, FolderScopedOptions } from '../../../models/common/types';
 import { UiPathError } from '../../../core/errors/base';
 import { NotFoundError } from '../../../core/errors/not-found';
@@ -18,7 +26,8 @@ import {
 } from '../../../models/orchestrator/functions.models';
 import { FunctionMap } from '../../../models/orchestrator/functions.constants';
 import { pascalToCamelCaseKeys, transformOptions } from '../../../utils/transform';
-import { FUNCTION_ENDPOINTS, FOLDER_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { FUNCTION_ENDPOINTS, FOLDER_ENDPOINTS, STUDIO_WEB_LICENSE_ENDPOINTS } from '../../../utils/constants/endpoints';
+import { decodeJwtClaims, extractUserIdFromToken } from '../../../utils/encoding/jwt';
 import { ODATA_PAGINATION, ODATA_OFFSET_PARAMS } from '../../../utils/constants/common';
 import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
 import { JOB_KEY } from '../../../utils/constants/headers';
@@ -27,9 +36,64 @@ import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '.
 import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
 import { track } from '../../../core/telemetry';
+import { SDKInternalsRegistry } from '../../../core/internals';
+import type { IUiPath } from '../../../core/types';
 
 /** Cap on the function names listed when a name lookup misses. */
 const MAX_SUGGESTED_NAMES = 20;
+
+/** Fallback TTL when a license token carries no readable `exp`. */
+const DEFAULT_LICENSE_TTL_MS = 5 * 60 * 1000;
+
+/** Renew slightly early so an invoke never races the expiry boundary. */
+const LICENSE_EXPIRY_SKEW_MS = 30 * 1000;
+
+/**
+ * Cap, so a long-lived server does not accumulate an entry per user served.
+ *
+ * @internal
+ */
+export const MAX_CACHED_LICENSES = 500;
+
+/**
+ * The license cache outlives any single service instance: consumers build one
+ * per request or per render, and an instance field would start empty each time.
+ * A shared symbol on `globalThis` also keeps it single when `core` and
+ * `functions` are bundled separately.
+ */
+const LICENSE_CACHE_KEY = Symbol.for('@uipath/functions-license-cache');
+
+/** The process-wide license cache, created on first use. */
+function getLicenseCache(): Map<string, LicenseCacheEntry> {
+  const store = globalThis as typeof globalThis & Record<symbol, Map<string, LicenseCacheEntry> | undefined>;
+  return (store[LICENSE_CACHE_KEY] ??= new Map<string, LicenseCacheEntry>());
+}
+
+/**
+ * Empties the license cache. The cache is process-wide, so tests need this to
+ * avoid inheriting licenses from each other.
+ *
+ * @internal
+ */
+export function clearLicenseCache(): void {
+  getLicenseCache().clear();
+}
+
+/** Drops expired entries, then oldest-first, to stay under the cap. */
+function evictIfFull(cache: Map<string, LicenseCacheEntry>): void {
+  if (cache.size < MAX_CACHED_LICENSES) return;
+
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (entry.expiresAtMs <= now) cache.delete(key);
+  }
+
+  // Map iterates in insertion order, so this drops the oldest first.
+  for (const key of cache.keys()) {
+    if (cache.size < MAX_CACHED_LICENSES) break;
+    cache.delete(key);
+  }
+}
 
 /**
  * Service for discovering and invoking UiPath Coded Functions
@@ -37,6 +101,25 @@ const MAX_SUGGESTED_NAMES = 20;
 export class FunctionService extends FolderScopedService implements FunctionServiceModel {
   /** Folder ID → folder key (GUID); folder keys are immutable, so cache hits stay valid. */
   private readonly folderKeyCache = new Map<number, string>();
+
+  /** Caller identity → its resolved or in-flight license acquisition. */
+  private get licenseCache(): Map<string, LicenseCacheEntry> {
+    return getLicenseCache();
+  }
+
+  /** Tenant this service talks to; scopes the shared license cache. */
+  private readonly tenantScope: string;
+
+  /**
+   * Creates an instance of the Functions service.
+   *
+   * @param instance - UiPath SDK instance providing authentication and configuration
+   */
+  constructor(instance: IUiPath) {
+    super(instance);
+    const { config } = SDKInternalsRegistry.get(instance);
+    this.tenantScope = `${config.orgName}/${config.tenantName}`;
+  }
 
   @track('Functions.GetAll')
   async getAll<T extends FunctionGetAllOptions = FunctionGetAllOptions>(
@@ -82,18 +165,100 @@ export class FunctionService extends FolderScopedService implements FunctionServ
     >;
   }
 
+  @track('Functions.AcquireLicense')
+  async acquireLicense(options?: FunctionAcquireLicenseOptions): Promise<StudioWebLicense> {
+    return this.resolveLicense(options?.refresh ?? false);
+  }
+
   @track('Functions.Invoke')
   async invoke<TInput extends object = Record<string, unknown>, TOutput = unknown>(
     func: FunctionRef,
     input?: TInput,
     options?: FunctionInvokeOptions
   ): Promise<TOutput> {
-    // jobKey governs only the invocation leg — keep it out of the folder-scoped
-    // discovery lookup, which would forward it as a query param.
-    const { jobKey, ...folderOptions } = options ?? {};
-    const fn = await this.findByName(func.name, folderOptions);
+    // jobKey and refreshLicense govern only the invocation leg — keep them out of
+    // the folder-scoped discovery lookup, which would forward them as query
+    // params.
+    const { jobKey, refreshLicense = false, ...folderOptions } = options ?? {};
+
+    // Licensing and the name lookup are independent, so run them together: only
+    // the slower of the two is paid. `allSettled` rather than `all` so a failure
+    // in one still observes the other — an unobserved rejection can take down a
+    // process configured to treat them as fatal.
+    const [licensing, lookup] = await Promise.allSettled([
+      this.resolveLicense(refreshLicense),
+      this.findByName(func.name, folderOptions),
+    ]);
+
+    // Licensing is a precondition, not an optimisation: acquiring is what
+    // provisions the personal robot the invocation runs on. Without it the
+    // invocation fails anyway, further in, as "no personal robot configured" —
+    // so surface the licensing failure instead of that.
+    if (licensing.status === 'rejected') throw licensing.reason;
+    if (lookup.status === 'rejected') throw lookup.reason;
+
+    const fn = lookup.value;
     const folderKey = await this.resolveInvokeFolderKey(fn, folderOptions);
     return this.invokeFunction<TOutput>(fn, folderKey, input ?? {}, jobKey);
+  }
+
+
+
+  /**
+   * Returns a license for the caller, reusing a cached one when still fresh.
+   *
+   * Shared by {@link invoke} and {@link acquireLicense} so only one `@track`
+   * decorator fires per call — a tracked method calling another tracked one
+   * would double-count the telemetry.
+   */
+  private async resolveLicense(refresh: boolean): Promise<StudioWebLicense> {
+    const cacheKey = await this.licenseCacheKey();
+    const cache = this.licenseCache;
+    const now = Date.now();
+
+    if (!refresh) {
+      const cached = cache.get(cacheKey);
+      // Awaiting a pending entry is the point: concurrent invokes share one
+      // round trip rather than each issuing their own.
+      if (cached && cached.expiresAtMs > now) return cached.acquisition;
+    }
+
+    const entry: LicenseCacheEntry = {
+      acquisition: this.requestLicense(),
+      // Optimistic until the real expiry arrives, so a pending entry is never
+      // read as stale by a concurrent caller.
+      expiresAtMs: now + DEFAULT_LICENSE_TTL_MS,
+    };
+    evictIfFull(cache);
+    cache.set(cacheKey, entry);
+
+    try {
+      const license = await entry.acquisition;
+      entry.expiresAtMs = licenseExpiryMs(license.expiresTime) ?? now + DEFAULT_LICENSE_TTL_MS;
+      return license;
+    } catch (error) {
+      // Never cache a rejection — the next call must retry, not replay it.
+      if (cache.get(cacheKey) === entry) cache.delete(cacheKey);
+      throw error;
+    }
+  }
+
+  /** Performs the acquisition. Takes no body and is not folder-scoped. */
+  private async requestLicense(): Promise<StudioWebLicense> {
+    const response = await this.post<RawStudioWebLicenseResponse>(STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE);
+    return toStudioWebLicense(response.data);
+  }
+
+  /**
+   * Identifies the caller. Prefers the token's `sub` so the entry survives a
+   * token refresh; opaque tokens fall back to the token itself.
+   */
+  private async licenseCacheKey(): Promise<string> {
+    const token = await this.getValidAuthToken();
+    // Tenant is in the key because the cache outlives any one service instance:
+    // without it, two tenants could share a license.
+    const identity = extractUserIdFromToken(token) || token;
+    return `${this.tenantScope}:${identity}`;
   }
 
   /**
@@ -233,6 +398,43 @@ export class FunctionService extends FolderScopedService implements FunctionServ
       folderId: trigger.organizationUnitId,
     };
   }
+}
+
+
+/**
+ * Maps the raw acquisition response to the SDK shape, folding in the token's
+ * claims. A token the SDK cannot read costs only the derived fields.
+ *
+ * @internal
+ */
+export function toStudioWebLicense(raw: RawStudioWebLicenseResponse): StudioWebLicense {
+  const claims = decodeJwtClaims<StudioWebLicenseTokenClaims>(raw.licenseToken);
+
+  return {
+    robotType: raw.robotType,
+    robotTypes: raw.robotTypes,
+    isLicensed: raw.isLicensed,
+    startedTime: raw.started,
+    expiresTime: claims?.exp ? new Date(claims.exp * 1000).toISOString() : undefined,
+    licenseTier: claims?.ubl,
+    licensedUnits: claims?.lu,
+  };
+}
+
+/**
+ * Epoch milliseconds at which a license should be renewed, from its expiry.
+ * Returns `undefined` when the license carries none, costing only the
+ * fallback lifetime.
+ *
+ * @internal
+ */
+export function licenseExpiryMs(expiresTime?: string): number | undefined {
+  if (!expiresTime) return undefined;
+
+  const expiresAt = new Date(expiresTime).getTime();
+  if (Number.isNaN(expiresAt)) return undefined;
+
+  return expiresAt - LICENSE_EXPIRY_SKEW_MS;
 }
 
 /** Serializes function input for GET invocations (query-string transport). */

--- a/src/services/orchestrator/functions/functions.ts
+++ b/src/services/orchestrator/functions/functions.ts
@@ -42,7 +42,12 @@ import type { IUiPath } from '../../../core/types';
 /** Cap on the function names listed when a name lookup misses. */
 const MAX_SUGGESTED_NAMES = 20;
 
-/** Fallback TTL when a license token carries no readable `exp`. */
+/**
+ * How long a license is reused when it states no expiry of its own — not every
+ * grant carries a token to read one from. Short, so a license the SDK cannot
+ * reason about is re-checked soon; long enough that a burst still costs one
+ * acquisition.
+ */
 const DEFAULT_LICENSE_TTL_MS = 5 * 60 * 1000;
 
 /** Renew slightly early so an invoke never races the expiry boundary. */
@@ -202,8 +207,6 @@ export class FunctionService extends FolderScopedService implements FunctionServ
     return this.invokeFunction<TOutput>(fn, folderKey, input ?? {}, jobKey);
   }
 
-
-
   /**
    * Returns a license for the caller, reusing a cached one when still fresh.
    *
@@ -229,7 +232,9 @@ export class FunctionService extends FolderScopedService implements FunctionServ
       // read as stale by a concurrent caller.
       expiresAtMs: now + DEFAULT_LICENSE_TTL_MS,
     };
-    evictIfFull(cache);
+    // Replacing an existing key does not grow the map, so no room is needed —
+    // evicting there would drop another caller's license for nothing.
+    if (!cache.has(cacheKey)) evictIfFull(cache);
     cache.set(cacheKey, entry);
 
     try {
@@ -399,7 +404,6 @@ export class FunctionService extends FolderScopedService implements FunctionServ
     };
   }
 }
-
 
 /**
  * Maps the raw acquisition response to the SDK shape, folding in the token's

--- a/src/utils/constants/endpoints/orchestrator.ts
+++ b/src/utils/constants/endpoints/orchestrator.ts
@@ -140,3 +140,15 @@ export const FUNCTION_ENDPOINTS = {
   INVOKE: (folderKey: string, processSlug: string, functionSlug: string) =>
     `${ORCHESTRATOR_BASE}/t/${folderKey}/${processSlug}/${functionSlug}`,
 } as const;
+
+/**
+ * Studio Web Licensing Endpoints
+ */
+export const STUDIO_WEB_LICENSE_ENDPOINTS = {
+  /**
+   * Acquires a license for the calling user, falling back to the free
+   * "Attended Studio Web" license. `POST` only, no request body, not
+   * folder-scoped.
+   */
+  ACQUIRE: `${ORCHESTRATOR_BASE}/api/StudioWeb/AcquireLicense`,
+} as const;

--- a/src/utils/encoding/jwt.ts
+++ b/src/utils/encoding/jwt.ts
@@ -17,6 +17,27 @@ function base64UrlToBase64(value: string): string {
 }
 
 /**
+ * Decodes a JWT payload without verifying its signature. Returns `undefined`
+ * for opaque (non-JWT) tokens and malformed payloads, so callers reading
+ * informational claims can degrade instead of failing.
+ *
+ * @param token - The token whose payload should be decoded
+ * @returns The decoded claims, or `undefined` if the payload cannot be read
+ */
+export function decodeJwtClaims<T = Record<string, unknown>>(token: string): T | undefined {
+  try {
+    const payload = token?.split('.')[1];
+    if (!payload) {
+      return undefined;
+    }
+
+    return JSON.parse(decodeBase64(base64UrlToBase64(payload))) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Extracts the user id (`sub` claim) from a JWT access token payload.
  * Returns an empty string for opaque (non-JWT) tokens or malformed payloads.
  *
@@ -24,16 +45,6 @@ function base64UrlToBase64(value: string): string {
  * @returns The user id, or an empty string if it cannot be extracted
  */
 export function extractUserIdFromToken(token: string): string {
-  try {
-    const payload = token.split('.')[1];
-    if (!payload) {
-      return '';
-    }
-
-    const claims = JSON.parse(decodeBase64(base64UrlToBase64(payload))) as Record<string, unknown>;
-    const sub = claims['sub'];
-    return typeof sub === 'string' && sub ? sub : '';
-  } catch {
-    return '';
-  }
+  const sub = decodeJwtClaims(token)?.['sub'];
+  return typeof sub === 'string' && sub ? sub : '';
 }

--- a/src/utils/encoding/jwt.ts
+++ b/src/utils/encoding/jwt.ts
@@ -24,7 +24,7 @@ function base64UrlToBase64(value: string): string {
  * @param token - The token whose payload should be decoded
  * @returns The decoded claims, or `undefined` if the payload cannot be read
  */
-export function decodeJwtClaims<T = Record<string, unknown>>(token: string): T | undefined {
+export function decodeJwtClaims<T = Record<string, unknown>>(token?: string | null): T | undefined {
   try {
     const payload = token?.split('.')[1];
     if (!payload) {

--- a/tests/integration/shared/orchestrator/functions.integration.test.ts
+++ b/tests/integration/shared/orchestrator/functions.integration.test.ts
@@ -157,4 +157,23 @@ describe.each(modes)('Functions - Integration Tests [%s]', (mode) => {
       expect(second).toBeDefined();
     });
   });
+
+  describe('acquireLicense', () => {
+    it('should return the license in the transformed SDK shape', async () => {
+      const license = await functions.acquireLicense({ refresh: true });
+
+      expect(license.isLicensed).toBe(true);
+      expect(typeof license.robotType).toBe('string');
+      expect(Array.isArray(license.robotTypes)).toBe(true);
+      // Renamed from the wire field `started`
+      expect(typeof license.startedTime).toBe('string');
+
+      // The wire names must not survive the transform, and the license token is
+      // credential-shaped, so it must not reach the SDK shape at all
+      expect('started' in license).toBe(false);
+      expect('ubl' in license).toBe(false);
+      expect('lu' in license).toBe(false);
+      expect('licenseToken' in license).toBe(false);
+    });
+  });
 });

--- a/tests/integration/shared/orchestrator/functions.integration.test.ts
+++ b/tests/integration/shared/orchestrator/functions.integration.test.ts
@@ -127,5 +127,34 @@ describe.each(modes)('Functions - Integration Tests [%s]', (mode) => {
 
       expect(output).toBeDefined();
     });
+
+    it('should invoke with a freshly acquired license', async () => {
+      // Licensing is always applied; refreshLicense forces a new acquisition
+      // rather than reusing the one already held for this user.
+      const output = await functions.invoke<Record<string, unknown>, unknown>(
+        { name: functionName },
+        {},
+        { folderId, refreshLicense: true },
+      );
+
+      expect(output).toBeDefined();
+    });
+
+    it('should reuse the acquired license across invocations', async () => {
+      // Second invocation is served from the license cache; both must succeed.
+      const first = await functions.invoke<Record<string, unknown>, unknown>(
+        { name: functionName },
+        {},
+        { folderId, refreshLicense: true },
+      );
+      const second = await functions.invoke<Record<string, unknown>, unknown>(
+        { name: functionName },
+        {},
+        { folderId },
+      );
+
+      expect(first).toBeDefined();
+      expect(second).toBeDefined();
+    });
   });
 });

--- a/tests/unit/models/orchestrator/functions.test.ts
+++ b/tests/unit/models/orchestrator/functions.test.ts
@@ -13,6 +13,7 @@ describe('Function Models Unit Tests', () => {
     mockService = {
       getAll: vi.fn(),
       invoke: vi.fn(),
+      acquireLicense: vi.fn(),
     };
   });
 

--- a/tests/unit/services/orchestrator/functions.test.ts
+++ b/tests/unit/services/orchestrator/functions.test.ts
@@ -1,10 +1,16 @@
 // ===== IMPORTS =====
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { FunctionService } from '../../../../src/services/orchestrator/functions/functions';
+import {
+  FunctionService,
+  clearLicenseCache,
+  licenseExpiryMs,
+  MAX_CACHED_LICENSES,
+} from '../../../../src/services/orchestrator/functions/functions';
 import { ApiClient } from '../../../../src/core/http/api-client';
 import { PaginationHelpers } from '../../../../src/utils/pagination/helpers';
 import {
   createMockRawFunctionTrigger,
+  createMockRawStudioWebLicense,
   createMockTransformedFunctionCollection,
 } from '../../../utils/mocks/functions';
 import { createServiceTestDependencies, createMockApiClient } from '../../../utils/setup';
@@ -13,8 +19,8 @@ import { FunctionGetAllOptions, FunctionHttpMethod } from '../../../../src/model
 import { FunctionGetResponse } from '../../../../src/models/orchestrator/functions.models';
 import { PaginatedResponse } from '../../../../src/utils/pagination';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
-import { FUNCTION_TEST_CONSTANTS } from '../../../utils/constants/functions';
-import { FUNCTION_ENDPOINTS, FOLDER_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import { FUNCTION_TEST_CONSTANTS, FUNCTION_LICENSE_TEST_CONSTANTS } from '../../../utils/constants/functions';
+import { FUNCTION_ENDPOINTS, FOLDER_ENDPOINTS, STUDIO_WEB_LICENSE_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { FOLDER_ID, FOLDER_KEY, JOB_KEY } from '../../../../src/utils/constants/headers';
 import { ValidationError, NotFoundError } from '../../../../src/core/errors';
 
@@ -39,6 +45,10 @@ describe('FunctionService Unit Tests', () => {
     vi.mocked(ApiClient).mockImplementation(function () { return mockApiClient; });
 
     vi.mocked(PaginationHelpers.getAll).mockReset();
+
+    // The license cache is process-wide by design, so it survives between tests
+    // unless cleared — otherwise one case inherits another's licenses.
+    clearLicenseCache();
 
     functionService = new FunctionService(instance);
   });
@@ -219,6 +229,25 @@ describe('FunctionService Unit Tests', () => {
   });
 
   describe('invoke', () => {
+    // Warm the license cache with a throwaway invocation, so the mocks in each
+    // test line up with the invocation legs alone. The license leg has its own
+    // describe block below.
+    beforeEach(async () => {
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+      mockApiClient.post.mockImplementation((endpoint: string) =>
+        Promise.resolve(
+          endpoint === STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE
+            ? createMockRawStudioWebLicense()
+            : FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT
+        )
+      );
+      await functionService.invoke({ name: FUNCTION_TEST_CONSTANTS.NAME }, FUNCTION_TEST_CONSTANTS.INVOKE_INPUT, {
+        folderKey: FUNCTION_TEST_CONSTANTS.FOLDER_KEY,
+      });
+      mockApiClient.post.mockReset();
+      mockApiClient.get.mockReset();
+    });
+
     it('should look up the function, resolve the folder key, and post the input', async () => {
       mockApiClient.get
         .mockResolvedValueOnce({ value: [createMockRawFunctionTrigger()] })
@@ -341,6 +370,8 @@ describe('FunctionService Unit Tests', () => {
       const { instance } = createServiceTestDependencies({ folderKey: FUNCTION_TEST_CONSTANTS.FOLDER_KEY });
       const service = new FunctionService(instance);
 
+      // No separate warm-up needed: the license cache is shared across service
+      // instances, so the one warmed above already covers this service.
       mockApiClient.get.mockResolvedValueOnce({ value: [createMockRawFunctionTrigger()] });
       mockApiClient.post.mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
 
@@ -492,6 +523,351 @@ describe('FunctionService Unit Tests', () => {
           { folderId: TEST_CONSTANTS.FOLDER_ID }
         )
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe('license acquisition', () => {
+    /** Queues the GETs an invocation makes: the name lookup, then the folder key. */
+    const mockInvocationLookups = () => {
+      mockApiClient.get
+        .mockResolvedValueOnce({ value: [createMockRawFunctionTrigger()] })
+        .mockResolvedValueOnce({ Key: FUNCTION_TEST_CONSTANTS.FOLDER_KEY });
+    };
+
+    const licenseCalls = () =>
+      mockApiClient.post.mock.calls.filter(
+        ([endpoint]) => endpoint === STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE
+      );
+
+    /** Invokes with the folder key, which needs no Folders({id}) lookup. */
+    const invoke = (options: Record<string, unknown> = {}) =>
+      functionService.invoke({ name: FUNCTION_TEST_CONSTANTS.NAME }, FUNCTION_TEST_CONSTANTS.INVOKE_INPUT, {
+        folderKey: FUNCTION_TEST_CONSTANTS.FOLDER_KEY,
+        ...options,
+      });
+
+    /** Whoever the current token belongs to; each caller gets its own cache entry. */
+    let caller = '';
+
+    const invokeAs = (identity: string) => {
+      caller = identity;
+      return invoke();
+    };
+
+    /**
+     * Serves a token per caller so invocations do not share a cache entry.
+     * `expiredFor` hands that one caller a license that is already expired.
+     */
+    const mockDistinctCallers = (expiredFor?: string) => {
+      const staleSeconds = Math.floor(Date.now() / 1000) - 3600;
+      mockApiClient.getValidToken.mockImplementation(() => Promise.resolve(caller));
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+      mockApiClient.post.mockImplementation((endpoint: string) =>
+        Promise.resolve(
+          endpoint === STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE
+            ? createMockRawStudioWebLicense({}, caller === expiredFor ? { exp: staleSeconds } : {})
+            : FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT
+        )
+      );
+    };
+
+    /** Fills the cache to its cap, one entry per caller. */
+    const fillCache = async () => {
+      for (let i = 0; i < MAX_CACHED_LICENSES; i++) await invokeAs(`user-${i}`);
+    };
+
+    it('should acquire a license before invoking', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce(createMockRawStudioWebLicense())
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+      mockInvocationLookups();
+
+      const result = await functionService.invoke(
+        { name: FUNCTION_TEST_CONSTANTS.NAME },
+        FUNCTION_TEST_CONSTANTS.INVOKE_INPUT,
+        { folderId: TEST_CONSTANTS.FOLDER_ID }
+      );
+
+      // Bodyless, and not folder-scoped
+      expect(mockApiClient.post).toHaveBeenNthCalledWith(
+        1,
+        STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE,
+        undefined,
+        expect.any(Object)
+      );
+      expect(result).toEqual(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+    });
+
+    it('should not send refreshLicense to the discovery lookup as a query param', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce(createMockRawStudioWebLicense())
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await invoke({ refreshLicense: true });
+
+      expect(mockApiClient.get).toHaveBeenNthCalledWith(
+        1,
+        FUNCTION_ENDPOINTS.GET_ALL,
+        expect.objectContaining({
+          params: expect.not.objectContaining({ refreshLicense: expect.anything() }),
+        })
+      );
+    });
+
+    it('should reuse a cached license across invocations', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce(createMockRawStudioWebLicense())
+        .mockResolvedValue(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await invoke();
+      await invoke();
+      await invoke();
+
+      expect(licenseCalls()).toHaveLength(1);
+    });
+
+    it('should force a fresh acquisition when refreshLicense is set', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce(createMockRawStudioWebLicense())
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT)
+        .mockResolvedValueOnce(createMockRawStudioWebLicense())
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await invoke();
+      await invoke({ refreshLicense: true });
+
+      expect(licenseCalls()).toHaveLength(2);
+    });
+
+    it('should re-acquire once a cached license has expired', async () => {
+      // A license that expired an hour ago must not be served from the cache
+      const staleSeconds = Math.floor(Date.now() / 1000) - 3600;
+      mockApiClient.post
+        .mockResolvedValueOnce(createMockRawStudioWebLicense({}, { exp: staleSeconds }))
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT)
+        .mockResolvedValueOnce(createMockRawStudioWebLicense())
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await invoke();
+      await invoke();
+
+      expect(licenseCalls()).toHaveLength(2);
+    });
+
+    it('should collapse concurrent invocations into a single acquisition', async () => {
+      mockApiClient.post.mockImplementation((endpoint: string) =>
+        Promise.resolve(
+          endpoint === STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE
+            ? createMockRawStudioWebLicense()
+            : FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT
+        )
+      );
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await Promise.all([invoke(), invoke(), invoke()]);
+
+      expect(licenseCalls()).toHaveLength(1);
+    });
+
+    it('should not invoke when the license cannot be acquired', async () => {
+      mockApiClient.post.mockRejectedValueOnce(
+        createMockError(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE)
+      );
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await expect(invoke()).rejects.toThrow(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE);
+
+      // Only the acquisition was attempted — the invocation itself never went out
+      expect(licenseCalls()).toHaveLength(1);
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('should surface the licensing failure rather than a name lookup failure', async () => {
+      // Acquiring provisions the robot the invocation runs on, so licensing is
+      // the precondition and its error is the more useful one to report.
+      mockApiClient.post.mockRejectedValueOnce(
+        createMockError(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE)
+      );
+      mockApiClient.get.mockRejectedValue(createMockError(TEST_CONSTANTS.ERROR_MESSAGE));
+
+      await expect(invoke()).rejects.toThrow(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE);
+    });
+
+    it('should not cache a failed acquisition', async () => {
+      mockApiClient.post
+        .mockRejectedValueOnce(createMockError(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE))
+        .mockResolvedValueOnce(createMockRawStudioWebLicense())
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await expect(invoke()).rejects.toThrow(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE);
+      // The failure was not cached, so the next invocation acquired afresh
+      await expect(invoke()).resolves.toEqual(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+
+      expect(licenseCalls()).toHaveLength(2);
+    });
+
+    it('should share the cache across separately constructed services', async () => {
+      // Consumers routinely build a service per request or per render. If the
+      // cache were an instance field, each would start empty and the licensing
+      // round trip would be paid every time — the case this cache exists for.
+      mockApiClient.post.mockImplementation((endpoint: string) =>
+        Promise.resolve(
+          endpoint === STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE
+            ? createMockRawStudioWebLicense()
+            : FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT
+        )
+      );
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+      const { instance } = createServiceTestDependencies();
+      const scope = { folderKey: FUNCTION_TEST_CONSTANTS.FOLDER_KEY };
+      const ref = { name: FUNCTION_TEST_CONSTANTS.NAME };
+
+      await new FunctionService(instance).invoke(ref, FUNCTION_TEST_CONSTANTS.INVOKE_INPUT, scope);
+      await new FunctionService(instance).invoke(ref, FUNCTION_TEST_CONSTANTS.INVOKE_INPUT, scope);
+
+      expect(licenseCalls()).toHaveLength(1);
+    });
+
+    it('should not share a license between tenants', async () => {
+      mockApiClient.post.mockImplementation((endpoint: string) =>
+        Promise.resolve(
+          endpoint === STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE
+            ? createMockRawStudioWebLicense()
+            : FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT
+        )
+      );
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+      const scope = { folderKey: FUNCTION_TEST_CONSTANTS.FOLDER_KEY };
+      const ref = { name: FUNCTION_TEST_CONSTANTS.NAME };
+
+      const tenantA = createServiceTestDependencies({ tenantName: 'TenantA' });
+      const tenantB = createServiceTestDependencies({ tenantName: 'TenantB' });
+      await new FunctionService(tenantA.instance).invoke(ref, FUNCTION_TEST_CONSTANTS.INVOKE_INPUT, scope);
+      await new FunctionService(tenantB.instance).invoke(ref, FUNCTION_TEST_CONSTANTS.INVOKE_INPUT, scope);
+
+      // Same user, different tenant — the second must not reuse the first
+      expect(licenseCalls()).toHaveLength(2);
+    });
+
+    it('should still invoke when the license token cannot be decoded', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce(createMockRawStudioWebLicense({ licenseToken: 'not-a-jwt' }))
+        .mockResolvedValueOnce(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      const result = await invoke();
+
+      expect(result).toEqual(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+    });
+
+    it('should evict the oldest entry once the cache is full', async () => {
+      mockDistinctCallers();
+      await fillCache();
+      const atCap = licenseCalls().length;
+
+      // One caller past the cap: room is made by dropping the oldest entry
+      await invokeAs(`user-${MAX_CACHED_LICENSES}`);
+      expect(licenseCalls()).toHaveLength(atCap + 1);
+
+      // The newest caller is still cached, so no further acquisition
+      await invokeAs(`user-${MAX_CACHED_LICENSES}`);
+      expect(licenseCalls()).toHaveLength(atCap + 1);
+
+      // The oldest was evicted, so it has to acquire again
+      await invokeAs('user-0');
+      expect(licenseCalls()).toHaveLength(atCap + 2);
+    });
+
+    it('should drop expired entries before evicting by age', async () => {
+      // Mid-cache, so evicting it cannot be confused with evicting the oldest
+      const expiredFor = `user-${Math.floor(MAX_CACHED_LICENSES / 2)}`;
+      mockDistinctCallers(expiredFor);
+      await fillCache();
+      const atCap = licenseCalls().length;
+
+      await invokeAs(`user-${MAX_CACHED_LICENSES}`);
+
+      // The expired entry made the room, so the oldest live one survived
+      await invokeAs('user-0');
+      expect(licenseCalls()).toHaveLength(atCap + 1);
+    });
+
+    it('should acquire a license without invoking a function', async () => {
+      mockApiClient.post.mockResolvedValueOnce(createMockRawStudioWebLicense());
+
+      const license = await functionService.acquireLicense();
+
+      expect(license.isLicensed).toBe(true);
+      expect(license.licenseTier).toBe(FUNCTION_LICENSE_TEST_CONSTANTS.LICENSE_TIER);
+      expect(license.startedTime).toBe(FUNCTION_LICENSE_TEST_CONSTANTS.STARTED);
+      // Only the acquisition — nothing was invoked
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reuse the cached license when acquiring directly', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawStudioWebLicense());
+
+      await functionService.acquireLicense();
+      await functionService.acquireLicense();
+
+      expect(licenseCalls()).toHaveLength(1);
+    });
+
+    it('should keep a refreshed license when an earlier acquisition then fails', async () => {
+      let rejectFirst!: (error: Error) => void;
+      let licenseAttempt = 0;
+      mockApiClient.post.mockImplementation((endpoint: string) => {
+        if (endpoint !== STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE) {
+          return Promise.resolve(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+        }
+        licenseAttempt += 1;
+        return licenseAttempt === 1
+          ? new Promise((_resolve, reject) => { rejectFirst = reject; })
+          : Promise.resolve(createMockRawStudioWebLicense());
+      });
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      const failing = invoke();
+      await vi.waitFor(() => expect(licenseCalls()).toHaveLength(1));
+
+      // A refresh replaces the pending entry before the first one settles
+      await invoke({ refreshLicense: true });
+      rejectFirst(createMockError(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE));
+      await expect(failing).rejects.toThrow(FUNCTION_LICENSE_TEST_CONSTANTS.ERROR_LICENSE_UNAVAILABLE);
+
+      // The failure must not evict the newer license, so nothing re-acquires
+      await invoke();
+      expect(licenseCalls()).toHaveLength(2);
+    });
+
+    it('should acquire a fresh license when asked to refresh', async () => {
+      mockApiClient.post.mockResolvedValue(createMockRawStudioWebLicense());
+
+      await functionService.acquireLicense();
+      await functionService.acquireLicense({ refresh: true });
+
+      expect(licenseCalls()).toHaveLength(2);
+    });
+  });
+
+  describe('licenseExpiryMs', () => {
+    it('should return undefined when the license carries no expiry', () => {
+      expect(licenseExpiryMs()).toBeUndefined();
+    });
+
+    it('should return undefined when the expiry cannot be parsed', () => {
+      expect(licenseExpiryMs('not-a-date')).toBeUndefined();
+    });
+
+    it('should renew slightly before the stated expiry', () => {
+      const expiresTime = '2026-08-18T12:00:00.000Z';
+
+      expect(licenseExpiryMs(expiresTime)).toBeLessThan(Date.parse(expiresTime));
     });
   });
 });

--- a/tests/unit/services/orchestrator/functions.test.ts
+++ b/tests/unit/services/orchestrator/functions.test.ts
@@ -765,6 +765,53 @@ describe('FunctionService Unit Tests', () => {
       expect(result).toEqual(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
     });
 
+    it('should still invoke when the platform issues no license token', async () => {
+      mockApiClient.post.mockImplementation((endpoint: string) =>
+        Promise.resolve(
+          endpoint === STUDIO_WEB_LICENSE_ENDPOINTS.ACQUIRE
+            ? createMockRawStudioWebLicense({ licenseToken: null })
+            : FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT
+        )
+      );
+      mockApiClient.get.mockResolvedValue({ value: [createMockRawFunctionTrigger()] });
+
+      await expect(invoke()).resolves.toEqual(FUNCTION_TEST_CONSTANTS.INVOKE_OUTPUT);
+
+      // No token means no expiry to read, so the fallback lifetime applies and a
+      // second invocation still reuses the license rather than re-acquiring
+      await invoke();
+      expect(licenseCalls()).toHaveLength(1);
+    });
+
+    it('should return the license with wire fields renamed to the SDK shape', async () => {
+      mockApiClient.post.mockResolvedValueOnce(createMockRawStudioWebLicense());
+
+      const license = await functionService.acquireLicense();
+
+      expect(license.startedTime).toBe(FUNCTION_LICENSE_TEST_CONSTANTS.STARTED);
+      expect(license.licenseTier).toBe(FUNCTION_LICENSE_TEST_CONSTANTS.LICENSE_TIER);
+      expect(license.licensedUnits).toEqual([...FUNCTION_LICENSE_TEST_CONSTANTS.LICENSED_UNITS]);
+      expect(license.robotType).toBe(FUNCTION_LICENSE_TEST_CONSTANTS.ROBOT_TYPE);
+
+      // The wire names must not survive the transform, and the token itself is
+      // credential-shaped, so it must not reach the SDK shape at all
+      expect('started' in license).toBe(false);
+      expect('ubl' in license).toBe(false);
+      expect('lu' in license).toBe(false);
+      expect('licenseToken' in license).toBe(false);
+    });
+
+    it('should report no tier or expiry when the platform issues no token', async () => {
+      mockApiClient.post.mockResolvedValueOnce(createMockRawStudioWebLicense({ licenseToken: null }));
+
+      const license = await functionService.acquireLicense();
+
+      expect(license.isLicensed).toBe(true);
+      expect(license.expiresTime).toBeUndefined();
+      expect(license.licenseTier).toBeUndefined();
+      expect(license.licensedUnits).toBeUndefined();
+    });
+
     it('should evict the oldest entry once the cache is full', async () => {
       mockDistinctCallers();
       await fillCache();

--- a/tests/utils/constants/functions.ts
+++ b/tests/utils/constants/functions.ts
@@ -19,3 +19,21 @@ export const FUNCTION_TEST_CONSTANTS = {
   INVOKE_OUTPUT: { message: 'Hello, Alice!' },
   JOB_KEY: '7f3f4bd6-6f2e-4c5a-9d38-6f3f0a1b2c3d',
 } as const;
+
+/**
+ * Test constants for the license acquisition that precedes an invocation.
+ * Values mirror a live `POST /api/StudioWeb/AcquireLicense` response.
+ */
+export const FUNCTION_LICENSE_TEST_CONSTANTS = {
+  ROBOT_TYPE: 'StudioX',
+  ROBOT_TYPES: ['Attended', 'StudioX'],
+  /** ISO 8601 session start, distinctive so the `started` → `startedTime` rename is verifiable. */
+  STARTED: '2026-08-11T13:24:05.2768387Z',
+  /** Base license tier of a licensed user, from the token's `ubl` claim. */
+  LICENSE_TIER: 'BASICNU',
+  /** Licensed units, from the token's `lu` claim. */
+  LICENSED_UNITS: ['APPS', 'ATTR', 'STDW', 'STDX'],
+  /** Orchestrator issues license tokens valid for two hours. */
+  TTL_SECONDS: 7200,
+  ERROR_LICENSE_UNAVAILABLE: 'No license available for this user',
+} as const;

--- a/tests/utils/mocks/functions.ts
+++ b/tests/utils/mocks/functions.ts
@@ -1,9 +1,50 @@
 import { RawFunctionGetResponse, FunctionHttpMethod } from '../../../src/models/orchestrator/functions.types';
+import { RawStudioWebLicenseResponse, StudioWebLicenseTokenClaims } from '../../../src/models/orchestrator/functions.internal-types';
 import { FunctionGetResponse } from '../../../src/models/orchestrator/functions.models';
 import { NonPaginatedResponse } from '../../../src/utils/pagination';
-import { FUNCTION_TEST_CONSTANTS } from '../constants/functions';
+import { FUNCTION_TEST_CONSTANTS, FUNCTION_LICENSE_TEST_CONSTANTS } from '../constants/functions';
 import { TEST_CONSTANTS } from '../constants/common';
 import { createMockBaseResponse, createMockCollection } from './core';
+
+/**
+ * Builds an unsigned license token carrying the given claims, in the shape
+ * Orchestrator issues: an empty header, a base64url payload, and no signature.
+ */
+export const createMockLicenseToken = (claims: StudioWebLicenseTokenClaims): string => {
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  return `e30.${payload}.`;
+};
+
+/**
+ * Creates a raw `POST /api/StudioWeb/AcquireLicense` response.
+ *
+ * The token's expiry is relative to now, so a mock license is live for the
+ * duration of a test rather than instantly stale.
+ */
+export const createMockRawStudioWebLicense = (
+  overrides: Partial<RawStudioWebLicenseResponse> = {},
+  claimOverrides: Partial<StudioWebLicenseTokenClaims> = {}
+): RawStudioWebLicenseResponse => {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  return {
+    robotType: FUNCTION_LICENSE_TEST_CONSTANTS.ROBOT_TYPE,
+    robotTypes: [...FUNCTION_LICENSE_TEST_CONSTANTS.ROBOT_TYPES],
+    externalLicense: false,
+    isLicensed: true,
+    started: FUNCTION_LICENSE_TEST_CONSTANTS.STARTED,
+    lastUpdated: '0001-01-01T00:00:00Z',
+    licenseToken: createMockLicenseToken({
+      nbf: nowSeconds,
+      exp: nowSeconds + FUNCTION_LICENSE_TEST_CONSTANTS.TTL_SECONDS,
+      ubl: FUNCTION_LICENSE_TEST_CONSTANTS.LICENSE_TIER,
+      lu: [...FUNCTION_LICENSE_TEST_CONSTANTS.LICENSED_UNITS],
+      status: 'VALID',
+      ...claimOverrides,
+    }),
+    ...overrides,
+  };
+};
 
 /**
  * Creates a raw HttpTriggers row as the API returns it (PascalCase wire format,


### PR DESCRIPTION
Coded Apps do not require a user license, yet they need to run work on Orchestrator. functions.invoke() now calls POST /api/StudioWeb/AcquireLicense first, so Orchestrator acquires the caller's own license or falls back to the free Attended Studio Web one.

Only the success matters. Nothing from the response is sent to the function -- the call is a precondition that provisions the personal robot the invocation requires, which is why a service principal fails with "Cannot find a personal robot configured". The only value read is the license expiry, used as the cache TTL.

Measured on alpha across four license tiers (none / basic / plus / pro): the acquisition is a flat 268-443 ms regardless of tier. Uncached it takes a ~890 ms invoke to ~1160 ms; cached it costs nothing.

- TTL comes from the license token's own exp claim, not a hardcoded guess.
- The cache is process-wide, keyed by tenant + user. Consumers routinely build a service per request or per render, and an instance field would start empty each time -- paying the round trip on every invocation, which is what caching is meant to avoid. Tenant is in the key because the cache outlives any one service instance.
- Concurrent invocations collapse to one acquisition: the pending promise is cached, not just the resolved value.
- A failed acquisition is never cached, so the next call retries.
- Bounded at 500 entries so a long-lived server does not accumulate one per user it has ever served.
- In memory only: coded apps in an org share one origin, so persisting would share the cache across every app, and a license token is credential-shaped.
- Licensing runs in parallel with the name lookup, which needs no license, so only the slower of the two is paid.
- Fail-open: a licensing failure warns and invokes anyway.

refreshLicense forces a fresh acquisition and is the only new public option.