### PR TITLE
feat(data-fabric): by-name addressing for entity ops (DS-8835) [WIP]

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -61,8 +61,11 @@ Before running the function, `invoke()` also acquires a Studio Web license for t
 |--------|-------------|
 | `getAll()` | `DataFabric.Schema.Read` |
 | `getById()` | `DataFabric.Schema.Read` |
+| `getByName()` | `DataFabric.Data.Read` |
 | `getAllRecords()` | `DataFabric.Data.Read` |
+| `getRecordsByName()` | `DataFabric.Data.Read` |
 | `getRecordById()` / `getRecord()`  | `DataFabric.Data.Read` |
+| `getRecordByName()` | `DataFabric.Data.Read` |
 | `insertRecordById()` / `insertRecord()` | `DataFabric.Data.Write` |
 | `insertRecordsById()` / `insertRecords()` | `DataFabric.Data.Write` |
 | `deleteRecordsById()` / `deleteRecords()` | `DataFabric.Data.Write` |

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -125,6 +125,8 @@ console.log(`Total count: ${allAssets.totalCount}`);
 | Buckets | `getFileMetaData()` | ❌ No |
 | Jobs | `getAll()` | ✅ Yes |
 | Entities | `getAllRecords()` | ✅ Yes |
+| Entities | `getRecordsByName()` | ✅ Yes |
+| Entities | `queryRecords()` | ✅ Yes |
 | Entities | `queryRecordsById()` | ✅ Yes |
 | ChoiceSets | `getById()` | ✅ Yes |
 | Processes | `getAll()` | ✅ Yes |

--- a/samples/coded-action-apps/action-app-with-data-fabric-entity/src/components/Form.tsx
+++ b/samples/coded-action-apps/action-app-with-data-fabric-entity/src/components/Form.tsx
@@ -182,7 +182,7 @@ const Form = ({ onInitTheme, darkTheme, onToggleTheme }: FormProps) => {
       try {
         setIsLoadingDocument(true);
         setDocumentError(null);
-        const blob = await uipath.entityService.downloadAttachment(entityId, recordId, LOAN_DOCUMENT_FIELD);
+        const blob = await uipath.entityService.downloadAttachment({ id: entityId }, recordId, LOAN_DOCUMENT_FIELD);
         if (cancelled) return;
         const url = URL.createObjectURL(blob);
         blobUrlRef.current = url;

--- a/samples/data-fabric-app-angular/RELEASE_NOTES.md
+++ b/samples/data-fabric-app-angular/RELEASE_NOTES.md
@@ -1,0 +1,32 @@
+# Release Notes — Data Fabric App (Angular)
+
+## Entity attachment API — breaking change (DS-8835, by-name addressing)
+
+The UiPath TypeScript SDK now lets you address a Data Fabric entity by **id or name**. As part of this, the entity **attachment** methods take an `EntityRef` as their first argument instead of a bare entity-id string.
+
+An `EntityRef` is either:
+
+- `{ id: "<entityId>" }`
+- `{ name: "<entityName>" }`
+
+### Affected methods
+
+`uploadAttachment`, `downloadAttachment`, `deleteAttachment`.
+
+### Migration
+
+```ts
+// Before
+await entityService.uploadAttachment(entityId, recordId, fieldName, file);
+await entityService.downloadAttachment(entityId, recordId, fieldName);
+await entityService.deleteAttachment(entityId, recordId, fieldName);
+
+// After
+await entityService.uploadAttachment({ id: entityId }, recordId, fieldName, file);
+await entityService.downloadAttachment({ id: entityId }, recordId, fieldName);
+await entityService.deleteAttachment({ id: entityId }, recordId, fieldName);
+```
+
+This sample has been updated to the new signatures.
+
+Record CRUD methods are **not** affected — the previous by-id methods (`insertRecordById`, `updateRecordById`, `deleteRecordsById`, `queryRecordsById`, `importRecordsById`, etc.) remain available as deprecated delegators alongside the new ref-based `insertRecord` / `updateRecord` / `deleteRecords` / `queryRecords` / `importRecords`.

--- a/samples/data-fabric-app-angular/src/app/components/record-editor.component.ts
+++ b/samples/data-fabric-app-angular/src/app/components/record-editor.component.ts
@@ -460,7 +460,7 @@ export class RecordEditorComponent implements OnInit, AfterViewInit, OnDestroy {
     this.removingAttachment.set(field.name)
     try {
       const entityService = new Entities(this.auth.sdk)
-      await entityService.deleteAttachment(this.entityId(), record.Id, field.name)
+      await entityService.deleteAttachment({ id: this.entityId() }, record.Id, field.name)
       // Reflect the removal locally so the "Remove" button disappears.
       this.removedAttachments.update((prev) => new Set(prev).add(field.name))
       this.toast.success(`Removed ${field.displayName || field.name}`)
@@ -535,7 +535,7 @@ export class RecordEditorComponent implements OnInit, AfterViewInit, OnDestroy {
       for (const [fieldName, file] of Object.entries(this.pickedFiles())) {
         try {
           await entityService.uploadAttachment(
-            this.entityId(),
+            { id: this.entityId() },
             recordId,
             fieldName,
             file,

--- a/samples/data-fabric-app-angular/src/app/components/row-inspector.component.ts
+++ b/samples/data-fabric-app-angular/src/app/components/row-inspector.component.ts
@@ -242,7 +242,7 @@ export class RowInspectorComponent implements OnInit, AfterViewInit, OnDestroy {
     try {
       const entityService = new Entities(this.auth.sdk)
       const blob = await entityService.downloadAttachment(
-        this.entityId(),
+        { id: this.entityId() },
         this.recordId(),
         fieldName,
       )

--- a/samples/data-fabric-app/src/components/RecordEditor.tsx
+++ b/samples/data-fabric-app/src/components/RecordEditor.tsx
@@ -160,7 +160,7 @@ export function RecordEditor({
       // record id; we don't fail the whole save if one fails.
       for (const [fieldName, file] of Object.entries(files)) {
         try {
-          await entityService.uploadAttachment(entityId, recordId, fieldName, file)
+          await entityService.uploadAttachment({ id: entityId }, recordId, fieldName, file)
         } catch (err) {
           toast.error(`Upload ${fieldName} failed`, {
             description:

--- a/samples/data-fabric-app/src/components/RowInspector.tsx
+++ b/samples/data-fabric-app/src/components/RowInspector.tsx
@@ -75,7 +75,7 @@ export function RowInspector({ entityId, recordId, schema, onClose }: Props) {
     try {
       const entityService = new Entities(sdk)
       const blob = await entityService.downloadAttachment(
-        entityId,
+        { id: entityId },
         recordId,
         fieldName,
       )

--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -1,6 +1,7 @@
 import {
   EntityGetRecordsByIdOptions,
   EntityGetRecordByIdOptions,
+  EntityGetRecordByNameOptions,
   EntityInsertOptions,
   EntityBatchInsertOptions,
   EntityInsertResponse,
@@ -32,6 +33,8 @@ import {
   EntityDeleteByIdOptions,
   EntityDeleteRecordByIdOptions,
   EntityUpdateByIdOptions,
+  EntityGetByNameOptions,
+  EntityRef,
 } from './entities.types';
 import { PaginatedResponse, NonPaginatedResponse, HasPaginationOptions } from '../../utils/pagination/types';
 
@@ -106,8 +109,7 @@ export interface EntityServiceModel {
    *
    * @param id - UUID of the entity
    * @param options - Optional {@link EntityGetByIdOptions} (e.g. `folderKey` for folder-scoped entities) The `folderKey` property is **experimental**.
-   * @returns Promise resolving to entity metadata with operation methods
-   * {@link EntityGetResponse}
+   * @returns Promise resolving to entity metadata with operation methods ({@link EntityGetResponse})
    * @example
    * ```typescript
    * import { Entities, ChoiceSets } from '@uipath/uipath-typescript/entities';
@@ -149,9 +151,8 @@ export interface EntityServiceModel {
    * instead of the full content — use {@link getRecordById} to retrieve the full value.
    *
    * @param entityId - UUID of the entity
-   * @param options - Query options The `folderKey` property is **experimental**.
-   * @returns Promise resolving to either an array of entity records NonPaginatedResponse<EntityRecord> or a PaginatedResponse<EntityRecord> when pagination options are used.
-   * {@link EntityRecord}
+   * @param options - Query options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to entity records ({@link EntityRecord}) — a NonPaginatedResponse, or a PaginatedResponse when pagination options are used.
    * @example
    * ```typescript
    * // Basic usage (non-paginated)
@@ -185,6 +186,36 @@ export interface EntityServiceModel {
   >;
 
   /**
+   * Gets entity records by entity name.
+   *
+   * Sibling of {@link getAllRecords} that addresses the entity by name — useful when you only
+   * have the resource name (e.g. solution binding overrides), avoiding a lookup to resolve the ID.
+   *
+   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
+   * instead of the full content — use {@link getRecordByName} to retrieve the full value.
+   *
+   * @param entityName - Name of the entity
+   * @param options - Query options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to entity records ({@link EntityRecord}) — a NonPaginatedResponse, or a PaginatedResponse when pagination options are used.
+   * @example
+   * ```typescript
+   * // Basic usage (non-paginated)
+   * const records = await entities.getRecordsByName("Customer");
+   *
+   * // With pagination and expansion level
+   * const paginatedResponse = await entities.getRecordsByName("Customer", { pageSize: 50, expansionLevel: 1 });
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * const records = await entities.getRecordsByName("Customer", { folderKey: "<folderKey>" });
+   * ```
+   */
+  getRecordsByName<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(entityName: string, options?: T): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<EntityRecord>
+      : NonPaginatedResponse<EntityRecord>
+  >;
+
+  /**
    * @deprecated Use {@link getAllRecords} instead.
    * @hidden
    */
@@ -201,9 +232,8 @@ export interface EntityServiceModel {
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record
-   * @param options - Query options The `folderKey` property is **experimental**.
-   * @returns Promise resolving to a single entity record
-   * {@link EntityRecord}
+   * @param options - Query options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to a single entity record ({@link EntityRecord})
    * @example
    * ```typescript
    * // First, get records to obtain the record ID
@@ -227,16 +257,66 @@ export interface EntityServiceModel {
   getRecordById(entityId: string, recordId: string, options?: EntityGetRecordByIdOptions): Promise<EntityRecord>;
 
   /**
+   * Gets a single entity record by entity name and record ID
+   *
+   * Sibling of {@link getRecordById} that addresses the entity by name. Returns the full record,
+   * including the complete content of `MULTILINE_MAX` fields.
+   *
+   * @param entityName - Name of the entity
+   * @param recordId - UUID of the record
+   * @param options - Query options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to a single entity record ({@link EntityRecord})
+   * @example
+   * ```typescript
+   * // First, get records to obtain the record ID
+   * const records = await entities.getRecordsByName("Customer");
+   * const recordId = records.items[0].Id;
+   *
+   * // Get the record
+   * const record = await entities.getRecordByName("Customer", recordId);
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * const record = await entities.getRecordByName("Customer", recordId, { folderKey: "<folderKey>" });
+   * ```
+   */
+  getRecordByName(entityName: string, recordId: string, options?: EntityGetRecordByNameOptions): Promise<EntityRecord>;
+
+  /**
+   * Inserts a single record into an entity, identified by ref (`{ id }` or `{ name }`)
+   *
+   * Note: Data Fabric supports trigger events only on individual inserts, not on inserting multiple records.
+   * Use this method if you need trigger events to fire for the inserted record.
+   *
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
+   * @param data - Record to insert
+   * @param options - Insert options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to the inserted record with generated record ID ({@link EntityInsertResponse})
+   * @example
+   * ```typescript
+   * // By id
+   * const result = await entities.insertRecord({ id: "<entityId>" }, { name: "John", age: 30 });
+   *
+   * // By name (e.g. solution binding overrides that resolve resources by name)
+   * const result = await entities.insertRecord({ name: "Customer" }, { name: "John", age: 30 });
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.insertRecord({ name: "Customer" }, { name: "John", age: 30 }, { folderKey: "<folderKey>" });
+   * ```
+   */
+  insertRecord(entityRef: EntityRef, data: Record<string, any>, options?: EntityInsertRecordOptions): Promise<EntityInsertResponse>;
+
+  /**
    * Inserts a single record into an entity by entity ID
+   *
+   * @deprecated Use {@link insertRecord} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
    *
    * Note: Data Fabric supports trigger events only on individual inserts, not on inserting multiple records.
    * Use this method if you need trigger events to fire for the inserted record.
    *
    * @param id - UUID of the entity
    * @param data - Record to insert
-   * @param options - Insert options The `folderKey` property is **experimental**.
-   * @returns Promise resolving to the inserted record with generated record ID
-   * {@link EntityInsertResponse}
+   * @param options - Insert options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to the inserted record with generated record ID ({@link EntityInsertResponse})
    * @example
    * ```typescript
    * // Basic usage
@@ -256,22 +336,47 @@ export interface EntityServiceModel {
   insertRecordById(id: string, data: Record<string, any>, options?: EntityInsertRecordOptions): Promise<EntityInsertResponse>;
 
   /**
-   * @deprecated Use {@link insertRecordById} instead.
+   * @deprecated Use {@link insertRecord} with `{ id }` or `{ name }` instead.
    * @hidden
    */
   insertById(id: string, data: Record<string, any>, options?: EntityInsertOptions): Promise<EntityInsertResponse>;
 
   /**
+   * Inserts one or more records into an entity, identified by ref (`{ id }` or `{ name }`)
+   *
+   * Note: Records inserted using insertRecords will not trigger Data Fabric trigger events. Use {@link insertRecord} if you need
+   * trigger events to fire for each inserted record.
+   *
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
+   * @param data - Array of records to insert
+   * @param options - Insert options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to insert response ({@link EntityBatchInsertResponse})
+   * @example
+   * ```typescript
+   * // By id
+   * const result = await entities.insertRecords({ id: "<entityId>" }, [{ name: "John", age: 30 }, { name: "Jane", age: 25 }]);
+   *
+   * // By name
+   * const result = await entities.insertRecords({ name: "Customer" }, [{ name: "John", age: 30 }], { failOnFirst: true });
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.insertRecords({ name: "Customer" }, [{ name: "John", age: 30 }], { folderKey: "<folderKey>" });
+   * ```
+   */
+  insertRecords(entityRef: EntityRef, data: Record<string, any>[], options?: EntityInsertRecordsOptions): Promise<EntityBatchInsertResponse>;
+
+  /**
    * Inserts one or more records into an entity by entity ID
    *
-   * Note: Records inserted using insertRecordsById will not trigger Data Fabric trigger events. Use {@link insertRecordById} if you need
+   * @deprecated Use {@link insertRecords} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
+   *
+   * Note: Records inserted using insertRecordsById will not trigger Data Fabric trigger events. Use {@link insertRecord} if you need
    * trigger events to fire for each inserted record.
    *
    * @param id - UUID of the entity
    * @param data - Array of records to insert
-   * @param options - Insert options The `folderKey` property is **experimental**.
-   * @returns Promise resolving to insert response
-   * {@link EntityBatchInsertResponse}
+   * @param options - Insert options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to insert response ({@link EntityBatchInsertResponse})
    * @example
    * ```typescript
    * // Basic usage
@@ -299,13 +404,40 @@ export interface EntityServiceModel {
   insertRecordsById(id: string, data: Record<string, any>[], options?: EntityInsertRecordsOptions): Promise<EntityBatchInsertResponse>;
 
   /**
-   * @deprecated Use {@link insertRecordsById} instead.
+   * @deprecated Use {@link insertRecords} with `{ id }` or `{ name }` instead.
    * @hidden
    */
   batchInsertById(id: string, data: Record<string, any>[], options?: EntityBatchInsertOptions): Promise<EntityBatchInsertResponse>;
 
   /**
+   * Updates a single record in an entity, identified by ref (`{ id }` or `{ name }`)
+   *
+   * Note: Data Fabric supports trigger events only on individual updates, not on updating multiple records.
+   * Use this method if you need trigger events to fire for the updated record.
+   *
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
+   * @param recordId - UUID of the record to update
+   * @param data - Key-value pairs of fields to update
+   * @param options - Update options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to the updated record ({@link EntityUpdateRecordResponse})
+   * @example
+   * ```typescript
+   * // By id
+   * const result = await entities.updateRecord({ id: "<entityId>" }, "<recordId>", { name: "John Updated", age: 31 });
+   *
+   * // By name
+   * const result = await entities.updateRecord({ name: "Customer" }, "<recordId>", { name: "John Updated" });
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.updateRecord({ name: "Customer" }, "<recordId>", { name: "John Updated" }, { folderKey: "<folderKey>" });
+   * ```
+   */
+  updateRecord(entityRef: EntityRef, recordId: string, data: Record<string, any>, options?: EntityUpdateRecordOptions): Promise<EntityUpdateRecordResponse>;
+
+  /**
    * Updates a single record in an entity by entity ID
+   *
+   * @deprecated Use {@link updateRecord} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
    *
    * Note: Data Fabric supports trigger events only on individual updates, not on updating multiple records.
    * Use this method if you need trigger events to fire for the updated record.
@@ -313,9 +445,8 @@ export interface EntityServiceModel {
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to update
    * @param data - Key-value pairs of fields to update
-   * @param options - Update options The `folderKey` property is **experimental**.
-   * @returns Promise resolving to the updated record
-   * {@link EntityUpdateRecordResponse}
+   * @param options - Update options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to the updated record ({@link EntityUpdateRecordResponse})
    * @example
    * ```typescript
    * // Basic usage
@@ -335,15 +466,39 @@ export interface EntityServiceModel {
   updateRecordById(entityId: string, recordId: string, data: Record<string, any>, options?: EntityUpdateRecordOptions): Promise<EntityUpdateRecordResponse>;
 
   /**
+   * Updates data in an entity, identified by ref (`{ id }` or `{ name }`)
+   *
+   * Note: Records updated using updateRecords will not trigger Data Fabric trigger events. Use {@link updateRecord} if you need trigger events to fire for each updated record.
+   *
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
+   * @param data - Array of records to update. Each record MUST contain the record id.
+   * @param options - Update options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to update response ({@link EntityUpdateResponse})
+   * @example
+   * ```typescript
+   * // By id
+   * const result = await entities.updateRecords({ id: "<entityId>" }, [{ Id: "123", name: "John Updated" }]);
+   *
+   * // By name
+   * const result = await entities.updateRecords({ name: "Customer" }, [{ Id: "123", name: "John Updated" }], { failOnFirst: true });
+   *
+   * // Folder-scoped entity: pass the entity's folder key
+   * await entities.updateRecords({ name: "Customer" }, [{ Id: "123", name: "John Updated" }], { folderKey: "<folderKey>" });
+   * ```
+   */
+  updateRecords(entityRef: EntityRef, data: EntityRecord[], options?: EntityUpdateRecordsOptions): Promise<EntityUpdateResponse>;
+
+  /**
    * Updates data in an entity by entity ID
    *
-   * Note: Records updated using updateRecordsById will not trigger Data Fabric trigger events. Use {@link updateRecordById} if you need trigger events to fire for each updated record.
+   * @deprecated Use {@link updateRecords} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
+   *
+   * Note: Records updated using updateRecordsById will not trigger Data Fabric trigger events. Use {@link updateRecord} if you need trigger events to fire for each updated record.
    *
    * @param id - UUID of the entity
    * @param data - Array of records to update. Each record MUST contain the record id.
-   * @param options - Update options The `folderKey` property is **experimental**.
-   * @returns Promise resolving to update response
-   * {@link EntityUpdateResponse}
+   * @param options - Update options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to update response ({@link EntityUpdateResponse})
    * @example
    * ```typescript
    * // Basic usage
@@ -371,15 +526,36 @@ export interface EntityServiceModel {
 
 
   /**
+   * Deletes data from an entity, identified by ref (`{ id }` or `{ name }`)
+   *
+   * Note: Records deleted using deleteRecords will not trigger Data Fabric trigger events. Use {@link deleteRecord} if you need trigger events to fire for the deleted record.
+   *
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
+   * @param recordIds - Array of record UUIDs to delete
+   * @param options - Delete options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to delete response ({@link EntityDeleteResponse})
+   * @example
+   * ```typescript
+   * // By id
+   * const result = await entities.deleteRecords({ id: "<entityId>" }, ["<recordId-1>", "<recordId-2>"]);
+   *
+   * // By name
+   * await entities.deleteRecords({ name: "Customer" }, ["<recordId-1>", "<recordId-2>"], { folderKey: "<folderKey>" });
+   * ```
+   */
+  deleteRecords(entityRef: EntityRef, recordIds: string[], options?: EntityDeleteRecordsOptions): Promise<EntityDeleteResponse>;
+
+  /**
    * Deletes data from an entity by entity ID
    *
-   * Note: Records deleted using deleteRecordsById will not trigger Data Fabric trigger events. Use {@link deleteRecordById} if you need trigger events to fire for the deleted record.
+   * @deprecated Use {@link deleteRecords} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
+   *
+   * Note: Records deleted using deleteRecordsById will not trigger Data Fabric trigger events. Use {@link deleteRecord} if you need trigger events to fire for the deleted record.
    *
    * @param id - UUID of the entity
    * @param recordIds - Array of record UUIDs to delete
-   * @param options - Delete options The `folderKey` property is **experimental**.
-   * @returns Promise resolving to delete response
-   * {@link EntityDeleteResponse}
+   * @param options - Delete options. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to delete response ({@link EntityDeleteResponse})
    * @example
    * ```typescript
    * // Basic usage
@@ -396,31 +572,91 @@ export interface EntityServiceModel {
   deleteRecordsById(id: string, recordIds: string[], options?: EntityDeleteRecordsOptions): Promise<EntityDeleteResponse>;
 
   /**
+   * Deletes a single record from an entity, identified by ref (`{ id }` or `{ name }`)
+   *
+   * Note: Data Fabric supports trigger events only on individual deletes, not on deleting multiple records.
+   * Use this method if you need trigger events to fire for the deleted record.
+   *
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
+   * @param recordId - UUID of the record to delete
+   * @param options - Optional delete options such as `folderKey` for folder-scoped entities. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to void on success
+   * @example
+   * ```typescript
+   * // By id
+   * await entities.deleteRecord({ id: "<entityId>" }, "<recordId>");
+   *
+   * // By name
+   * await entities.deleteRecord({ name: "Customer" }, "<recordId>", { folderKey: "<folderKey>" });
+   * ```
+   */
+  deleteRecord(entityRef: EntityRef, recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void>;
+
+  /**
    * Deletes a single record from an entity by entity ID and record ID
+   *
+   * @deprecated Use {@link deleteRecord} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
    *
    * Note: Data Fabric supports trigger events only on individual deletes, not on deleting multiple records.
    * Use this method if you need trigger events to fire for the deleted record.
    *
    * @param entityId - UUID of the entity
    * @param recordId - UUID of the record to delete
-   * @param options - Optional {@link EntityDeleteRecordByIdOptions} (e.g. `folderKey` for folder-scoped entities) The `folderKey` property is **experimental**.
+   * @param options - Optional delete options such as `folderKey` for folder-scoped entities. The `folderKey` property is **experimental**.
    * @returns Promise resolving to void on success
    * @example
    * ```typescript
-   * import { Entities } from '@uipath/uipath-typescript/entities';
-   *
-   * const entities = new Entities(sdk);
-   *
    * await entities.deleteRecordById("<entityId>", "<recordId>");
-   *
-   * // Folder-scoped: pass the entity's folder key
-   * await entities.deleteRecordById("<entityId>", "<recordId>", { folderKey: "<folderKey>" });
    * ```
    */
   deleteRecordById(entityId: string, recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void>;
 
   /**
+   * Queries entity records with filters, sorting, aggregates, and SDK-managed pagination,
+   * identified by ref (`{ id }` or `{ name }`)
+   *
+   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
+   * instead of the full content — use {@link getRecordById} to retrieve the full value.
+   *
+   * Cross-entity joins are supported via the `joins` option — see {@link EntityJoin}
+   * for constraints and the result-row key format.
+   *
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, joins, havingFilter, and pagination. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
+   *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
+   * @example
+   * ```typescript
+   * import { Entities, LogicalOperator, QueryFilterOperator } from '@uipath/uipath-typescript/entities';
+   *
+   * const entities = new Entities(sdk);
+   *
+   * // By id, non-paginated query with a filter
+   * const result = await entities.queryRecords({ id: "<entityId>" }, {
+   *   filterGroup: {
+   *     logicalOperator: LogicalOperator.And,
+   *     queryFilters: [{ fieldName: "status", operator: QueryFilterOperator.Equals, value: "active" }]
+   *   },
+   *   sortOptions: [{ fieldName: "createdTime", isDescending: true }],
+   * });
+   *
+   * // By name, with pagination
+   * const page1 = await entities.queryRecords({ name: "Customer" }, { pageSize: 25 });
+   * if (page1.hasNextPage) {
+   *   const page2 = await entities.queryRecords({ name: "Customer" }, { cursor: page1.nextCursor });
+   * }
+   * ```
+   */
+  queryRecords<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(entityRef: EntityRef, options?: T): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<EntityRecord>
+      : NonPaginatedResponse<EntityRecord>
+  >;
+
+  /**
    * Queries entity records with filters, sorting, aggregates, and SDK-managed pagination
+   *
+   * @deprecated Use {@link queryRecords} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
    *
    * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
    * instead of the full content — use {@link getRecordById} to retrieve the full value.
@@ -429,7 +665,7 @@ export interface EntityServiceModel {
    * for constraints and the result-row key format.
    *
    * @param id - UUID of the entity
-   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, joins, havingFilter, and pagination The `folderKey` property is **experimental**.
+   * @param options - Query options including filterGroup, selectedFields, sortOptions, aggregates, groupBy, joins, havingFilter, and pagination. The `folderKey` property is **experimental**.
    * @returns Promise resolving to {@link NonPaginatedResponse} without pagination options,
    *   or {@link PaginatedResponse} when `pageSize`, `cursor`, or `jumpToPage` are provided
    * @example
@@ -519,43 +755,55 @@ export interface EntityServiceModel {
   >;
 
   /**
-   * Imports records from a CSV file into an entity
+   * Imports records from a CSV file into an entity, identified by ref (`{ id }` or `{ name }`)
    *
-   * @param id - UUID of the entity
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
    * @param file - CSV file to import as a Blob or File or Uint8Array
-   * @param options - Optional {@link EntityImportRecordsByIdOptions} (e.g. `folderKey` for folder-scoped entities) The `folderKey` property is **experimental**.
+   * @param options - Optional import options such as `folderKey` for folder-scoped entities. The `folderKey` property is **experimental**.
    * @returns Promise resolving to {@link EntityImportRecordsResponse} with record counts
    * @example
    * ```typescript
-   * // Browser: upload from file input
+   * const fileInput = document.getElementById('csv-input') as HTMLInputElement;
+   *
+   * // By id
+   * const result = await entities.importRecords({ id: "<entityId>" }, fileInput.files[0]);
+   *
+   * // By name
+   * await entities.importRecords({ name: "Customer" }, fileInput.files[0], { folderKey: "<folderKey>" });
+   * ```
+   */
+  importRecords(entityRef: EntityRef, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>;
+
+  /**
+   * Imports records from a CSV file into an entity
+   *
+   * @deprecated Use {@link importRecords} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
+   *
+   * @param id - UUID of the entity
+   * @param file - CSV file to import as a Blob or File or Uint8Array
+   * @param options - Optional import options such as `folderKey` for folder-scoped entities. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to {@link EntityImportRecordsResponse} with record counts
+   * @example
+   * ```typescript
    * const fileInput = document.getElementById('csv-input') as HTMLInputElement;
    * const result = await entities.importRecordsById(<id>, fileInput.files[0]);
-   * console.log(`Inserted ${result.insertedRecords} of ${result.totalRecords} records`);
-   *
-   * // Folder-scoped entity: pass the entity's folder key
-   * await entities.importRecordsById(<id>, fileInput.files[0], { folderKey: "<folderKey>" });
    * ```
    */
   importRecordsById(id: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse>;
 
   /**
-   * Downloads an attachment stored in a File-type field of an entity record.
+   * Downloads an attachment stored in a File-type field of an entity record, identified by ref (`{ id }` or `{ name }`).
    *
-   * @param entityId - UUID of the entity
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
-   * @param options - Optional {@link EntityDownloadAttachmentOptions} (e.g. `folderKey` for folder-scoped entities) The `folderKey` property is **experimental**.
+   * @param options - Optional download options (e.g. `folderKey` for folder-scoped entities). The `folderKey` property is **experimental**.
    * @returns Promise resolving to Blob containing the file content
    * @example
    * ```typescript
    * import { Entities } from '@uipath/uipath-typescript/entities';
    *
    * const entities = new Entities(sdk);
-   *
-   * // First, get records to obtain the record ID
-   * const records = await entities.getAllRecords("<entityId>");
-   * // Get the recordId for the record that contains the attachment
-   * const recordId = records.items[0].Id;
    *
    * // Get the entityId from getAll()
    * const allEntities = await entities.getAll();
@@ -565,8 +813,11 @@ export interface EntityServiceModel {
    * const records = await entities.getAllRecords(entityId);
    * const recordId = records[0].Id;
    *
-   * // Download attachment using service method
-   * const response = await entities.downloadAttachment(entityId, recordId, 'Documents');
+   * // Download attachment by id
+   * const response = await entities.downloadAttachment({ id: entityId }, recordId, 'Documents');
+   *
+   * // Or by name
+   * const byName = await entities.downloadAttachment({ name: 'Customer' }, recordId, 'Documents');
    *
    * // Or download using entity method (entityId is already known)
    * const entity = await entities.getById(entityId);
@@ -591,18 +842,19 @@ export interface EntityServiceModel {
    * fs.writeFileSync('attachment.pdf', buffer);
    * ```
    */
-  downloadAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob>;
+  downloadAttachment(entityRef: EntityRef, recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob>;
 
   /**
    * Uploads an attachment to a File-type field of an entity record.
    *
    * Uses multipart/form-data to upload the file content to the specified field.
+   * Identified by ref (`{ id }` or `{ name }`).
    *
-   * @param entityId - UUID of the entity
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
    * @param recordId - UUID of the record to upload the attachment to
    * @param fieldName - Name of the File-type field
    * @param file - File to upload (Blob, File, or Uint8Array)
-   * @param options - Optional {@link EntityUploadAttachmentOptions} (e.g. `expansionLevel`, `folderKey` for folder-scoped entities) The `folderKey` property is **experimental**.
+   * @param options - Optional upload options (e.g. `expansionLevel`, `folderKey` for folder-scoped entities). The `folderKey` property is **experimental**.
    * @returns Promise resolving to {@link EntityUploadAttachmentResponse}
    * @example
    * ```typescript
@@ -621,26 +873,28 @@ export interface EntityServiceModel {
    * // Browser: Upload a file from an input element
    * const fileInput = document.getElementById('file-input') as HTMLInputElement;
    * const file = fileInput.files[0];
-   * const response = await entities.uploadAttachment(entityId, recordId, 'Documents', file);
    *
-   * // Folder-scoped entity: pass the entity's folder key
-   * await entities.uploadAttachment(entityId, recordId, 'Documents', file, { folderKey: "<folderKey>" });
+   * // By id
+   * const response = await entities.uploadAttachment({ id: entityId }, recordId, 'Documents', file);
+   *
+   * // By name, folder-scoped
+   * await entities.uploadAttachment({ name: 'Customer' }, recordId, 'Documents', file, { folderKey: "<folderKey>" });
    *
    * // Node.js: Upload a file from disk
    * const fileBuffer = fs.readFileSync('document.pdf');
    * const blob = new Blob([fileBuffer], { type: 'application/pdf' });
-   * const response = await entities.uploadAttachment(entityId, recordId, 'Documents', blob);
+   * const uploaded = await entities.uploadAttachment({ id: entityId }, recordId, 'Documents', blob);
    * ```
    */
-  uploadAttachment(entityId: string, recordId: string, fieldName: string, file: EntityFileType, options?: EntityUploadAttachmentOptions): Promise<EntityUploadAttachmentResponse>;
+  uploadAttachment(entityRef: EntityRef, recordId: string, fieldName: string, file: EntityFileType, options?: EntityUploadAttachmentOptions): Promise<EntityUploadAttachmentResponse>;
 
   /**
-   * Removes an attachment from a File-type field of an entity record.
+   * Removes an attachment from a File-type field of an entity record, identified by ref (`{ id }` or `{ name }`).
    *
-   * @param entityId - UUID of the entity
+   * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
    * @param recordId - UUID of the record containing the attachment
    * @param fieldName - Name of the File-type field containing the attachment
-   * @param options - Optional {@link EntityDeleteAttachmentOptions} (e.g. `folderKey` for folder-scoped entities) The `folderKey` property is **experimental**.
+   * @param options - Optional delete options (e.g. `folderKey` for folder-scoped entities). The `folderKey` property is **experimental**.
    * @returns Promise resolving to {@link EntityDeleteAttachmentResponse}
    * @example
    * ```typescript
@@ -656,15 +910,42 @@ export interface EntityServiceModel {
    * const records = await entities.getAllRecords(entityId);
    * const recordId = records[0].Id;
    *
-   * // Delete attachment for a specific record and field
-   * await entities.deleteAttachment(entityId, recordId, 'Documents');
+   * // Delete attachment by id
+   * await entities.deleteAttachment({ id: entityId }, recordId, 'Documents');
+   *
+   * // Or by name
+   * await entities.deleteAttachment({ name: 'Customer' }, recordId, 'Documents');
    *
    * // Or delete using entity method (entityId is already known)
    * const entity = await entities.getById(entityId);
    * await entity.deleteAttachment(recordId, 'Documents');
    * ```
    */
-  deleteAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse>;
+  deleteAttachment(entityRef: EntityRef, recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse>;
+
+  /**
+   * Gets entity metadata by entity name with attached operation methods.
+   *
+   * Sibling of {@link getById} that addresses the entity by name — useful when
+   * you only have the resource name (e.g. solution binding overrides that resolve
+   * resources by name and `folderKey`), avoiding a lookup to resolve the entity ID.
+   *
+   * @param entityName - Name of the entity
+   * @param options - Optional lookup options such as `folderKey` for folder-scoped entities. The `folderKey` property is **experimental**.
+   * @returns Promise resolving to entity metadata with operation methods ({@link EntityGetResponse})
+   * @example
+   * ```typescript
+   * // Get entity metadata by name
+   * const entity = await entities.getByName("Customer");
+   *
+   * // Folder-scoped: pass the entity's folder key
+   * const folderEntity = await entities.getByName("Customer", { folderKey: "<folderKey>" });
+   *
+   * // Call operations directly on the entity
+   * const records = await entity.getAllRecords();
+   * ```
+   */
+  getByName(entityName: string, options?: EntityGetByNameOptions): Promise<EntityGetResponse>;
 
   /**
    * Creates a new Data Fabric entity with the given schema
@@ -867,7 +1148,7 @@ export interface EntityMethods {
   /**
    * Get all records from this entity
    *
-   * @param options - Query options The `folderKey` property is **experimental**.
+   * @param options - Query options. The `folderKey` property is **experimental**.
    * @returns Promise resolving to query response
    */
   getAllRecords<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(options?: T): Promise<
@@ -1100,34 +1381,34 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
   return {
     async insertRecord(data: Record<string, any>, options?: EntityInsertRecordOptions): Promise<EntityInsertResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.insertRecordById(entityData.id, data, options);
+      return service.insertRecord({ id: entityData.id }, data, options);
     },
 
     async insertRecords(data: Record<string, any>[], options?: EntityInsertRecordsOptions): Promise<EntityBatchInsertResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.insertRecordsById(entityData.id, data, options);
+      return service.insertRecords({ id: entityData.id }, data, options);
     },
 
     async updateRecord(recordId: string, data: Record<string, any>, options?: EntityUpdateRecordOptions): Promise<EntityUpdateRecordResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
       if (!recordId) throw new Error('Record ID is undefined');
-      return service.updateRecordById(entityData.id, recordId, data, options);
+      return service.updateRecord({ id: entityData.id }, recordId, data, options);
     },
 
     async updateRecords(data: EntityRecord[], options?: EntityUpdateRecordsOptions): Promise<EntityUpdateResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.updateRecordsById(entityData.id, data, options);
+      return service.updateRecords({ id: entityData.id }, data, options);
     },
 
     async deleteRecords(recordIds: string[], options?: EntityDeleteRecordsOptions): Promise<EntityDeleteResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.deleteRecordsById(entityData.id, recordIds, options);
+      return service.deleteRecords({ id: entityData.id }, recordIds, options);
     },
 
     async deleteRecord(recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
       if (!recordId) throw new Error('Record ID is undefined');
-      return service.deleteRecordById(entityData.id, recordId, options);
+      return service.deleteRecord({ id: entityData.id }, recordId, options);
     },
 
     async getAllRecords<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(options?: T): Promise<
@@ -1147,17 +1428,17 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
 
     async downloadAttachment(recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.downloadAttachment(entityData.id, recordId, fieldName, options);
+      return service.downloadAttachment({ id: entityData.id }, recordId, fieldName, options);
     },
 
     async uploadAttachment(recordId: string, fieldName: string, file: EntityFileType, options?: EntityUploadAttachmentOptions): Promise<EntityUploadAttachmentResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.uploadAttachment(entityData.id, recordId, fieldName, file, options);
+      return service.uploadAttachment({ id: entityData.id }, recordId, fieldName, file, options);
     },
 
     async deleteAttachment(recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.deleteAttachment(entityData.id, recordId, fieldName, options);
+      return service.deleteAttachment({ id: entityData.id }, recordId, fieldName, options);
     },
 
     async queryRecords<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(options?: T): Promise<
@@ -1166,12 +1447,12 @@ function createEntityMethods(entityData: RawEntityGetResponse, service: EntitySe
         : NonPaginatedResponse<EntityRecord>
     > {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.queryRecordsById(entityData.id, options);
+      return service.queryRecords({ id: entityData.id }, options);
     },
 
     async importRecords(file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse> {
       if (!entityData.id) throw new Error('Entity ID is undefined');
-      return service.importRecordsById(entityData.id, file, options);
+      return service.importRecords({ id: entityData.id }, file, options);
     },
 
     async insert(data: Record<string, any>, options?: EntityInsertOptions): Promise<EntityInsertResponse> {

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -1,8 +1,17 @@
 import { PaginationOptions } from "../../utils/pagination/types";
+import { ResourceRef } from "../common/types";
 import { EntityFolderScopedOptions } from "./data-fabric.types";
 
 // Re-export — canonical definition is in `./data-fabric.types`.
 export type { EntityFolderScopedOptions };
+
+/**
+ * Selects an entity by exactly one identifier — `{ id }` (GUID) or `{ name }`.
+ *
+ * Operational record and attachment methods accept an `EntityRef` and route to the
+ * matching Data Fabric by-id or by-name endpoint. See {@link ResourceRef}.
+ */
+export type EntityRef = ResourceRef<string>;
 
 /**
  * Entity field data type names (SQL-level types returned by the API)
@@ -70,6 +79,11 @@ export interface EntityGetRecordByIdOptions extends EntityFolderScopedOptions {
   /** Level of entity expansion (default: 0) */
   expansionLevel?: number;
 }
+
+/**
+ * Options for getting a single entity record by entity name and record ID
+ */
+export interface EntityGetRecordByNameOptions extends EntityGetRecordByIdOptions {}
 
 /**
  * Common options for entity operations that modify multiple records
@@ -439,6 +453,11 @@ export interface EntityGetAllOptions extends EntityFolderScopedOptions {
 }
 
 export interface EntityGetByIdOptions extends EntityFolderScopedOptions {}
+
+/**
+ * Options for getting entity metadata by entity name
+ */
+export interface EntityGetByNameOptions extends EntityGetByIdOptions {}
 
 export interface EntityDeleteByIdOptions extends EntityFolderScopedOptions {}
 

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -5,6 +5,7 @@ import {
   EntityGetRecordsByIdOptions,
   EntityGetAllRecordsOptions,
   EntityGetRecordByIdOptions,
+  EntityGetRecordByNameOptions,
   EntityInsertOptions,
   EntityInsertRecordOptions,
   EntityBatchInsertOptions,
@@ -37,9 +38,11 @@ import {
   EntityType,
   EntityGetAllOptions,
   EntityGetByIdOptions,
+  EntityGetByNameOptions,
   EntityDeleteByIdOptions,
   EntityDeleteRecordByIdOptions,
   EntityUpdateByIdOptions,
+  EntityRef,
   SqlType,
   FieldDisplayType,
   ReferenceType,
@@ -92,25 +95,40 @@ function toWireJoin(join: EntityJoin, baseEntityName: string): EntityJoinPayload
 }
 
 /**
+ * Unwraps an {@link EntityRef} into the identifier and which Data Fabric route to hit.
+ * Data Fabric exposes parallel by-id and by-name record/attachment routes, so a ref maps
+ * to a direct endpoint switch — this is a synchronous check, not a lookup call.
+ */
+function unwrapEntityRef(entityRef: EntityRef, callerLabel: string): { byId: boolean; identifier: string } {
+  const { id, name } = (entityRef ?? {}) as { id?: string; name?: string };
+  if (id && name) {
+    throw new ValidationError({
+      message: `${callerLabel}: entityRef must supply exactly one of 'id' or 'name', not both.`,
+    });
+  }
+  if (id) {
+    return { byId: true, identifier: id };
+  }
+  if (name) {
+    return { byId: false, identifier: name };
+  }
+  throw new ValidationError({
+    message: `${callerLabel}: entityRef must supply exactly one of 'id' or 'name'.`,
+  });
+}
+
+/**
  * Service for interacting with the Data Fabric Entity API
  */
 export class EntityService extends BaseService implements EntityServiceModel {
   @track('Entities.GetById')
   async getById(id: string, options?: EntityGetByIdOptions): Promise<EntityGetResponse> {
-    // Get entity metadata
-    const response = await this.get<RawEntityGetResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(id),
-      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) }
-    );
+    return this.fetchEntityMetadata(DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_ID(id), options?.folderKey);
+  }
 
-    // Apply EntityMap transformations
-    const metadata = transformData(response.data as RawEntityGetResponse, EntityMap)
-
-    // Transform metadata with field mappers
-    this.applyFieldMappings(metadata);
-
-    // Return the entity metadata with methods attached
-    return createEntityWithMethods(metadata, this);
+  @track('Entities.GetByName')
+  async getByName(entityName: string, options?: EntityGetByNameOptions): Promise<EntityGetResponse> {
+    return this.fetchEntityMetadata(DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_NAME(entityName), options?.folderKey);
   }
 
   @track('Entities.GetAllRecords')
@@ -122,26 +140,19 @@ export class EntityService extends BaseService implements EntityServiceModel {
       ? PaginatedResponse<EntityRecord>
       : NonPaginatedResponse<EntityRecord>
   > {
-    // folderKey is header-only — destructure it out so PaginationHelpers doesn't serialise it
-    // into the query string as $folderKey.
-    const { folderKey, ...rest } = options ?? {};
-    const downstreamOptions = options === undefined ? undefined : (rest as T);
-    return PaginationHelpers.getAll({
-      serviceAccess: this.createPaginationServiceAccess(),
-      getEndpoint: () => DATA_FABRIC_ENDPOINTS.ENTITY.GET_ENTITY_RECORDS(entityId),
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
-      pagination: {
-        paginationType: PaginationType.OFFSET,
-        itemsField: ENTITY_PAGINATION.ITEMS_FIELD,
-        totalCountField: ENTITY_PAGINATION.TOTAL_COUNT_FIELD,
-        paginationParams: {
-          pageSizeParam: ENTITY_OFFSET_PARAMS.PAGE_SIZE_PARAM,
-          offsetParam: ENTITY_OFFSET_PARAMS.OFFSET_PARAM,
-          countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
-        }
-      },
-      excludeFromPrefix: ['expansionLevel'] // Don't add ODATA prefix to expansionLevel
-    }, downstreamOptions);
+    return this.getRecordsImpl<T>(true, entityId, options);
+  }
+
+  @track('Entities.GetRecordsByName')
+  async getRecordsByName<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(
+    entityName: string,
+    options?: T
+  ): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<EntityRecord>
+      : NonPaginatedResponse<EntityRecord>
+  > {
+    return this.getRecordsImpl<T>(false, entityName, options);
   }
 
   @track('Entities.GetRecordById')
@@ -150,116 +161,82 @@ export class EntityService extends BaseService implements EntityServiceModel {
     recordId: string,
     options: EntityGetRecordByIdOptions = {}
   ): Promise<EntityRecord> {
-    const params = createParams({
-      expansionLevel: options.expansionLevel
-    });
+    return this.getRecordImpl(true, entityId, recordId, options);
+  }
 
-    const response = await this.get<EntityRecord>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.GET_RECORD_BY_ID(entityId, recordId),
-      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
-    );
+  @track('Entities.GetRecordByName')
+  async getRecordByName(
+    entityName: string,
+    recordId: string,
+    options: EntityGetRecordByNameOptions = {}
+  ): Promise<EntityRecord> {
+    return this.getRecordImpl(false, entityName, recordId, options);
+  }
 
-    return response.data;
+  @track('Entities.InsertRecord')
+  async insertRecord(entityRef: EntityRef, data: Record<string, any>, options: EntityInsertRecordOptions = {}): Promise<EntityInsertResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.insertRecord');
+    return this.insertRecordImpl(byId, identifier, data, options);
   }
 
   @track('Entities.InsertRecordById')
   async insertRecordById(id: string, data: Record<string, any>, options: EntityInsertRecordOptions = {}): Promise<EntityInsertResponse> {
-    const params = createParams({
-      expansionLevel: options.expansionLevel
-    });
+    return this.insertRecordImpl(true, id, data, options);
+  }
 
-    const response = await this.post<EntityInsertResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.INSERT_BY_ID(id),
-      data,
-      {
-        params,
-        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
-      }
-    );
-
-    return response.data;
+  @track('Entities.InsertRecords')
+  async insertRecords(entityRef: EntityRef, data: Record<string, any>[], options: EntityInsertRecordsOptions = {}): Promise<EntityBatchInsertResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.insertRecords');
+    return this.insertRecordsImpl(byId, identifier, data, options);
   }
 
   @track('Entities.InsertRecordsById')
   async insertRecordsById(id: string, data: Record<string, any>[], options: EntityInsertRecordsOptions = {}): Promise<EntityBatchInsertResponse> {
-    const params = createParams({
-      expansionLevel: options.expansionLevel,
-      failOnFirst: options.failOnFirst
-    });
+    return this.insertRecordsImpl(true, id, data, options);
+  }
 
-    const response = await this.post<EntityBatchInsertResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.BATCH_INSERT_BY_ID(id),
-      data,
-      {
-        params,
-        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
-      }
-    );
-
-    return response.data;
+  @track('Entities.UpdateRecord')
+  async updateRecord(entityRef: EntityRef, recordId: string, data: Record<string, any>, options: EntityUpdateRecordOptions = {}): Promise<EntityUpdateRecordResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.updateRecord');
+    return this.updateRecordImpl(byId, identifier, recordId, data, options);
   }
 
   @track('Entities.UpdateRecordById')
   async updateRecordById(entityId: string, recordId: string, data: Record<string, any>, options: EntityUpdateRecordOptions = {}): Promise<EntityUpdateRecordResponse> {
-    const params = createParams({
-      expansionLevel: options.expansionLevel
-    });
+    return this.updateRecordImpl(true, entityId, recordId, data, options);
+  }
 
-    const response = await this.post<EntityUpdateRecordResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_RECORD_BY_ID(entityId, recordId),
-      data,
-      {
-        params,
-        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
-      }
-    );
-
-    return response.data;
+  @track('Entities.UpdateRecords')
+  async updateRecords(entityRef: EntityRef, data: EntityRecord[], options: EntityUpdateRecordsOptions = {}): Promise<EntityUpdateResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.updateRecords');
+    return this.updateRecordsImpl(byId, identifier, data, options);
   }
 
   @track('Entities.UpdateRecordsById')
   async updateRecordsById(id: string, data: EntityRecord[], options: EntityUpdateRecordsOptions = {}): Promise<EntityUpdateResponse> {
-    const params = createParams({
-      expansionLevel: options.expansionLevel,
-      failOnFirst: options.failOnFirst
-    });
+    return this.updateRecordsImpl(true, id, data, options);
+  }
 
-    const response = await this.post<EntityUpdateResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_BY_ID(id),
-      data,
-      {
-        params,
-        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
-      }
-    );
-
-    return response.data;
+  @track('Entities.DeleteRecords')
+  async deleteRecords(entityRef: EntityRef, recordIds: string[], options: EntityDeleteRecordsOptions = {}): Promise<EntityDeleteResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.deleteRecords');
+    return this.deleteRecordsImpl(byId, identifier, recordIds, options);
   }
 
   @track('Entities.DeleteRecordsById')
   async deleteRecordsById(id: string, recordIds: string[], options: EntityDeleteRecordsOptions = {}): Promise<EntityDeleteResponse> {
-    const params = createParams({
-      failOnFirst: options.failOnFirst
-    });
+    return this.deleteRecordsImpl(true, id, recordIds, options);
+  }
 
-    const response = await this.post<EntityDeleteResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_BY_ID(id),
-      recordIds,
-      {
-        params,
-        headers: createHeaders({ [FOLDER_KEY]: options.folderKey }),
-      }
-    );
-
-    return response.data;
+  @track('Entities.DeleteRecord')
+  async deleteRecord(entityRef: EntityRef, recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.deleteRecord');
+    return this.deleteRecordImpl(byId, identifier, recordId, options);
   }
 
   @track('Entities.DeleteRecordById')
   async deleteRecordById(entityId: string, recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void> {
-    await this.delete(
-      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(entityId, recordId),
-      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
-    );
+    return this.deleteRecordImpl(true, entityId, recordId, options);
   }
 
   @track('Entities.GetAll')
@@ -290,84 +267,41 @@ export class EntityService extends BaseService implements EntityServiceModel {
     return entities;
   }
 
+  @track('Entities.QueryRecords')
+  async queryRecords<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(
+    entityRef: EntityRef,
+    options?: T
+  ): Promise<T extends HasPaginationOptions<T> ? PaginatedResponse<EntityRecord> : NonPaginatedResponse<EntityRecord>> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.queryRecords');
+    return this.queryRecordsImpl<T>(byId, identifier, options);
+  }
+
   @track('Entities.QueryRecordsById')
   async queryRecordsById<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(
     id: string,
     options?: T
   ): Promise<T extends HasPaginationOptions<T> ? PaginatedResponse<EntityRecord> : NonPaginatedResponse<EntityRecord>> {
-    if (options?.joins && options.joins.length > MAX_QUERY_JOINS) {
-      throw new ValidationError({
-        message: `A maximum of ${MAX_QUERY_JOINS} joins is supported per query (received ${options.joins.length})`,
-      });
-    }
-    // The multi-entity query API rejects join queries without a projection;
-    // surface that requirement client-side with an actionable message.
-    if (options?.joins && options.joins.length > 0 && !options.selectedFields?.length && !options.aggregates?.length) {
-      throw new ValidationError({
-        message: 'Join queries require selectedFields or aggregates — reference fields as "<EntityName>.<FieldName>" (e.g. "Customer.name")',
-      });
-    }
-    // The server's aggregates-only HAVING contract requires aggregates + groupBy;
-    // surface that requirement client-side with an actionable message.
-    if (options?.havingFilter && (!options.aggregates?.length || !options.groupBy?.length)) {
-      throw new ValidationError({
-        message: 'havingFilter requires aggregates and groupBy — conditions reference declared aggregate aliases; use filterGroup for row-level conditions',
-      });
-    }
-    // folderKey is header-only; expansionLevel must be sent as a query param by PaginationHelpers.
-    const { folderKey, expansionLevel, ...rest } = options ?? {};
-    // The multi-entity (joins) contract only exists on the name-based query route —
-    // the ID-based route silently drops the `joins` body key. Resolve the entity name
-    // and translate each join to the wire shape ({ type, entity, on: { left, right } }).
-    let getEndpoint = () => DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_ID(id);
-    if (options?.joins && options.joins.length > 0) {
-      const baseEntityName = await this.resolveEntityName(id, folderKey);
-      (rest as Record<string, unknown>).joins = options.joins.map(join => toWireJoin(join, baseEntityName));
-      getEndpoint = () => DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_NAME(baseEntityName);
-    }
-    const downstreamOptions = options === undefined ? undefined : (rest as T);
-    return PaginationHelpers.getAll({
-      serviceAccess: this.createPaginationServiceAccess(),
-      getEndpoint,
-      method: HTTP_METHODS.POST,
-      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
-      queryParams: createParams({ expansionLevel }),
-      pagination: {
-        paginationType: PaginationType.OFFSET,
-        itemsField: ENTITY_PAGINATION.ITEMS_FIELD,
-        totalCountField: ENTITY_PAGINATION.TOTAL_COUNT_FIELD,
-        paginationParams: {
-          pageSizeParam: ENTITY_OFFSET_PARAMS.PAGE_SIZE_PARAM,
-          offsetParam: ENTITY_OFFSET_PARAMS.OFFSET_PARAM,
-          countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
-        }
-      },
-      excludeFromPrefix: ['filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy', 'joins', 'havingFilter']
-    }, downstreamOptions);
+    return this.queryRecordsImpl<T>(true, id, options);
+  }
+
+  @track('Entities.ImportRecords')
+  async importRecords(entityRef: EntityRef, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.importRecords');
+    return this.importRecordsImpl(byId, identifier, file, options);
   }
 
   @track('Entities.ImportRecordsById')
   async importRecordsById(id: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse> {
-    const formData = new FormData();
-    if (file instanceof Uint8Array) {
-      formData.append('file', new Blob([file.buffer as ArrayBuffer]));
-    } else {
-      formData.append('file', file);
-    }
-
-    const response = await this.post<EntityImportRecordsResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_ID(id),
-      formData,
-      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
-    );
-
-    return response.data;
+    return this.importRecordsImpl(true, id, file, options);
   }
 
   @track('Entities.DownloadAttachment')
-  async downloadAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob> {
+  async downloadAttachment(entityRef: EntityRef, recordId: string, fieldName: string, options?: EntityDownloadAttachmentOptions): Promise<Blob> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.downloadAttachment');
     const response = await this.get<Blob>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.DOWNLOAD_ATTACHMENT(entityId, recordId, fieldName),
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.DOWNLOAD_ATTACHMENT(identifier, recordId, fieldName)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(identifier, recordId, fieldName),
       {
         responseType: RESPONSE_TYPES.BLOB,
         headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }),
@@ -378,7 +312,8 @@ export class EntityService extends BaseService implements EntityServiceModel {
   }
 
   @track('Entities.UploadAttachment')
-  async uploadAttachment(entityId: string, recordId: string, fieldName: string, file: EntityFileType, options?: EntityUploadAttachmentOptions): Promise<EntityUploadAttachmentResponse> {
+  async uploadAttachment(entityRef: EntityRef, recordId: string, fieldName: string, file: EntityFileType, options?: EntityUploadAttachmentOptions): Promise<EntityUploadAttachmentResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.uploadAttachment');
     const formData = new FormData();
     if (file instanceof Uint8Array) {
       formData.append('file', new Blob([file.buffer as ArrayBuffer]));
@@ -389,7 +324,9 @@ export class EntityService extends BaseService implements EntityServiceModel {
     const params = createParams({ expansionLevel: options?.expansionLevel });
 
     const response = await this.post<EntityUploadAttachmentResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.UPLOAD_ATTACHMENT(entityId, recordId, fieldName),
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.UPLOAD_ATTACHMENT(identifier, recordId, fieldName)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(identifier, recordId, fieldName),
       formData,
       {
         params,
@@ -401,9 +338,12 @@ export class EntityService extends BaseService implements EntityServiceModel {
   }
 
   @track('Entities.DeleteAttachment')
-  async deleteAttachment(entityId: string, recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse> {
+  async deleteAttachment(entityRef: EntityRef, recordId: string, fieldName: string, options?: EntityDeleteAttachmentOptions): Promise<EntityDeleteAttachmentResponse> {
+    const { byId, identifier } = unwrapEntityRef(entityRef, 'Entities.deleteAttachment');
     const response = await this.delete<EntityDeleteAttachmentResponse>(
-      DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_ATTACHMENT(entityId, recordId, fieldName),
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_ATTACHMENT(identifier, recordId, fieldName)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(identifier, recordId, fieldName),
       { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
     );
 
@@ -888,6 +828,211 @@ export class EntityService extends BaseService implements EntityServiceModel {
         // UUID, CHOICE_SET_SINGLE, AUTO_NUMBER, DATETIME — (sqlType: { name })
         return {};
     }
+  }
+
+  private async fetchEntityMetadata(endpoint: string, folderKey?: string): Promise<EntityGetResponse> {
+    const response = await this.get<RawEntityGetResponse>(
+      endpoint,
+      { headers: createHeaders({ [FOLDER_KEY]: folderKey }) }
+    );
+    const metadata = transformData(response.data as RawEntityGetResponse, EntityMap);
+    this.applyFieldMappings(metadata);
+    return createEntityWithMethods(metadata, this);
+  }
+
+  private getRecordsImpl<T extends EntityGetAllRecordsOptions = EntityGetAllRecordsOptions>(
+    byId: boolean,
+    identifier: string,
+    options?: T
+  ): Promise<
+    T extends HasPaginationOptions<T>
+      ? PaginatedResponse<EntityRecord>
+      : NonPaginatedResponse<EntityRecord>
+  > {
+    // folderKey is header-only — destructure it out so PaginationHelpers doesn't serialise it
+    // into the query string as $folderKey.
+    const { folderKey, ...rest } = options ?? {};
+    const downstreamOptions = options === undefined ? undefined : (rest as T);
+    return PaginationHelpers.getAll({
+      serviceAccess: this.createPaginationServiceAccess(),
+      getEndpoint: () => byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_ENTITY_RECORDS(identifier)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.GET_ENTITY_RECORDS_BY_NAME(identifier),
+      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      pagination: {
+        paginationType: PaginationType.OFFSET,
+        itemsField: ENTITY_PAGINATION.ITEMS_FIELD,
+        totalCountField: ENTITY_PAGINATION.TOTAL_COUNT_FIELD,
+        paginationParams: {
+          pageSizeParam: ENTITY_OFFSET_PARAMS.PAGE_SIZE_PARAM,
+          offsetParam: ENTITY_OFFSET_PARAMS.OFFSET_PARAM,
+          countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
+        }
+      },
+      excludeFromPrefix: ['expansionLevel'] // Don't add ODATA prefix to expansionLevel
+    }, downstreamOptions);
+  }
+
+  private async getRecordImpl(
+    byId: boolean,
+    identifier: string,
+    recordId: string,
+    options: EntityGetRecordByIdOptions
+  ): Promise<EntityRecord> {
+    const params = createParams({ expansionLevel: options.expansionLevel });
+    const response = await this.get<EntityRecord>(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.GET_RECORD_BY_ID(identifier, recordId)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.GET_RECORD_BY_NAME(identifier, recordId),
+      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
+    return response.data;
+  }
+
+  private async insertRecordImpl(byId: boolean, identifier: string, data: Record<string, any>, options: EntityInsertRecordOptions): Promise<EntityInsertResponse> {
+    const params = createParams({ expansionLevel: options.expansionLevel });
+    const response = await this.post<EntityInsertResponse>(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.INSERT_BY_ID(identifier)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.INSERT_BY_NAME(identifier),
+      data,
+      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
+    return response.data;
+  }
+
+  private async insertRecordsImpl(byId: boolean, identifier: string, data: Record<string, any>[], options: EntityInsertRecordsOptions): Promise<EntityBatchInsertResponse> {
+    const params = createParams({ expansionLevel: options.expansionLevel, failOnFirst: options.failOnFirst });
+    const response = await this.post<EntityBatchInsertResponse>(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.BATCH_INSERT_BY_ID(identifier)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.BATCH_INSERT_BY_NAME(identifier),
+      data,
+      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
+    return response.data;
+  }
+
+  private async updateRecordImpl(byId: boolean, identifier: string, recordId: string, data: Record<string, any>, options: EntityUpdateRecordOptions): Promise<EntityUpdateRecordResponse> {
+    const params = createParams({ expansionLevel: options.expansionLevel });
+    const response = await this.post<EntityUpdateRecordResponse>(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_RECORD_BY_ID(identifier, recordId)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_RECORD_BY_NAME(identifier, recordId),
+      data,
+      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
+    return response.data;
+  }
+
+  private async updateRecordsImpl(byId: boolean, identifier: string, data: EntityRecord[], options: EntityUpdateRecordsOptions): Promise<EntityUpdateResponse> {
+    const params = createParams({ expansionLevel: options.expansionLevel, failOnFirst: options.failOnFirst });
+    const response = await this.post<EntityUpdateResponse>(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_BY_ID(identifier)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_BY_NAME(identifier),
+      data,
+      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
+    return response.data;
+  }
+
+  private async deleteRecordsImpl(byId: boolean, identifier: string, recordIds: string[], options: EntityDeleteRecordsOptions): Promise<EntityDeleteResponse> {
+    const params = createParams({ failOnFirst: options.failOnFirst });
+    const response = await this.post<EntityDeleteResponse>(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_BY_ID(identifier)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_BY_NAME(identifier),
+      recordIds,
+      { params, headers: createHeaders({ [FOLDER_KEY]: options.folderKey }) }
+    );
+    return response.data;
+  }
+
+  private async deleteRecordImpl(byId: boolean, identifier: string, recordId: string, options?: EntityDeleteRecordByIdOptions): Promise<void> {
+    await this.delete(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(identifier, recordId)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_NAME(identifier, recordId),
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
+    );
+  }
+
+  private async queryRecordsImpl<T extends EntityQueryRecordsOptions = EntityQueryRecordsOptions>(
+    byId: boolean,
+    identifier: string,
+    options?: T
+  ): Promise<T extends HasPaginationOptions<T> ? PaginatedResponse<EntityRecord> : NonPaginatedResponse<EntityRecord>> {
+    if (options?.joins && options.joins.length > MAX_QUERY_JOINS) {
+      throw new ValidationError({
+        message: `A maximum of ${MAX_QUERY_JOINS} joins is supported per query (received ${options.joins.length})`,
+      });
+    }
+    // The multi-entity query API rejects join queries without a projection;
+    // surface that requirement client-side with an actionable message.
+    if (options?.joins && options.joins.length > 0 && !options.selectedFields?.length && !options.aggregates?.length) {
+      throw new ValidationError({
+        message: 'Join queries require selectedFields or aggregates — reference fields as "<EntityName>.<FieldName>" (e.g. "Customer.name")',
+      });
+    }
+    // The server's aggregates-only HAVING contract requires aggregates + groupBy;
+    // surface that requirement client-side with an actionable message.
+    if (options?.havingFilter && (!options.aggregates?.length || !options.groupBy?.length)) {
+      throw new ValidationError({
+        message: 'havingFilter requires aggregates and groupBy — conditions reference declared aggregate aliases; use filterGroup for row-level conditions',
+      });
+    }
+    // folderKey is header-only; expansionLevel must be sent as a query param by PaginationHelpers.
+    const { folderKey, expansionLevel, ...rest } = options ?? {};
+    // The multi-entity (joins) contract only exists on the name-based query route —
+    // the ID-based route silently drops the `joins` body key. When addressing by id, resolve
+    // the name (by name, it is already known); then translate each join to the wire shape.
+    let getEndpoint = () => byId
+      ? DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_ID(identifier)
+      : DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_NAME(identifier);
+    if (options?.joins && options.joins.length > 0) {
+      const baseEntityName = byId ? await this.resolveEntityName(identifier, folderKey) : identifier;
+      (rest as Record<string, unknown>).joins = options.joins.map(join => toWireJoin(join, baseEntityName));
+      getEndpoint = () => DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_NAME(baseEntityName);
+    }
+    const downstreamOptions = options === undefined ? undefined : (rest as T);
+    return PaginationHelpers.getAll({
+      serviceAccess: this.createPaginationServiceAccess(),
+      getEndpoint,
+      method: HTTP_METHODS.POST,
+      headers: createHeaders({ [FOLDER_KEY]: folderKey }),
+      queryParams: createParams({ expansionLevel }),
+      pagination: {
+        paginationType: PaginationType.OFFSET,
+        itemsField: ENTITY_PAGINATION.ITEMS_FIELD,
+        totalCountField: ENTITY_PAGINATION.TOTAL_COUNT_FIELD,
+        paginationParams: {
+          pageSizeParam: ENTITY_OFFSET_PARAMS.PAGE_SIZE_PARAM,
+          offsetParam: ENTITY_OFFSET_PARAMS.OFFSET_PARAM,
+          countParam: ENTITY_OFFSET_PARAMS.COUNT_PARAM
+        }
+      },
+      excludeFromPrefix: ['filterGroup', 'selectedFields', 'sortOptions', 'aggregates', 'groupBy', 'joins', 'havingFilter']
+    }, downstreamOptions);
+  }
+
+  private async importRecordsImpl(byId: boolean, identifier: string, file: EntityFileType, options?: EntityImportRecordsByIdOptions): Promise<EntityImportRecordsResponse> {
+    const formData = new FormData();
+    if (file instanceof Uint8Array) {
+      formData.append('file', new Blob([file.buffer as ArrayBuffer]));
+    } else {
+      formData.append('file', file);
+    }
+
+    const response = await this.post<EntityImportRecordsResponse>(
+      byId
+        ? DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_ID(identifier)
+        : DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_NAME(identifier),
+      formData,
+      { headers: createHeaders({ [FOLDER_KEY]: options?.folderKey }) },
+    );
+
+    return response.data;
   }
 
 }

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -46,6 +46,26 @@ export const DATA_FABRIC_ENDPOINTS = {
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
     DELETE_ATTACHMENT: (entityId: string, recordId: string, fieldName: string) =>
       `${DATAFABRIC_BASE}/api/Attachment/entity/${entityId}/${recordId}/${fieldName}`,
+
+    // ---- By-name variants ----
+    // The Data Fabric API exposes a parallel `{entityName}/...` route for every
+    // record operation, letting callers address an entity by name instead of id
+    // (used by solution binding overrides, which resolve resources by name + folderKey).
+    GET_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/Entity/${entityName}/metadata`,
+    GET_ENTITY_RECORDS_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/read`,
+    // v2 single-record read by name — mirrors GET_RECORD_BY_ID (full MULTILINE_MAX content).
+    GET_RECORD_BY_NAME: (entityName: string, recordId: string) =>
+      `${DATAFABRIC_BASE}/api/v2/EntityService/${entityName}/read/${recordId}`,
+    INSERT_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/insert`,
+    BATCH_INSERT_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/insert-batch`,
+    UPDATE_RECORD_BY_NAME: (entityName: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/update/${recordId}`,
+    UPDATE_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/update-batch`,
+    DELETE_RECORD_BY_NAME: (entityName: string, recordId: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/delete/${recordId}`,
+    DELETE_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/delete-batch`,
+    BULK_UPLOAD_BY_NAME: (entityName: string) => `${DATAFABRIC_BASE}/api/EntityService/${entityName}/bulk-upload`,
+    // Download (GET), upload (POST), and delete (DELETE) all share this URL; the HTTP method is chosen at the call site.
+    ATTACHMENT_BY_NAME: (entityName: string, recordId: string, fieldName: string) =>
+      `${DATAFABRIC_BASE}/api/Attachment/${entityName}/${recordId}/${fieldName}`,
   },
   CHOICESETS: {
     GET_ALL: `${DATAFABRIC_BASE}/api/Entity/choiceset`,

--- a/tests/integration/shared/data-fabric/attachment.integration.test.ts
+++ b/tests/integration/shared/data-fabric/attachment.integration.test.ts
@@ -34,9 +34,14 @@ describe.skipIf(!hasAttachmentConfig).each(modes)(
     setupUnifiedTests(mode);
 
     let recordId!: string;
+    let entityName!: string;
 
     beforeAll(async () => {
       const { entities } = getServices();
+
+      // Resolve the entity name once so by-name attachment tests can address it.
+      const entity = await entities.getById(ATTACHMENT_CONFIG.entityId);
+      entityName = entity.name;
 
       const inserted = await entities.insertRecordById(ATTACHMENT_CONFIG.entityId, {});
 
@@ -65,7 +70,7 @@ describe.skipIf(!hasAttachmentConfig).each(modes)(
         const file = new Blob(['Hello from UiPath TypeScript SDK integration test!'], { type: 'text/plain' });
 
         const result = await entities.uploadAttachment(
-          ATTACHMENT_CONFIG.entityId,
+          { id: ATTACHMENT_CONFIG.entityId },
           recordId,
           ATTACHMENT_CONFIG.fieldName,
           file,
@@ -97,14 +102,14 @@ describe.skipIf(!hasAttachmentConfig).each(modes)(
         const file = new Blob(['Temporary file for delete attachment test'], { type: 'text/plain' });
 
         await entities.uploadAttachment(
-          ATTACHMENT_CONFIG.entityId,
+          { id: ATTACHMENT_CONFIG.entityId },
           recordId,
           ATTACHMENT_CONFIG.fieldName,
           file,
         );
 
         const result = await entities.deleteAttachment(
-          ATTACHMENT_CONFIG.entityId,
+          { id: ATTACHMENT_CONFIG.entityId },
           recordId,
           ATTACHMENT_CONFIG.fieldName,
         );
@@ -140,14 +145,14 @@ describe.skipIf(!hasAttachmentConfig).each(modes)(
         const file = new Blob(['Temporary file for download attachment test'], { type: 'text/plain' });
 
         await entities.uploadAttachment(
-          ATTACHMENT_CONFIG.entityId,
+          { id: ATTACHMENT_CONFIG.entityId },
           recordId,
           ATTACHMENT_CONFIG.fieldName,
           file,
         );
 
         const downloadedFile = await entities.downloadAttachment(
-          ATTACHMENT_CONFIG.entityId,
+          { id: ATTACHMENT_CONFIG.entityId },
           recordId,
           ATTACHMENT_CONFIG.fieldName,
         );
@@ -173,6 +178,36 @@ describe.skipIf(!hasAttachmentConfig).each(modes)(
         );
 
         expect(downloadedFile).toBeDefined();
+      });
+    });
+
+    describe('attachment by name', () => {
+      it('should upload, download, and delete an attachment addressing the entity by name', async () => {
+        const { entities } = getServices();
+
+        const file = new Blob(['Attachment by-name round-trip test'], { type: 'text/plain' });
+
+        const uploadResult = await entities.uploadAttachment(
+          { name: entityName },
+          recordId,
+          ATTACHMENT_CONFIG.fieldName,
+          file,
+        );
+        expect(uploadResult).toBeDefined();
+
+        const downloadedFile = await entities.downloadAttachment(
+          { name: entityName },
+          recordId,
+          ATTACHMENT_CONFIG.fieldName,
+        );
+        expect(downloadedFile).toBeDefined();
+
+        const deleteResult = await entities.deleteAttachment(
+          { name: entityName },
+          recordId,
+          ATTACHMENT_CONFIG.fieldName,
+        );
+        expect(deleteResult).toBeDefined();
       });
     });
   }

--- a/tests/integration/shared/data-fabric/entities-records.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities-records.integration.test.ts
@@ -1086,6 +1086,221 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
     });
   });
 
+  // ─── By-name methods ──────────────────────────────────────────────────────
+
+  describe('By-name methods', () => {
+    let byNameEntityId!: string;
+    let byNameEntityName!: string;
+    let byNameMetadata!: RawEntityGetResponse;
+
+    beforeAll(async () => {
+      const { entities } = getServices();
+      const config = getTestConfig();
+
+      const entityId = config.dataFabricTestEntityId || testEntityId;
+      if (!entityId) {
+        throw new Error('No entity ID available for by-name tests. Set DATA_FABRIC_TEST_ENTITY_ID.');
+      }
+
+      // Resolve the entity name from its id so by-name calls have a real name to address.
+      byNameMetadata = await entities.getById(entityId);
+      byNameEntityId = byNameMetadata.id;
+      byNameEntityName = byNameMetadata.name;
+    });
+
+    describe('getByName', () => {
+      it('should retrieve entity metadata by name with methods attached', async () => {
+        const { entities } = getServices();
+
+        const result = await entities.getByName(byNameEntityName);
+
+        expect(result).toBeDefined();
+        expect(result.id).toBe(byNameEntityId);
+        expect(result.name).toBe(byNameEntityName);
+        expect(Array.isArray(result.fields)).toBe(true);
+        expect(result.fields.length).toBeGreaterThan(0);
+        expect(typeof result.insertRecord).toBe('function');
+        expect(typeof result.getAllRecords).toBe('function');
+      });
+    });
+
+    describe('getRecordsByName', () => {
+      it('should retrieve records by entity name', async () => {
+        const { entities } = getServices();
+
+        const result = await entities.getRecordsByName(byNameEntityName, { pageSize: 5 });
+
+        expect(result).toBeDefined();
+        expect(Array.isArray(result.items)).toBe(true);
+        expect(typeof result.totalCount).toBe('number');
+      });
+    });
+
+    describe('queryRecords (by name ref)', () => {
+      it('should query records by entity name', async () => {
+        const { entities } = getServices();
+
+        const result = await entities.queryRecords({ name: byNameEntityName }, { pageSize: 5 });
+
+        expect(result).toBeDefined();
+        expect(Array.isArray(result.items)).toBe(true);
+        expect(typeof result.totalCount).toBe('number');
+      });
+    });
+
+    describe('Record CRUD operations (by name)', () => {
+      const byNameRecordIds: string[] = [];
+
+      it('should insert a single record using insertRecord with a name ref', async () => {
+        const { entities } = getServices();
+
+        const testData = await buildDummyRecord(byNameMetadata);
+        const result = await entities.insertRecord({ name: byNameEntityName }, testData);
+
+        expect(result).toBeDefined();
+        expect(result.Id).toBeDefined();
+
+        byNameRecordIds.push(result.Id);
+        createdRecordIds.push(result.Id);
+        registerResource('entityRecords', { entityId: byNameEntityId, recordIds: [result.Id] });
+      });
+
+      it('should verify the inserted record via getRecordByName', async () => {
+        const { entities } = getServices();
+
+        if (byNameRecordIds.length === 0) {
+          throw new Error('No record inserted to verify via getRecordByName');
+        }
+
+        const recordId = byNameRecordIds[0];
+        const record = await entities.getRecordByName(byNameEntityName, recordId);
+
+        expect(record).toBeDefined();
+        expect(record.Id).toBe(recordId);
+      });
+
+      it('should batch insert records using insertRecords with a name ref', async () => {
+        const { entities } = getServices();
+
+        const testData = await Promise.all([
+          buildDummyRecord(byNameMetadata),
+          buildDummyRecord(byNameMetadata),
+        ]);
+        const result = await entities.insertRecords({ name: byNameEntityName }, testData);
+
+        expect(result).toBeDefined();
+        expect(Array.isArray(result.successRecords)).toBe(true);
+
+        const insertedIds = result.successRecords.filter((r) => r.Id).map((r) => r.Id);
+        byNameRecordIds.push(...insertedIds);
+        createdRecordIds.push(...insertedIds);
+        registerResource('entityRecords', { entityId: byNameEntityId, recordIds: insertedIds });
+      });
+
+      it('should update a single record using updateRecord with a name ref', async () => {
+        const { entities } = getServices();
+
+        if (byNameRecordIds.length === 0) {
+          throw new Error('No record available to update via updateRecord (by name ref)');
+        }
+
+        const writableFields = getWritableFields(byNameMetadata.fields);
+        const updates: Record<string, any> = {};
+        if (writableFields.length > 0) {
+          updates[writableFields[0].name] = generateFieldValue(writableFields[0]);
+        }
+
+        const result = await entities.updateRecord({ name: byNameEntityName }, byNameRecordIds[0], updates);
+
+        expect(result).toBeDefined();
+        expect(result.Id).toBe(byNameRecordIds[0]);
+      });
+
+      it('should update records using updateRecords with a name ref', async () => {
+        const { entities } = getServices();
+
+        if (byNameRecordIds.length === 0) {
+          throw new Error('No records available to update via updateRecords (by name ref)');
+        }
+
+        const writableFields = getWritableFields(byNameMetadata.fields);
+        const updateData: EntityRecord[] = byNameRecordIds.map((id) => {
+          const updates = { Id: id } as EntityRecord;
+          if (writableFields.length > 0) {
+            updates[writableFields[0].name] = generateFieldValue(writableFields[0]);
+          }
+          return updates;
+        });
+
+        const result = await entities.updateRecords({ name: byNameEntityName }, updateData);
+
+        expect(result).toBeDefined();
+        expect(Array.isArray(result.successRecords)).toBe(true);
+      });
+
+      it('should delete records using deleteRecords with a name ref', async () => {
+        const { entities } = getServices();
+
+        if (byNameRecordIds.length === 0) {
+          throw new Error('No records available to delete via deleteRecords (by name ref)');
+        }
+
+        const result = await entities.deleteRecords({ name: byNameEntityName }, byNameRecordIds);
+
+        expect(result).toBeDefined();
+        expect(Array.isArray(result.successRecords)).toBe(true);
+
+        // Deleted here — drop from the shared tracking list so afterAll doesn't re-delete.
+        for (const id of byNameRecordIds) {
+          const idx = createdRecordIds.indexOf(id);
+          if (idx !== -1) createdRecordIds.splice(idx, 1);
+        }
+        byNameRecordIds.length = 0;
+      });
+    });
+
+    describe('deleteRecord (by name ref)', () => {
+      it('should insert then delete a single record by name', async () => {
+        const { entities } = getServices();
+
+        const testData = await buildDummyRecord(byNameMetadata);
+        const inserted = await entities.insertRecord({ name: byNameEntityName }, testData);
+        expect(inserted.Id).toBeDefined();
+        createdRecordIds.push(inserted.Id);
+
+        await entities.deleteRecord({ name: byNameEntityName }, inserted.Id);
+
+        // Removed — drop from the shared tracking list so afterAll doesn't re-delete.
+        const idx = createdRecordIds.indexOf(inserted.Id);
+        if (idx !== -1) createdRecordIds.splice(idx, 1);
+      });
+    });
+
+    describe('importRecords (by name ref)', () => {
+      it('should import records from a CSV blob by entity name', async () => {
+        const { entities } = getServices();
+
+        const writableFields = getWritableFields(byNameMetadata.fields).filter(
+          (f) => f.fieldDataType?.name === EntityFieldDataType.STRING,
+        );
+
+        if (writableFields.length === 0) {
+          throw new Error('No string fields available for by-name bulk import test');
+        }
+
+        const fieldName = writableFields[0].name;
+        const csvContent = `${fieldName}\nBulkImport_${generateRandomString(8)}\nBulkImport_${generateRandomString(8)}`;
+        const csvBlob = new Blob([csvContent], { type: 'text/csv' });
+
+        const result = await entities.importRecords({ name: byNameEntityName }, csvBlob);
+
+        expect(result).toBeDefined();
+        expect(typeof result.totalRecords).toBe('number');
+        expect(typeof result.insertedRecords).toBe('number');
+      });
+    });
+  });
+
   // ─── Cleanup ──────────────────────────────────────────────────────────────
 
   afterAll(async () => {

--- a/tests/unit/models/data-fabric/entities.test.ts
+++ b/tests/unit/models/data-fabric/entities.test.ts
@@ -26,18 +26,29 @@ describe("Entity Models", () => {
     mockService = {
       getAll: vi.fn(),
       getById: vi.fn(),
+      getByName: vi.fn(),
       getAllRecords: vi.fn(),
+      getRecordsByName: vi.fn(),
       getRecordsById: vi.fn(),
       getRecordById: vi.fn(),
+      getRecordByName: vi.fn(),
+      insertRecord: vi.fn(),
       insertRecordById: vi.fn(),
       insertById: vi.fn(),
+      insertRecords: vi.fn(),
       insertRecordsById: vi.fn(),
       batchInsertById: vi.fn(),
+      updateRecord: vi.fn(),
       updateRecordById: vi.fn(),
+      updateRecords: vi.fn(),
       updateRecordsById: vi.fn(),
+      deleteRecords: vi.fn(),
       deleteRecordsById: vi.fn(),
+      queryRecords: vi.fn(),
       queryRecordsById: vi.fn(),
+      importRecords: vi.fn(),
       importRecordsById: vi.fn(),
+      deleteRecord: vi.fn(),
       deleteRecordById: vi.fn(),
       downloadAttachment: vi.fn(),
       uploadAttachment: vi.fn(),
@@ -60,12 +71,12 @@ describe("Entity Models", () => {
 
         const testData = ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA;
         const mockResponse = createMockSingleInsertResponse(testData);
-        mockService.insertRecordById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.insertRecord = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.insertRecord(testData);
 
-        expect(mockService.insertRecordById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.insertRecord).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           testData,
           undefined,
         );
@@ -95,12 +106,12 @@ describe("Entity Models", () => {
         const mockResponse = createMockSingleInsertResponse(testData, {
           expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
         });
-        mockService.insertRecordById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.insertRecord = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.insertRecord(testData, options);
 
-        expect(mockService.insertRecordById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.insertRecord).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           testData,
           options,
         );
@@ -118,12 +129,12 @@ describe("Entity Models", () => {
           ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA_2,
         ];
         const mockResponse = createMockInsertResponse(testData);
-        mockService.insertRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.insertRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.insertRecords(testData);
 
-        expect(mockService.insertRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.insertRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           testData,
           undefined,
         );
@@ -155,12 +166,12 @@ describe("Entity Models", () => {
         const mockResponse = createMockInsertResponse(testData, {
           expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
         });
-        mockService.insertRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.insertRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.insertRecords(testData, options);
 
-        expect(mockService.insertRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.insertRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           testData,
           options,
         );
@@ -178,7 +189,7 @@ describe("Entity Models", () => {
         const mockResponse = createMockInsertResponse(testData, {
           successCount: 1,
         });
-        mockService.insertRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.insertRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.insertRecords(testData);
 
@@ -211,15 +222,15 @@ describe("Entity Models", () => {
           Id: ENTITY_TEST_CONSTANTS.RECORD_ID,
           ...testData,
         });
-        mockService.updateRecordById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.updateRecord = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.updateRecord(
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           testData,
         );
 
-        expect(mockService.updateRecordById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.updateRecord).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           testData,
           undefined,
@@ -245,7 +256,7 @@ describe("Entity Models", () => {
             expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
           },
         );
-        mockService.updateRecordById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.updateRecord = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.updateRecord(
           ENTITY_TEST_CONSTANTS.RECORD_ID,
@@ -253,8 +264,8 @@ describe("Entity Models", () => {
           options,
         );
 
-        expect(mockService.updateRecordById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.updateRecord).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           testData,
           options,
@@ -305,12 +316,12 @@ describe("Entity Models", () => {
           },
         ];
         const mockResponse = createMockUpdateResponse(testData);
-        mockService.updateRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.updateRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.updateRecords(testData);
 
-        expect(mockService.updateRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.updateRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           testData,
           undefined,
         );
@@ -337,12 +348,12 @@ describe("Entity Models", () => {
         const mockResponse = createMockUpdateResponse(testData, {
           expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
         });
-        mockService.updateRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.updateRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.updateRecords(testData, options);
 
-        expect(mockService.updateRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.updateRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           testData,
           options,
         );
@@ -379,7 +390,7 @@ describe("Entity Models", () => {
         const mockResponse = createMockUpdateResponse(testData, {
           successCount: 1,
         });
-        mockService.updateRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.updateRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.updateRecords(testData);
 
@@ -419,12 +430,12 @@ describe("Entity Models", () => {
           ENTITY_TEST_CONSTANTS.RECORD_ID_2,
         ];
         const mockResponse = createMockDeleteResponse(recordIds);
-        mockService.deleteRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.deleteRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.deleteRecords(recordIds);
 
-        expect(mockService.deleteRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.deleteRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           recordIds,
           undefined,
         );
@@ -442,12 +453,12 @@ describe("Entity Models", () => {
           failOnFirst: ENTITY_TEST_CONSTANTS.FAIL_ON_FIRST,
         };
         const mockResponse = createMockDeleteResponse(recordIds);
-        mockService.deleteRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.deleteRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.deleteRecords(recordIds, options);
 
-        expect(mockService.deleteRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.deleteRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           recordIds,
           options,
         );
@@ -471,7 +482,7 @@ describe("Entity Models", () => {
         const mockResponse = createMockDeleteResponse(recordIds, {
           successCount: 1,
         });
-        mockService.deleteRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.deleteRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.deleteRecords(recordIds);
 
@@ -495,12 +506,12 @@ describe("Entity Models", () => {
         const entityData = createBasicEntity();
         const entity = createEntityWithMethods(entityData, mockService);
 
-        mockService.deleteRecordById = vi.fn().mockResolvedValue(undefined);
+        mockService.deleteRecord = vi.fn().mockResolvedValue(undefined);
 
         await entity.deleteRecord(ENTITY_TEST_CONSTANTS.RECORD_ID);
 
-        expect(mockService.deleteRecordById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.deleteRecord).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           undefined,
         );
@@ -597,12 +608,12 @@ describe("Entity Models", () => {
         const entity = createEntityWithMethods(entityData, mockService);
 
         const mockResponse = { items: createMockEntityRecords(2), totalCount: 2 };
-        mockService.queryRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.queryRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.queryRecords();
 
-        expect(mockService.queryRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.queryRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           undefined,
         );
         expect(result).toEqual(mockResponse);
@@ -632,12 +643,12 @@ describe("Entity Models", () => {
           items: [{ status: "active", total: 12 }, { status: "closed", total: 5 }],
           totalCount: 2,
         };
-        mockService.queryRecordsById = vi.fn().mockResolvedValue(mockResponse);
+        mockService.queryRecords = vi.fn().mockResolvedValue(mockResponse);
 
         const result = await entity.queryRecords(options);
 
-        expect(mockService.queryRecordsById).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        expect(mockService.queryRecords).toHaveBeenCalledWith(
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           options,
         );
         expect(result).toEqual(mockResponse);
@@ -710,7 +721,7 @@ describe("Entity Models", () => {
         );
 
         expect(mockService.downloadAttachment).toHaveBeenCalledWith(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
           undefined,
@@ -766,7 +777,7 @@ describe("Entity Models", () => {
       );
 
       expect(mockService.uploadAttachment).toHaveBeenCalledWith(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         file,
@@ -805,7 +816,7 @@ describe("Entity Models", () => {
       );
 
       expect(mockService.deleteAttachment).toHaveBeenCalledWith(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         undefined,

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -32,6 +32,8 @@ import type {
   EntityRecord,
   EntityGetAllRecordsOptions,
   EntityUpdateByIdOptions,
+  EntityGetRecordByNameOptions,
+  EntityRef,
 } from "../../../../src/models/data-fabric/entities.types";
 import {
   EntityFieldDataType,
@@ -55,6 +57,7 @@ import { ENTITY_TEST_CONSTANTS } from "../../../utils/constants/entities";
 import { TEST_CONSTANTS } from "../../../utils/constants/common";
 import { DATA_FABRIC_ENDPOINTS } from "../../../../src/utils/constants/endpoints";
 import { DATA_FABRIC_TENANT_FOLDER_ID } from "../../../../src/utils/constants/endpoints/data-fabric";
+import { ValidationError } from "../../../../src/core/errors";
 import { SqlFieldType, FieldSchemaPayload } from "@/models/data-fabric/entities.internal-types";
 
 // ===== MOCKING =====
@@ -1282,7 +1285,7 @@ describe("EntityService Unit Tests", () => {
       mockApiClient.get.mockResolvedValue(mockBlob);
 
       const result = await entityService.downloadAttachment(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
       );
@@ -1308,7 +1311,7 @@ describe("EntityService Unit Tests", () => {
       mockApiClient.get.mockResolvedValue(mockBlob);
 
       await entityService.downloadAttachment(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
@@ -1330,7 +1333,7 @@ describe("EntityService Unit Tests", () => {
 
       await expect(
         entityService.downloadAttachment(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         ),
@@ -1356,7 +1359,7 @@ describe("EntityService Unit Tests", () => {
         mockApiClient.post.mockResolvedValue(response);
 
         const result = await entityService.uploadAttachment(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
           file,
@@ -1382,7 +1385,7 @@ describe("EntityService Unit Tests", () => {
       const file = new Blob(["test"]);
 
       await entityService.uploadAttachment(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         file,
@@ -1406,7 +1409,7 @@ describe("EntityService Unit Tests", () => {
       const file = new Blob(["test"]);
 
       await entityService.uploadAttachment(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         file,
@@ -1432,7 +1435,7 @@ describe("EntityService Unit Tests", () => {
 
       await expect(
         entityService.uploadAttachment(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
           file,
@@ -1446,7 +1449,7 @@ describe("EntityService Unit Tests", () => {
       mockApiClient.delete.mockResolvedValue(undefined);
 
       await entityService.deleteAttachment(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
       );
@@ -1465,7 +1468,7 @@ describe("EntityService Unit Tests", () => {
       mockApiClient.delete.mockResolvedValue(undefined);
 
       await entityService.deleteAttachment(
-        ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
         ENTITY_TEST_CONSTANTS.RECORD_ID,
         ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
@@ -1487,7 +1490,7 @@ describe("EntityService Unit Tests", () => {
 
       await expect(
         entityService.deleteAttachment(
-          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
           ENTITY_TEST_CONSTANTS.RECORD_ID,
           ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
         ),
@@ -2121,6 +2124,1190 @@ describe("EntityService Unit Tests", () => {
       await expect(
         entityService.importRecordsById(ENTITY_TEST_CONSTANTS.ENTITY_ID, file),
       ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  // ===== By-name method tests =====
+
+  describe("getByName", () => {
+    it("should get entity by name with fields transformed and methods attached", async () => {
+      const mockResponse = createMockEntityResponse();
+      mockApiClient.get.mockResolvedValue(mockResponse);
+
+      const result = await entityService.getByName(
+        ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe(ENTITY_TEST_CONSTANTS.ENTITY_ID);
+      expect(result.name).toBe(ENTITY_TEST_CONSTANTS.ENTITY_NAME);
+      expect(result.fields.length).toBe(3);
+
+      // Transform validation: camelCase present, raw PascalCase/API names absent
+      expect(result.createdTime).toBe(ENTITY_TEST_CONSTANTS.CREATED_TIME);
+      expect(result).not.toHaveProperty("createTime");
+      expect(result.fields[0].fieldDataType.name).toBe(
+        ENTITY_TEST_CONSTANTS.FIELD_TYPE_UUID,
+      );
+      expect(result.fields[0]).not.toHaveProperty("sqlType");
+
+      // Bound methods attached (same as getById)
+      expect(typeof result.insertRecord).toBe("function");
+      expect(typeof result.getAllRecords).toBe("function");
+      expect(typeof result.deleteRecord).toBe("function");
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        { headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      const mockResponse = createMockEntityResponse();
+      mockApiClient.get.mockResolvedValue(mockResponse);
+
+      await entityService.getByName(ENTITY_TEST_CONSTANTS.ENTITY_NAME, {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+      });
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.get.mockRejectedValue(error);
+
+      await expect(
+        entityService.getByName(ENTITY_TEST_CONSTANTS.ENTITY_NAME),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe("getRecordsByName", () => {
+    beforeEach(() => {
+      vi.mocked(PaginationHelpers.getAll).mockReset();
+    });
+
+    it("should delegate to PaginationHelpers.getAll with the by-name read endpoint", async () => {
+      const mockResponse = { items: createMockEntityRecords(5), totalCount: 5 };
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const result = await entityService.getRecordsByName(
+        ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+      );
+
+      const [config] = vi.mocked(PaginationHelpers.getAll).mock.calls[0];
+      expect((config as any).getEndpoint()).toBe(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_ENTITY_RECORDS_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+      );
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceAccess: expect.any(Object),
+          getEndpoint: expect.any(Function),
+          pagination: expect.any(Object),
+          excludeFromPrefix: ["expansionLevel"],
+        }),
+        undefined,
+      );
+      expect(result.items).toHaveLength(5);
+    });
+
+    it("should forward folderKey as header but strip it from PaginationHelpers options", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.getRecordsByName(ENTITY_TEST_CONSTANTS.ENTITY_NAME, {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+        pageSize: TEST_CONSTANTS.PAGE_SIZE,
+      });
+
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID },
+        }),
+        { pageSize: TEST_CONSTANTS.PAGE_SIZE },
+      );
+    });
+
+    it("should return paginated records when pagination options provided", async () => {
+      const mockResponse = {
+        items: createMockEntityRecords(10),
+        totalCount: 100,
+        hasNextPage: true,
+        nextCursor: TEST_CONSTANTS.NEXT_CURSOR,
+      };
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const result = (await entityService.getRecordsByName(
+        ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        { pageSize: TEST_CONSTANTS.PAGE_SIZE } as EntityGetAllRecordsOptions,
+      )) as any;
+
+      expect(result.hasNextPage).toBe(true);
+      expect(result.items).toHaveLength(10);
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
+
+      await expect(
+        entityService.getRecordsByName(ENTITY_TEST_CONSTANTS.ENTITY_NAME),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe("getRecordByName", () => {
+    it("should get a single record by entity name and record ID successfully", async () => {
+      const mockRecord = {
+        Id: ENTITY_TEST_CONSTANTS.RECORD_ID,
+        name: ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA.name,
+      };
+      mockApiClient.get.mockResolvedValue(mockRecord);
+
+      const result = await entityService.getRecordByName(
+        ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+      );
+
+      expect(result.Id).toBe(ENTITY_TEST_CONSTANTS.RECORD_ID);
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_RECORD_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+        { params: {}, headers: {} },
+      );
+    });
+
+    it("should send expansionLevel query param and folderKey header when provided", async () => {
+      mockApiClient.get.mockResolvedValue({ Id: ENTITY_TEST_CONSTANTS.RECORD_ID });
+
+      const options: EntityGetRecordByNameOptions = {
+        expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+      };
+
+      await entityService.getRecordByName(
+        ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        options,
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.GET_RECORD_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+        {
+          params: expect.objectContaining({
+            expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
+          }),
+          headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID },
+        },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.get.mockRejectedValue(error);
+
+      await expect(
+        entityService.getRecordByName(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+  });
+
+  describe("insertRecord (by name ref)", () => {
+    it("should insert a single record successfully", async () => {
+      const response = createMockSingleInsertResponse(
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+      );
+      mockApiClient.post.mockResolvedValue(response);
+
+      const result = await entityService.insertRecord(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+      );
+
+      expect(result).toEqual(response);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.INSERT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        { params: {}, headers: {} },
+      );
+    });
+
+    it("should send expansionLevel param and folderKey header when provided", async () => {
+      mockApiClient.post.mockResolvedValue(
+        createMockSingleInsertResponse(ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA),
+      );
+
+      const options: EntityInsertRecordOptions = {
+        expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+      };
+
+      await entityService.insertRecord(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        options,
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.INSERT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        {
+          params: expect.objectContaining({
+            expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
+          }),
+          headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID },
+        },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        entityService.insertRecord(
+          { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+          ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      const response = createMockSingleInsertResponse(
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+      );
+      mockApiClient.post.mockResolvedValue(response);
+
+      await entityService.insertRecord(
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.INSERT_BY_ID(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+        ),
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        expect.any(Object),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.insertRecord(
+          {} as EntityRef,
+          ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        ),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    it("should reject with a ValidationError when the ref supplies both id and name", async () => {
+      await expect(
+        entityService.insertRecord(
+          {
+            id: ENTITY_TEST_CONSTANTS.ENTITY_ID,
+            name: ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          } as EntityRef,
+          ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        ),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("insertRecords (by name ref)", () => {
+    it("should insert records successfully", async () => {
+      const data = [
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA_2,
+      ];
+      const response = createMockInsertResponse(data);
+      mockApiClient.post.mockResolvedValue(response);
+
+      const result = await entityService.insertRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        data,
+      );
+
+      expect(result.successRecords).toHaveLength(2);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.BATCH_INSERT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        data,
+        { params: {}, headers: {} },
+      );
+    });
+
+    it("should send failOnFirst param when provided and handle partial failures", async () => {
+      const data = [
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA_2,
+      ];
+      mockApiClient.post.mockResolvedValue(
+        createMockInsertResponse(data, { successCount: 1 }),
+      );
+
+      const options: EntityInsertRecordsOptions = {
+        failOnFirst: ENTITY_TEST_CONSTANTS.FAIL_ON_FIRST,
+      };
+
+      const result = await entityService.insertRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        data,
+        options,
+      );
+
+      expect(result.successRecords).toHaveLength(1);
+      expect(result.failureRecords).toHaveLength(1);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.BATCH_INSERT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        data,
+        {
+          params: expect.objectContaining({
+            failOnFirst: ENTITY_TEST_CONSTANTS.FAIL_ON_FIRST,
+          }),
+          headers: {},
+        },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        entityService.insertRecords({ name: ENTITY_TEST_CONSTANTS.ENTITY_NAME }, [
+          ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA,
+        ]),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      const data = [ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA];
+      mockApiClient.post.mockResolvedValue(createMockInsertResponse(data));
+
+      await entityService.insertRecords({ id: ENTITY_TEST_CONSTANTS.ENTITY_ID }, data);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.BATCH_INSERT_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        data,
+        expect.any(Object),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.insertRecords({} as EntityRef, [ENTITY_TEST_CONSTANTS.TEST_RECORD_DATA]),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("updateRecord (by name ref)", () => {
+    it("should update a single record successfully", async () => {
+      const updateData = {
+        name: ENTITY_TEST_CONSTANTS.TEST_JOHN_UPDATED_NAME,
+        age: ENTITY_TEST_CONSTANTS.TEST_JOHN_UPDATED_AGE,
+      };
+      mockApiClient.post.mockResolvedValue(
+        createMockSingleUpdateResponse({
+          Id: ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ...updateData,
+        }),
+      );
+
+      const result = await entityService.updateRecord(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        updateData,
+      );
+
+      expect(result.name).toBe(ENTITY_TEST_CONSTANTS.TEST_JOHN_UPDATED_NAME);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_RECORD_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+        updateData,
+        { params: {}, headers: {} },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        entityService.updateRecord(
+          { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          { name: ENTITY_TEST_CONSTANTS.TEST_UPDATED_NAME },
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      const updateData = { name: ENTITY_TEST_CONSTANTS.TEST_JOHN_UPDATED_NAME };
+      mockApiClient.post.mockResolvedValue(
+        createMockSingleUpdateResponse({ Id: ENTITY_TEST_CONSTANTS.RECORD_ID, ...updateData }),
+      );
+
+      await entityService.updateRecord(
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        updateData,
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_RECORD_BY_ID(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+        updateData,
+        expect.any(Object),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.updateRecord({} as EntityRef, ENTITY_TEST_CONSTANTS.RECORD_ID, {}),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("updateRecords (by name ref)", () => {
+    it("should update records successfully", async () => {
+      const data: EntityRecord[] = [
+        { Id: ENTITY_TEST_CONSTANTS.RECORD_ID, name: ENTITY_TEST_CONSTANTS.TEST_JOHN_UPDATED_NAME },
+        { Id: ENTITY_TEST_CONSTANTS.RECORD_ID_2, name: ENTITY_TEST_CONSTANTS.TEST_JANE_UPDATED_NAME },
+      ];
+      mockApiClient.post.mockResolvedValue(createMockUpdateResponse(data));
+
+      const result = await entityService.updateRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        data,
+      );
+
+      expect(result.successRecords).toHaveLength(2);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        data,
+        { params: {}, headers: {} },
+      );
+    });
+
+    it("should handle partial update failures", async () => {
+      const data: EntityRecord[] = [
+        { Id: ENTITY_TEST_CONSTANTS.RECORD_ID, name: ENTITY_TEST_CONSTANTS.TEST_VALID_UPDATE_NAME },
+        { Id: ENTITY_TEST_CONSTANTS.RECORD_ID_2, name: ENTITY_TEST_CONSTANTS.TEST_INVALID_UPDATE_NAME },
+      ];
+      mockApiClient.post.mockResolvedValue(
+        createMockUpdateResponse(data, { successCount: 1 }),
+      );
+
+      const result = await entityService.updateRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        data,
+      );
+
+      expect(result.successRecords).toHaveLength(1);
+      expect(result.failureRecords).toHaveLength(1);
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        entityService.updateRecords({ name: ENTITY_TEST_CONSTANTS.ENTITY_NAME }, [
+          { Id: ENTITY_TEST_CONSTANTS.RECORD_ID },
+        ]),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      const data: EntityRecord[] = [{ Id: ENTITY_TEST_CONSTANTS.RECORD_ID }];
+      mockApiClient.post.mockResolvedValue(createMockUpdateResponse(data));
+
+      await entityService.updateRecords({ id: ENTITY_TEST_CONSTANTS.ENTITY_ID }, data);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPDATE_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        data,
+        expect.any(Object),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.updateRecords({} as EntityRef, [{ Id: ENTITY_TEST_CONSTANTS.RECORD_ID }]),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("deleteRecords (by name ref)", () => {
+    it("should delete records successfully", async () => {
+      const ids = [
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID_2,
+      ];
+      mockApiClient.post.mockResolvedValue(createMockDeleteResponse(ids));
+
+      const result = await entityService.deleteRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ids,
+      );
+
+      expect(result.successRecords).toHaveLength(2);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        ids,
+        { params: {}, headers: {} },
+      );
+    });
+
+    it("should handle partial delete failures", async () => {
+      const ids = [
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.RECORD_ID_2,
+      ];
+      mockApiClient.post.mockResolvedValue(
+        createMockDeleteResponse(ids, { successCount: 1 }),
+      );
+
+      const result = await entityService.deleteRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ids,
+      );
+
+      expect(result.successRecords).toHaveLength(1);
+      expect(result.failureRecords).toHaveLength(1);
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        entityService.deleteRecords({ name: ENTITY_TEST_CONSTANTS.ENTITY_NAME }, [
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ]),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      const ids = [ENTITY_TEST_CONSTANTS.RECORD_ID];
+      mockApiClient.post.mockResolvedValue(createMockDeleteResponse(ids));
+
+      await entityService.deleteRecords({ id: ENTITY_TEST_CONSTANTS.ENTITY_ID }, ids);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        ids,
+        expect.any(Object),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.deleteRecords({} as EntityRef, [ENTITY_TEST_CONSTANTS.RECORD_ID]),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("deleteRecord (by name ref)", () => {
+    it("should delete a single record successfully", async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await entityService.deleteRecord(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+        { headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await entityService.deleteRecord(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.delete.mockRejectedValue(error);
+
+      await expect(
+        entityService.deleteRecord(
+          { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      mockApiClient.delete.mockResolvedValue(undefined);
+
+      await entityService.deleteRecord(
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_RECORD_BY_ID(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ),
+        { headers: {} },
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.deleteRecord({} as EntityRef, ENTITY_TEST_CONSTANTS.RECORD_ID),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("queryRecords (by name ref)", () => {
+    beforeEach(() => {
+      vi.mocked(PaginationHelpers.getAll).mockReset();
+    });
+
+    it("should delegate to PaginationHelpers.getAll with POST and the by-name query endpoint", async () => {
+      const mockResponse = { items: createMockEntityRecords(2), totalCount: 2 };
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue(mockResponse);
+
+      const result = await entityService.queryRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+      );
+
+      const [config] = vi.mocked(PaginationHelpers.getAll).mock.calls[0];
+      expect((config as any).getEndpoint()).toBe(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+      );
+      expect(PaginationHelpers.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "POST",
+          excludeFromPrefix: expect.arrayContaining(["filterGroup", "sortOptions"]),
+        }),
+        undefined,
+      );
+      expect(result.items).toHaveLength(2);
+    });
+
+    it("should forward folderKey as header and strip it from the POST body", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecords({ name: ENTITY_TEST_CONSTANTS.ENTITY_NAME }, {
+        folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID,
+        filterGroup: {
+          logicalOperator: 0 as const,
+          queryFilters: [{ fieldName: "isActive", operator: QueryFilterOperator.Equals, value: "true" }],
+        },
+      });
+
+      const [config, downstreamOptions] = vi.mocked(PaginationHelpers.getAll).mock.calls[0];
+      expect((config as { headers: Record<string, string> }).headers).toEqual({
+        "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID,
+      });
+      expect(downstreamOptions).not.toHaveProperty("folderKey");
+      expect(downstreamOptions).toHaveProperty("filterGroup");
+    });
+
+    it("should route expansionLevel to queryParams and strip it from the body options", async () => {
+      let capturedConfig: any;
+      let capturedDownstream: any;
+      vi.mocked(PaginationHelpers.getAll).mockImplementation(async (config, downstream) => {
+        capturedConfig = config;
+        capturedDownstream = downstream;
+        return { items: [], totalCount: 0 };
+      });
+
+      await entityService.queryRecords({ name: ENTITY_TEST_CONSTANTS.ENTITY_NAME }, {
+        expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
+      });
+
+      expect(capturedConfig.queryParams).toEqual({
+        expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
+      });
+      expect(capturedDownstream).not.toHaveProperty("expansionLevel");
+    });
+
+    it("should translate joins to the wire contract using the ref name, without a metadata lookup", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        {
+          selectedFields: ["Customer.name"],
+          // entityName omitted → the base entity defaults to the ref name.
+          joins: [
+            {
+              joinType: JoinType.LeftJoin,
+              joinFieldName: "customerId",
+              relatedEntityName: "Customer",
+              relatedFieldName: "Id",
+            },
+          ],
+        },
+      );
+
+      // A by-name ref already carries the name, so the joins path must NOT make a
+      // resolveEntityName GET (unlike the by-id path).
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+
+      const [config, downstream] = vi.mocked(PaginationHelpers.getAll).mock.calls[0];
+      expect((config as any).getEndpoint()).toBe(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_NAME(ENTITY_TEST_CONSTANTS.ENTITY_NAME),
+      );
+      expect(downstream).toMatchObject({
+        joins: [
+          {
+            type: "LEFT",
+            entity: "Customer",
+            on: {
+              left: `${ENTITY_TEST_CONSTANTS.ENTITY_NAME}.customerId`,
+              right: "Customer.Id",
+            },
+          },
+        ],
+      });
+    });
+
+    it("should throw ValidationError when more than 3 joins are supplied", async () => {
+      const joins = Array.from({ length: 4 }, () => ({
+        joinFieldName: "customerId",
+        relatedEntityName: "Customer",
+        relatedFieldName: "Id",
+        joinType: JoinType.LeftJoin,
+      }));
+
+      await expect(
+        entityService.queryRecords({ name: ENTITY_TEST_CONSTANTS.ENTITY_NAME }, { joins }),
+      ).rejects.toThrow(/A maximum of 3 joins is supported per query \(received 4\)/);
+
+      expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      vi.mocked(PaginationHelpers.getAll).mockRejectedValue(error);
+
+      await expect(
+        entityService.queryRecords({ name: ENTITY_TEST_CONSTANTS.ENTITY_NAME }),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id query endpoint when given an id ref", async () => {
+      vi.mocked(PaginationHelpers.getAll).mockResolvedValue({ items: [], totalCount: 0 });
+
+      await entityService.queryRecords({ id: ENTITY_TEST_CONSTANTS.ENTITY_ID });
+
+      const [config] = vi.mocked(PaginationHelpers.getAll).mock.calls[0];
+      expect((config as any).getEndpoint()).toBe(
+        DATA_FABRIC_ENDPOINTS.ENTITY.QUERY_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.queryRecords({} as EntityRef),
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(PaginationHelpers.getAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("importRecords (by name ref)", () => {
+    it.each([
+      { type: "Blob", file: new Blob(["a,b\n1,2"], { type: "text/csv" }) },
+      { type: "Uint8Array", file: new Uint8Array([97, 44, 98]) },
+    ])("should import records successfully with $type", async ({ file }) => {
+      const response = { totalRecords: 1, insertedRecords: 1, errorFileLink: null };
+      mockApiClient.post.mockResolvedValue(response);
+
+      const result = await entityService.importRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        file,
+      );
+
+      expect(result).toEqual(response);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        expect.any(FormData),
+        { headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      mockApiClient.post.mockResolvedValue({ totalRecords: 0, insertedRecords: 0 });
+
+      await entityService.importRecords(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        new Blob(["a,b\n1,2"], { type: "text/csv" }),
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+        ),
+        expect.any(FormData),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        entityService.importRecords(
+          { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+          new Blob(["a,b\n1,2"], { type: "text/csv" }),
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      mockApiClient.post.mockResolvedValue({ totalRecords: 1, insertedRecords: 1 });
+
+      await entityService.importRecords(
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
+        new Blob(["a,b\n1,2"], { type: "text/csv" }),
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.BULK_UPLOAD_BY_ID(ENTITY_TEST_CONSTANTS.ENTITY_ID),
+        expect.any(FormData),
+        expect.any(Object),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.importRecords({} as EntityRef, new Blob(["a,b\n1,2"], { type: "text/csv" })),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("downloadAttachment (by name ref)", () => {
+    it("should download attachment successfully", async () => {
+      const mockBlob = new Blob(["test content"], { type: "application/pdf" });
+      mockApiClient.get.mockResolvedValue(mockBlob);
+
+      const result = await entityService.downloadAttachment(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+      );
+
+      expect(result).toBeInstanceOf(Blob);
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { responseType: "blob", headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      mockApiClient.get.mockResolvedValue(new Blob(["x"]));
+
+      await entityService.downloadAttachment(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { responseType: "blob", headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.get.mockRejectedValue(error);
+
+      await expect(
+        entityService.downloadAttachment(
+          { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      mockApiClient.get.mockResolvedValue(new Blob(["x"]));
+
+      await entityService.downloadAttachment(
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DOWNLOAD_ATTACHMENT(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { responseType: "blob", headers: {} },
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.downloadAttachment(
+          {} as EntityRef,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("uploadAttachment (by name ref)", () => {
+    it.each([
+      { type: "Blob", file: new Blob(["test file content"], { type: "application/pdf" }) },
+      { type: "Uint8Array", file: new Uint8Array([72, 101, 108, 108, 111]) },
+    ])("should upload attachment successfully with $type", async ({ file }) => {
+      const response = { id: ENTITY_TEST_CONSTANTS.RECORD_ID, status: "uploaded" };
+      mockApiClient.post.mockResolvedValue(response);
+
+      const result = await entityService.uploadAttachment(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        file,
+      );
+
+      expect(result).toEqual(response);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        expect.any(FormData),
+        { params: {}, headers: {} },
+      );
+    });
+
+    it("should include expansionLevel query parameter when provided", async () => {
+      mockApiClient.post.mockResolvedValue({ id: ENTITY_TEST_CONSTANTS.RECORD_ID });
+
+      await entityService.uploadAttachment(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        new Blob(["test"]),
+        { expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL },
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        expect.any(FormData),
+        {
+          params: expect.objectContaining({
+            expansionLevel: ENTITY_TEST_CONSTANTS.EXPANSION_LEVEL,
+          }),
+          headers: {},
+        },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.post.mockRejectedValue(error);
+
+      await expect(
+        entityService.uploadAttachment(
+          { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+          new Blob(["test"]),
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      mockApiClient.post.mockResolvedValue({ id: ENTITY_TEST_CONSTANTS.RECORD_ID });
+
+      await entityService.uploadAttachment(
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        new Blob(["test"]),
+      );
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.UPLOAD_ATTACHMENT(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        expect.any(FormData),
+        expect.any(Object),
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.uploadAttachment(
+          {} as EntityRef,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+          new Blob(["test"]),
+        ),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe("deleteAttachment (by name ref)", () => {
+    it("should delete attachment successfully", async () => {
+      const response = { status: "deleted" };
+      mockApiClient.delete.mockResolvedValue(response);
+
+      const result = await entityService.deleteAttachment(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+      );
+
+      expect(result).toEqual(response);
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { headers: {} },
+      );
+    });
+
+    it("should pass folderKey via X-UIPATH-FolderKey header when provided", async () => {
+      mockApiClient.delete.mockResolvedValue({ status: "deleted" });
+
+      await entityService.deleteAttachment(
+        { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        { folderKey: ENTITY_TEST_CONSTANTS.FIELD_ID },
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.ATTACHMENT_BY_NAME(
+          ENTITY_TEST_CONSTANTS.ENTITY_NAME,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { headers: { "X-UIPATH-FolderKey": ENTITY_TEST_CONSTANTS.FIELD_ID } },
+      );
+    });
+
+    it("should handle API errors", async () => {
+      const error = createMockError(TEST_CONSTANTS.ERROR_MESSAGE);
+      mockApiClient.delete.mockRejectedValue(error);
+
+      await expect(
+        entityService.deleteAttachment(
+          { name: ENTITY_TEST_CONSTANTS.ENTITY_NAME },
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+      ).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it("should route to the by-id endpoint when given an id ref", async () => {
+      mockApiClient.delete.mockResolvedValue({ status: "deleted" });
+
+      await entityService.deleteAttachment(
+        { id: ENTITY_TEST_CONSTANTS.ENTITY_ID },
+        ENTITY_TEST_CONSTANTS.RECORD_ID,
+        ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+      );
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        DATA_FABRIC_ENDPOINTS.ENTITY.DELETE_ATTACHMENT(
+          ENTITY_TEST_CONSTANTS.ENTITY_ID,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+        { headers: {} },
+      );
+    });
+
+    it("should reject with a ValidationError when the ref supplies neither id nor name", async () => {
+      await expect(
+        entityService.deleteAttachment(
+          {} as EntityRef,
+          ENTITY_TEST_CONSTANTS.RECORD_ID,
+          ENTITY_TEST_CONSTANTS.ATTACHMENT_FIELD_NAME,
+        ),
+      ).rejects.toBeInstanceOf(ValidationError);
     });
   });
 


### PR DESCRIPTION
## Description

Adds by-name addressing to the Data Fabric Entity service (DS-8835) so entity record/attachment operations are usable by solution-binding overrides, which resolve resources by name + folderKey. Adds a native `getByName()` metadata lookup and by-name routes for every record/attachment op.

> **🚧 Draft — WIP handover, do not merge.** Unit tests are currently red (43 failing) and the implementation, tests, and docs describe three different API shapes. See below.

## Changes Walkthrough and Testing

**Implemented**
- `*_BY_NAME` endpoint constants mirroring every by-id record/attachment route (native DF routes — direct switch, no resolve GET).
- `getByName()` + `EntityGetByNameOptions`.
- Record/attachment methods renamed to accept `idOrName` and route via a GUID regex; old `*ById` methods kept as delegators.
- Updated `oauth-scopes.md`, `pagination.md`, unit + integration tests.

**⚠️ Needs convergence before merge — three conflicting designs:**
1. **Agreed design** ([thread](https://uipath-product.slack.com/archives/C092C80PJV7/p1784695456675079?thread_ts=1782974393.665309) + [framework doc](https://uipath.atlassian.net/wiki/spaces/CLD/pages/90924515367)): operational ops take a `ResourceRef`/`EntityRef` selector `{ id } | { name }`; old methods `@deprecated`.
2. **Tests + docs** here: expect explicit `*ByName` methods (`insertRecordByName`, `getRecordsByName`, …).
3. **Implementation** here: single `idOrName: string` + GUID-regex disambiguation.

**Test status:** `typecheck` ✅ · `lint` ✅ · `test:unit` ❌ (43 failing — tests call 13 `*ByName` methods the implementation never defines) · integration not run.

**Next step:** refactor to the agreed `EntityRef` selector, add `@deprecated` delegators, and align tests + docs to that shape.
