### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.6.2",
+            "version": "1.7.0",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.6.2",
+  "sdkVersion": "1.7.0",
   "services": [
     {
       "name": "AgentMemory",
@@ -288,12 +288,24 @@
       "since": null,
       "methods": [
         {
+          "name": "create",
+          "since": "1.7.0"
+        },
+        {
+          "name": "deleteById",
+          "since": "1.7.0"
+        },
+        {
           "name": "getAll",
           "since": null
         },
         {
           "name": "getById",
           "since": null
+        },
+        {
+          "name": "updateById",
+          "since": "1.7.0"
         }
       ]
     },
@@ -342,8 +354,16 @@
           "since": null
         },
         {
+          "name": "create",
+          "since": "1.7.0"
+        },
+        {
           "name": "deleteAttachment",
           "since": null
+        },
+        {
+          "name": "deleteById",
+          "since": "1.7.0"
         },
         {
           "name": "deleteRecordById",
@@ -396,6 +416,10 @@
         {
           "name": "queryRecordsById",
           "since": null
+        },
+        {
+          "name": "updateById",
+          "since": "1.7.0"
         },
         {
           "name": "updateRecordById",
@@ -715,7 +739,8 @@
         },
         {
           "name": "getAllWithMethods",
-          "since": "1.6.2"
+          "since": "1.6.2",
+          "deleted": "1.7.0"
         },
         {
           "name": "getById",
@@ -723,7 +748,8 @@
         },
         {
           "name": "getByIdWithMethods",
-          "since": "1.6.2"
+          "since": "1.6.2",
+          "deleted": "1.7.0"
         },
         {
           "name": "getByKey",


### PR DESCRIPTION
Version bump `1.6.2` → `1.7.0` for today's release. Changes only `package.json` and `package-lock.json`; `release-metadata.json` is regenerated off a fresh build and committed on this branch (the `Regenerate release-metadata` workflow re-verifies it).

**Why minor, not patch:** #681 removes `getAllWithMethods()` / `getByIdWithMethods()` on the Queues service — methods that shipped in `1.6.2` two days ago — and changes `getAll()`'s return shape from plain data to data-with-methods. These are breaking for existing callers, so the release carries a Breaking Changes section (below) and a minor bump, per the same convention #633 followed for 1.6.0.

## Draft release notes (1.7.0)

```
### New Features & Improvements

- Functions: `invoke()` now acquires a license for the calling user automatically, falling back to a free license when none is assigned; added a `refreshLicense` option to force a fresh license check (#669)
- Auth: added an optional `endSession` flag to `logout()` for RP-initiated logout, ending the platform session in addition to local SDK state (#636). Sessions established before this version have no ID token yet, so their first `logout({ endSession: true })` clears local state and logs a warning instead of redirecting; one fresh sign-in is enough to enable it from then on. Plain `logout()` is unchanged.
- Added runtime resolution of admin-configured resource overrides for `getByName` lookups across Assets, Buckets, and Processes (#680)
- Auth: added an opt-in `enforceSso` option to route sign-in through the org's own identity provider instead of the UiPath account screen. Off by default; requires `orgName` to be the org id (#700)
- `new UiPath()` now also resolves configuration from a coded function's execution context (`new UiPath(ctx)`) and from environment variables (`UIPATH_BASE_URL` / `UIPATH_ORG_NAME` / `UIPATH_TENANT_NAME` / `UIPATH_ACCESS_TOKEN`) on Node and Deno, so a coded function or script no longer needs to map platform values into config fields by hand. Fully backward compatible — browser meta-tag resolution is unchanged and still takes precedence (#675)
- Data Fabric: `entities.create()` / `updateById()` / `deleteById()` and the equivalent `choicesets` methods are promoted from `@internal` to `@experimental`, so they now appear in generated docs and IDE tooltips. `updateById` also gains input validation — no-op updates, an unknown `removeFields` name, or an `updateFields` id that isn't a real field now throw a `ValidationError` instead of silently no-oping or ignoring the input (#635)

---

### Breaking Changes

- **`Queues.getAllWithMethods()` is removed — `Queues.getAll()` now does its job**: it supports full folder scoping (`folderId` / `folderKey` / `folderPath`, previously only `folderId`) and returns every queue with the operational methods attached (`getAllItems`, `insertItem`, `startTransaction`, `completeTransaction`) (#681).
- **`Queues.getByIdWithMethods()` is removed — `Queues.getById(id, { folderId })` now does its job**: the options form accepts `folderId`, `folderKey`, or `folderPath` and returns the queue with the same methods attached. The old positional `getById(id, folderId)` still works and returns plain data, but is deprecated (#681).
- Notes for existing `getAll()` callers (#681): code compiles unchanged (all previous fields remain), but returned queues now carry functions. Type renames: `QueueGetAllWithMethodsOptions` → `QueueGetAllOptions`, `QueueGetByIdWithMethodsOptions` → `QueueGetByIdScopedOptions`; `QueueGetWithMethodsResponse` is unchanged.

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.6.2...1.7.0
```

Excluded as not user-facing: [#592](https://github.com/UiPath/uipath-typescript/pull/592) (JSDoc `@internal` tagging + CI docs-completeness validation), [#679](https://github.com/UiPath/uipath-typescript/pull/679) (Dependabot dev-dependency bumps in the sample apps), [#674](https://github.com/UiPath/uipath-typescript/pull/674) (CI: enable Maestro integration tests), [#686](https://github.com/UiPath/uipath-typescript/pull/686) (Dependabot dev-dependency bump in a sample app), [#687](https://github.com/UiPath/uipath-typescript/pull/687) (internal agent-instructions docs), [#688](https://github.com/UiPath/uipath-typescript/pull/688) (Maestro integration test fixture fix), [#683](https://github.com/UiPath/uipath-typescript/pull/683) (internal resource-resolution primitive, not yet exported or wired into any service).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
