### PR TITLE
refactor(integration-service): remove Connections reauthenticate API

### DIFF
--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -319,7 +319,6 @@ The `ConversationalAgents` scope is required for real-time WebSocket sessions (`
 | `getAll()` | `IS.Connections.Read` |
 | `getById()` | `IS.Connections.Read` |
 | `ping()` | `IS.Connections.Read` |
-| `reauthenticate()` | `IS.Connections.Read` |
 
 ### Elements
 

--- a/src/models/integration-service/connections.models.ts
+++ b/src/models/integration-service/connections.models.ts
@@ -1,7 +1,7 @@
 /**
  * Integration Service — Connection models
  *
- * Combines raw connection data with bound entity methods (`ping`, `reauthenticate`).
+ * Combines raw connection data with bound entity methods (`ping`).
  */
 
 import {
@@ -10,16 +10,14 @@ import {
   ConnectionGetByIdOptions,
   ConnectionPingOptions,
   ConnectionPingResponse,
-  ConnectionReauthenticateOptions,
-  ConnectionReauthenticateResponse,
 } from './connections.types';
 
 /**
  * A Connection entity enriched with bound methods.
  *
  * Returned by every Connection-yielding method on the {@link ConnectionsServiceModel}
- * and {@link ConnectorsServiceModel}. The bound methods (`ping`, `reauthenticate`)
- * close over this connection's ID so callers can act on the entity directly.
+ * and {@link ConnectorsServiceModel}. The bound `ping` method closes over this
+ * connection's ID so callers can act on the entity directly.
  */
 export type ConnectionGetResponse = RawConnectionGetResponse & ConnectionMethods;
 
@@ -154,31 +152,6 @@ export interface ConnectionsServiceModel {
    * ```
    */
   ping(connectionId: string, options?: ConnectionPingOptions): Promise<ConnectionPingResponse>;
-
-  /**
-   * Start an OAuth re-authentication session for a connection.
-   *
-   * Returns a session handle plus the URL the end user must visit to grant or
-   * refresh consent. The session expires at {@link ConnectionReauthenticateResponse.expiresAt}.
-   *
-   * @param connectionId - Connection GUID
-   * @param options - Folder scoping (`folderId` / `folderKey` / `folderPath`)
-   * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
-   * @example
-   * ```typescript
-   * import { Connections } from '@uipath/uipath-typescript/is-connections';
-   *
-   * const connections = new Connections(sdk);
-   *
-   * const session = await connections.reauthenticate('<connectionId>');
-   * // Direct the user to session.authUrl to complete OAuth consent.
-   * console.log(`Visit: ${session.authUrl}`);
-   * ```
-   */
-  reauthenticate(
-    connectionId: string,
-    options?: ConnectionReauthenticateOptions,
-  ): Promise<ConnectionReauthenticateResponse>;
 }
 
 /**
@@ -195,14 +168,6 @@ export interface ConnectionMethods {
    * @returns Promise resolving to a {@link ConnectionPingResponse}
    */
   ping(options?: ConnectionPingOptions): Promise<ConnectionPingResponse>;
-
-  /**
-   * Start an OAuth re-authentication session for this connection.
-   *
-   * @param options - Optional folder scoping (`folderId` / `folderKey` / `folderPath`)
-   * @returns Promise resolving to a {@link ConnectionReauthenticateResponse}
-   */
-  reauthenticate(options?: ConnectionReauthenticateOptions): Promise<ConnectionReauthenticateResponse>;
 }
 
 function createConnectionMethods(
@@ -213,10 +178,6 @@ function createConnectionMethods(
     async ping(options?: ConnectionPingOptions): Promise<ConnectionPingResponse> {
       if (!data.id) throw new Error('Connection id is undefined');
       return service.ping(data.id, options);
-    },
-    async reauthenticate(options?: ConnectionReauthenticateOptions): Promise<ConnectionReauthenticateResponse> {
-      if (!data.id) throw new Error('Connection id is undefined');
-      return service.reauthenticate(data.id, options);
     },
   };
 }

--- a/src/models/integration-service/connections.types.ts
+++ b/src/models/integration-service/connections.types.ts
@@ -146,25 +146,3 @@ export interface ConnectionPingResponse {
   /** Error message if the ping failed. */
   error?: string;
 }
-
-/**
- * Options for {@link ConnectionsServiceModel.reauthenticate}.
- */
-export interface ConnectionReauthenticateOptions extends IntegrationServiceFolderContextOptions {}
-
-/**
- * Response from {@link ConnectionsServiceModel.reauthenticate}.
- *
- * Re-authentication is a multi-step OAuth flow — the SDK returns the session
- * handle and the auth URL the user must visit to grant consent.
- */
-export interface ConnectionReauthenticateResponse {
-  /** Connector key for the connection being re-authenticated. */
-  connector: string;
-  /** Session ID used to poll for auth completion. */
-  sessionId: string;
-  /** Epoch milliseconds when the auth session expires. */
-  expiresAt: number;
-  /** URL the user must visit to grant or refresh OAuth consent. */
-  authUrl: string;
-}

--- a/src/services/integration-service/connections/connections.ts
+++ b/src/services/integration-service/connections/connections.ts
@@ -9,8 +9,6 @@ import {
   ConnectionGetByIdOptions,
   ConnectionPingOptions,
   ConnectionPingResponse,
-  ConnectionReauthenticateOptions,
-  ConnectionReauthenticateResponse,
   RawConnectionGetResponse,
 } from '../../../models/integration-service/connections.types';
 import {
@@ -86,27 +84,4 @@ export class ConnectionsService extends BaseService implements ConnectionsServic
     return response.data;
   }
 
-  @track('Connections.Reauthenticate')
-  async reauthenticate(
-    connectionId: string,
-    options?: ConnectionReauthenticateOptions,
-  ): Promise<ConnectionReauthenticateResponse> {
-    if (!connectionId) {
-      throw new ValidationError({ message: 'connectionId is required for reauthenticate' });
-    }
-    const { headers, queryOptions } = resolveFolderScope(
-      options ?? {},
-      'Connections.reauthenticate',
-      this.config.folderKey,
-    );
-    const response = await this.post<ConnectionReauthenticateResponse>(
-      CONNECTION_ENDPOINTS.REAUTHENTICATE(connectionId),
-      undefined,
-      {
-        headers,
-        params: queryOptions as QueryParams,
-      },
-    );
-    return response.data;
-  }
 }

--- a/src/utils/constants/endpoints/integration-service.ts
+++ b/src/utils/constants/endpoints/integration-service.ts
@@ -19,7 +19,6 @@ export const CONNECTION_ENDPOINTS = {
   GET_ALL: `${CONNECTIONS_BASE}/api/v1/Connections`,
   GET_BY_ID: (connectionId: string) => `${CONNECTIONS_BASE}/api/v1/Connections/${encodeURIComponent(connectionId)}`,
   PING: (connectionId: string) => `${CONNECTIONS_BASE}/api/v1/Connections/${encodeURIComponent(connectionId)}/ping`,
-  REAUTHENTICATE: (connectionId: string) => `${CONNECTIONS_BASE}/api/v1/Connections/${encodeURIComponent(connectionId)}/auth`,
 } as const;
 
 export const ELEMENT_ENDPOINTS = {

--- a/tests/unit/models/integration-service/connections.test.ts
+++ b/tests/unit/models/integration-service/connections.test.ts
@@ -14,7 +14,6 @@ describe('Connection bound methods', () => {
       getAll: vi.fn(),
       getById: vi.fn(),
       ping: vi.fn(),
-      reauthenticate: vi.fn(),
     };
   });
 
@@ -74,58 +73,6 @@ describe('Connection bound methods', () => {
     });
   });
 
-  describe('connection.reauthenticate()', () => {
-    it('should delegate to service.reauthenticate with bound id', async () => {
-      const connection = createConnectionWithMethods(createMockConnection(), mockService);
-      const mockResponse = {
-        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
-        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
-        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
-        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
-      };
-      mockService.reauthenticate = vi.fn().mockResolvedValue(mockResponse);
-
-      const result = await connection.reauthenticate();
-
-      expect(mockService.reauthenticate).toHaveBeenCalledWith(
-        IS_TEST_CONSTANTS.CONNECTION_ID,
-        undefined,
-      );
-      expect(result).toBe(mockResponse);
-    });
-
-    it('should pass folderKey through', async () => {
-      const connection = createConnectionWithMethods(createMockConnection(), mockService);
-      mockService.reauthenticate = vi.fn().mockResolvedValue({
-        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
-        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
-        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
-        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
-      });
-
-      await connection.reauthenticate({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
-
-      expect(mockService.reauthenticate).toHaveBeenCalledWith(IS_TEST_CONSTANTS.CONNECTION_ID, {
-        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
-      });
-    });
-
-    it('should pass folderId through', async () => {
-      const connection = createConnectionWithMethods(createMockConnection(), mockService);
-      mockService.reauthenticate = vi.fn().mockResolvedValue({
-        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
-        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
-        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
-        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
-      });
-
-      await connection.reauthenticate({ folderId: IS_TEST_CONSTANTS.FOLDER_ID });
-
-      expect(mockService.reauthenticate).toHaveBeenCalledWith(IS_TEST_CONSTANTS.CONNECTION_ID, {
-        folderId: IS_TEST_CONSTANTS.FOLDER_ID,
-      });
-    });
-  });
 
   describe('createConnectionWithMethods', () => {
     it('should attach raw data fields verbatim', () => {
@@ -139,10 +86,9 @@ describe('Connection bound methods', () => {
       expect(connection.folder?.key).toBe(raw.folder?.key);
     });
 
-    it('should attach both bound methods', () => {
+    it('should attach the bound ping method', () => {
       const connection = createConnectionWithMethods(createMockConnection(), mockService);
       expect(typeof connection.ping).toBe('function');
-      expect(typeof connection.reauthenticate).toBe('function');
     });
   });
 });

--- a/tests/unit/services/integration-service/connections.test.ts
+++ b/tests/unit/services/integration-service/connections.test.ts
@@ -48,7 +48,6 @@ describe('ConnectionsService', () => {
       expect(result).toHaveLength(2);
       for (const conn of result) {
         expect(typeof conn.ping).toBe('function');
-        expect(typeof conn.reauthenticate).toBe('function');
       }
     });
 
@@ -190,7 +189,6 @@ describe('ConnectionsService', () => {
       );
       expect(result.id).toBe(IS_TEST_CONSTANTS.CONNECTION_ID);
       expect(typeof result.ping).toBe('function');
-      expect(typeof result.reauthenticate).toBe('function');
     });
 
     it('should forward includeConfigs as a query param', async () => {
@@ -313,81 +311,4 @@ describe('ConnectionsService', () => {
     });
   });
 
-  describe('reauthenticate', () => {
-    it('should start an OAuth session', async () => {
-      mockApiClient.post.mockResolvedValue({
-        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
-        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
-        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
-        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
-      });
-
-      const result = await service.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID);
-
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
-        undefined,
-        { headers: {}, params: {} },
-      );
-      expect(result.sessionId).toBe(IS_TEST_CONSTANTS.AUTH_SESSION_ID);
-      expect(result.authUrl).toBe(IS_TEST_CONSTANTS.AUTH_URL);
-    });
-
-    it('should send folder header when folderKey is provided', async () => {
-      mockApiClient.post.mockResolvedValue({
-        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
-        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
-        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
-        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
-      });
-      await service.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID, {
-        folderKey: IS_TEST_CONSTANTS.FOLDER_KEY,
-      });
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
-        undefined,
-        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
-      );
-    });
-
-    it('should route folderPath to the encoded folder path header', async () => {
-      mockApiClient.post.mockResolvedValue({
-        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
-        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
-        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
-        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
-      });
-      await service.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID, {
-        folderPath: IS_TEST_CONSTANTS.FOLDER_PATH,
-      });
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
-        undefined,
-        { headers: { [FOLDER_PATH_ENCODED]: IS_TEST_CONSTANTS.FOLDER_PATH_ENCODED_VALUE }, params: {} },
-      );
-    });
-
-    it('should fall back to the init-time folder key when no folder context is supplied', async () => {
-      const { instance } = createServiceTestDependencies({ folderKey: IS_TEST_CONSTANTS.FOLDER_KEY });
-      const scopedService = new ConnectionsService(instance);
-      mockApiClient.post.mockResolvedValue({
-        connector: IS_TEST_CONSTANTS.CONNECTOR_KEY,
-        sessionId: IS_TEST_CONSTANTS.AUTH_SESSION_ID,
-        expiresAt: IS_TEST_CONSTANTS.AUTH_EXPIRES_AT,
-        authUrl: IS_TEST_CONSTANTS.AUTH_URL,
-      });
-
-      await scopedService.reauthenticate(IS_TEST_CONSTANTS.CONNECTION_ID);
-
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        CONNECTION_ENDPOINTS.REAUTHENTICATE(IS_TEST_CONSTANTS.CONNECTION_ID),
-        undefined,
-        { headers: { [FOLDER_KEY]: IS_TEST_CONSTANTS.FOLDER_KEY }, params: {} },
-      );
-    });
-
-    it('should throw ValidationError when connectionId is empty', async () => {
-      await expect(service.reauthenticate('')).rejects.toThrow(ValidationError);
-    });
-  });
 });

--- a/tests/unit/services/integration-service/connectors.test.ts
+++ b/tests/unit/services/integration-service/connectors.test.ts
@@ -113,7 +113,6 @@ describe('ConnectorsService', () => {
       expect(result.id).toBe(IS_TEST_CONSTANTS.CONNECTION_ID);
       // Bound methods attached:
       expect(typeof result.ping).toBe('function');
-      expect(typeof result.reauthenticate).toBe('function');
     });
 
     it('should send no folder header when folderKey is omitted', async () => {
@@ -201,7 +200,6 @@ describe('ConnectorsService', () => {
       expect(result).toHaveLength(2);
       for (const conn of result) {
         expect(typeof conn.ping).toBe('function');
-        expect(typeof conn.reauthenticate).toBe('function');
       }
     });
 

--- a/tests/utils/constants/integration-service.ts
+++ b/tests/utils/constants/integration-service.ts
@@ -25,9 +25,6 @@ export const IS_TEST_CONSTANTS = {
   /** `FOLDER_PATH` encoded as base64-of-UTF-16-LE, per the Orchestrator folder-path contract. */
   FOLDER_PATH_ENCODED_VALUE: 'UwBoAGEAcgBlAGQALwBGAGkAbgBhAG4AYwBlAA==',
   FOLDER_DISPLAY_NAME: 'Test Folder',
-  AUTH_SESSION_ID: 'sess_abcdef0123456789',
-  AUTH_URL: 'https://alpha.uipath.com/oauth/authorize?session_id=sess_abcdef0123456789',
-  AUTH_EXPIRES_AT: 1782303998000,
   ERROR_CONNECTOR_NOT_FOUND: 'Connector not found',
   ERROR_CONNECTION_NOT_FOUND: 'Connection not found',
   ERROR_PING_FAILED: 'Ping failed',


### PR DESCRIPTION
## Summary

- **Removed `reauthenticate()` from Connections** — service method, bound entity method, types, endpoint constant, oauth-scopes row, and 8 unit tests. Initial release is scoped to consuming connections, not managing them. `getAll()`, `getById()`, `ping()` remain.

- **It was unusable under external-app auth anyway** — `POST /Connections/{id}/auth` returns **403 `CNS1044`** ("External applications are not permitted on this endpoint"), with or without folder context, as it lacks `[ExternalAppScope]`. Verified against a token that got 200 on `GET /Connections/{id}` in the same batch.

## Removed

| Area | File | What |
|------|------|------|
| Models | `src/models/integration-service/connections.models.ts` | `ConnectionsServiceModel.reauthenticate()`, `ConnectionMethods.reauthenticate()`, factory delegate |
| Types | `src/models/integration-service/connections.types.ts` | `ConnectionReauthenticateOptions`, `ConnectionReauthenticateResponse` |
| Service | `src/services/integration-service/connections/connections.ts` | `@track('Connections.Reauthenticate')` method |
| Endpoint | `src/utils/constants/endpoints/integration-service.ts` | `CONNECTION_ENDPOINTS.REAUTHENTICATE` → `POST connections_/api/v1/Connections/{id}/auth` |
| Docs | `docs/oauth-scopes.md` | `reauthenticate()` / `IS.Connections.Read` row |
| Tests | `tests/unit/services/integration-service/connections.test.ts` | 5 tests |
| Tests | `tests/unit/models/integration-service/connections.test.ts` | 3 tests |
| Tests | `tests/unit/services/integration-service/connectors.test.ts` | 2 assertions |
| Test utils | `tests/utils/constants/integration-service.ts` | orphaned `AUTH_SESSION_ID` / `AUTH_URL` / `AUTH_EXPIRES_AT` |

9 files changed, 4 insertions, 230 deletions.

`ping` is still bound, so `createConnectionWithMethods()` and the method-attachment pattern are unchanged. No transform or response-shape changes.

## Coverage

No coverage lost — `getAll`, `getById`, and `ping` each independently cover the encoded folder-path header, the init-time folder-key fallback, and `ValidationError`.

## Verification

```
npm run typecheck   clean
npm run lint        0 warnings, 0 errors
npm run test:unit   82 files, 2318 passed
npm run build       dist/ produced, no "reauthenticate" in output
```

## Notes

- Targets `feat/is-connections`, not `main` — the method was never released, so this is not a breaking change.
- `release-metadata.json` still lists `reauthenticate`; it is regenerated by `release-metadata:gen` on the version-bump PR, so it is intentionally not hand-edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
