### PR TITLE
test(traces): self-discover a trace with spans instead of pinning one

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -78,7 +78,6 @@ jobs:
           echo "data_fabric_test_join_related_field_name=${{ secrets.UIPATH_DATA_FABRIC_TEST_JOIN_RELATED_FIELD_NAME_DEV || secrets.UIPATH_DATA_FABRIC_TEST_JOIN_RELATED_FIELD_NAME }}" >> $GITHUB_OUTPUT
           echo "orchestrator_attachment_id=${{ secrets.UIPATH_ORCHESTRATOR_ATTACHMENT_ID_DEV || secrets.UIPATH_ORCHESTRATOR_ATTACHMENT_ID }}" >> $GITHUB_OUTPUT
           echo "jobs_test_folder_id=${{ secrets.UIPATH_JOBS_TEST_FOLDER_ID_DEV || secrets.UIPATH_JOBS_TEST_FOLDER_ID }}" >> $GITHUB_OUTPUT
-          echo "traces_test_trace_id=${{ secrets.UIPATH_TRACES_TEST_TRACE_ID_DEV || secrets.UIPATH_TRACES_TEST_TRACE_ID }}" >> $GITHUB_OUTPUT
           echo "tasks_test_user_group_id=${{ secrets.UIPATH_TASKS_TEST_USER_GROUP_ID_DEV || secrets.UIPATH_TASKS_TEST_USER_GROUP_ID }}" >> $GITHUB_OUTPUT
           echo "tasks_test_user_id=${{ secrets.UIPATH_TASKS_TEST_USER_ID_DEV || secrets.UIPATH_TASKS_TEST_USER_ID }}" >> $GITHUB_OUTPUT
           echo "functions_test_folder_id=${{ secrets.UIPATH_FUNCTIONS_TEST_FOLDER_ID_DEV || secrets.UIPATH_FUNCTIONS_TEST_FOLDER_ID }}" >> $GITHUB_OUTPUT
@@ -115,7 +114,6 @@ jobs:
           QUEUES_TEST_QUEUE_NAME=${{ steps.config.outputs.queues_test_queue_name }}
           ORCHESTRATOR_ATTACHMENT_ID=${{ steps.config.outputs.orchestrator_attachment_id }}
           JOBS_TEST_FOLDER_ID=${{ steps.config.outputs.jobs_test_folder_id }}
-          TRACES_TEST_TRACE_ID=${{ steps.config.outputs.traces_test_trace_id }}
           TASKS_TEST_USER_GROUP_ID=${{ steps.config.outputs.tasks_test_user_group_id }}
           TASKS_TEST_USER_ID=${{ steps.config.outputs.tasks_test_user_id }}
           FUNCTIONS_TEST_FOLDER_ID=${{ steps.config.outputs.functions_test_folder_id }}

--- a/tests/integration/shared/observability/traces.integration.test.ts
+++ b/tests/integration/shared/observability/traces.integration.test.ts
@@ -21,30 +21,24 @@ describe.each(modes)('Traces - Integration Tests [%s]', (mode) => {
     traces = services.traces;
 
     // Span data expires with the observability retention window, so a fixed trace ID
-    // fixture rots over time. Prefer self-discovery: recent Maestro process instances
-    // carry a traceId with spans. TRACES_TEST_TRACE_ID remains as an explicit override.
-    const candidateTraceIds: string[] = [];
-    if (process.env.TRACES_TEST_TRACE_ID) {
-      candidateTraceIds.push(process.env.TRACES_TEST_TRACE_ID);
-    }
+    // fixture would rot over time. Self-discover instead: Maestro process instances
+    // carry a traceId (their instanceId) with spans, and getAll returns newest first,
+    // so recent instances are tried before ones whose spans may have expired.
     const instances = await services.processInstances.getAll({ pageSize: 10 });
-    for (const instance of instances.items) {
-      candidateTraceIds.push(instance.instanceId);
-    }
 
     let spans: SpanGetResponse[] = [];
-    for (const traceId of candidateTraceIds) {
-      spans = await traces.getById(traceId);
+    for (const instance of instances.items) {
+      spans = await traces.getById(instance.instanceId);
       if (spans.length > 0) {
-        existingTraceId = traceId;
+        existingTraceId = instance.instanceId;
         break;
       }
     }
 
     if (spans.length === 0) {
       throw new Error(
-        'No trace with spans found (checked TRACES_TEST_TRACE_ID and recent process ' +
-          'instances) — ensure recent trace data exists before running these tests'
+        'No recent process instance has a trace with spans — ensure recent trace data ' +
+          'exists (e.g. run the maestro suite) before running these tests'
       );
     }
 

--- a/tests/integration/shared/observability/traces.integration.test.ts
+++ b/tests/integration/shared/observability/traces.integration.test.ts
@@ -16,20 +16,35 @@ describe.each(modes)('Traces - Integration Tests [%s]', (mode) => {
   let existingSpanId!: string;
 
   beforeAll(async () => {
-    if (!process.env.TRACES_TEST_TRACE_ID) {
-      throw new Error('TRACES_TEST_TRACE_ID env var required for Traces integration tests');
-    }
-
     const services = getServices();
     if (!services.traces) throw new Error('Traces service not available');
     traces = services.traces;
 
-    existingTraceId = process.env.TRACES_TEST_TRACE_ID;
+    // Span data expires with the observability retention window, so a fixed trace ID
+    // fixture rots over time. Prefer self-discovery: recent Maestro process instances
+    // carry a traceId with spans. TRACES_TEST_TRACE_ID remains as an explicit override.
+    const candidateTraceIds: string[] = [];
+    if (process.env.TRACES_TEST_TRACE_ID) {
+      candidateTraceIds.push(process.env.TRACES_TEST_TRACE_ID);
+    }
+    const instances = await services.processInstances.getAll({ pageSize: 10 });
+    for (const instance of instances.items) {
+      candidateTraceIds.push(instance.instanceId);
+    }
 
-    const spans = await traces.getById(existingTraceId);
+    let spans: SpanGetResponse[] = [];
+    for (const traceId of candidateTraceIds) {
+      spans = await traces.getById(traceId);
+      if (spans.length > 0) {
+        existingTraceId = traceId;
+        break;
+      }
+    }
+
     if (spans.length === 0) {
       throw new Error(
-        `No spans found for traceId ${existingTraceId} — ensure trace data exists before running these tests`
+        'No trace with spans found (checked TRACES_TEST_TRACE_ID and recent process ' +
+          'instances) — ensure recent trace data exists before running these tests'
       );
     }
 


### PR DESCRIPTION
The traces suite failed once the pinned `TRACES_TEST_TRACE_ID` fixture's spans were purged by the observability retention window (currently blocking runs). Since there is no API to write spans into an existing trace, a pinned trace ID always rots — so the fixture is removed entirely: the setup now self-discovers a trace by walking recent Maestro process instances (their instanceId doubles as a traceId; getAll returns newest first) and using the first one with spans.

Also removes the env var from the coverage workflow — the `UIPATH_TRACES_TEST_TRACE_ID` secret can be deleted.

Verified: 10/10 traces tests green with no env var set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)