### PR TITLE
feat(core): zero-config authentication from the execution context

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -85,13 +85,82 @@ To create a confidential app-scoped External App:
     The client-credentials flow does **not** support refresh tokens. To refresh, request a new token directly using the External App's client-credentials.
 
 
+## Coded Functions
+
+A coded function receives its platform coordinates as the handler's `ctx`. Pass
+that straight to the SDK — it maps the context itself, so the handler names no
+credential fields and never touches the workload token:
+
+```typescript
+import { defineFunction } from '@uipath/coded-functions-js-sdk';
+import { UiPath } from '@uipath/uipath-typescript/core';
+import { Entities } from '@uipath/uipath-typescript/entities';
+
+export default defineFunction({
+  name: 'list-entities',
+  handler: async (_input, ctx) => {
+    const sdk = new UiPath(ctx);
+
+    const entities = await new Entities(sdk).getAll();
+    return { entityCount: entities.length };
+  },
+});
+```
+
+Construct the SDK **inside the handler**, once per invocation. A single instance
+hoisted to module scope would keep serving the org, tenant and token of whichever
+invocation created it.
+
+## Server-side and scripts (environment contract)
+
+Outside the browser — a script, a test, a CI job — the SDK configures itself
+from environment variables, so `new UiPath()` needs no arguments:
+
+```typescript
+import { UiPath } from '@uipath/uipath-typescript/core';
+
+const sdk = new UiPath();
+```
+
+```bash
+UIPATH_BASE_URL=https://cloud.uipath.com
+UIPATH_ORG_NAME=<organization>          # an id works here as well as a name
+UIPATH_TENANT_NAME=<tenant>
+UIPATH_ACCESS_TOKEN=<accessToken>       # PAT or bearer token
+```
+
+These are the names this SDK already uses elsewhere for the same values, so one
+`.env` serves a script and a test run alike.
+
+The variables are read from `process.env` or `Deno.env`, whichever the runtime
+provides.
+
+To state the configuration explicitly instead, pass it to the constructor — this
+takes precedence over both the environment and meta tags:
+
+```typescript
+const sdk = new UiPath({
+  baseUrl: 'https://cloud.uipath.com',
+  orgName: '<organizationId>',   // an id works here as well as a name
+  tenantName: '<tenantId>',
+  secret: '<accessToken>'        // any bearer token
+});
+```
+
+The access token is consumed internally and is never exposed on `sdk.config`.
+
+!!! info "Precedence"
+    Constructor arguments win over meta tags, which win over the environment.
+    Meta tags apply in the browser only; the environment contract applies
+    outside it.
+
 ## SDK Initialization - The initialize() Method
 
 ### When to Use initialize()
 
 The `initialize()` method completes the authentication process for the SDK:
 
-- **Secret Authentication**: Auto-initializes when creating the SDK instance - **no need to call initialize()**
+- **Secret Authentication**: Auto-initializes when creating the SDK instance - **no need to call initialize()**. This covers `secret`, `accessToken`, a coded function's `ctx`, and the environment contract.
 - **OAuth Authentication**: **MUST call** `await sdk.initialize()` before using any SDK services
 
 ### Example: Secret Authentication (Auto-initialized)

--- a/src/core/config/config-utils.ts
+++ b/src/core/config/config-utils.ts
@@ -1,4 +1,5 @@
 import { UiPathSDKConfig, PartialUiPathConfig, hasOAuthConfig, hasSecretConfig } from './sdk-config';
+import { isBrowser } from '../../utils/platform';
 
 /**
  * Check if config has all required base fields
@@ -44,6 +45,38 @@ export function isCompleteConfig(config: PartialUiPathConfig): config is UiPathS
   return hasRequiredBaseFields(config) && hasValidAuthConfig(config);
 }
 
+/**
+ * Drop keys whose value is undefined so a sparse higher-precedence layer never
+ * blanks out a value supplied by a lower-precedence one during a merge.
+ */
+export function compactConfig(config: PartialUiPathConfig): PartialUiPathConfig {
+  // Cast: Object.fromEntries resolves to its any-returning overload for a
+  // mutable [string, string | undefined][] input.
+  return Object.fromEntries(
+    Object.entries(config).filter(([, value]) => value !== undefined),
+  ) as PartialUiPathConfig;
+}
+
 export function normalizeBaseUrl(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 } 
+/**
+ * Configuration-not-found guidance, matched to where the SDK is running.
+ *
+ * Shared so the registry can reuse it when a service is constructed from a
+ * UiPath instance that never resolved a configuration — otherwise the caller
+ * only learns their instance is "invalid", not why.
+ */
+export function missingConfigMessage(): string {
+  if (isBrowser) {
+    return 'UiPath SDK configuration not found. ' +
+      'Ensure @uipath/coded-apps plugin is set up in your bundler to inject configuration during development and build.';
+  }
+
+  // Ordered by likelihood: on a runner the environment is never populated, so 
+  // leading with it would point the reader at the one option that cannot work.
+  return 'UiPath SDK configuration not found. ' +
+    'In a UiPath coded function, pass the handler context: new UiPath(ctx). ' +
+    'Otherwise pass { baseUrl, orgName, tenantName, secret }, ' +
+    'or set UIPATH_BASE_URL, UIPATH_ORG_NAME, UIPATH_TENANT_NAME and UIPATH_ACCESS_TOKEN.';
+}

--- a/src/core/config/environment.ts
+++ b/src/core/config/environment.ts
@@ -1,0 +1,73 @@
+import { PartialUiPathConfig } from './sdk-config';
+import { isBrowser } from '../../utils/platform';
+
+/**
+ * Shape of the globals that expose environment variables. Read defensively so
+ * the SDK works under Node and Deno, and stays inert in browser bundles where
+ * neither exists.
+ */
+interface EnvCapableGlobal {
+  process?: { env?: Record<string, string | undefined> };
+  Deno?: { env?: { get?(name: string): string | undefined } };
+}
+
+/**
+ * Reads a single environment variable, returning undefined for missing or
+ * empty values so a blank variable never satisfies a required field.
+ */
+export function readEnv(name: string): string | undefined {
+  const globals = globalThis as EnvCapableGlobal;
+
+  // Both reads are guarded: Deno throws without `--allow-env`, and its
+  // `process.env` shim proxies the same permission-gated `Deno.env`, so reading
+  // either one unguarded would escape the SDK constructor.
+  try {
+    const fromNode = globals.process?.env?.[name];
+    if (fromNode) return fromNode;
+  } catch {
+    // No env permission; fall through to the Deno accessor.
+  }
+
+  try {
+    const fromDeno = globals.Deno?.env?.get?.(name);
+    if (fromDeno) return fromDeno;
+  } catch {
+    // No env permission; treat the variable as absent.
+  }
+
+  return undefined;
+}
+
+/**
+ * The environment contract, matching the names this repository already uses for
+ * the same values in its integration configuration and documentation, so one
+ * `.env` serves both.
+ */
+export const UiPathEnvVars = {
+  BASE_URL: 'UIPATH_BASE_URL',
+  ORG_NAME: 'UIPATH_ORG_NAME',
+  TENANT_NAME: 'UIPATH_TENANT_NAME',
+  ACCESS_TOKEN: 'UIPATH_ACCESS_TOKEN',
+} as const;
+
+/**
+ * Load configuration from the execution-context environment contract.
+ *
+ * Returns null in browsers (where meta tags are the configuration source) and
+ * whenever no contract variable is present, so callers can fall through to
+ * other sources instead of acting on a half-populated config.
+ */
+export function loadFromEnvironment(): PartialUiPathConfig | null {
+  if (isBrowser) return null;
+
+  // Org and tenant accept an id as readily as a name — both go into the same URL
+  // position — and the token goes to `secret`, used verbatim as the bearer value.
+  const config: PartialUiPathConfig = {
+    baseUrl: readEnv(UiPathEnvVars.BASE_URL),
+    orgName: readEnv(UiPathEnvVars.ORG_NAME),
+    tenantName: readEnv(UiPathEnvVars.TENANT_NAME),
+    secret: readEnv(UiPathEnvVars.ACCESS_TOKEN),
+  };
+
+  return Object.values(config).some(Boolean) ? config : null;
+}

--- a/src/core/config/function-context.ts
+++ b/src/core/config/function-context.ts
@@ -1,0 +1,80 @@
+import { PartialUiPathConfig } from './sdk-config';
+
+/**
+ * Platform coordinates a coded function receives, mirroring `PlatformContext`
+ * from `@uipath/coded-functions-js-sdk`.
+ */
+export interface CodedFunctionPlatform {
+  /** Platform host, without a path — for example `https://cloud.uipath.com`. */
+  baseUrl: string;
+  /** Organization id (GUID, not slug). */
+  orgId: string;
+  /** Tenant id (GUID, not slug). */
+  tenantId: string;
+  /** Folder key of the invocation, if any. The SDK ignores it. */
+  folderKey?: string | null;
+}
+
+/**
+ * The function's own platform identity, mirroring `RobotContext` from
+ * `@uipath/coded-functions-js-sdk`.
+ */
+export interface CodedFunctionRobot {
+  /** Platform-issued token the SDK uses to authenticate its calls. */
+  accessToken: string | null;
+  /** Serverless robot key. The SDK ignores it. */
+  key?: string | null;
+}
+
+/**
+ * The execution context a coded function receives, which can be passed straight
+ * to the {@link UiPath} constructor.
+ *
+ * Mirrors `FunctionContext` from `@uipath/coded-functions-js-sdk` by shape, so
+ * neither package depends on the other. Fields the SDK does not read — `user`,
+ * `params`, `headers` — are ignored.
+ */
+export interface CodedFunctionContext {
+  /** Coordinates for outbound calls. Null when the host supplies none. */
+  platform: CodedFunctionPlatform | null;
+  /** The function's identity, carrying the token. Null on a local run. */
+  robot: CodedFunctionRobot | null;
+}
+
+/**
+ * Distinguishes a coded-function context from SDK configuration.
+ *
+ * The shapes are disjoint — configuration never carries `platform` or `robot` —
+ * so the caller never has to say which one it passed.
+ */
+export function isFunctionContext(
+  value: PartialUiPathConfig | CodedFunctionContext,
+): value is CodedFunctionContext {
+  return 'platform' in value || 'robot' in value;
+}
+
+/**
+ * Maps a coded-function context onto SDK configuration.
+ *
+ * Null when the context has no coordinates — a local run, where `platform` is
+ * null — so the caller falls through to its other sources.
+ */
+export function configFromFunctionContext(
+  context: CodedFunctionContext,
+): PartialUiPathConfig | null {
+  const { platform, robot } = context;
+  if (!platform) return null;
+
+  // Org and tenant ids go where orgName/tenantName go — the platform accepts
+  // either in that URL position — and the token goes to `secret`, used verbatim
+  // as the bearer value. `baseUrl` must already be host-only: a host that holds
+  // a longer URL has to reduce it, or org and tenant appear in the path twice.
+  const config: PartialUiPathConfig = {
+    baseUrl: platform.baseUrl,
+    orgName: platform.orgId,
+    tenantName: platform.tenantId,
+    secret: robot?.accessToken ?? undefined,
+  };
+
+  return Object.values(config).some(Boolean) ? config : null;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,6 +45,11 @@
 
 export { UiPath } from './uipath';
 export type { UiPathSDKConfig } from './config/sdk-config';
+export type {
+  CodedFunctionContext,
+  CodedFunctionPlatform,
+  CodedFunctionRobot,
+} from './config/function-context';
 export type { TokenInfo, LogoutOptions } from './auth/types';
 export * from './errors';
 

--- a/src/core/internals/registry.ts
+++ b/src/core/internals/registry.ts
@@ -9,6 +9,7 @@
  */
 
 import type { PrivateSDK } from './types';
+import { missingConfigMessage } from '../config/config-utils';
 
 // Global symbol key to ensure WeakMap is shared across module instances
 // This prevents issues when core and service modules are bundled separately
@@ -22,6 +23,16 @@ const getGlobalStore = (): WeakMap<object, PrivateSDK> => {
   }
   return globalObj[REGISTRY_KEY];
 };
+
+/**
+ * Whether a value looks like a UiPath instance — used only to choose between two
+ * diagnostics, never to grant access.
+ *
+ * Structural because importing UiPath here would be circular, and each bundled
+ * subpath can hold its own copy of the class, which `instanceof` would reject.
+ */
+const looksLikeUiPath = (instance: object): boolean =>
+  typeof (instance as { initialize?: unknown }).initialize === 'function';
 
 /**
  * Internal registry for SDK private components.
@@ -54,6 +65,13 @@ export class SDKInternalsRegistry {
   static get(instance: object): PrivateSDK {
     const internals = this.store.get(instance);
     if (!internals) {
+      if (looksLikeUiPath(instance)) {
+        throw new Error(
+          'Cannot create a service: the UiPath instance was never configured. ' +
+          missingConfigMessage()
+        );
+      }
+
       throw new Error(
         'Invalid SDK instance. Make sure to pass a valid UiPath instance to the service constructor.'
       );

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -3,10 +3,12 @@ import { ExecutionContext } from './context/execution';
 import { AuthService } from './auth/service';
 import { TokenInfo, LogoutOptions } from './auth/types';
 import { UiPathSDKConfig, PartialUiPathConfig, BaseConfig, hasOAuthConfig, hasSecretConfig } from './config/sdk-config';
-import { validateConfig, normalizeBaseUrl, isCompleteConfig } from './config/config-utils';
+import { validateConfig, normalizeBaseUrl, isCompleteConfig, compactConfig, missingConfigMessage } from './config/config-utils';
 import { telemetryClient, trackEvent } from './telemetry';
 import { SDKInternalsRegistry } from './internals';
 import { loadFromMetaTags } from './config/runtime';
+import { loadFromEnvironment } from './config/environment';
+import { configFromFunctionContext, isFunctionContext, type CodedFunctionContext } from './config/function-context';
 import type { IUiPath } from './types';
 import { isInActionCenter } from '../utils/platform';
 import { trustedEmbeddingOrigin } from './auth/host-token-request';
@@ -17,9 +19,12 @@ import { trustedEmbeddingOrigin } from './auth/host-token-request';
  * Handles authentication, configuration, and provides access to SDK internals
  * for service instantiation in the modular pattern.
  *
- * Supports two usage patterns:
- * 1. Full config in constructor — for server-side or explicit configuration
- * 2. No config / partial config — loads from meta tags injected by @uipath/coded-apps-dev plugin
+ * Configuration is resolved from three sources, in precedence order:
+ * 1. The constructor argument — either an explicit config or a coded function's
+ *    `ctx`, which the SDK maps onto the config fields itself
+ * 2. Meta tags injected by the @uipath/coded-apps-dev plugin — browser only
+ * 3. The environment contract — `UIPATH_BASE_URL`, `UIPATH_ORG_NAME`,
+ *    `UIPATH_TENANT_NAME`, `UIPATH_ACCESS_TOKEN` — outside the browser
  *
  * @example
  * ```typescript
@@ -37,9 +42,38 @@ import { trustedEmbeddingOrigin } from './auth/host-token-request';
  *
  * @example
  * ```typescript
- * // Auto-load from meta tags (coded apps)
+ * // No arguments: meta tags in a coded app, the environment contract elsewhere
  * const sdk = new UiPath();
  * await sdk.initialize();
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Coded function: pass the handler's context, ready to use straight away
+ * import { defineFunction } from '@uipath/coded-functions-js-sdk';
+ * import { UiPath } from '@uipath/uipath-typescript/core';
+ * import { Entities } from '@uipath/uipath-typescript/entities';
+ *
+ * export default defineFunction({
+ *   name: 'list-entities',
+ *   handler: async (_input, ctx) => {
+ *     const sdk = new UiPath(ctx);
+ *     const entities = await new Entities(sdk).getAll();
+ *     return { count: entities.length };
+ *   },
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Explicit ids and a bearer token — org and tenant accept either an id or a
+ * // name, and `secret` takes any bearer token
+ * const sdk = new UiPath({
+ *   baseUrl: 'https://cloud.uipath.com',
+ *   orgName: '<organizationId>',
+ *   tenantName: '<tenantId>',
+ *   secret: '<accessToken>'
+ * });
  * ```
  */
 export class UiPath implements IUiPath {
@@ -66,22 +100,29 @@ export class UiPath implements IUiPath {
   /**
    * Creates a UiPath SDK instance.
    *
-   * @param config - Optional SDK configuration; when omitted, configuration is loaded from meta tags
+   * @param config - Optional SDK configuration, or the execution context a coded function receives; when omitted, configuration is loaded from meta tags or the environment
    */
-  constructor(config?: PartialUiPathConfig) {
+  constructor(config?: PartialUiPathConfig | CodedFunctionContext) {
+    // A coded function passes its ctx here. A context with no coordinates (the
+    // local case) resolves to undefined and falls through to the other sources.
+    const resolved = config && isFunctionContext(config)
+      ? configFromFunctionContext(config) ?? undefined
+      : config;
+
     // Load configuration from meta tags
     const configFromMetaTags = loadFromMetaTags();
     this.#metaFolderKey = configFromMetaTags?.folderKey;
     this.#metaOrgId = configFromMetaTags?.orgName;
     this.#metaTenantId = configFromMetaTags?.tenantName;
 
-    // Merge configuration: constructor config overrides meta tags
-    const mergedConfig = config ? { ...configFromMetaTags, ...config } : configFromMetaTags;
+    // Merge configuration: constructor config overrides meta tags, which
+    // override the ambient execution-context environment contract.
+    const mergedConfig = UiPath.#mergeConfigSources(configFromMetaTags, resolved);
 
     if (mergedConfig && isCompleteConfig(mergedConfig)) {
       this.#initializeWithConfig(mergedConfig);
-    } else if (config) {
-      this.#partialConfig = config;
+    } else if (resolved) {
+      this.#partialConfig = resolved;
     }
   }
 
@@ -149,21 +190,60 @@ export class UiPath implements IUiPath {
     }
   }
 
+  /**
+   * Merge every configuration source in precedence order: constructor config,
+   * then meta tags, then the environment contract.
+   *
+   * Each layer is compacted before merging so a sparse layer never blanks out
+   * values from the layer beneath it.
+   */
+  static #mergeConfigSources(
+    metaConfig?: PartialUiPathConfig | null,
+    config?: PartialUiPathConfig | null,
+  ): PartialUiPathConfig | undefined {
+    const layers = [loadFromEnvironment(), metaConfig, config]
+      .filter((layer): layer is PartialUiPathConfig => Boolean(layer))
+      .map((layer) => compactConfig(layer));
+
+    if (layers.length === 0) return undefined;
+
+    const merged = layers.reduce<PartialUiPathConfig>((acc, layer) => ({ ...acc, ...layer }), {});
+
+    // Auth is `secret` or OAuth, never both, and merging can end up with both.
+    // Whichever the caller named here wins; the other's fields are dropped.
+    // A caller naming both is contradicting themselves: left intact for validateConfig() to reject.
+    const namesSecret = config ? hasSecretConfig(config) : false;
+    // Any OAuth field, not all three: a half-filled OAuth config should error,
+    // not quietly fall back to a `secret` from a lower layer.
+    const namesOAuth = Boolean(config?.clientId || config?.redirectUri || config?.scope);
+
+    if (namesSecret !== namesOAuth) {
+      if (namesSecret) {
+        delete merged.clientId;
+        delete merged.redirectUri;
+        delete merged.scope;
+      } else {
+        delete merged.secret;
+      }
+    }
+
+    return merged;
+  }
+
   #loadConfig(): UiPathSDKConfig {
-    // Load from meta tags
+    // Re-reads every source rather than reusing the constructor's merge: meta
+    // tags can be injected after construction, and recovering that is why this
+    // runs at all.
     const metaConfig = loadFromMetaTags();
     this.#metaFolderKey = metaConfig?.folderKey;
     this.#metaOrgId = metaConfig?.orgName;
     this.#metaTenantId = metaConfig?.tenantName;
 
-    // Merge with any partial config from constructor (constructor overrides meta tags)
-    const merged = { ...metaConfig, ...this.#partialConfig };
+    // Constructor config overrides meta tags, which override the environment.
+    const merged = UiPath.#mergeConfigSources(metaConfig, this.#partialConfig);
 
-    if (!isCompleteConfig(merged)) {
-      throw new Error(
-        'UiPath SDK configuration not found. ' +
-        'Ensure @uipath/coded-apps plugin is set up in your bundler to inject configuration during development and build.'
-      );
+    if (!merged || !isCompleteConfig(merged)) {
+      throw new Error(missingConfigMessage());
     }
 
     return merged;
@@ -173,7 +253,8 @@ export class UiPath implements IUiPath {
    * Initialize the SDK based on the provided configuration.
    * This method handles both OAuth flow initiation and completion automatically.
    * For secret-based authentication, initialization is automatic and this returns immediately.
-   * If no config was provided in constructor, loads from meta tags.
+   * If no config was provided in constructor, loads from meta tags in the browser,
+   * or from the execution-context environment contract outside it.
    */
   public async initialize(): Promise<void> {
     // Load config from meta tags if not provided in constructor

--- a/tests/unit/core/config/compact-config.test.ts
+++ b/tests/unit/core/config/compact-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { compactConfig } from '@/core/config/config-utils';
+
+describe('compactConfig', () => {
+  it('drops keys whose value is undefined', () => {
+    const result = compactConfig({ baseUrl: 'https://cloud.uipath.com', orgName: undefined });
+    expect(result).toEqual({ baseUrl: 'https://cloud.uipath.com' });
+    expect(result).not.toHaveProperty('orgName');
+  });
+
+  it('keeps a sparse layer from blanking out the layer beneath it on merge', () => {
+    const lower = { baseUrl: 'https://cloud.uipath.com', orgName: 'from-env' };
+    const upper = compactConfig({ orgName: undefined, tenantName: 'from-ctor' });
+
+    expect({ ...lower, ...upper }).toEqual({
+      baseUrl: 'https://cloud.uipath.com',
+      orgName: 'from-env',
+      tenantName: 'from-ctor',
+    });
+  });
+});

--- a/tests/unit/core/config/environment-browser.test.ts
+++ b/tests/unit/core/config/environment-browser.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// The browser branch of loadFromEnvironment: meta tags are the browser's
+// configuration source, so the environment contract must never be consulted.
+vi.mock('@/utils/platform', () => ({ isBrowser: true }));
+
+import { loadFromEnvironment } from '@/core/config/environment';
+import { clearContractEnv } from '../../../utils/env-contract';
+
+let restoreEnv: () => void;
+
+beforeEach(() => {
+  restoreEnv = clearContractEnv();
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe('loadFromEnvironment in the browser', () => {
+  it('returns null even when every contract variable is populated', () => {
+    process.env.UIPATH_BASE_URL = 'https://alpha.uipath.com';
+    process.env.UIPATH_ORG_NAME = 'org-guid';
+    process.env.UIPATH_TENANT_NAME = 'tenant-guid';
+    process.env.UIPATH_ACCESS_TOKEN = 'token-abc';
+
+    expect(loadFromEnvironment()).toBeNull();
+  });
+});

--- a/tests/unit/core/config/environment.test.ts
+++ b/tests/unit/core/config/environment.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Must mock platform before importing environment — the loader is a no-op in browsers.
+vi.mock('@/utils/platform', () => ({ isBrowser: false }));
+
+import { loadFromEnvironment, readEnv } from '@/core/config/environment';
+import { clearContractEnv } from '../../../utils/env-contract';
+
+let restoreEnv: () => void;
+
+beforeEach(() => {
+  restoreEnv = clearContractEnv();
+});
+
+afterEach(() => {
+  restoreEnv();
+  vi.unstubAllGlobals();
+});
+
+describe('readEnv', () => {
+  it('returns the value when the variable is set', () => {
+    process.env.UIPATH_BASE_URL = 'https://cloud.uipath.com';
+    expect(readEnv('UIPATH_BASE_URL')).toBe('https://cloud.uipath.com');
+  });
+
+  it('returns undefined for an unset variable', () => {
+    expect(readEnv('UIPATH_BASE_URL')).toBeUndefined();
+  });
+
+  it('treats an empty value as absent', () => {
+    process.env.UIPATH_BASE_URL = '';
+    expect(readEnv('UIPATH_BASE_URL')).toBeUndefined();
+  });
+
+  it('falls back to Deno.env when process does not provide the value', () => {
+    vi.stubGlobal('Deno', { env: { get: (name: string) => (name === 'UIPATH_BASE_URL' ? 'https://deno.uipath.com' : undefined) } });
+    expect(readEnv('UIPATH_BASE_URL')).toBe('https://deno.uipath.com');
+  });
+
+  it('returns undefined when a permission-gated process.env throws', () => {
+    // Deno's process.env shim proxies the same permission-gated Deno.env, so an
+    // unguarded read here would escape the SDK constructor.
+    vi.stubGlobal('process', { env: new Proxy({}, { get() { throw new Error('permission denied'); } }) });
+
+    expect(() => readEnv('UIPATH_BASE_URL')).not.toThrow();
+    expect(readEnv('UIPATH_BASE_URL')).toBeUndefined();
+  });
+
+  it('falls back to Deno.env when process.env throws', () => {
+    vi.stubGlobal('process', { env: new Proxy({}, { get() { throw new Error('permission denied'); } }) });
+    vi.stubGlobal('Deno', { env: { get: (n: string) => (n === 'UIPATH_BASE_URL' ? 'https://deno.uipath.com' : undefined) } });
+
+    expect(readEnv('UIPATH_BASE_URL')).toBe('https://deno.uipath.com');
+  });
+
+  it('returns undefined when Deno throws on a missing env permission', () => {
+    vi.stubGlobal('Deno', { env: { get: () => { throw new Error('permission denied'); } } });
+    expect(readEnv('UIPATH_BASE_URL')).toBeUndefined();
+  });
+});
+
+describe('loadFromEnvironment', () => {
+  it('returns null when no contract variable is set', () => {
+    expect(loadFromEnvironment()).toBeNull();
+  });
+
+  it('reads the contract the Functions runtime uses locally', () => {
+    process.env.UIPATH_BASE_URL = 'https://cloud.uipath.com';
+    process.env.UIPATH_ORG_NAME = 'org-guid';
+    process.env.UIPATH_TENANT_NAME = 'tenant-guid';
+    process.env.UIPATH_ACCESS_TOKEN = 'token-abc';
+
+    expect(loadFromEnvironment()).toEqual({
+      baseUrl: 'https://cloud.uipath.com',
+      orgName: 'org-guid',
+      tenantName: 'tenant-guid',
+      secret: 'token-abc',
+    });
+  });
+
+  it('returns a partial config when only some variables are set', () => {
+    process.env.UIPATH_BASE_URL = 'https://alpha.uipath.com';
+    const config = loadFromEnvironment();
+    expect(config?.baseUrl).toBe('https://alpha.uipath.com');
+    expect(config?.orgName).toBeUndefined();
+  });
+});

--- a/tests/unit/core/config/function-context.test.ts
+++ b/tests/unit/core/config/function-context.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  configFromFunctionContext,
+  isFunctionContext,
+  type CodedFunctionContext,
+} from '@/core/config/function-context';
+import type { PartialUiPathConfig } from '@/core/config/sdk-config';
+import { TEST_CONSTANTS } from '../../../utils/constants/common';
+
+describe('isFunctionContext', () => {
+  it('recognises a context carrying platform coordinates', () => {
+    const context: CodedFunctionContext = {
+      platform: { baseUrl: TEST_CONSTANTS.BASE_URL, orgId: 'o', tenantId: 't' },
+      robot: null,
+    };
+
+    expect(isFunctionContext(context)).toBe(true);
+  });
+
+  it('recognises a context carrying only a robot identity', () => {
+    const context: CodedFunctionContext = { platform: null, robot: { accessToken: 't' } };
+
+    expect(isFunctionContext(context)).toBe(true);
+  });
+
+  it('recognises a context whose platform is null, as on a local run', () => {
+    const context: CodedFunctionContext = { platform: null, robot: null };
+
+    expect(isFunctionContext(context)).toBe(true);
+  });
+
+  it('does not mistake SDK configuration for a context', () => {
+    const config: PartialUiPathConfig = {
+      baseUrl: TEST_CONSTANTS.BASE_URL,
+      orgName: 'my-org',
+      tenantName: 'my-tenant',
+      secret: 'pat',
+    };
+
+    expect(isFunctionContext(config)).toBe(false);
+  });
+});
+
+describe('configFromFunctionContext', () => {
+  it('maps platform coordinates and the workload token onto the config fields', () => {
+    const context: CodedFunctionContext = {
+      platform: {
+        baseUrl: TEST_CONSTANTS.BASE_URL,
+        orgId: TEST_CONSTANTS.ORGANIZATION_ID,
+        tenantId: TEST_CONSTANTS.TENANT_ID,
+      },
+      robot: { accessToken: TEST_CONSTANTS.DEFAULT_ACCESS_TOKEN },
+    };
+
+    expect(configFromFunctionContext(context)).toEqual({
+      baseUrl: TEST_CONSTANTS.BASE_URL,
+      orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+      tenantName: TEST_CONSTANTS.TENANT_ID,
+      secret: TEST_CONSTANTS.DEFAULT_ACCESS_TOKEN,
+    });
+  });
+
+  it('returns null when the host supplies no platform, so callers fall through', () => {
+    const context: CodedFunctionContext = { platform: null, robot: null };
+
+    expect(configFromFunctionContext(context)).toBeNull();
+  });
+
+  it('normalises a null accessToken to undefined', () => {
+    const context: CodedFunctionContext = {
+      platform: { baseUrl: TEST_CONSTANTS.BASE_URL, orgId: 'o', tenantId: 't' },
+      robot: { accessToken: null },
+    };
+    const result = configFromFunctionContext(context);
+
+    expect(result?.secret).toBeUndefined();
+  });
+
+  it('maps coordinates even when the robot identity is absent', () => {
+    const context: CodedFunctionContext = {
+      platform: { baseUrl: TEST_CONSTANTS.BASE_URL, orgId: 'o', tenantId: 't' },
+      robot: null,
+    };
+    const result = configFromFunctionContext(context);
+
+    expect(result?.orgName).toBe('o');
+    expect(result?.secret).toBeUndefined();
+  });
+});

--- a/tests/unit/core/internals/registry.test.ts
+++ b/tests/unit/core/internals/registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@/utils/platform', () => ({
+  isBrowser: false,
+  isInActionCenter: false,
+  isHostEmbedded: false,
+  embeddingOrigin: null,
+}));
+
+vi.mock('@/core/http/api-client');
+
+import { UiPath } from '@/core/uipath';
+import { EntityService } from '@/services/data-fabric/entities';
+import { clearContractEnv } from '../../../utils/env-contract';
+import { TEST_CONSTANTS } from '../../../utils/constants/common';
+
+let restoreEnv: () => void;
+
+beforeEach(() => {
+  restoreEnv = clearContractEnv();
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe('SDKInternalsRegistry error reporting', () => {
+  it('explains the missing configuration when the instance never resolved one', () => {
+    // The deployed-Function failure mode: no contract present, so `new UiPath()`
+    // cannot configure itself and the service must report why.
+    const sdk = new UiPath();
+
+    expect(() => new EntityService(sdk)).toThrow(/was never configured/);
+    expect(() => new EntityService(sdk)).toThrow(/new UiPath\(ctx\)/);
+  });
+
+  it('keeps the generic message for something that is not a UiPath instance', () => {
+    const notAnSdk = {} as unknown as UiPath;
+
+    expect(() => new EntityService(notAnSdk)).toThrow(/Invalid SDK instance/);
+    expect(() => new EntityService(notAnSdk)).not.toThrow(/was never configured/);
+  });
+
+  it('constructs services normally from a configured instance', () => {
+    const sdk = new UiPath({
+      baseUrl: TEST_CONSTANTS.BASE_URL,
+      orgName: TEST_CONSTANTS.ORGANIZATION_ID,
+      tenantName: TEST_CONSTANTS.TENANT_ID,
+      secret: TEST_CONSTANTS.DEFAULT_ACCESS_TOKEN,
+    });
+
+    expect(() => new EntityService(sdk)).not.toThrow();
+  });
+});

--- a/tests/unit/core/uipath-zero-config.test.ts
+++ b/tests/unit/core/uipath-zero-config.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/utils/platform', () => ({
+  isBrowser: false,
+  isInActionCenter: false,
+  isHostEmbedded: false,
+  embeddingOrigin: null,
+}));
+
+vi.mock('@/core/auth/service', () => {
+  // Object.assign intersects both argument types, so the static property is
+  // typed without resorting to `any`.
+  const AuthService = Object.assign(
+    vi.fn().mockImplementation(function () {
+      return {
+        getTokenManager: () => ({ getToken: () => 'token', hasValidToken: () => true, destroy: vi.fn() }),
+        hasValidToken: () => true,
+        authenticateWithSecret: vi.fn(),
+        authenticate: vi.fn().mockResolvedValue(true),
+        logout: vi.fn(),
+      };
+    }),
+    { isInOAuthCallback: vi.fn(() => false) },
+  );
+  return { AuthService };
+});
+
+vi.mock('@/core/http/api-client');
+
+vi.mock('@/core/config/runtime', () => ({ loadFromMetaTags: vi.fn(() => null) }));
+
+import { UiPath } from '@/core/uipath';
+import { loadFromMetaTags } from '@/core/config/runtime';
+import type { CodedFunctionContext } from '@/core/config/function-context';
+import { clearContractEnv } from '../../utils/env-contract';
+import { TEST_CONSTANTS } from '../../utils/constants/common';
+
+const BASE_URL = TEST_CONSTANTS.BASE_URL;
+const ORG_ID = TEST_CONSTANTS.ORGANIZATION_ID;
+const TENANT_ID = TEST_CONSTANTS.TENANT_ID;
+const TOKEN = TEST_CONSTANTS.DEFAULT_ACCESS_TOKEN;
+
+let restoreEnv: () => void;
+
+function setContract(vars: Record<string, string>): void {
+  Object.assign(process.env, vars);
+}
+
+beforeEach(() => {
+  restoreEnv = clearContractEnv();
+});
+
+afterEach(() => {
+  vi.mocked(loadFromMetaTags).mockReturnValue(null);
+  restoreEnv();
+});
+
+describe('UiPath zero-config from the execution-context contract', () => {
+  it('configures itself from the environment with no constructor arguments', () => {
+    setContract({
+      UIPATH_BASE_URL: BASE_URL,
+      UIPATH_ORG_NAME: 'my-org',
+      UIPATH_TENANT_NAME: 'my-tenant',
+      UIPATH_ACCESS_TOKEN: TOKEN,
+    });
+
+    const sdk = new UiPath();
+
+    expect(sdk.config.baseUrl).toBe(BASE_URL);
+    expect(sdk.config.orgName).toBe('my-org');
+    expect(sdk.config.tenantName).toBe('my-tenant');
+    expect(sdk.isInitialized()).toBe(true);
+  });
+
+  it('accepts the id-based spelling of the contract', () => {
+    setContract({
+      UIPATH_BASE_URL: BASE_URL,
+      UIPATH_ORG_NAME: ORG_ID,
+      UIPATH_TENANT_NAME: TENANT_ID,
+      UIPATH_ACCESS_TOKEN: TOKEN,
+    });
+
+    const sdk = new UiPath();
+
+    expect(sdk.config.orgName).toBe(ORG_ID);
+    expect(sdk.config.tenantName).toBe(TENANT_ID);
+  });
+
+  it('never exposes the token on the public config', () => {
+    setContract({
+      UIPATH_BASE_URL: BASE_URL,
+      UIPATH_ORG_NAME: ORG_ID,
+      UIPATH_TENANT_NAME: TENANT_ID,
+      UIPATH_ACCESS_TOKEN: TOKEN,
+    });
+
+    const sdk = new UiPath();
+
+    expect(Object.values(sdk.config)).not.toContain(TOKEN);
+    expect(JSON.stringify(sdk.config)).not.toContain(TOKEN);
+  });
+
+  it('lets constructor config override the environment', () => {
+    setContract({
+      UIPATH_BASE_URL: 'https://wrong.uipath.com',
+      UIPATH_ORG_NAME: 'wrong-org',
+      UIPATH_TENANT_NAME: 'wrong-tenant',
+      UIPATH_ACCESS_TOKEN: TOKEN,
+    });
+
+    const sdk = new UiPath({ baseUrl: BASE_URL, orgName: 'right-org', tenantName: 'right-tenant' });
+
+    expect(sdk.config.baseUrl).toBe(BASE_URL);
+    expect(sdk.config.orgName).toBe('right-org');
+    expect(sdk.config.tenantName).toBe('right-tenant');
+  });
+
+  it('completes a partial constructor config from the environment', () => {
+    setContract({ UIPATH_BASE_URL: BASE_URL, UIPATH_ACCESS_TOKEN: TOKEN });
+
+    const sdk = new UiPath({ orgName: ORG_ID, tenantName: TENANT_ID });
+
+    expect(sdk.config.baseUrl).toBe(BASE_URL);
+    expect(sdk.config.orgName).toBe(ORG_ID);
+  });
+});
+
+describe('UiPath explicit id/token constructor override', () => {
+  it('accepts ids in orgName/tenantName and a bearer token in secret', () => {
+    const sdk = new UiPath({ baseUrl: BASE_URL, orgName: ORG_ID, tenantName: TENANT_ID, secret: TOKEN });
+
+    expect(sdk.config.orgName).toBe(ORG_ID);
+    expect(sdk.config.tenantName).toBe(TENANT_ID);
+    expect(sdk.isInitialized()).toBe(true);
+  });
+
+  it('still accepts the canonical orgName/tenantName/secret spelling', () => {
+    const sdk = new UiPath({ baseUrl: BASE_URL, orgName: 'my-org', tenantName: 'my-tenant', secret: TOKEN });
+
+    expect(sdk.config.orgName).toBe('my-org');
+    expect(sdk.isInitialized()).toBe(true);
+  });
+});
+
+describe('UiPath auth-method precedence across sources', () => {
+  const OAUTH = {
+    clientId: TEST_CONSTANTS.CLIENT_ID,
+    redirectUri: TEST_CONSTANTS.REDIRECT_URI,
+    scope: TEST_CONSTANTS.OAUTH_SCOPE,
+  };
+
+  it('keeps an explicit OAuth config usable when the environment supplies a token', () => {
+    setContract({ UIPATH_ACCESS_TOKEN: TOKEN });
+
+    const sdk = new UiPath({ baseUrl: BASE_URL, orgName: 'my-org', tenantName: 'my-tenant', ...OAUTH });
+
+    expect(sdk.config.orgName).toBe('my-org');
+    expect(sdk.isInitialized()).toBe(false); // OAuth defers to initialize(), not secret auto-init
+  });
+
+  it('keeps an explicit secret config usable when meta tags supply OAuth fields', () => {
+    // Meta tags are the only layer that can carry OAuth, so this is the other
+    // reachable cross-layer conflict.
+    vi.mocked(loadFromMetaTags).mockReturnValue({
+      baseUrl: BASE_URL,
+      orgName: 'meta-org',
+      tenantName: 'meta-tenant',
+      ...OAUTH,
+    });
+
+    const sdk = new UiPath({ secret: 'ctor-secret' });
+
+    expect(sdk.isInitialized()).toBe(true); // secret wins, OAuth fields dropped
+  });
+
+  it('leaves a single layer carrying both auth methods for validation to reject', async () => {
+    const sdk = new UiPath({
+      baseUrl: BASE_URL,
+      orgName: 'my-org',
+      tenantName: 'my-tenant',
+      secret: 'ctor-secret',
+      ...OAUTH,
+    });
+
+    // Contradictory input is not a precedence question — it must not be
+    // silently resolved by dropping one of the two.
+    await expect(sdk.initialize()).rejects.toThrow();
+  });
+});
+
+describe('UiPath missing configuration', () => {
+  it('points a coded function at the handler context first', async () => {
+    const sdk = new UiPath();
+    await expect(sdk.initialize()).rejects.toThrow(/new UiPath\(ctx\)/);
+  });
+
+  it('also names the environment variables it looks for', async () => {
+    const sdk = new UiPath();
+
+    for (const name of ['UIPATH_BASE_URL', 'UIPATH_ORG_NAME', 'UIPATH_TENANT_NAME', 'UIPATH_ACCESS_TOKEN']) {
+      await expect(sdk.initialize()).rejects.toThrow(name);
+    }
+  });
+
+  it('does not mention the browser bundler plugin outside the browser', async () => {
+    const sdk = new UiPath();
+    await expect(sdk.initialize()).rejects.not.toThrow(/coded-apps plugin/);
+  });
+});
+
+describe('UiPath constructed from a coded-function context', () => {
+  it('configures itself from ctx with no environment present', () => {
+    const ctx: CodedFunctionContext = {
+      platform: { baseUrl: BASE_URL, orgId: ORG_ID, tenantId: TENANT_ID },
+      robot: { accessToken: TOKEN },
+    };
+
+    const sdk = new UiPath(ctx);
+
+    expect(sdk.config.baseUrl).toBe(BASE_URL);
+    expect(sdk.config.orgName).toBe(ORG_ID);
+    expect(sdk.config.tenantName).toBe(TENANT_ID);
+    expect(sdk.isInitialized()).toBe(true);
+  });
+
+  it('never exposes the workload token on the public config', () => {
+    const ctx: CodedFunctionContext = {
+      platform: { baseUrl: BASE_URL, orgId: ORG_ID, tenantId: TENANT_ID },
+      robot: { accessToken: TOKEN },
+    };
+
+    const sdk = new UiPath(ctx);
+
+    expect(JSON.stringify(sdk.config)).not.toContain(TOKEN);
+  });
+
+  it('falls through to the environment when the host has no platform, as on a local run', () => {
+    setContract({
+      UIPATH_BASE_URL: BASE_URL,
+      UIPATH_ORG_NAME: ORG_ID,
+      UIPATH_TENANT_NAME: TENANT_ID,
+      UIPATH_ACCESS_TOKEN: TOKEN,
+    });
+
+    const localCtx: CodedFunctionContext = { platform: null, robot: null };
+    const sdk = new UiPath(localCtx);
+
+    expect(sdk.config.orgName).toBe(ORG_ID);
+    expect(sdk.isInitialized()).toBe(true);
+  });
+
+  it('reports missing configuration when neither the host nor the environment has any', async () => {
+    const localCtx: CodedFunctionContext = { platform: null, robot: null };
+    const sdk = new UiPath(localCtx);
+
+    await expect(sdk.initialize()).rejects.toThrow(/configuration not found/);
+  });
+
+  it('still accepts plain configuration objects unchanged', () => {
+    const sdk = new UiPath({
+      baseUrl: BASE_URL,
+      orgName: 'my-org',
+      tenantName: 'my-tenant',
+      secret: 'pat',
+    });
+
+    expect(sdk.config.orgName).toBe('my-org');
+    expect(sdk.isInitialized()).toBe(true);
+  });
+});

--- a/tests/utils/env-contract.ts
+++ b/tests/utils/env-contract.ts
@@ -1,0 +1,30 @@
+import { UiPathEnvVars } from '@/core/config/environment';
+
+/**
+ * The execution-context environment contract the SDK reads outside the browser.
+ *
+ * Unit tests must not depend on whichever of these a developer happens to have
+ * exported, so any suite that constructs a UiPath instance clears them first and
+ * restores them afterwards.
+ */
+// Derived from the SDK's own contract rather than restated: a new alias added to
+// UiPathEnvVars is then cleared here automatically, instead of silently leaking
+// into tests until someone notices.
+export const UIPATH_CONTRACT_VARS: readonly string[] = Object.values(UiPathEnvVars);
+
+/** Clears every contract variable and returns a restore function for afterEach. */
+export function clearContractEnv(): () => void {
+  const saved: Record<string, string | undefined> = {};
+
+  for (const key of UIPATH_CONTRACT_VARS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  return () => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}


### PR DESCRIPTION
Closes [APPS-35692](https://uipath.atlassian.net/browse/APPS-35692).

## Problem

`new UiPath()` resolved configuration only from browser meta tags, so it always threw outside the browser — and the error told the caller to configure a bundler plugin, advice that cannot apply on a server:

> UiPath SDK configuration not found. Ensure @uipath/coded-apps plugin is set up in your bundler…

A coded function receives its platform coordinates as the handler's `ctx`, which the SDK could not reach. Authors therefore mapped it by hand, naming fields the SDK does not document as interchangeable — an org **id** passed as `orgName`, a tenant **id** as `tenantName`, a workload token as `secret` — and repeated that glue in every function.

## What changed

```ts
handler: async (_input, ctx) => {
  const sdk = new UiPath(ctx);      // coded function: pass the handler context
}

const sdk = new UiPath();           // script or test: reads the environment contract
```

- **`new UiPath(ctx)`** — the constructor also accepts a coded function's context and maps it onto the existing config fields. `CodedFunctionContext` mirrors the Functions SDK's type *structurally*, so neither package depends on the other. Configuration and a context are disjoint shapes, so the constructor tells them apart without the caller saying which was passed. A context whose `platform` is null falls through to the remaining sources.
- **`loadFromEnvironment()`** reads `UIPATH_BASE_URL` / `UIPATH_ORG_NAME` / `UIPATH_TENANT_NAME` / `UIPATH_ACCESS_TOKEN` — the names this repository already uses for the same values, so an existing `.env` works unchanged. Both org and tenant accept an id as readily as a name. Reads work under Node **and** Deno, are a no-op in browsers so meta tags remain the browser source, and treat empty values as absent.
- **No new config options.** The context and the environment both resolve to `orgName` / `tenantName` / `secret`, which already accept these values: org and tenant go into the same URL position either way, and `secret` is documented as taking a PAT or a bearer token.
- **Merge order:** constructor > meta tags > environment. Each layer is compacted before merging so a sparse layer cannot blank out the layer beneath it.
- **Missing-configuration errors** now match where the SDK is running, and a service built from an unconfigured instance reports that rather than `Invalid SDK instance`.

## Security

- The resolved token stays in `SDKInternalsRegistry` and is never placed on the public `config` object — [a test asserts this](tests/unit/core/uipath-zero-config.test.ts).
- Organization and tenant come only from the environment, an explicit config, or the runtime-supplied context — never from caller-controlled request data. This preserves the reason the `_baseUrl` / `_orgId` / `_tenantId` input-field pattern was deprecated on the Functions side.

## Compatibility

Fully backward compatible, and the public config shape is unchanged. `{ baseUrl, orgName, tenantName, secret }` and the OAuth/PKCE flow behave as before; browser meta-tag resolution is untouched and still takes precedence over the environment.

## Testing

- `npm run test:unit` — **2372 passing** (86 files), including new coverage for context mapping, the environment contract, merge precedence, and the unconfigured-instance diagnostic
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean
- Exercised against a live tenant through all three paths — a coded function's `ctx`, the environment contract, and an explicit config — including from a function deployed to a runner

## Follow-ups (not in this PR)

- `ctx.platform.folderKey` is mirrored on the context type but not consumed; wiring it would let folder-scoped services resolve their folder from the invocation.
- The token manager treats `secret` as non-expiring, which does not hold for a short-lived bearer token.
- Version bump for release, per the separate-PR convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APPS-35692]: https://uipath.atlassian.net/browse/APPS-35692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
