### PR TITLE
fix(docs): preserve sidebar nav collapse state across page navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,20 @@ logs/
 npm-debug.log* 
 
 dist/
-docs/api/
 site/
 .uipath/
+
+# Generated API docs (npm run docs:api). Regenerate; never commit.
+#   typedoc          -> docs/api/
+#   docs-post-process -> docs/agents/, docs/conversational-agent/, docs/conversations/
+#   packages/coded-action-app typedoc -> docs/coded-action-app-sdk/
+docs/api/
+docs/agents/
+docs/conversational-agent/
+docs/conversations/
+# getting-started.md here is hand-written and tracked; the rest is typedoc output
+docs/coded-action-app-sdk/*
+!docs/coded-action-app-sdk/getting-started.md
 
 # Python bytecode cache (created by the mkdocs-llmstxt preprocess hook)
 __pycache__/

--- a/docs/overrides/assets/javascripts/extra.js
+++ b/docs/overrides/assets/javascripts/extra.js
@@ -197,3 +197,130 @@ function extractMarkdownContent() {
     
     return markdown;
 }
+/* ------------------------------------------------------------------
+ * Sidebar nav collapse-state persistence
+ *
+ * Material re-renders the sidebar from scratch on every page load, so any
+ * section the reader collapsed springs back open when they navigate. There is
+ * no built-in setting for this (`navigation.expand` is the opposite knob), so
+ * we remember which sections are open and reapply it.
+ *
+ * Keys are Material's positional toggle ids (`__nav_2_1_8`), which are stable
+ * across pages but NOT across nav-tree edits — so state is fingerprinted
+ * against the tree and dropped when the tree changes.
+ * ------------------------------------------------------------------ */
+
+const NAV_STATE_KEY = "uipath-sdk-docs.nav-open";
+// Swap to localStorage to persist across tabs and future visits.
+const navStore = () => window.sessionStorage;
+
+function navToggles() {
+    return document.querySelectorAll('.md-nav__toggle[id^="__nav"]');
+}
+
+// Cheap fingerprint of the nav tree: ids + labels. Any structural edit
+// invalidates saved state rather than reopening the wrong sections.
+function navSignature() {
+    let hash = 5381;
+    for (const toggle of navToggles()) {
+        const label = document.querySelector(`label[for="${CSS.escape(toggle.id)}"]`);
+        const text = label ? label.textContent.trim().split("\n")[0].trim() : "";
+        for (const ch of `${toggle.id}:${text}|`) {
+            hash = ((hash << 5) + hash + ch.charCodeAt(0)) | 0;
+        }
+    }
+    return hash;
+}
+
+function readNavState() {
+    try {
+        const raw = navStore().getItem(NAV_STATE_KEY);
+        if (!raw) return null;
+        const saved = JSON.parse(raw);
+        if (!saved || !Array.isArray(saved.open)) return null;
+        if (saved.sig !== navSignature()) return null; // nav tree changed
+        return new Set(saved.open);
+    } catch {
+        return null; // storage blocked (private mode) or corrupt — use defaults
+    }
+}
+
+// Only sections the reader *explicitly* opened are remembered. Sections that
+// Material opens on its own because they contain the current page are handled
+// by the pin below instead — otherwise every section you ever browsed through
+// would accumulate as permanently open, recreating the fully-expanded sidebar.
+function updateNavState(toggle) {
+    const open = readNavState() ?? new Set();
+    if (toggle.checked) {
+        open.add(toggle.id);
+    } else {
+        open.delete(toggle.id);
+    }
+    try {
+        navStore().setItem(
+            NAV_STATE_KEY,
+            JSON.stringify({ sig: navSignature(), open: [...open] })
+        );
+    } catch {
+        // Storage unavailable or full — silently fall back to default behaviour.
+    }
+}
+
+// Sections that must stay open regardless of saved state: the ancestors of the
+// current page, otherwise the reader cannot see where they are.
+function activeAncestorIds() {
+    const ids = new Set();
+    const active = document.querySelectorAll(
+        ".md-nav--primary .md-nav__link--active"
+    );
+    for (const link of active) {
+        if (link.closest(".md-nav--secondary")) continue; // table of contents
+        let item = link.closest(".md-nav__item--nested");
+        while (item) {
+            const toggle = item.querySelector(
+                ':scope > input.md-nav__toggle[id^="__nav"]'
+            );
+            if (toggle) ids.add(toggle.id);
+            item = item.parentElement
+                ? item.parentElement.closest(".md-nav__item--nested")
+                : null;
+        }
+    }
+    return ids;
+}
+
+function restoreNavState() {
+    const saved = readNavState();
+    if (!saved) return; // nothing stored yet — leave server-rendered state alone
+
+    const pinned = activeAncestorIds();
+    const root = document.documentElement;
+
+    // Suppress the expand/collapse animation while we reconcile.
+    root.setAttribute("data-md-nav-restoring", "");
+    for (const toggle of navToggles()) {
+        const shouldBeOpen = pinned.has(toggle.id) || saved.has(toggle.id);
+        if (toggle.checked !== shouldBeOpen) toggle.checked = shouldBeOpen;
+    }
+    requestAnimationFrame(() =>
+        requestAnimationFrame(() => root.removeAttribute("data-md-nav-restoring"))
+    );
+}
+
+// Delegated so it survives Material swapping the nav out.
+document.addEventListener("change", (event) => {
+    const toggle = event.target;
+    if (
+        toggle instanceof HTMLInputElement &&
+        toggle.classList.contains("md-nav__toggle") &&
+        toggle.id.startsWith("__nav")
+    ) {
+        updateNavState(toggle);
+    }
+});
+
+// Run immediately (the nav is already parsed by the time this script executes)
+// to keep the reflow within the same frame, then again per page render in case
+// instant navigation is ever enabled.
+restoreNavState();
+document$.subscribe(restoreNavState);

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -317,3 +317,11 @@ video {
   height: 100%;
   border: 0;
 }
+
+/* Suppress the sidebar expand/collapse animation while extra.js reapplies the
+   reader's saved section state on page load, so restoring reads as the page's
+   initial state rather than a visible animation. */
+[data-md-nav-restoring] .md-nav__toggle ~ .md-nav,
+[data-md-nav-restoring] .md-nav__toggle ~ .md-nav__link .md-nav__icon:after {
+  transition: none !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,6 @@ theme:
     - content.footnote.tooltips
     - content.tabs.link
     - content.tooltips
-    - navigation.expand
     - navigation.footer
     - navigation.indexes
     - navigation.sections
@@ -59,7 +58,6 @@ theme:
     - content.footnote.tooltips
     - content.tabs.link
     - content.tooltips
-    - navigation.expand
     - navigation.footer
     - navigation.sections
     - search.highlight


### PR DESCRIPTION
Collapsible sections in the docs sidebar re-expanded on every page load, so any section a reader collapsed sprang back open as soon as they navigated. This turns off the theme flag causing it and remembers the reader's own expand/collapse choices.

Docs-site only — no SDK source, no public API surface, no endpoints.

<details open>
<summary><b>Demo — before / after</b></summary>

<img src="https://raw.githubusercontent.com/UiPath/uipath-typescript/6ce2fce5df9284a29f67859d97b3e8419837bc2c/nav-collapse-demo.gif" alt="Sidebar nav collapse state, before and after" width="470">

Recorded against two real builds of this site: **before** = `main` (with `navigation.expand`, previous `extra.js`), **after** = this branch. Both scripted identically — collapse/open a section, then navigate from *Maestro › Cases* to *Tasks*.

| Sections open in the sidebar | On `Cases` | After navigating to `Tasks` |
|---|---|---|
| Before | 18 of 18 | 18 of 18 — reader's collapses discarded |
| After | 3 (active path only) | 4 — active path + the one section they opened |

In the final frame `Entities` is still open because the reader opened it, `Tasks` is open because it holds the current page, and `Maestro` has correctly dropped away.

</details>

<details>
<summary><b>Details</b></summary>

### Root cause

`navigation.expand` was enabled in `mkdocs.yml` (twice — the `features:` list contains a duplicated block). It renders every collapsible section with Material's `md-toggle--indeterminate` class, which the theme's own stylesheet treats identically to `:checked`:

```css
.md-nav__toggle.md-toggle--indeterminate ~ .md-nav,
.md-nav__toggle:checked ~ .md-nav { opacity:1; visibility:visible; }
```

Material's JS strips that class when you manually collapse a section, but the server re-emits it on the next page load — hence the reset. On a representative API page, 15 of 18 sections carried it; now 0 do, and only the current page's ancestors open.

### Persistence

Removing the flag fixes the re-expansion, but Material has no built-in memory of manual expand/collapse. `extra.js` now stores open-section ids in `sessionStorage` and reapplies them per load. Three decisions worth reviewing:

- **Only explicitly-opened sections are remembered.** The first version saved every open section, including ones Material auto-opens because they contain the current page — which made each visited section permanently sticky and drifted back toward a fully-expanded sidebar. Auto-opened ancestors are now transient.
- **Ancestors of the current page are pinned open**, so collapsing the section you are currently inside cannot hide where you are.
- **Stale state is discarded.** Material's `__nav_2_1_8`-style ids are positional, so editing the `nav:` tree would remap saved ids onto the wrong sections. State is fingerprinted (ids + labels, djb2-hashed) and dropped when the tree changes.

All storage access is wrapped in `try/catch` — private mode, disabled storage, or corrupt JSON fall back to default behaviour. `sessionStorage` is per-tab; switching to `localStorage` is a one-line change if we want it to persist across visits.

### `.gitignore`

`docs/api/` was already ignored while its sibling outputs from the same `npm run docs:api` command were not, so they surfaced as untracked noise. All four are now grouped and ignored. `docs/coded-action-app-sdk/` is mixed — `getting-started.md` is hand-written and tracked — so it uses the negation form rather than a blanket rule.

### Verification

Ran the real `extra.js` against the real generated nav markup under jsdom, simulating navigation between pages with a shared `sessionStorage`. 15 assertions, all passing:

| Scenario | Result |
|---|---|
| First visit — no saved state, server rendering untouched | pass |
| Explicit open persists; only that section is stored | pass |
| Open section survives navigating to another page | pass |
| Collapse persists across reload | pass |
| Section auto-opened for the current page is not sticky | pass |
| Ancestor of current page forced open when collapsed | pass |
| Nav-tree change invalidates stale state | pass |
| Storage blocked (private mode) / corrupt JSON | pass |

`npm run typecheck` clean, `npm run lint` 0/0, `npm run test:unit` 2526 passed. `mkdocs build` ships both assets (`HTTP 200`). `docs` is in oxlint's `ignorePatterns`, so the added JS is outside lint scope.

### Files

| Area | File |
|---|---|
| Theme config | `mkdocs.yml` |
| Sidebar persistence | `docs/overrides/assets/javascripts/extra.js` |
| Restore-animation suppression | `docs/stylesheets/extra.css` |
| Generated-docs ignore rules | `.gitignore` |

The demo GIF is **not** part of this branch — it lives on `assets/pr-696-demo`, which is never merged, so no binary enters `main`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
