### PR TITLE
feat(data-fabric): tag DF service requests with x-uipath-source

### DIFF
--- a/src/services/data-fabric/choicesets.ts
+++ b/src/services/data-fabric/choicesets.ts
@@ -16,7 +16,7 @@ import {
 } from '../../models/data-fabric/choicesets.types';
 import { RawChoiceSetGetAllResponse, RawChoiceSetGetResponse } from '../../models/data-fabric/choicesets.internal-types';
 import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../utils/constants/endpoints/data-fabric';
-import { FOLDER_KEY, UIPATH_SOURCE } from '../../utils/constants/headers';
+import { FOLDER_KEY, UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from '../../utils/constants/headers';
 import { createHeaders } from '../../utils/http/headers';
 import type { IUiPath } from '../../core/types';
 import { transformData, pascalToCamelCaseKeys } from '../../utils/transform';
@@ -30,7 +30,7 @@ import { ValidationError, NotFoundError } from '../../core/errors';
 
 export class ChoiceSetService extends BaseService implements ChoiceSetServiceModel {
   constructor(instance: IUiPath) {
-    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+    super(instance, { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK });
   }
 
   @track('Choicesets.GetAll')

--- a/src/services/data-fabric/choicesets.ts
+++ b/src/services/data-fabric/choicesets.ts
@@ -16,8 +16,9 @@ import {
 } from '../../models/data-fabric/choicesets.types';
 import { RawChoiceSetGetAllResponse, RawChoiceSetGetResponse } from '../../models/data-fabric/choicesets.internal-types';
 import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../utils/constants/endpoints/data-fabric';
-import { FOLDER_KEY } from '../../utils/constants/headers';
+import { FOLDER_KEY, UIPATH_SOURCE } from '../../utils/constants/headers';
 import { createHeaders } from '../../utils/http/headers';
+import type { IUiPath } from '../../core/types';
 import { transformData, pascalToCamelCaseKeys } from '../../utils/transform';
 import { EntityMap } from '../../models/data-fabric/entities.constants';
 import { track } from '../../core/telemetry';
@@ -28,6 +29,10 @@ import { CHOICESET_VALUES_PAGINATION, ENTITY_OFFSET_PARAMS, HTTP_METHODS } from 
 import { ValidationError, NotFoundError } from '../../core/errors';
 
 export class ChoiceSetService extends BaseService implements ChoiceSetServiceModel {
+  constructor(instance: IUiPath) {
+    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+  }
+
   @track('Choicesets.GetAll')
   async getAll(options?: ChoiceSetGetAllOptions): Promise<ChoiceSetGetAllResponse[]> {
     return this.fetchAllChoiceSets(options);

--- a/src/services/data-fabric/directory.ts
+++ b/src/services/data-fabric/directory.ts
@@ -18,8 +18,10 @@ import {
   RawDataFabricDirectoryListResponse,
 } from '../../models/data-fabric/directory.internal-types';
 import { DATA_FABRIC_ENDPOINTS } from '../../utils/constants/endpoints/data-fabric';
+import { UIPATH_SOURCE } from '../../utils/constants/headers';
 import { createParams } from '../../utils/http/params';
 import { BaseService } from '../base';
+import type { IUiPath } from '../../core/types';
 
 const DEFAULT_DIRECTORY_PAGE_SIZE = 100;
 const MAX_DIRECTORY_PAGE_SIZE = 100;
@@ -144,6 +146,10 @@ function clampDirectoryPageSize(pageSize?: number): number {
  * @internal
  */
 export class DataFabricDirectoryService extends BaseService implements DataFabricDirectoryServiceModel {
+  constructor(instance: IUiPath) {
+    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+  }
+
   private async fetchAllEntries(options: DataFabricDirectoryGetAllOptions = {}): Promise<DataFabricDirectoryEntry[]> {
     const top = clampDirectoryPageSize(options.pageSize);
     const entries: DataFabricDirectoryEntry[] = [];

--- a/src/services/data-fabric/directory.ts
+++ b/src/services/data-fabric/directory.ts
@@ -18,7 +18,7 @@ import {
   RawDataFabricDirectoryListResponse,
 } from '../../models/data-fabric/directory.internal-types';
 import { DATA_FABRIC_ENDPOINTS } from '../../utils/constants/endpoints/data-fabric';
-import { UIPATH_SOURCE } from '../../utils/constants/headers';
+import { UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from '../../utils/constants/headers';
 import { createParams } from '../../utils/http/params';
 import { BaseService } from '../base';
 import type { IUiPath } from '../../core/types';
@@ -147,7 +147,7 @@ function clampDirectoryPageSize(pageSize?: number): number {
  */
 export class DataFabricDirectoryService extends BaseService implements DataFabricDirectoryServiceModel {
   constructor(instance: IUiPath) {
-    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+    super(instance, { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK });
   }
 
   private async fetchAllEntries(options: DataFabricDirectoryGetAllOptions = {}): Promise<DataFabricDirectoryEntry[]> {

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -49,8 +49,9 @@ import { PaginationType } from '../../utils/pagination/internal-types';
 import { PaginationHelpers } from '../../utils/pagination/helpers';
 import { ENTITY_PAGINATION, ENTITY_OFFSET_PARAMS, HTTP_METHODS } from '../../utils/constants/common';
 import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../utils/constants/endpoints/data-fabric';
-import { FOLDER_KEY, RESPONSE_TYPES } from '../../utils/constants/headers';
+import { FOLDER_KEY, RESPONSE_TYPES, UIPATH_SOURCE } from '../../utils/constants/headers';
 import { createHeaders } from '../../utils/http/headers';
+import type { IUiPath } from '../../core/types';
 import { createParams } from '../../utils/http/params';
 import { transformData } from '../../utils/transform';
 import {
@@ -95,6 +96,10 @@ function toWireJoin(join: EntityJoin, baseEntityName: string): EntityJoinPayload
  * Service for interacting with the Data Fabric Entity API
  */
 export class EntityService extends BaseService implements EntityServiceModel {
+  constructor(instance: IUiPath) {
+    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+  }
+
   @track('Entities.GetById')
   async getById(id: string, options?: EntityGetByIdOptions): Promise<EntityGetResponse> {
     // Get entity metadata

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -49,7 +49,7 @@ import { PaginationType } from '../../utils/pagination/internal-types';
 import { PaginationHelpers } from '../../utils/pagination/helpers';
 import { ENTITY_PAGINATION, ENTITY_OFFSET_PARAMS, HTTP_METHODS } from '../../utils/constants/common';
 import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../utils/constants/endpoints/data-fabric';
-import { FOLDER_KEY, RESPONSE_TYPES, UIPATH_SOURCE } from '../../utils/constants/headers';
+import { FOLDER_KEY, RESPONSE_TYPES, UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from '../../utils/constants/headers';
 import { createHeaders } from '../../utils/http/headers';
 import type { IUiPath } from '../../core/types';
 import { createParams } from '../../utils/http/params';
@@ -97,7 +97,7 @@ function toWireJoin(join: EntityJoin, baseEntityName: string): EntityJoinPayload
  */
 export class EntityService extends BaseService implements EntityServiceModel {
   constructor(instance: IUiPath) {
-    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+    super(instance, { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK });
   }
 
   @track('Entities.GetById')

--- a/src/services/data-fabric/roles.ts
+++ b/src/services/data-fabric/roles.ts
@@ -6,11 +6,12 @@ import {
   DataFabricRoleGetAllOptions,
   DataFabricRoleType,
 } from '../../models/data-fabric/roles.types';
-import { FOLDER_KEY } from '../../utils/constants/headers';
+import { FOLDER_KEY, UIPATH_SOURCE } from '../../utils/constants/headers';
 import { DATA_FABRIC_ENDPOINTS } from '../../utils/constants/endpoints/data-fabric';
 import { createHeaders } from '../../utils/http/headers';
 import { createParams } from '../../utils/http/params';
 import { BaseService } from '../base';
+import type { IUiPath } from '../../core/types';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -45,6 +46,10 @@ function validateRolesResponse(data: unknown): DataFabricRole[] {
  * @internal
  */
 export class DataFabricRoleService extends BaseService implements DataFabricRoleServiceModel {
+  constructor(instance: IUiPath) {
+    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+  }
+
   @track('DataFabricRoles.GetAll')
   async getAll(options: DataFabricRoleGetAllOptions = {}): Promise<DataFabricRole[]> {
     const params = createParams({

--- a/src/services/data-fabric/roles.ts
+++ b/src/services/data-fabric/roles.ts
@@ -6,7 +6,7 @@ import {
   DataFabricRoleGetAllOptions,
   DataFabricRoleType,
 } from '../../models/data-fabric/roles.types';
-import { FOLDER_KEY, UIPATH_SOURCE } from '../../utils/constants/headers';
+import { FOLDER_KEY, UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from '../../utils/constants/headers';
 import { DATA_FABRIC_ENDPOINTS } from '../../utils/constants/endpoints/data-fabric';
 import { createHeaders } from '../../utils/http/headers';
 import { createParams } from '../../utils/http/params';
@@ -47,7 +47,7 @@ function validateRolesResponse(data: unknown): DataFabricRole[] {
  */
 export class DataFabricRoleService extends BaseService implements DataFabricRoleServiceModel {
   constructor(instance: IUiPath) {
-    super(instance, { [UIPATH_SOURCE]: 'uipath-typescript-sdk' });
+    super(instance, { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK });
   }
 
   @track('DataFabricRoles.GetAll')

--- a/src/utils/constants/headers.ts
+++ b/src/utils/constants/headers.ts
@@ -10,11 +10,20 @@ export const  INSTANCE_ID = 'X-UIPATH-InstanceId';
 export const  TRACEPARENT = 'traceparent';
 export const  UIPATH_TRACEPARENT_ID = 'x-uipath-traceparent-id';
 /**
- * Identifies the implementing service/domain of an SDK request. Set once per
- * service via `BaseService`'s constructor `headers` arg so `ApiClient` includes
+ * Identifies SDK-originated requests. Set once per DF service via
+ * `BaseService`'s constructor `headers` arg so `ApiClient` includes
  * it on every request from that service.
+ *
+ * @internal
  */
 export const  UIPATH_SOURCE = 'x-uipath-source';
+
+/**
+ * Value sent with the `UIPATH_SOURCE` header to identify this SDK.
+ *
+ * @internal
+ */
+export const  UIPATH_TYPESCRIPT_SDK = 'uipath-typescript-sdk';
 
 /**
  * Content type constants for HTTP requests/responses

--- a/src/utils/constants/headers.ts
+++ b/src/utils/constants/headers.ts
@@ -9,6 +9,12 @@ export const  FOLDER_ID = 'X-UIPATH-OrganizationUnitId';
 export const  INSTANCE_ID = 'X-UIPATH-InstanceId';
 export const  TRACEPARENT = 'traceparent';
 export const  UIPATH_TRACEPARENT_ID = 'x-uipath-traceparent-id';
+/**
+ * Identifies the implementing service/domain of an SDK request. Set once per
+ * service via `BaseService`'s constructor `headers` arg so `ApiClient` includes
+ * it on every request from that service.
+ */
+export const  UIPATH_SOURCE = 'x-uipath-source';
 
 /**
  * Content type constants for HTTP requests/responses

--- a/tests/unit/services/data-fabric/choicesets.test.ts
+++ b/tests/unit/services/data-fabric/choicesets.test.ts
@@ -17,6 +17,7 @@ import { DATA_FABRIC_ENDPOINTS, DATA_FABRIC_TENANT_FOLDER_ID } from '../../../..
 import type { PaginatedResponse } from '../../../../src/utils/pagination/types';
 import type { ChoiceSetGetResponse } from '../../../../src/models/data-fabric/choicesets.types';
 import { ValidationError, NotFoundError } from '../../../../src/core/errors';
+import { UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from '../../../../src/utils/constants/headers';
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -58,7 +59,7 @@ describe('ChoiceSetService Unit Tests', () => {
   describe('constructor', () => {
     it('should send x-uipath-source: uipath-typescript-sdk on every ApiClient request', () => {
       const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
-      expect(clientConfig).toEqual({ headers: { 'x-uipath-source': 'uipath-typescript-sdk' } });
+      expect(clientConfig).toEqual({ headers: { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK } });
     });
   });
 

--- a/tests/unit/services/data-fabric/choicesets.test.ts
+++ b/tests/unit/services/data-fabric/choicesets.test.ts
@@ -55,6 +55,13 @@ describe('ChoiceSetService Unit Tests', () => {
     vi.clearAllMocks();
   });
 
+  describe('constructor', () => {
+    it('should send x-uipath-source: uipath-typescript-sdk on every ApiClient request', () => {
+      const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
+      expect(clientConfig).toEqual({ headers: { 'x-uipath-source': 'uipath-typescript-sdk' } });
+    });
+  });
+
   describe('getAll', () => {
     it('should get all choice sets successfully', async () => {
       const mockResponse = [createMockChoiceSetResponse()];

--- a/tests/unit/services/data-fabric/directory.test.ts
+++ b/tests/unit/services/data-fabric/directory.test.ts
@@ -30,6 +30,13 @@ describe('DataFabricDirectoryService Unit Tests', () => {
     vi.clearAllMocks();
   });
 
+  describe('constructor', () => {
+    it('should send x-uipath-source: uipath-typescript-sdk on every ApiClient request', () => {
+      const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
+      expect(clientConfig).toEqual({ headers: { 'x-uipath-source': 'uipath-typescript-sdk' } });
+    });
+  });
+
   describe('list', () => {
     it('should list Data Fabric directory entries', async () => {
       mockApiClient.get.mockResolvedValue({

--- a/tests/unit/services/data-fabric/directory.test.ts
+++ b/tests/unit/services/data-fabric/directory.test.ts
@@ -12,6 +12,7 @@ import {
   createServiceTestDependencies,
 } from '../../../utils/setup';
 import { TEST_CONSTANTS } from '../../../utils/constants';
+import { UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from '../../../../src/utils/constants/headers';
 
 vi.mock('../../../../src/core/http/api-client');
 
@@ -33,7 +34,7 @@ describe('DataFabricDirectoryService Unit Tests', () => {
   describe('constructor', () => {
     it('should send x-uipath-source: uipath-typescript-sdk on every ApiClient request', () => {
       const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
-      expect(clientConfig).toEqual({ headers: { 'x-uipath-source': 'uipath-typescript-sdk' } });
+      expect(clientConfig).toEqual({ headers: { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK } });
     });
   });
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -54,6 +54,7 @@ import { TEST_CONSTANTS } from "../../../utils/constants/common";
 import { DATA_FABRIC_ENDPOINTS } from "../../../../src/utils/constants/endpoints";
 import { DATA_FABRIC_TENANT_FOLDER_ID } from "../../../../src/utils/constants/endpoints/data-fabric";
 import { SqlFieldType, FieldSchemaPayload } from "@/models/data-fabric/entities.internal-types";
+import { UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from "../../../../src/utils/constants/headers";
 
 // ===== MOCKING =====
 // Mock the dependencies
@@ -98,7 +99,7 @@ describe("EntityService Unit Tests", () => {
   describe("constructor", () => {
     it("should send x-uipath-source: uipath-typescript-sdk on every ApiClient request", () => {
       const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
-      expect(clientConfig).toEqual({ headers: { "x-uipath-source": "uipath-typescript-sdk" } });
+      expect(clientConfig).toEqual({ headers: { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK } });
     });
   });
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -95,6 +95,13 @@ describe("EntityService Unit Tests", () => {
     vi.clearAllMocks();
   });
 
+  describe("constructor", () => {
+    it("should send x-uipath-source: uipath-typescript-sdk on every ApiClient request", () => {
+      const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
+      expect(clientConfig).toEqual({ headers: { "x-uipath-source": "uipath-typescript-sdk" } });
+    });
+  });
+
   describe("getById", () => {
     it("should get entity by ID successfully with all fields mapped correctly", async () => {
       const mockResponse = createMockEntityResponse();

--- a/tests/unit/services/data-fabric/roles.test.ts
+++ b/tests/unit/services/data-fabric/roles.test.ts
@@ -8,6 +8,7 @@ import {
   createServiceTestDependencies,
 } from '../../../utils/setup';
 import { TEST_CONSTANTS } from '../../../utils/constants';
+import { UIPATH_SOURCE, UIPATH_TYPESCRIPT_SDK } from '../../../../src/utils/constants/headers';
 
 vi.mock('../../../../src/core/http/api-client');
 
@@ -29,7 +30,7 @@ describe('DataFabricRoleService Unit Tests', () => {
   describe('constructor', () => {
     it('should send x-uipath-source: uipath-typescript-sdk on every ApiClient request', () => {
       const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
-      expect(clientConfig).toEqual({ headers: { 'x-uipath-source': 'uipath-typescript-sdk' } });
+      expect(clientConfig).toEqual({ headers: { [UIPATH_SOURCE]: UIPATH_TYPESCRIPT_SDK } });
     });
   });
 

--- a/tests/unit/services/data-fabric/roles.test.ts
+++ b/tests/unit/services/data-fabric/roles.test.ts
@@ -26,6 +26,13 @@ describe('DataFabricRoleService Unit Tests', () => {
     vi.clearAllMocks();
   });
 
+  describe('constructor', () => {
+    it('should send x-uipath-source: uipath-typescript-sdk on every ApiClient request', () => {
+      const [, , , clientConfig] = vi.mocked(ApiClient).mock.calls[0];
+      expect(clientConfig).toEqual({ headers: { 'x-uipath-source': 'uipath-typescript-sdk' } });
+    });
+  });
+
   describe('getAll', () => {
     it('should list Data Fabric roles with stats enabled by default', async () => {
       mockApiClient.get.mockResolvedValue([


### PR DESCRIPTION
Set x-uipath-source: uipath-typescript-sdk on every request from the four DataFabric services (Entities, ChoiceSets, Directory, Roles) via BaseService's constructor headers arg, so the DF backend can distinguish SDK-originated traffic. Unit tests assert the header lands on the ApiClient config.