### PR TITLE
ci: enable maestro integration tests [APPS-35728]

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -84,6 +84,9 @@ jobs:
           echo "functions_test_function_name=${{ secrets.UIPATH_FUNCTIONS_TEST_FUNCTION_NAME_DEV || secrets.UIPATH_FUNCTIONS_TEST_FUNCTION_NAME }}" >> $GITHUB_OUTPUT
           echo "identity_test_user_id=${{ secrets.UIPATH_IDENTITY_TEST_USER_ID_DEV || secrets.UIPATH_IDENTITY_TEST_USER_ID }}" >> $GITHUB_OUTPUT
           echo "organization_id=${{ secrets.UIPATH_ORGANIZATION_ID_DEV || secrets.UIPATH_ORGANIZATION_ID }}" >> $GITHUB_OUTPUT
+          echo "maestro_test_process_key=${{ secrets.UIPATH_MAESTRO_TEST_PROCESS_KEY_DEV || secrets.UIPATH_MAESTRO_TEST_PROCESS_KEY }}" >> $GITHUB_OUTPUT
+          echo "maestro_test_case_process_key=${{ secrets.UIPATH_MAESTRO_TEST_CASE_PROCESS_KEY_DEV || secrets.UIPATH_MAESTRO_TEST_CASE_PROCESS_KEY }}" >> $GITHUB_OUTPUT
+          echo "maestro_test_completed_case_process_key=${{ secrets.UIPATH_MAESTRO_TEST_COMPLETED_CASE_PROCESS_KEY_DEV || secrets.UIPATH_MAESTRO_TEST_COMPLETED_CASE_PROCESS_KEY }}" >> $GITHUB_OUTPUT
 
       - name: Create Integration Test Configuration
         run: |
@@ -117,6 +120,9 @@ jobs:
           FUNCTIONS_TEST_FUNCTION_NAME=${{ steps.config.outputs.functions_test_function_name }}
           IDENTITY_TEST_USER_ID=${{ steps.config.outputs.identity_test_user_id }}
           UIPATH_ORGANIZATION_ID=${{ steps.config.outputs.organization_id }}
+          MAESTRO_TEST_PROCESS_KEY=${{ steps.config.outputs.maestro_test_process_key }}
+          MAESTRO_TEST_CASE_PROCESS_KEY=${{ steps.config.outputs.maestro_test_case_process_key }}
+          MAESTRO_TEST_COMPLETED_CASE_PROCESS_KEY=${{ steps.config.outputs.maestro_test_completed_case_process_key }}
           EOF
 
       - name: Run Integration Tests

--- a/tests/integration/config/test-config.ts
+++ b/tests/integration/config/test-config.ts
@@ -23,6 +23,19 @@ export interface IntegrationConfig {
   folderKey?: string;
   folderPath?: string;
   maestroTestProcessKey?: string;
+  /**
+   * Release key of a deployed case-management process used to self-seed a running case
+   * instance via Orchestrator jobs. Must be a case process that stays Running after start
+   * (e.g. one with a human task). The release key doubles as the Maestro processKey.
+   */
+  maestroCaseProcessKey?: string;
+  /**
+   * Release key of a deployed case-management process that runs to Completed without
+   * human interaction (e.g. timer-driven). Used to seed reopenable instances — reopen
+   * requires Completed status. Reopened instances do not re-complete on their own, so
+   * tests must close them afterwards.
+   */
+  maestroCompletedCaseProcessKey?: string;
   orchestratorTestProcessKey?: string;
   dataFabricTestEntityId?: string;
   dataFabricTestFolderEntityId?: string;
@@ -107,6 +120,8 @@ function validateConfig(rawConfig: Record<string, unknown>): IntegrationConfig {
     folderKey: typeof rawConfig.folderKey === 'string' ? rawConfig.folderKey : undefined,
     folderPath: typeof rawConfig.folderPath === 'string' ? rawConfig.folderPath : undefined,
     maestroTestProcessKey: typeof rawConfig.maestroTestProcessKey === 'string' ? rawConfig.maestroTestProcessKey : undefined,
+    maestroCaseProcessKey: typeof rawConfig.maestroCaseProcessKey === 'string' ? rawConfig.maestroCaseProcessKey : undefined,
+    maestroCompletedCaseProcessKey: typeof rawConfig.maestroCompletedCaseProcessKey === 'string' ? rawConfig.maestroCompletedCaseProcessKey : undefined,
     orchestratorTestProcessKey: typeof rawConfig.orchestratorTestProcessKey === 'string' ? rawConfig.orchestratorTestProcessKey : undefined,
     dataFabricTestEntityId: typeof rawConfig.dataFabricTestEntityId === 'string' ? rawConfig.dataFabricTestEntityId : undefined,
     dataFabricTestFolderEntityId: typeof rawConfig.dataFabricTestFolderEntityId === 'string' ? rawConfig.dataFabricTestFolderEntityId : undefined,
@@ -158,6 +173,8 @@ export function loadIntegrationConfig(): IntegrationConfig {
     folderKey: process.env.INTEGRATION_TEST_FOLDER_KEY || undefined,
     folderPath: process.env.INTEGRATION_TEST_FOLDER_PATH || undefined,
     maestroTestProcessKey: process.env.MAESTRO_TEST_PROCESS_KEY || undefined,
+    maestroCaseProcessKey: process.env.MAESTRO_TEST_CASE_PROCESS_KEY || undefined,
+    maestroCompletedCaseProcessKey: process.env.MAESTRO_TEST_COMPLETED_CASE_PROCESS_KEY || undefined,
     orchestratorTestProcessKey: process.env.ORCHESTRATOR_TEST_PROCESS_KEY || undefined,
     dataFabricTestEntityId: process.env.DATA_FABRIC_TEST_ENTITY_ID || undefined,
     dataFabricTestFolderEntityId: process.env.DATA_FABRIC_TEST_FOLDER_ENTITY_ID || undefined,

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -124,7 +124,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
           );
           return;
         }
-        console.log('Case instances retrieval failed:', error.message);
+        throw error;
       }
     });
 
@@ -147,7 +147,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
           );
           return;
         }
-        console.log('Case instances with limit failed:', error.message);
+        throw error;
       }
     });
 
@@ -179,7 +179,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
           );
           return;
         }
-        console.log('Case instances pagination failed:', error.message);
+        throw error;
       }
     });
   });
@@ -302,42 +302,49 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     });
   });
 
-  // pause must target a FRESHLY started instance: once the human task fully activates,
-  // PIMS keeps the instance in Pausing until the task settles (observed 90s+), while a
-  // fresh instance pauses within seconds. So this test seeds and cleans up its own
-  // instance instead of sharing the run's seeded one.
+  // pause → resume is self-restoring: the instance ends Running again for later tests.
+  // Resume is valid from both Pausing and Paused (verified against the live API), so the
+  // test does not wait for the Pausing→Paused transition — that transition is
+  // load-dependent and can hang while the case's human task is active.
   describe('pause and resume', () => {
     it('should pause a running case instance and resume it', async () => {
       const { caseInstances } = getServices();
 
-      const target = await seedRunningInstance();
+      const target = await resolveRunningInstance();
       if (!target) {
-        throw new Error(
-          'MAESTRO_TEST_CASE_PROCESS_KEY / folder config not set — cannot seed an instance for pause/resume'
-        );
+        throw new Error('No running case instance available — cannot test pause/resume');
       }
 
       const pauseResult = await caseInstances.pause(target.instanceId, target.folderKey);
       expect(pauseResult.success).toBe(true);
 
-      // Pausing is asynchronous; wait for the Paused state before resuming
-      let lastStatus = '';
+      // The pause takes effect asynchronously: status leaves Running for Pausing/Paused
+      let pausedStatus = '';
       for (let attempt = 0; attempt < 10; attempt++) {
-        await new Promise((resolve) => setTimeout(resolve, 3000));
         const current = await caseInstances.getById(target.instanceId, target.folderKey);
-        lastStatus = current.latestRunStatus;
-        if (lastStatus === InstanceStatus.PAUSED) {
+        pausedStatus = current.latestRunStatus;
+        if (pausedStatus === InstanceStatus.PAUSED || pausedStatus === InstanceStatus.PAUSING) {
           break;
         }
+        await new Promise((resolve) => setTimeout(resolve, 2000));
       }
-      expect(lastStatus).toBe(InstanceStatus.PAUSED);
+      expect([InstanceStatus.PAUSED, InstanceStatus.PAUSING]).toContain(pausedStatus);
 
       const resumeResult = await caseInstances.resume(target.instanceId, target.folderKey);
       expect(resumeResult.success).toBe(true);
 
-      // Cleanup: this test seeded its own instance
-      await caseInstances.close(target.instanceId, target.folderKey);
-    }, 180_000);
+      // The instance must return to Running so later tests can keep using it
+      let resumedStatus = '';
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const current = await caseInstances.getById(target.instanceId, target.folderKey);
+        resumedStatus = current.latestRunStatus;
+        if (resumedStatus === InstanceStatus.RUNNING) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+      expect(resumedStatus).toBe(InstanceStatus.RUNNING);
+    }, 60_000);
   });
 
   // Runs after pause/resume (see note there): the ad-hoc trigger spawns an in-flight task
@@ -457,8 +464,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
         });
 
         if (result.items.length === 0) {
-          console.log('No case instances available to validate structure');
-          return;
+          throw new Error('No case instances available — cannot validate instance structure');
         }
 
         const instance = result.items[0];
@@ -481,7 +487,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
           );
           return;
         }
-        console.log('Case instance structure validation failed:', error.message);
+        throw error;
       }
     });
   });

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import {
   getServices,
+  getTestConfig,
   setupUnifiedTests,
   InitMode,
 } from '../../config/unified-setup';
@@ -15,12 +16,96 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
   let testCaseInstanceId: string | null = null;
   let testCaseFolderKey: string | null = null;
 
+  // Instance seeded for this run via Orchestrator jobs (see beforeAll). Consumed by the
+  // close test or cleaned up in afterAll.
+  let seededInstance: { instanceId: string; folderKey: string } | null = null;
+
+  // Self-seeding: a deployed case process is also an Orchestrator release whose release
+  // key equals the Maestro processKey, and the started job's key is the case instanceId.
+  // Starting one removes the dependency on manually pre-seeded running instances.
+  // Returns null when the required config is not set.
+  const seedRunningInstance = async (): Promise<{
+    instanceId: string;
+    folderKey: string;
+  } | null> => {
+    const { processes, caseInstances } = getServices();
+    const config = getTestConfig();
+
+    if (!config.maestroCaseProcessKey || !config.folderId || !config.folderKey) {
+      return null;
+    }
+
+    const [job] = await processes.start(
+      { processKey: config.maestroCaseProcessKey },
+      { folderId: Number(config.folderId) }
+    );
+
+    // The case instance usually surfaces in PIMS within seconds; the window allows for
+    // occasional tenant slowness (polling exits as soon as the instance is Running)
+    for (let attempt = 0; attempt < 18; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+      try {
+        const instance = await caseInstances.getById(job.key, config.folderKey);
+        if (instance.latestRunStatus === InstanceStatus.RUNNING) {
+          return { instanceId: job.key, folderKey: config.folderKey };
+        }
+      } catch {
+        // not yet visible in PIMS
+      }
+    }
+    throw new Error('Seeded case instance did not reach Running state within 90s');
+  };
+
+  // Timer-case instance started at suite start for the reopen test. It completes in the
+  // background (~45s) while the earlier tests run, so reopen rarely has to wait.
+  let seededCompletedJobKey: string | null = null;
+
+  beforeAll(async () => {
+    const { processes } = getServices();
+    const config = getTestConfig();
+
+    // Fire-and-forget the reopen fixture first so its completion overlaps the suite
+    if (config.maestroCompletedCaseProcessKey && config.folderId) {
+      const [job] = await processes.start(
+        { processKey: config.maestroCompletedCaseProcessKey },
+        { folderId: Number(config.folderId) }
+      );
+      seededCompletedJobKey = job.key;
+    }
+
+    seededInstance = await seedRunningInstance();
+    if (!seededInstance) {
+      console.log(
+        'MAESTRO_TEST_CASE_PROCESS_KEY / folder config not set — running-instance tests ' +
+          'will fall back to pre-existing instances'
+      );
+    }
+  }, 120_000);
+
+  /** Prefers the instance seeded for this run; falls back to any running instance. */
+  const resolveRunningInstance = async (): Promise<{
+    instanceId: string;
+    folderKey: string;
+  } | null> => {
+    if (seededInstance) {
+      return seededInstance;
+    }
+    const { caseInstances } = getServices();
+    const instances = await caseInstances.getAll({ pageSize: 20 });
+    const found = instances.items.find(
+      (inst) => inst.latestRunStatus === InstanceStatus.RUNNING && inst.folderKey
+    );
+    return found ? { instanceId: found.instanceId, folderKey: found.folderKey } : null;
+  };
+
   describe('getAll', () => {
     it('should retrieve all case instances', async () => {
       const { caseInstances } = getServices();
 
       try {
-        const result = await caseInstances.getAll();
+        // Keep the page small: getAll enriches every returned instance with its case JSON
+        // (one extra API call each), so unbounded pages get slower as history accumulates.
+        const result = await caseInstances.getAll({ pageSize: 10 });
 
         expect(result).toBeDefined();
         expect(hasValidPagination(result)).toBe(true);
@@ -164,7 +249,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     beforeAll(async () => {
       const { caseInstances } = getServices();
 
-      const result = await caseInstances.getAll();
+      const result = await caseInstances.getAll({ pageSize: 10 });
       const instance = result.items.find((item) => item.instanceId && item.folderKey);
       if (!instance) {
         throw new Error('No case instance with a folder key available for getVariables testing');
@@ -220,23 +305,58 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     });
   });
 
-  // sendMessage runs before close: it needs a running instance but does not alter case
-  // state, while close consumes one. Order matters when few running instances exist.
+  // pause must target a FRESHLY started instance: once the human task fully activates,
+  // PIMS keeps the instance in Pausing until the task settles (observed 90s+), while a
+  // fresh instance pauses within seconds. So this test seeds and cleans up its own
+  // instance instead of sharing the run's seeded one.
+  describe('pause and resume', () => {
+    it('should pause a running case instance and resume it', async () => {
+      const { caseInstances } = getServices();
+
+      const target = await seedRunningInstance();
+      if (!target) {
+        throw new Error(
+          'MAESTRO_TEST_CASE_PROCESS_KEY / folder config not set — cannot seed an instance for pause/resume'
+        );
+      }
+
+      const pauseResult = await caseInstances.pause(target.instanceId, target.folderKey);
+      expect(pauseResult.success).toBe(true);
+
+      // Pausing is asynchronous; wait for the Paused state before resuming
+      let lastStatus = '';
+      for (let attempt = 0; attempt < 10; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        const current = await caseInstances.getById(target.instanceId, target.folderKey);
+        lastStatus = current.latestRunStatus;
+        if (lastStatus === InstanceStatus.PAUSED) {
+          break;
+        }
+      }
+      expect(lastStatus).toBe(InstanceStatus.PAUSED);
+
+      const resumeResult = await caseInstances.resume(target.instanceId, target.folderKey);
+      expect(resumeResult.success).toBe(true);
+
+      // Cleanup: this test seeded its own instance
+      await caseInstances.close(target.instanceId, target.folderKey);
+    }, 180_000);
+  });
+
+  // Runs after pause/resume (see note there): the ad-hoc trigger spawns an in-flight task
+  // on the instance, which blocks a subsequent pause from completing.
   describe('sendMessage', () => {
     it('should send a message to a running case instance', async () => {
       const { caseInstances } = getServices();
 
-      const instances = await caseInstances.getAll({ pageSize: 50 });
-      const runningInstance = instances.items.find(
-        (instance) => instance.latestRunStatus === InstanceStatus.RUNNING && instance.folderKey
-      );
+      const runningInstance = await resolveRunningInstance();
 
       if (!runningInstance) {
         throw new Error('No running case instance available — cannot test sendMessage');
       }
 
       // Publishing an ad-hoc trigger with an unmatched task name exercises the endpoint,
-      // auth, folder-key header, and body format without altering the case state.
+      // auth, folder-key header, and body format without completing or closing the case.
       await expect(
         caseInstances.sendMessage(
           runningInstance.instanceId,
@@ -248,44 +368,86 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     });
   });
 
-  // Snapshot+restore: closing consumes a shared running instance, so the test reopens the
-  // same instance afterwards. This keeps the suite re-runnable against a fixed set of
-  // seeded running instances instead of draining one per run.
-  describe('close and reopen', () => {
-    it('should close a case instance and reopen it from its active stage', async () => {
+  describe('close', () => {
+    it('should close a running case instance', async () => {
       const { caseInstances } = getServices();
 
-      const instances = await caseInstances.getAll({ pageSize: 50 });
+      const target = await resolveRunningInstance();
 
-      const openInstance = instances.items.find(
-        (inst) => inst.latestRunStatus === InstanceStatus.RUNNING && inst.folderKey
-      );
-
-      if (!openInstance) {
-        throw new Error('No running case instance available — cannot test close/reopen');
+      if (!target) {
+        throw new Error('No running case instance available — cannot test close');
       }
 
-      // Snapshot the stage to restore from before mutating state
-      const stages = await caseInstances.getStages(openInstance.instanceId, openInstance.folderKey);
-      const activeStage = stages.find((stage) => /progress|active|running/i.test(stage.status)) ?? stages[0];
-      if (!activeStage) {
-        throw new Error('Case instance has no stages — cannot determine reopen target');
+      const result = await caseInstances.close(target.instanceId, target.folderKey);
+
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+
+      if (seededInstance && seededInstance.instanceId === target.instanceId) {
+        // Consumed the seeded instance; afterAll must not close it again
+        seededInstance = null;
+      }
+    });
+  });
+
+  // Reopen requires a Completed instance (close produces Cancelled, which PIMS rejects),
+  // so this test seeds one from the auto-completing case process (runs to Completed
+  // without human interaction), reopens that same instance, and closes it afterwards.
+  describe('reopen', () => {
+    it('should reopen a completed case instance from a stage', async () => {
+      const { processes, caseInstances } = getServices();
+      const config = getTestConfig();
+
+      if (!config.maestroCompletedCaseProcessKey || !config.folderId || !config.folderKey) {
+        throw new Error(
+          'MAESTRO_TEST_COMPLETED_CASE_PROCESS_KEY / folder config not set — cannot seed a completed instance for reopen'
+        );
       }
 
-      const closeResult = await caseInstances.close(openInstance.instanceId, openInstance.folderKey);
+      // Use the instance started in beforeAll — it has been completing in the background
+      // while the earlier tests ran, so this usually needs no waiting at all.
+      let instanceId = seededCompletedJobKey;
+      if (!instanceId) {
+        const [job] = await processes.start(
+          { processKey: config.maestroCompletedCaseProcessKey },
+          { folderId: Number(config.folderId) }
+        );
+        instanceId = job.key;
+      }
 
-      expect(closeResult).toBeDefined();
-      expect(closeResult.success).toBe(true);
+      // Check immediately, then poll only if it has not completed yet
+      let completed = false;
+      for (let attempt = 0; attempt < 24; attempt++) {
+        try {
+          const instance = await caseInstances.getById(instanceId, config.folderKey);
+          if (instance.latestRunStatus === InstanceStatus.COMPLETED) {
+            completed = true;
+            break;
+          }
+        } catch {
+          // not yet visible in PIMS
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+      if (!completed) {
+        throw new Error('Seeded auto-completing case instance did not complete within 120s');
+      }
 
-      // Restore: reopen the same instance from the stage that was active at close
-      const reopenResult = await caseInstances.reopen(openInstance.instanceId, openInstance.folderKey, {
-        stageId: activeStage.id,
-        comment: 'Reopened by the SDK integration suite after close test',
+      const stages = await caseInstances.getStages(instanceId, config.folderKey);
+      expect(stages.length).toBeGreaterThan(0);
+
+      const result = await caseInstances.reopen(instanceId, config.folderKey, {
+        stageId: stages[0].id,
+        comment: 'Reopened by the SDK integration suite',
       });
 
-      expect(reopenResult).toBeDefined();
-      expect(reopenResult.success).toBe(true);
-    });
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+
+      // Cleanup: close the reopened instance — reopened instances do NOT re-complete on
+      // their own, and letting them accumulate saturates the tenant's execution queue.
+      await caseInstances.close(instanceId, config.folderKey);
+    }, 180_000);
   });
 
   describe('Case instance structure validation', () => {
@@ -431,6 +593,11 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
   });
 
   afterAll(async () => {
-    // Note: We don't cleanup test case instances as they may be pre-existing
+    // Close the seeded instance unless the close test already consumed it.
+    // Pre-existing instances are never cleaned up here.
+    if (!seededInstance) return;
+    const { caseInstances } = getServices();
+    await caseInstances.close(seededInstance.instanceId, seededInstance.folderKey);
+    seededInstance = null;
   });
 });

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -187,8 +187,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
   describe('getById', () => {
     it('should retrieve a specific case instance by ID', async () => {
       if (!testCaseInstanceId || !testCaseFolderKey) {
-        console.log('No case instance available for testing');
-        return;
+        throw new Error('No case instance with a folder key available — cannot test getById');
       }
 
       const { caseInstances } = getServices();
@@ -203,8 +202,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
   describe('getStages', () => {
     it('should retrieve stages for a case instance', async () => {
       if (!testCaseInstanceId || !testCaseFolderKey) {
-        console.log('No case instance available for testing');
-        return;
+        throw new Error('No case instance with a folder key available — cannot test getStages');
       }
 
       const { caseInstances } = getServices();
@@ -223,8 +221,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
 
     it('should validate stage structure', async () => {
       if (!testCaseInstanceId || !testCaseFolderKey) {
-        console.log('No case instance available for testing');
-        return;
+        throw new Error('No case instance with a folder key available — cannot validate stage structure');
       }
 
       const { caseInstances } = getServices();

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import {
   getServices,
-  getTestConfig,
   setupUnifiedTests,
   InitMode,
 } from '../../config/unified-setup';
-import { registerResource } from '../../utils/cleanup';
 import { hasValidPagination, generateRandomString } from '../../utils/helpers';
 import { CaseInstanceMessageName, InstanceStatus } from '../../../../src/models/maestro';
 
@@ -15,6 +13,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
   setupUnifiedTests(mode);
 
   let testCaseInstanceId: string | null = null;
+  let testCaseFolderKey: string | null = null;
 
   describe('getAll', () => {
     it('should retrieve all case instances', async () => {
@@ -27,8 +26,10 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
         expect(hasValidPagination(result)).toBe(true);
         expect(Array.isArray(result.items)).toBe(true);
 
-        if (result.items.length > 0) {
-          testCaseInstanceId = result.items[0].id;
+        const instance = result.items.find((item) => item.instanceId && item.folderKey);
+        if (instance) {
+          testCaseInstanceId = instance.instanceId;
+          testCaseFolderKey = instance.folderKey;
         }
       } catch (error: any) {
         if (error.message?.includes('Forbidden') || error.statusCode === 403) {
@@ -47,7 +48,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
 
       try {
         const result = await caseInstances.getAll({
-          limit: 5,
+          pageSize: 5,
         });
 
         expect(result).toBeDefined();
@@ -70,7 +71,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
 
       try {
         const firstPage = await caseInstances.getAll({
-          limit: 2,
+          pageSize: 2,
         });
 
         expect(firstPage).toBeDefined();
@@ -78,7 +79,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
 
         if (firstPage.hasNextPage && firstPage.nextCursor) {
           const secondPage = await caseInstances.getAll({
-            limit: 2,
+            pageSize: 2,
             cursor: firstPage.nextCursor,
           });
 
@@ -100,70 +101,55 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
 
   describe('getById', () => {
     it('should retrieve a specific case instance by ID', async () => {
-      if (!testCaseInstanceId) {
-        console.log('No case instance ID available for testing');
+      if (!testCaseInstanceId || !testCaseFolderKey) {
+        console.log('No case instance available for testing');
         return;
       }
 
       const { caseInstances } = getServices();
-      const config = getTestConfig();
 
-      try {
-        const result = await caseInstances.getById(testCaseInstanceId, config.folderId);
+      const result = await caseInstances.getById(testCaseInstanceId, testCaseFolderKey);
 
-        expect(result).toBeDefined();
-        expect(result.id).toBe(testCaseInstanceId);
-      } catch (error: any) {
-        console.log('Get case instance by ID failed:', error.message);
-      }
+      expect(result).toBeDefined();
+      expect(result.instanceId).toBe(testCaseInstanceId);
     });
   });
 
   describe('getStages', () => {
     it('should retrieve stages for a case instance', async () => {
-      if (!testCaseInstanceId) {
-        console.log('No case instance ID available for testing');
+      if (!testCaseInstanceId || !testCaseFolderKey) {
+        console.log('No case instance available for testing');
         return;
       }
 
       const { caseInstances } = getServices();
-      const config = getTestConfig();
 
-      try {
-        const result = await caseInstances.getStages(testCaseInstanceId, config.folderId);
+      const result = await caseInstances.getStages(testCaseInstanceId, testCaseFolderKey);
 
-        expect(result).toBeDefined();
-        expect(Array.isArray(result) || typeof result === 'object').toBe(true);
+      expect(result).toBeDefined();
+      expect(Array.isArray(result) || typeof result === 'object').toBe(true);
 
-        if (Array.isArray(result) && result.length > 0) {
-          const stage = result[0];
-          expect(stage).toBeDefined();
-          expect(typeof stage).toBe('object');
-        }
-      } catch (error: any) {
-        console.log('Get case stages failed:', error.message);
+      if (Array.isArray(result) && result.length > 0) {
+        const stage = result[0];
+        expect(stage).toBeDefined();
+        expect(typeof stage).toBe('object');
       }
     });
 
     it('should validate stage structure', async () => {
-      if (!testCaseInstanceId) {
-        console.log('No case instance ID available for testing');
+      if (!testCaseInstanceId || !testCaseFolderKey) {
+        console.log('No case instance available for testing');
         return;
       }
 
       const { caseInstances } = getServices();
-      const config = getTestConfig();
 
-      try {
-        const stages = await caseInstances.getStages(testCaseInstanceId, config.folderId);
+      const stages = await caseInstances.getStages(testCaseInstanceId, testCaseFolderKey);
 
-        if (Array.isArray(stages) && stages.length > 0) {
-          const stage = stages[0];
-          expect(stage).toBeDefined();
-          console.log('Stage fields:', Object.keys(stage));
-        }
-      } catch (error: any) {
-        console.log('Stage validation failed:', error.message);
+      if (Array.isArray(stages) && stages.length > 0) {
+        const stage = stages[0];
+        expect(stage).toBeDefined();
+        console.log('Stage fields:', Object.keys(stage));
       }
     });
   });
@@ -234,50 +220,8 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     });
   });
 
-  describe('close', () => {
-    it('should close a case instance', async () => {
-      const { caseInstances } = getServices();
-      const config = getTestConfig();
-
-      try {
-        const instances = await caseInstances.getAll({
-          limit: 10,
-        });
-
-        const openInstance = instances.data.find(
-          (inst: any) =>
-            inst.status && inst.status.toLowerCase().match(/open|active|in progress/)
-        );
-
-        if (!openInstance) {
-          console.log('No open case instance available to test closure');
-          return;
-        }
-
-        const result = await caseInstances.close(openInstance.id, config.folderId);
-
-        expect(result).toBeDefined();
-
-        const closedInstance = await caseInstances.getById(openInstance.id, config.folderId);
-        expect(closedInstance.status).toMatch(/closed|completed/i);
-
-        registerResource('caseInstances', {
-          id: openInstance.id,
-          folderKey: config.folderId,
-        });
-      } catch (error: any) {
-        if (error.message?.includes('Forbidden') || error.statusCode === 403) {
-          console.log(
-            'Skipping test: PAT token does not have Maestro permissions. ' +
-              'Grant Maestro (Read) scope when creating the token.'
-          );
-          return;
-        }
-        console.log('Close case instance test failed:', error.message);
-      }
-    });
-  });
-
+  // sendMessage runs before close: it needs a running instance but does not alter case
+  // state, while close consumes one. Order matters when few running instances exist.
   describe('sendMessage', () => {
     it('should send a message to a running case instance', async () => {
       const { caseInstances } = getServices();
@@ -304,13 +248,53 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     });
   });
 
+  // Snapshot+restore: closing consumes a shared running instance, so the test reopens the
+  // same instance afterwards. This keeps the suite re-runnable against a fixed set of
+  // seeded running instances instead of draining one per run.
+  describe('close and reopen', () => {
+    it('should close a case instance and reopen it from its active stage', async () => {
+      const { caseInstances } = getServices();
+
+      const instances = await caseInstances.getAll({ pageSize: 50 });
+
+      const openInstance = instances.items.find(
+        (inst) => inst.latestRunStatus === InstanceStatus.RUNNING && inst.folderKey
+      );
+
+      if (!openInstance) {
+        throw new Error('No running case instance available — cannot test close/reopen');
+      }
+
+      // Snapshot the stage to restore from before mutating state
+      const stages = await caseInstances.getStages(openInstance.instanceId, openInstance.folderKey);
+      const activeStage = stages.find((stage) => /progress|active|running/i.test(stage.status)) ?? stages[0];
+      if (!activeStage) {
+        throw new Error('Case instance has no stages — cannot determine reopen target');
+      }
+
+      const closeResult = await caseInstances.close(openInstance.instanceId, openInstance.folderKey);
+
+      expect(closeResult).toBeDefined();
+      expect(closeResult.success).toBe(true);
+
+      // Restore: reopen the same instance from the stage that was active at close
+      const reopenResult = await caseInstances.reopen(openInstance.instanceId, openInstance.folderKey, {
+        stageId: activeStage.id,
+        comment: 'Reopened by the SDK integration suite after close test',
+      });
+
+      expect(reopenResult).toBeDefined();
+      expect(reopenResult.success).toBe(true);
+    });
+  });
+
   describe('Case instance structure validation', () => {
     it('should have expected fields in case instance objects', async () => {
       const { caseInstances } = getServices();
 
       try {
         const result = await caseInstances.getAll({
-          limit: 1,
+          pageSize: 1,
         });
 
         if (result.items.length === 0) {
@@ -320,15 +304,15 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
 
         const instance = result.items[0];
 
-        expect(instance.id).toBeDefined();
-        expect(typeof instance.id).toBe('string');
+        expect(instance.instanceId).toBeDefined();
+        expect(typeof instance.instanceId).toBe('string');
 
-        if (instance.status) {
-          expect(typeof instance.status).toBe('string');
+        if (instance.latestRunStatus) {
+          expect(typeof instance.latestRunStatus).toBe('string');
         }
 
-        if (instance.caseDefinitionId || instance.caseKey) {
-          expect(typeof (instance.caseDefinitionId || instance.caseKey)).toBe('string');
+        if (instance.processKey) {
+          expect(typeof instance.processKey).toBe('string');
         }
       } catch (error: any) {
         if (error.message?.includes('Forbidden') || error.statusCode === 403) {
@@ -343,7 +327,8 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     });
   });
 
-  describe.skipIf(mode === 'v0')('getSlaSummary', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getSlaSummary', () => {
     it('should retrieve SLA summary for case instances', async () => {
       const { caseInstances } = getServices();
 
@@ -378,7 +363,8 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     });
   });
 
-  describe.skipIf(mode === 'v0')('getStagesSlaSummary', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getStagesSlaSummary', () => {
     it('should retrieve stages SLA summary for case instances', async () => {
       const { caseInstances } = getServices();
 

--- a/tests/integration/shared/maestro/cases.integration.test.ts
+++ b/tests/integration/shared/maestro/cases.integration.test.ts
@@ -36,7 +36,7 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
           );
           return;
         }
-        console.log('Case retrieval test:', error.message);
+        throw error;
       }
     });
   });

--- a/tests/integration/shared/maestro/cases.integration.test.ts
+++ b/tests/integration/shared/maestro/cases.integration.test.ts
@@ -72,7 +72,7 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getInstanceStatusTimeline', () => {
+  describe('getInstanceStatusTimeline', () => {
     it('should retrieve instance status by date for case management', async () => {
       const { cases } = getServices();
       await testGetInstanceStatusTimeline(cases);
@@ -129,14 +129,14 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopRunCount', () => {
+  describe('getTopRunCount', () => {
     it('should retrieve top case processes by run count', async () => {
       const { cases } = getServices();
       await testGetTopRunCount(cases);
     });
   });
 
-  describe.skip('getTopFaultedCount', () => {
+  describe('getTopFaultedCount', () => {
     it('should retrieve top case processes by failure count', async () => {
       const { cases } = getServices();
       const now = new Date();
@@ -159,7 +159,7 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopElementFailedCount', () => {
+  describe('getTopElementFailedCount', () => {
     it('should retrieve top elements by failure count for cases', async () => {
       const { cases } = getServices();
       const now = new Date();
@@ -182,7 +182,7 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopExecutionDuration', () => {
+  describe('getTopExecutionDuration', () => {
     it('should retrieve top case processes by duration', async () => {
       const { cases } = getServices();
       const now = new Date();

--- a/tests/integration/shared/maestro/cases.integration.test.ts
+++ b/tests/integration/shared/maestro/cases.integration.test.ts
@@ -72,7 +72,8 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getInstanceStatusTimeline', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getInstanceStatusTimeline', () => {
     it('should retrieve instance status by date for case management', async () => {
       const { cases } = getServices();
       await testGetInstanceStatusTimeline(cases);
@@ -129,14 +130,16 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopRunCount', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopRunCount', () => {
     it('should retrieve top case processes by run count', async () => {
       const { cases } = getServices();
       await testGetTopRunCount(cases);
     });
   });
 
-  describe('getTopFaultedCount', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopFaultedCount', () => {
     it('should retrieve top case processes by failure count', async () => {
       const { cases } = getServices();
       const now = new Date();
@@ -159,7 +162,8 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopElementFailedCount', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopElementFailedCount', () => {
     it('should retrieve top elements by failure count for cases', async () => {
       const { cases } = getServices();
       const now = new Date();
@@ -182,7 +186,8 @@ describe.each(modes)('Maestro Cases - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopExecutionDuration', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopExecutionDuration', () => {
     it('should retrieve top case processes by duration', async () => {
       const { cases } = getServices();
       const now = new Date();

--- a/tests/integration/shared/maestro/process-incidents.integration.test.ts
+++ b/tests/integration/shared/maestro/process-incidents.integration.test.ts
@@ -22,25 +22,20 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
         });
 
         if (processes.length === 0) {
-          console.log('No processes available to test incidents');
-          return;
+          throw new Error('No Maestro processes available — cannot test incident retrieval');
         }
 
         const { processKey, folderKey } = processes[0];
 
-        try {
-          const incidents = await maestroProcesses.getIncidents(processKey, folderKey);
+        const incidents = await maestroProcesses.getIncidents(processKey, folderKey);
 
-          expect(incidents).toBeDefined();
-          expect(Array.isArray(incidents)).toBe(true);
+        expect(incidents).toBeDefined();
+        expect(Array.isArray(incidents)).toBe(true);
 
-          if (incidents.length > 0) {
-            const incident = incidents[0];
-            expect(incident).toBeDefined();
-            expect(incident.id || incident.incidentId).toBeDefined();
-          }
-        } catch (error: any) {
-          console.log('Incident retrieval failed:', error.message);
+        if (incidents.length > 0) {
+          const incident = incidents[0];
+          expect(incident).toBeDefined();
+          expect(incident.id || incident.incidentId).toBeDefined();
         }
       } catch (error: any) {
         if (error.message?.includes('Forbidden') || error.statusCode === 403) {
@@ -61,34 +56,27 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
       const processKey = config.maestroTestProcessKey;
 
       if (!processKey) {
-        console.log(
-          'Skipping incident structure test: MAESTRO_TEST_PROCESS_KEY not configured'
-        );
-        return;
+        throw new Error('MAESTRO_TEST_PROCESS_KEY not configured — cannot validate incident structure');
       }
 
-      try {
-        const incidents = await maestroProcesses.getIncidents(processKey, config.folderKey);
+      const incidents = await maestroProcesses.getIncidents(processKey, config.folderKey);
 
-        expect(incidents).toBeDefined();
-        expect(Array.isArray(incidents)).toBe(true);
+      expect(incidents).toBeDefined();
+      expect(Array.isArray(incidents)).toBe(true);
 
-        if (incidents.length > 0) {
-          const incident = incidents[0];
+      if (incidents.length > 0) {
+        const incident = incidents[0];
 
-          expect(incident).toBeDefined();
-          expect(typeof incident).toBe('object');
+        expect(incident).toBeDefined();
+        expect(typeof incident).toBe('object');
 
-          if (incident.id || incident.incidentId) {
-            expect(typeof (incident.id || incident.incidentId)).toBe('string');
-          }
-
-          if (incident.type) {
-            expect(typeof incident.type).toBe('string');
-          }
+        if (incident.id || incident.incidentId) {
+          expect(typeof (incident.id || incident.incidentId)).toBe('string');
         }
-      } catch (error: any) {
-        console.log('Incident structure validation failed:', error.message);
+
+        if (incident.type) {
+          expect(typeof incident.type).toBe('string');
+        }
       }
     });
   });
@@ -103,8 +91,7 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
         });
 
         if (processes.length === 0) {
-          console.log('No processes available');
-          return;
+          throw new Error('No Maestro processes available — cannot test empty incident results');
         }
 
         let foundEmptyIncidents = false;
@@ -144,27 +131,21 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
       const processKey = config.maestroTestProcessKey;
 
       if (!processKey) {
-        console.log('Skipping incident details test: process key not configured');
-        return;
+        throw new Error('MAESTRO_TEST_PROCESS_KEY not configured — cannot test incident details');
       }
 
-      try {
-        const incidents = await maestroProcesses.getIncidents(processKey, config.folderKey);
+      const incidents = await maestroProcesses.getIncidents(processKey, config.folderKey);
 
-        if (incidents.length === 0) {
-          console.log('No incidents available for the configured process');
-          return;
-        }
-
-        const incident = incidents[0];
-
-        expect(incident).toBeDefined();
-        expect(Object.keys(incident).length).toBeGreaterThan(0);
-
-        console.log('Incident fields:', Object.keys(incident));
-      } catch (error: any) {
-        console.log('Incident details test failed:', error.message);
+      if (incidents.length === 0) {
+        throw new Error(
+          'No incidents available for the configured process — MAESTRO_TEST_PROCESS_KEY must point at a process with faulted runs'
+        );
       }
+
+      const incident = incidents[0];
+
+      expect(incident).toBeDefined();
+      expect(Object.keys(incident).length).toBeGreaterThan(0);
     });
   });
 

--- a/tests/integration/shared/maestro/process-incidents.integration.test.ts
+++ b/tests/integration/shared/maestro/process-incidents.integration.test.ts
@@ -15,7 +15,6 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
 
     it('should retrieve incidents through process context', async () => {
       const { maestroProcesses } = getServices();
-      const config = getTestConfig();
 
       try {
         const processes = await maestroProcesses.getAll({
@@ -27,10 +26,10 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
           return;
         }
 
-        const processKey = processes[0].key;
+        const { processKey, folderKey } = processes[0];
 
         try {
-          const incidents = await maestroProcesses.getIncidents(processKey, config.folderId);
+          const incidents = await maestroProcesses.getIncidents(processKey, folderKey);
 
           expect(incidents).toBeDefined();
           expect(Array.isArray(incidents)).toBe(true);
@@ -69,7 +68,7 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
       }
 
       try {
-        const incidents = await maestroProcesses.getIncidents(processKey, config.folderId);
+        const incidents = await maestroProcesses.getIncidents(processKey, config.folderKey);
 
         expect(incidents).toBeDefined();
         expect(Array.isArray(incidents)).toBe(true);
@@ -112,7 +111,7 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
 
         for (const process of processes) {
           try {
-            const incidents = await maestroProcesses.getIncidents(process.key);
+            const incidents = await maestroProcesses.getIncidents(process.processKey, process.folderKey);
 
             if (incidents.length === 0) {
               foundEmptyIncidents = true;
@@ -150,7 +149,7 @@ describe.each(modes)('Maestro Process Incidents - Integration Tests [%s]', (mode
       }
 
       try {
-        const incidents = await maestroProcesses.getIncidents(processKey, config.folderId);
+        const incidents = await maestroProcesses.getIncidents(processKey, config.folderKey);
 
         if (incidents.length === 0) {
           console.log('No incidents available for the configured process');

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -5,7 +5,6 @@ import {
   setupUnifiedTests,
   InitMode,
 } from '../../config/unified-setup';
-import { registerResource } from '../../utils/cleanup';
 import { InstanceStatus } from '../../../../src/models/maestro';
 import type { ProcessInstanceExecutionHistoryResponse } from '../../../../src/models/maestro/process-instances.types';
 
@@ -183,59 +182,55 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
     it('should cancel a process instance', async () => {
       const { processInstances } = getServices();
 
-      try {
-        const instances = await processInstances.getAll({
-          pageSize: 10,
-        });
+      const { processes } = getServices();
+      const config = getTestConfig();
 
-        // Never cancel the faulting-process instance seeded for the retry test — it is
-        // briefly Running before it faults
-        const runnableInstance = instances.items.find(
-          (inst) =>
-            inst.folderKey &&
-            inst.instanceId !== seededFaultedJobKey &&
-            inst.latestRunStatus &&
-            inst.latestRunStatus.toLowerCase().match(/running|active|pending/)
+      if (!config.maestroTestProcessKey || !config.folderId || !config.folderKey) {
+        throw new Error(
+          'MAESTRO_TEST_PROCESS_KEY / folder config not set — cannot seed an instance for cancel'
         );
-
-        if (!runnableInstance) {
-          console.log('No running instance available to test cancellation');
-          return;
-        }
-
-        try {
-          const result = await processInstances.cancel(
-            runnableInstance.instanceId,
-            runnableInstance.folderKey
-          );
-
-          expect(result).toBeDefined();
-          expect(result.success).toBe(true);
-
-          const instance = await processInstances.getById(
-            runnableInstance.instanceId,
-            runnableInstance.folderKey
-          );
-          expect(instance.latestRunStatus).toMatch(/cancel|stopped|terminated/i);
-
-          registerResource('processInstances', {
-            id: runnableInstance.instanceId,
-            folderKey: runnableInstance.folderKey,
-          });
-        } catch (error: any) {
-          console.log('Cancel test failed:', error.message);
-        }
-      } catch (error: any) {
-        if (error.message?.includes('Forbidden') || error.statusCode === 403) {
-          console.log(
-            'Skipping test: PAT token does not have Maestro permissions. ' +
-              'Grant Maestro (Read) scope when creating the token.'
-          );
-          return;
-        }
-        throw error;
       }
-    });
+
+      // Seed our own instance and cancel it during its Pending/Running window (the
+      // faulting process runs ~15s before it faults). Operating only on our own
+      // instance keeps the test safe under parallel runs.
+      const [job] = await processes.start(
+        { processKey: config.maestroTestProcessKey },
+        { folderId: Number(config.folderId) }
+      );
+
+      // Wait for Running specifically — cancelling while still Pending is rejected
+      let running = false;
+      for (let attempt = 0; attempt < 20; attempt++) {
+        try {
+          const instance = await processInstances.getById(job.key, config.folderKey);
+          if (instance.latestRunStatus === InstanceStatus.RUNNING) {
+            running = true;
+            break;
+          }
+          if (instance.latestRunStatus === InstanceStatus.FAULTED) {
+            throw new Error('Seeded instance faulted before it could be cancelled — cannot test cancel');
+          }
+        } catch (error: any) {
+          if (error.message?.includes('cannot test cancel')) {
+            throw error;
+          }
+          // not yet visible in PIMS
+        }
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+      }
+      if (!running) {
+        throw new Error('Seeded instance did not reach Running within 60s — cannot test cancel');
+      }
+
+      const result = await processInstances.cancel(job.key, config.folderKey);
+
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+
+      const instance = await processInstances.getById(job.key, config.folderKey);
+      expect(instance.latestRunStatus).toMatch(/cancel|stopped|terminated/i);
+    }, 60_000);
   });
 
   // Self-seeding: starts a fresh instance of the deliberately-faulting process (faults in
@@ -311,21 +306,16 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
   describe('Instance details', () => {
     it('should retrieve process variables', async () => {
       if (!testInstanceId || !testFolderKey) {
-        console.log('No instance available for testing');
-        return;
+        throw new Error('No process instance with a folder key available — cannot test getVariables');
       }
 
       const { processInstances } = getServices();
 
-      try {
-        const result = await processInstances.getVariables(testInstanceId, testFolderKey);
+      const result = await processInstances.getVariables(testInstanceId, testFolderKey);
 
-        expect(result).toBeDefined();
-        expect(result.instanceId).toBe(testInstanceId);
-        expect(Array.isArray(result.globalVariables)).toBe(true);
-      } catch (error: any) {
-        console.log('Get variables test failed:', error.message);
-      }
+      expect(result).toBeDefined();
+      expect(result.instanceId).toBe(testInstanceId);
+      expect(Array.isArray(result.globalVariables)).toBe(true);
     });
 
     describe('execution history', () => {
@@ -390,8 +380,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
         });
 
         if (result.items.length === 0) {
-          console.log('No instances available to validate structure');
-          return;
+          throw new Error('No process instances available — cannot validate instance structure');
         }
 
         const instance = result.items[0];

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import {
   getServices,
-  getTestConfig,
   setupUnifiedTests,
   InitMode,
 } from '../../config/unified-setup';
@@ -14,6 +13,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
   setupUnifiedTests(mode);
 
   let testInstanceId: string | null = null;
+  let testFolderKey: string | null = null;
 
   describe('getAll', () => {
     it('should retrieve all process instances', async () => {
@@ -26,8 +26,10 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
         expect(result.items).toBeDefined();
         expect(Array.isArray(result.items)).toBe(true);
 
-        if (result.items.length > 0) {
-          testInstanceId = result.items[0].instanceId;
+        const instance = result.items.find((item) => item.instanceId && item.folderKey);
+        if (instance) {
+          testInstanceId = instance.instanceId;
+          testFolderKey = instance.folderKey;
         }
       } catch (error: any) {
         if (error.message?.includes('Forbidden') || error.statusCode === 403) {
@@ -99,15 +101,14 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
   describe('getById', () => {
     it('should retrieve a specific process instance by ID', async () => {
-      if (!testInstanceId) {
-        console.log('No instance ID available for testing');
+      if (!testInstanceId || !testFolderKey) {
+        console.log('No instance available for testing');
         return;
       }
 
       const { processInstances } = getServices();
-      const config = getTestConfig();
 
-      const result = await processInstances.getById(testInstanceId, config.folderId || '');
+      const result = await processInstances.getById(testInstanceId, testFolderKey);
 
       expect(result).toBeDefined();
       expect(result.instanceId).toBe(testInstanceId);
@@ -116,21 +117,20 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
   describe('Instance lifecycle operations', () => {
     it('should pause a process instance', async () => {
-      if (!testInstanceId) {
-        console.log('No instance ID available for testing');
+      if (!testInstanceId || !testFolderKey) {
+        console.log('No instance available for testing');
         return;
       }
 
       const { processInstances } = getServices();
-      const config = getTestConfig();
 
       try {
-        const result = await processInstances.pause(testInstanceId, config.folderId || '');
+        const result = await processInstances.pause(testInstanceId, testFolderKey);
 
         expect(result).toBeDefined();
         expect(result.success).toBe(true);
 
-        const instance = await processInstances.getById(testInstanceId, config.folderId || '');
+        const instance = await processInstances.getById(testInstanceId, testFolderKey);
         expect(instance.latestRunStatus).toMatch(/paused|suspended/i);
       } catch (error: any) {
         console.log(
@@ -141,21 +141,20 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
     });
 
     it('should resume a paused process instance', async () => {
-      if (!testInstanceId) {
-        console.log('No instance ID available for testing');
+      if (!testInstanceId || !testFolderKey) {
+        console.log('No instance available for testing');
         return;
       }
 
       const { processInstances } = getServices();
-      const config = getTestConfig();
 
       try {
-        const result = await processInstances.resume(testInstanceId, config.folderId || '');
+        const result = await processInstances.resume(testInstanceId, testFolderKey);
 
         expect(result).toBeDefined();
         expect(result.success).toBe(true);
 
-        const instance = await processInstances.getById(testInstanceId, config.folderId || '');
+        const instance = await processInstances.getById(testInstanceId, testFolderKey);
         expect(instance.latestRunStatus).toMatch(/running|active|resumed/i);
       } catch (error: any) {
         console.log(
@@ -167,7 +166,6 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
     it('should cancel a process instance', async () => {
       const { processInstances } = getServices();
-      const config = getTestConfig();
 
       try {
         const instances = await processInstances.getAll({
@@ -175,7 +173,8 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
         });
 
         const runnableInstance = instances.items.find(
-          (inst: any) =>
+          (inst) =>
+            inst.folderKey &&
             inst.latestRunStatus &&
             inst.latestRunStatus.toLowerCase().match(/running|active|pending/)
         );
@@ -188,7 +187,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
         try {
           const result = await processInstances.cancel(
             runnableInstance.instanceId,
-            config.folderId || ''
+            runnableInstance.folderKey
           );
 
           expect(result).toBeDefined();
@@ -196,13 +195,13 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
           const instance = await processInstances.getById(
             runnableInstance.instanceId,
-            config.folderId || ''
+            runnableInstance.folderKey
           );
           expect(instance.latestRunStatus).toMatch(/cancel|stopped|terminated/i);
 
           registerResource('processInstances', {
             id: runnableInstance.instanceId,
-            folderKey: config.folderId,
+            folderKey: runnableInstance.folderKey,
           });
         } catch (error: any) {
           console.log('Cancel test failed:', error.message);
@@ -257,16 +256,15 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
   describe('Instance details', () => {
     it('should retrieve process variables', async () => {
-      if (!testInstanceId) {
-        console.log('No instance ID available for testing');
+      if (!testInstanceId || !testFolderKey) {
+        console.log('No instance available for testing');
         return;
       }
 
       const { processInstances } = getServices();
-      const config = getTestConfig();
 
       try {
-        const result = await processInstances.getVariables(testInstanceId, config.folderId || '');
+        const result = await processInstances.getVariables(testInstanceId, testFolderKey);
 
         expect(result).toBeDefined();
         expect(result.instanceId).toBe(testInstanceId);
@@ -280,18 +278,13 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
       let executionHistory!: ProcessInstanceExecutionHistoryResponse[];
 
       beforeAll(async () => {
-        if (!testInstanceId) {
-          throw new Error('No instance ID available for testing');
+        if (!testInstanceId || !testFolderKey) {
+          throw new Error('No instance available for testing');
         }
 
         const { processInstances } = getServices();
-        const config = getTestConfig();
 
-        if (!config.folderKey) {
-          throw new Error('No folderKey configured for testing');
-        }
-
-        executionHistory = await processInstances.getExecutionHistory(testInstanceId, config.folderKey);
+        executionHistory = await processInstances.getExecutionHistory(testInstanceId, testFolderKey);
       });
 
       it('should retrieve execution history', () => {

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -121,8 +121,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
   describe('getById', () => {
     it('should retrieve a specific process instance by ID', async () => {
       if (!testInstanceId || !testFolderKey) {
-        console.log('No instance available for testing');
-        return;
+        throw new Error('No process instance with a folder key available — cannot test getById');
       }
 
       const { processInstances } = getServices();
@@ -137,8 +136,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
   describe('Instance lifecycle operations', () => {
     it('should pause a process instance', async () => {
       if (!testInstanceId || !testFolderKey) {
-        console.log('No instance available for testing');
-        return;
+        throw new Error('No process instance with a folder key available — cannot test pause');
       }
 
       const { processInstances } = getServices();
@@ -161,8 +159,7 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
     it('should resume a paused process instance', async () => {
       if (!testInstanceId || !testFolderKey) {
-        console.log('No instance available for testing');
-        return;
+        throw new Error('No process instance with a folder key available — cannot test resume');
       }
 
       const { processInstances } = getServices();

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import {
   getServices,
+  getTestConfig,
   setupUnifiedTests,
   InitMode,
 } from '../../config/unified-setup';
 import { registerResource } from '../../utils/cleanup';
+import { InstanceStatus } from '../../../../src/models/maestro';
 import type { ProcessInstanceExecutionHistoryResponse } from '../../../../src/models/maestro/process-instances.types';
 
 const modes: InitMode[] = ['v0', 'v1'];
@@ -14,6 +16,23 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
   let testInstanceId: string | null = null;
   let testFolderKey: string | null = null;
+
+  // Faulting-process instance started at suite start for the retry test. It faults in the
+  // background (~15s idle, minutes under full-suite load) while earlier tests run.
+  let seededFaultedJobKey: string | null = null;
+
+  beforeAll(async () => {
+    const { processes } = getServices();
+    const config = getTestConfig();
+
+    if (config.maestroTestProcessKey && config.folderId) {
+      const [job] = await processes.start(
+        { processKey: config.maestroTestProcessKey },
+        { folderId: Number(config.folderId) }
+      );
+      seededFaultedJobKey = job.key;
+    }
+  }, 60_000);
 
   describe('getAll', () => {
     it('should retrieve all process instances', async () => {
@@ -172,9 +191,12 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
           pageSize: 10,
         });
 
+        // Never cancel the faulting-process instance seeded for the retry test — it is
+        // briefly Running before it faults
         const runnableInstance = instances.items.find(
           (inst) =>
             inst.folderKey &&
+            inst.instanceId !== seededFaultedJobKey &&
             inst.latestRunStatus &&
             inst.latestRunStatus.toLowerCase().match(/running|active|pending/)
         );
@@ -219,39 +241,74 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
     });
   });
 
+  // Self-seeding: starts a fresh instance of the deliberately-faulting process (faults in
+  // ~15s), retries it, then cancels it so nothing keeps executing. Operating only on our
+  // own instance makes the test safe when multiple runs execute in parallel.
   describe('retry', () => {
-    let faultedInstanceId!: string;
-    let faultedFolderKey!: string;
+    it('should retry a faulted process instance', async () => {
+      const { processes, processInstances } = getServices();
+      const config = getTestConfig();
 
-    beforeAll(async () => {
-      const { processInstances } = getServices();
-
-      const instances = await processInstances.getAll({ pageSize: 50 });
-      const faulted = instances.items.find((inst) =>
-        /fault|fail/i.test(inst.latestRunStatus ?? '')
-      );
-
-      if (!faulted) {
+      if (!config.maestroTestProcessKey || !config.folderId || !config.folderKey) {
         throw new Error(
-          'No faulted process instance available in the test tenant to exercise retry. ' +
-            'Seed one by running a deliberately-faulting Maestro process.'
+          'MAESTRO_TEST_PROCESS_KEY / folder config not set — cannot seed a faulted instance for retry'
         );
       }
-      faultedInstanceId = faulted.instanceId;
-      faultedFolderKey = faulted.folderKey;
-    });
 
-    it('should retry a faulted process instance', async () => {
-      const { processInstances } = getServices();
+      // Use the instance started in beforeAll — it has been faulting in the background
+      // while the earlier tests ran. Fall back to seeding one here if the hook could not.
+      let instanceId = seededFaultedJobKey;
+      if (!instanceId) {
+        const [job] = await processes.start(
+          { processKey: config.maestroTestProcessKey },
+          { folderId: Number(config.folderId) }
+        );
+        instanceId = job.key;
+      }
 
-      const result = await processInstances.retry(faultedInstanceId, faultedFolderKey, {
+      // Check immediately, then poll: faulting takes ~15s on an idle tenant but can take
+      // minutes when the full integration suite loads the tenant (e.g. the CI PR gate)
+      let faulted = false;
+      for (let attempt = 0; attempt < 36; attempt++) {
+        try {
+          const instance = await processInstances.getById(instanceId, config.folderKey);
+          if (instance.latestRunStatus === InstanceStatus.FAULTED) {
+            faulted = true;
+            break;
+          }
+        } catch {
+          // not yet visible in PIMS
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+      if (!faulted) {
+        throw new Error('Seeded instance of the faulting process did not fault within 180s');
+      }
+
+      const result = await processInstances.retry(instanceId, config.folderKey, {
         comment: 'Integration test retry',
       });
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-    });
+
+      // Cleanup: cancel the retried (re-running) instance so it does not keep executing.
+      // The Retrying→Canceling transition can be briefly invalid, so allow a few attempts.
+      let cancelled = false;
+      for (let attempt = 0; attempt < 10 && !cancelled; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        try {
+          await processInstances.cancel(instanceId, config.folderKey);
+          cancelled = true;
+        } catch {
+          // transition not yet valid
+        }
+      }
+      if (!cancelled) {
+        console.log(`Could not cancel retried instance ${instanceId} — it will fault again on its own`);
+      }
+    }, 180_000);
   });
 
   describe('Instance details', () => {

--- a/tests/integration/shared/maestro/processes.integration.test.ts
+++ b/tests/integration/shared/maestro/processes.integration.test.ts
@@ -35,8 +35,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
         const result = await maestroProcesses.getAll();
 
         if (result.length === 0) {
-          console.log('No Maestro processes available to validate structure');
-          return;
+          throw new Error('No Maestro processes available — cannot validate process structure');
         }
 
         const process = result[0];
@@ -118,11 +117,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
       const processKey = config.maestroTestProcessKey;
 
       if (!processKey) {
-        console.log(
-          'Skipping incidents test: MAESTRO_TEST_PROCESS_KEY not configured. ' +
-            'Set this environment variable to test incident retrieval.'
-        );
-        return;
+        throw new Error('MAESTRO_TEST_PROCESS_KEY not configured — cannot test incident retrieval');
       }
 
       const result = await maestroProcesses.getIncidents(processKey, config.folderKey);
@@ -140,19 +135,14 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
         });
 
         if (processes.length === 0) {
-          console.log('No Maestro processes available to test incidents');
-          return;
+          throw new Error('No Maestro processes available — cannot test incident retrieval');
         }
 
         const { processKey, folderKey } = processes[0];
 
-        try {
-          const result = await maestroProcesses.getIncidents(processKey, folderKey);
-          expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
-        } catch (error: any) {
-          console.log(`Could not retrieve incidents for process ${processKey}:`, error.message);
-        }
+        const result = await maestroProcesses.getIncidents(processKey, folderKey);
+        expect(result).toBeDefined();
+        expect(Array.isArray(result)).toBe(true);
       } catch (error: any) {
         if (error.message?.includes('Forbidden') || error.statusCode === 403) {
           console.log(
@@ -275,8 +265,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
         });
 
         if (result.length === 0) {
-          console.log('No processes available to validate metadata');
-          return;
+          throw new Error('No Maestro processes available — cannot validate process metadata');
         }
 
         const process = result[0];

--- a/tests/integration/shared/maestro/processes.integration.test.ts
+++ b/tests/integration/shared/maestro/processes.integration.test.ts
@@ -166,14 +166,14 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopRunCount', () => {
+  describe('getTopRunCount', () => {
     it('should retrieve top processes by run count', async () => {
       const { maestroProcesses } = getServices();
       await testGetTopRunCount(maestroProcesses);
     });
   });
 
-  describe.skip('getInstanceStatusTimeline', () => {
+  describe('getInstanceStatusTimeline', () => {
     it('should retrieve instance status by date', async () => {
       const { maestroProcesses } = getServices();
       await testGetInstanceStatusTimeline(maestroProcesses);
@@ -188,7 +188,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopFaultedCount', () => {
+  describe('getTopFaultedCount', () => {
     it('should retrieve top processes by failure count', async () => {
       const { maestroProcesses } = getServices();
       const now = new Date();
@@ -210,7 +210,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopElementFailedCount', () => {
+  describe('getTopElementFailedCount', () => {
     it('should retrieve top elements by failure count', async () => {
       const { maestroProcesses } = getServices();
       const now = new Date();
@@ -233,7 +233,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe.skip('getTopExecutionDuration', () => {
+  describe('getTopExecutionDuration', () => {
     it('should retrieve top processes by duration', async () => {
       const { maestroProcesses } = getServices();
       const now = new Date();

--- a/tests/integration/shared/maestro/processes.integration.test.ts
+++ b/tests/integration/shared/maestro/processes.integration.test.ts
@@ -41,8 +41,8 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
 
         const process = result[0];
         expect(process).toBeDefined();
-        expect(process.key).toBeDefined();
-        expect(typeof process.key).toBe('string');
+        expect(process.processKey).toBeDefined();
+        expect(typeof process.processKey).toBe('string');
       } catch (error: any) {
         if (error.message?.includes('Forbidden') || error.statusCode === 403) {
           console.log(
@@ -125,7 +125,7 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
         return;
       }
 
-      const result = await maestroProcesses.getIncidents(processKey, config.folderId);
+      const result = await maestroProcesses.getIncidents(processKey, config.folderKey);
 
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
@@ -144,10 +144,10 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
           return;
         }
 
-        const processKey = processes[0].key;
+        const { processKey, folderKey } = processes[0];
 
         try {
-          const result = await maestroProcesses.getIncidents(processKey);
+          const result = await maestroProcesses.getIncidents(processKey, folderKey);
           expect(result).toBeDefined();
           expect(Array.isArray(result)).toBe(true);
         } catch (error: any) {
@@ -166,14 +166,16 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopRunCount', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopRunCount', () => {
     it('should retrieve top processes by run count', async () => {
       const { maestroProcesses } = getServices();
       await testGetTopRunCount(maestroProcesses);
     });
   });
 
-  describe('getInstanceStatusTimeline', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getInstanceStatusTimeline', () => {
     it('should retrieve instance status by date', async () => {
       const { maestroProcesses } = getServices();
       await testGetInstanceStatusTimeline(maestroProcesses);
@@ -188,7 +190,8 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopFaultedCount', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopFaultedCount', () => {
     it('should retrieve top processes by failure count', async () => {
       const { maestroProcesses } = getServices();
       const now = new Date();
@@ -210,7 +213,8 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopElementFailedCount', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopElementFailedCount', () => {
     it('should retrieve top elements by failure count', async () => {
       const { maestroProcesses } = getServices();
       const now = new Date();
@@ -233,7 +237,8 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
     });
   });
 
-  describe('getTopExecutionDuration', () => {
+  // skip: insightsrtm_ endpoints do not support PAT auth — requires OAuth
+  describe.skip('getTopExecutionDuration', () => {
     it('should retrieve top processes by duration', async () => {
       const { maestroProcesses } = getServices();
       const now = new Date();
@@ -276,8 +281,8 @@ describe.each(modes)('Maestro Processes - Integration Tests [%s]', (mode) => {
 
         const process = result[0];
 
-        expect(process.key).toBeDefined();
-        expect(typeof process.key).toBe('string');
+        expect(process.processKey).toBeDefined();
+        expect(typeof process.processKey).toBe('string');
 
         if (process.name) {
           expect(typeof process.name).toBe('string');

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -12,9 +12,6 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["tests/integration/**/*.integration.test.ts"],
-    exclude: [
-      "tests/integration/shared/maestro/**",
-    ],
     testTimeout: 30000,
     hookTimeout: 30000,
     coverage: {


### PR DESCRIPTION
Enables the Maestro integration suites in CI and makes them self-seeding, parallel-safe, and self-cleaning.

## What changed

- **Removed the `tests/integration/shared/maestro/**` exclusion** from `vitest.integration.config.ts` — the suites now run in CI.
- **Self-seeding fixtures**: a deployed case process is also an Orchestrator release (release key = Maestro `processKey`), and the job started via `Processes.start()` has `key` = case `instanceId`. Each state-mutating test starts, uses, and closes/cancels its own instance — safe under parallel runs, no pre-seeded tenant state needed:
  - running case (`sendMessage`, `close`, `pause`/`resume`) — seeded in `beforeAll` / per test
  - timer case (`reopen` — reopen requires `Completed`; close ⇒ `Cancelled` is not reopenable)
  - faulting process (`retry` + incident tests)
  - slow fixtures (timer completion, faulting) start fire-and-forget in `beforeAll` so they progress while earlier tests run
- **Skipped all `insightsrtm_`-backed blocks** (`getTop*`, timelines, stats, SLA summaries) with the standard comment — those endpoints reject PAT auth and need OAuth.
- **Test fixes**: pass each instance's own folder **key** in `x-uipath-folderkey` (not the numeric folder ID), correct field names (`processKey`, `instanceId`, `latestRunStatus`), `pageSize` caps on `caseInstances.getAll()` (it makes one extra case-JSON call per returned item), and measured polling windows sized for full-suite CI load.
- **`coverage.yml`**: wires three new secrets into the generated test env.

## Required repository secrets

| Secret | Purpose |
|---|---|
| `UIPATH_MAESTRO_TEST_PROCESS_KEY` | deliberately-faulting process (retry + incidents) |
| `UIPATH_MAESTRO_TEST_CASE_PROCESS_KEY` | human-task case, stays Running |
| `UIPATH_MAESTRO_TEST_COMPLETED_CASE_PROCESS_KEY` | timer case, completes on its own (reopen fixture) |

Without them the seeding preconditions throw (tests fail loudly rather than silently skip).

## Verification

Full maestro suite green locally in both init modes (100 passed / 40 insightsrtm-skipped), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)