### PR TITLE
chore: bump version to 1.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.6.2",
+  "sdkVersion": "1.6.3",
   "services": [
     {
       "name": "AgentMemory",


### PR DESCRIPTION
## Summary

Version bump `1.6.2` → `1.6.3` for the next release. Changes only `package.json` and `package-lock.json`; `release-metadata.json` is regenerated off a fresh build and committed on this branch (the `Regenerate release-metadata` workflow re-verifies it). No new public API surface was added since 1.6.2, so the metadata change is the `sdkVersion` stamp only.

**Why patch, not minor:** per this repo's convention, minor bumps are reserved for releases that carry **breaking changes**; additive, backward-compatible changes ship in patch releases. This release contains only backward-compatible behavior improvements — no signature or type changes.

## Draft release notes (1.6.3)

````markdown
### New Features & Improvements

- Auth: logging out now ends the platform session as well (OIDC RP-initiated logout), so users are fully signed out instead of being silently re-authenticated on the next login (#636)
- Functions: a Studio Web license is acquired automatically before invoking, preventing invocation failures for users without an active license session (#669)
- Overrides: resource overrides are now resolved through an ambient channel (#680)

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.6.2...1.6.3
````

Excluded as not user-facing: #592 (JSDoc completeness CI check), #674 (CI — Maestro integration tests enablement), #679 (Dependabot dependency bumps in sample apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)