### PR TITLE
chore: bump version to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.6.1",
+  "sdkVersion": "1.6.2",
   "services": [
     {
       "name": "AgentMemory",
@@ -307,8 +307,16 @@
           "since": "1.5.4"
         },
         {
+          "name": "getAddConnectionUrl",
+          "since": "1.6.2"
+        },
+        {
           "name": "getAll",
           "since": null
+        },
+        {
+          "name": "getAvailableConnections",
+          "since": "1.6.2"
         },
         {
           "name": "getById",
@@ -317,6 +325,10 @@
         {
           "name": "onConnectionStatusChanged",
           "since": null
+        },
+        {
+          "name": "updateConnectionSelections",
+          "since": "1.6.2"
         }
       ]
     },
@@ -690,12 +702,44 @@
       "since": null,
       "methods": [
         {
+          "name": "completeTransaction",
+          "since": "1.6.2"
+        },
+        {
           "name": "getAll",
           "since": null
         },
         {
+          "name": "getAllItems",
+          "since": "1.6.2"
+        },
+        {
+          "name": "getAllWithMethods",
+          "since": "1.6.2"
+        },
+        {
           "name": "getById",
           "since": null
+        },
+        {
+          "name": "getByIdWithMethods",
+          "since": "1.6.2"
+        },
+        {
+          "name": "getByKey",
+          "since": "1.6.2"
+        },
+        {
+          "name": "getByName",
+          "since": "1.6.2"
+        },
+        {
+          "name": "insertItemByName",
+          "since": "1.6.2"
+        },
+        {
+          "name": "startTransaction",
+          "since": "1.6.2"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Version bump `1.6.1` → `1.6.2` for today's release. Changes only `package.json` and `package-lock.json`; `release-metadata.json` is regenerated off a fresh build and committed on this branch (the `Regenerate release-metadata` workflow re-verifies it).

**Why patch, not minor:** per this repo's convention, minor bumps are reserved for releases that carry **breaking changes**; additive, backward-compatible features ship in patch releases. This release is purely additive — the existing `Queues.getAll()`/`getById()` are byte-identical to 1.6.1 and only gain `@deprecated` JSDoc pointing at their successors (deprecation, not removal — no consumer code change required).

## Draft release notes (1.6.2)

````markdown
### New Features & Improvements

- Queues: added `getAllWithMethods()` / `getByIdWithMethods()` — queue retrieval with operational methods attached and folder scoping (existing `getAll()` / `getById()` retained but deprecated) (#643)
- Queues: added `getByName()` and `getByKey()` lookups (#643)
- Queues: added queue item APIs — `getAllItems()` and `insertItemByName()`(#643)
- Queues: added transaction operations — `startTransaction()` acquires the next available queue item for exclusive processing (marks it `InProgress`), and `completeTransaction()` reports the processing outcome as `Successful` or `Failed` with failure details that drive the queue's retry rules (#644)
- Conversational Agent: added personal connections — `getAvailableConnections()`, `getAddConnectionUrl()`, `updateConnectionSelections()` (#620)
- Data Fabric: added `havingFilter` support to entity record queries (#647)

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.6.1...1.6.2
````

Excluded as not user-facing: #518 (subscriptions publisher/group updates — `@internal`), #662/#668 (changes to the separate `@uipath/core-telemetry` package, released independently), #623/#655/#659 (docs), #650/#672 (docs build dependencies), #613 (Dependabot dev-dependency bumps in the sample apps).
