### PR TITLE
fix(docs): bump mkdocs-material so pymdown-extensions 11 resolves

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ mkdocs==1.6.1
 mkdocs-autorefs==1.4.3
 mkdocs-get-deps==0.2.0
 mkdocs-llmstxt==0.3.1
-mkdocs-material==9.6.18
+mkdocs-material==9.7.7
 mkdocs-material-extensions==1.3.1
 mkdocstrings==0.30.0
 mkdocstrings-python==1.18.2


### PR DESCRIPTION
## What

Bumps `mkdocs-material` from `9.6.18` to `9.7.7` in `docs/requirements.txt`. One line; `pymdown-extensions` stays at `11.0.1`.

## Why

#650 bumped `pymdown-extensions` to `11.0.1`, but `mkdocs-material==9.6.18` declares:

    Requires-Dist: pymdown-extensions~=10.2

`~=10.2` means `>=10.2,<11`, so pip has two rules it cannot both satisfy and aborts before rendering anything:

    ERROR: Cannot install -r docs/requirements.txt (line 13) and pymdown-extensions==11.0.1
    because these package versions have conflicting dependencies.

    The conflict is caused by:
        The user requested pymdown-extensions==11.0.1
        mkdocs-material 9.6.18 depends on pymdown-extensions~=10.2
    ERROR: ResolutionImpossible

This breaks `Docs PR Preview` on every open PR, and main's own docs build — the *Install docs requirements* step never completes.

`mkdocs-material` 9.7.0 is the first release to relax the ceiling to `pymdown-extensions>=10.2`; 9.6.20, the last 9.6.x, still pins `~=10.2`. So no patch-level bump escapes this — the only ways out are downgrading `pymdown-extensions` below 11 or moving `mkdocs-material` to >= 9.7.0.