### PR TITLE
feat(auth): add enforceSso option to sign in via the org's identity provider

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -40,13 +40,13 @@ const sdk = new UiPath();
 await sdk.initialize();
 ```
 
-### Forcing sign-in through the organization's identity provider
+### Enforcing sign-in through the organization's identity provider
 
-By default users see the UiPath account sign-in screen. Set `forceSso: true` to send them
+By default users see the UiPath account sign-in screen. Set `enforceSso: true` to send them
 straight to the organization's configured identity provider instead.
 
 ```typescript
-const sdk = new UiPath({ forceSso: true });
+const sdk = new UiPath({ enforceSso: true });
 ```
 
 !!! warning "Only where everyone signs in through SSO"
@@ -56,7 +56,7 @@ const sdk = new UiPath({ forceSso: true });
 !!! note "Needs the organization id"
     This uses the organization id, which the platform and `uipath.json` supply for you. If
     you instead pass configuration directly to the constructor, set `orgName` to the
-    organization id, otherwise `forceSso` is ignored and a warning is logged.
+    organization id, otherwise `enforceSso` is ignored and a warning is logged.
 
 
 ## Secret-based Authentication

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -40,6 +40,25 @@ const sdk = new UiPath();
 await sdk.initialize();
 ```
 
+### Forcing sign-in through the organization's identity provider
+
+By default users see the UiPath account sign-in screen. Set `forceSso: true` to send them
+straight to the organization's configured identity provider instead.
+
+```typescript
+const sdk = new UiPath({ forceSso: true });
+```
+
+!!! warning "Only where everyone signs in through SSO"
+    Users who sign in with a UiPath account do not exist in the organization's identity
+    provider and will be rejected by it.
+
+!!! note "Needs the organization id"
+    This uses the organization id, which the platform and `uipath.json` supply for you. If
+    you instead pass configuration directly to the constructor, set `orgName` to the
+    organization id, otherwise `forceSso` is ignored and a warning is logged.
+
+
 ## Secret-based Authentication
 ```typescript
 import { UiPath } from '@uipath/uipath-typescript/core';

--- a/src/core/auth/service.ts
+++ b/src/core/auth/service.ts
@@ -7,6 +7,8 @@ import { hasOAuthConfig } from '../config/sdk-config';
 import { isBrowser } from '../../utils/platform';
 import { IDENTITY_ENDPOINTS } from '../../utils/constants/endpoints';
 
+const GUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export class AuthService {
   private config: Config;
   private tokenManager: TokenManager;
@@ -362,10 +364,24 @@ export class AuthService {
       state: params.state || this.generateCodeVerifier().slice(0, 16)
     });
 
-    // acr_values is intentionally omitted: Identity resolves the target org from
+    // acr_values is omitted by default: Identity resolves the target org from
     // client_id, and sending acr_values routes directly to the org's SAML IdP,
-    // which blocks Basic Auth users in mixed-auth orgs.
-    return `${this.config.baseUrl}/${IDENTITY_ENDPOINTS.AUTHORIZE}?${queryParams.toString()}`;
+    // which blocks Basic Auth users in mixed-auth orgs. `forceSso` opts back in.
+    const authorizeUrl = `${this.config.baseUrl}/${IDENTITY_ENDPOINTS.AUTHORIZE}?${queryParams.toString()}`;
+    if (!this.config.forceSso) {
+      return authorizeUrl;
+    }
+
+    const orgName = this.config.orgName;
+    if (!GUID_REGEX.test(orgName)) {
+      console.warn(
+        `[UiPath SDK] forceSso was ignored: orgName "${orgName}" is not an organization id. ` +
+        'Pass the organization id (GUID) as orgName to sign in through the org\'s identity provider.'
+      );
+      return authorizeUrl;
+    }
+
+    return `${authorizeUrl}&acr_values=${encodeURIComponent(`tenant:${orgName}`)}`;
   }
 
   /**

--- a/src/core/auth/service.ts
+++ b/src/core/auth/service.ts
@@ -366,16 +366,16 @@ export class AuthService {
 
     // acr_values is omitted by default: Identity resolves the target org from
     // client_id, and sending acr_values routes directly to the org's SAML IdP,
-    // which blocks Basic Auth users in mixed-auth orgs. `forceSso` opts back in.
+    // which blocks Basic Auth users in mixed-auth orgs. `enforceSso` opts back in.
     const authorizeUrl = `${this.config.baseUrl}/${IDENTITY_ENDPOINTS.AUTHORIZE}?${queryParams.toString()}`;
-    if (!this.config.forceSso) {
+    if (!this.config.enforceSso) {
       return authorizeUrl;
     }
 
     const orgName = this.config.orgName;
     if (!GUID_REGEX.test(orgName)) {
       console.warn(
-        `[UiPath SDK] forceSso was ignored: orgName "${orgName}" is not an organization id. ` +
+        `[UiPath SDK] enforceSso was ignored: orgName "${orgName}" is not an organization id. ` +
         'Pass the organization id (GUID) as orgName to sign in through the org\'s identity provider.'
       );
       return authorizeUrl;

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -8,6 +8,7 @@ export const ConfigSchema = z.object({
   clientId: z.string().optional(),
   redirectUri: z.string().url().optional(),
   scope: z.string().optional(),
+  forceSso: z.boolean().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -20,6 +21,7 @@ interface ConfigOptions {
   clientId?: string;
   redirectUri?: string;
   scope?: string;
+  forceSso?: boolean;
 }
 
 export class UiPathConfig {
@@ -30,6 +32,7 @@ export class UiPathConfig {
   public readonly clientId?: string;
   public readonly redirectUri?: string;
   public readonly scope?: string;
+  public readonly forceSso?: boolean;
 
   constructor(options: ConfigOptions) {
     this.baseUrl = options.baseUrl;
@@ -39,6 +42,7 @@ export class UiPathConfig {
     this.clientId = options.clientId;
     this.redirectUri = options.redirectUri;
     this.scope = options.scope;
+    this.forceSso = options.forceSso;
   }
 }
 

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -8,7 +8,7 @@ export const ConfigSchema = z.object({
   clientId: z.string().optional(),
   redirectUri: z.string().url().optional(),
   scope: z.string().optional(),
-  forceSso: z.boolean().optional(),
+  enforceSso: z.boolean().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -21,7 +21,7 @@ interface ConfigOptions {
   clientId?: string;
   redirectUri?: string;
   scope?: string;
-  forceSso?: boolean;
+  enforceSso?: boolean;
 }
 
 export class UiPathConfig {
@@ -32,7 +32,7 @@ export class UiPathConfig {
   public readonly clientId?: string;
   public readonly redirectUri?: string;
   public readonly scope?: string;
-  public readonly forceSso?: boolean;
+  public readonly enforceSso?: boolean;
 
   constructor(options: ConfigOptions) {
     this.baseUrl = options.baseUrl;
@@ -42,7 +42,7 @@ export class UiPathConfig {
     this.clientId = options.clientId;
     this.redirectUri = options.redirectUri;
     this.scope = options.scope;
-    this.forceSso = options.forceSso;
+    this.enforceSso = options.enforceSso;
   }
 }
 

--- a/src/core/config/sdk-config.ts
+++ b/src/core/config/sdk-config.ts
@@ -12,15 +12,20 @@ export interface OAuthFields {
   scope: string;
 }
 
+// Opt-in sign-in behaviour.
+export interface SsoFields {
+  forceSso?: boolean;
+}
+
 // Configuration type that enforces either secret or complete OAuth fields
-export type UiPathSDKConfig = BaseConfig & (
+export type UiPathSDKConfig = BaseConfig & SsoFields & (
   | { secret: string; clientId?: never; redirectUri?: never; scope?: never }
   | ({ secret?: never } & OAuthFields)
 );
 
 // Flexible partial type for constructor input (allows any combination of fields)
 // The isCompleteConfig function validates the final merged config
-export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string }>;
+export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string } & SsoFields>;
 
 // Type guard to check if config has OAuth credentials
 export function hasOAuthConfig(config: { clientId?: string; redirectUri?: string; scope?: string }): config is { clientId: string; redirectUri: string; scope: string } {

--- a/src/core/config/sdk-config.ts
+++ b/src/core/config/sdk-config.ts
@@ -14,7 +14,7 @@ export interface OAuthFields {
 
 // Opt-in sign-in behaviour.
 export interface SsoFields {
-  forceSso?: boolean;
+  enforceSso?: boolean;
 }
 
 // Configuration type that enforces either secret or complete OAuth fields

--- a/src/core/config/sdk-config.ts
+++ b/src/core/config/sdk-config.ts
@@ -12,20 +12,20 @@ export interface OAuthFields {
   scope: string;
 }
 
-// Opt-in sign-in behaviour.
-export interface SsoFields {
+// Opt-in login behaviour.
+export interface LoginFields {
   enforceSso?: boolean;
 }
 
 // Configuration type that enforces either secret or complete OAuth fields
-export type UiPathSDKConfig = BaseConfig & SsoFields & (
+export type UiPathSDKConfig = BaseConfig & LoginFields & (
   | { secret: string; clientId?: never; redirectUri?: never; scope?: never }
   | ({ secret?: never } & OAuthFields)
 );
 
 // Flexible partial type for constructor input (allows any combination of fields)
 // The isCompleteConfig function validates the final merged config
-export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string } & SsoFields>;
+export type PartialUiPathConfig = Partial<BaseConfig & OAuthFields & { secret: string } & LoginFields>;
 
 // Type guard to check if config has OAuth credentials
 export function hasOAuthConfig(config: { clientId?: string; redirectUri?: string; scope?: string }): config is { clientId: string; redirectUri: string; scope: string } {

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -142,7 +142,7 @@ export class UiPath implements IUiPath {
       clientId: hasOAuthAuth ? config.clientId : undefined,
       redirectUri: hasOAuthAuth ? config.redirectUri : undefined,
       scope: hasOAuthAuth ? config.scope : undefined,
-      forceSso: config.forceSso,
+      enforceSso: config.enforceSso,
     });
 
     const executionContext = new ExecutionContext();

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -142,6 +142,7 @@ export class UiPath implements IUiPath {
       clientId: hasOAuthAuth ? config.clientId : undefined,
       redirectUri: hasOAuthAuth ? config.redirectUri : undefined,
       scope: hasOAuthAuth ? config.scope : undefined,
+      forceSso: config.forceSso,
     });
 
     const executionContext = new ExecutionContext();

--- a/tests/unit/core/auth/service.test.ts
+++ b/tests/unit/core/auth/service.test.ts
@@ -3,6 +3,7 @@ import { AuthService } from '../../../../src/core/auth/service';
 import { ExecutionContext } from '../../../../src/core/context/execution';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
 import { IDENTITY_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
+import type { LoginFields } from '../../../../src/core/config/sdk-config';
 
 // Mock platform detection for Node test environment
 vi.mock('../../../../src/utils/platform', () => ({
@@ -18,7 +19,7 @@ describe('AuthService', () => {
   const codeChallenge = TEST_CONSTANTS.CODE_CHALLENGE;
   const scope = TEST_CONSTANTS.OAUTH_SCOPE;
 
-  function createService(orgName: string, extra: Record<string, unknown> = {}) {
+  function createService(orgName: string, extra: LoginFields = {}) {
     const config = {
       baseUrl: TEST_CONSTANTS.BASE_URL,
       orgName,

--- a/tests/unit/core/auth/service.test.ts
+++ b/tests/unit/core/auth/service.test.ts
@@ -18,14 +18,15 @@ describe('AuthService', () => {
   const codeChallenge = TEST_CONSTANTS.CODE_CHALLENGE;
   const scope = TEST_CONSTANTS.OAUTH_SCOPE;
 
-  function createService(orgName: string) {
+  function createService(orgName: string, extra: Record<string, unknown> = {}) {
     const config = {
       baseUrl: TEST_CONSTANTS.BASE_URL,
       orgName,
       tenantName: TEST_CONSTANTS.TENANT_ID,
       clientId,
       redirectUri,
-      scope
+      scope,
+      ...extra
     };
     return new AuthService(config, new ExecutionContext());
   }
@@ -52,9 +53,9 @@ describe('AuthService', () => {
       expect(params.get('scope')).toContain(scope);
     });
 
-    // acr_values is never sent: Identity resolves the org from client_id, and
-    // sending it routes directly to the org's SAML IdP, blocking Basic Auth users.
-    it('should never emit acr_values, regardless of orgName format', () => {
+    // acr_values is not sent by default: Identity resolves the org from client_id,
+    // and sending it routes directly to the org's SAML IdP, blocking Basic Auth users.
+    it('should not emit acr_values by default, regardless of orgName format', () => {
       for (const orgName of [
         TEST_CONSTANTS.ORGANIZATION_ID,
         TEST_CONSTANTS.GUID_ORG_ID,
@@ -64,6 +65,26 @@ describe('AuthService', () => {
         const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
         expect(new URL(url).searchParams.has('acr_values')).toBe(false);
         expect(url).not.toContain('acr_values');
+      }
+    });
+
+    it('should emit acr_values with the org id when forceSso is enabled', () => {
+      const service = createService(TEST_CONSTANTS.GUID_ORG_ID, { forceSso: true });
+      const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
+      expect(new URL(url).searchParams.get('acr_values')).toBe(`tenant:${TEST_CONSTANTS.GUID_ORG_ID}`);
+    });
+
+    it('should ignore forceSso and warn when orgName is not an org id', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        for (const orgName of [ TEST_CONSTANTS.ORGANIZATION_ID, TEST_CONSTANTS.INVALID_GUID_ORG_ID ]) {
+          const service = createService(orgName, { forceSso: true });
+          const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
+          expect(url).not.toContain('acr_values');
+        }
+        expect(warn).toHaveBeenCalledTimes(2);
+      } finally {
+        warn.mockRestore();
       }
     });
 

--- a/tests/unit/core/auth/service.test.ts
+++ b/tests/unit/core/auth/service.test.ts
@@ -68,17 +68,17 @@ describe('AuthService', () => {
       }
     });
 
-    it('should emit acr_values with the org id when forceSso is enabled', () => {
-      const service = createService(TEST_CONSTANTS.GUID_ORG_ID, { forceSso: true });
+    it('should emit acr_values with the org id when enforceSso is enabled', () => {
+      const service = createService(TEST_CONSTANTS.GUID_ORG_ID, { enforceSso: true });
       const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
       expect(new URL(url).searchParams.get('acr_values')).toBe(`tenant:${TEST_CONSTANTS.GUID_ORG_ID}`);
     });
 
-    it('should ignore forceSso and warn when orgName is not an org id', () => {
+    it('should ignore enforceSso and warn when orgName is not an org id', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
         for (const orgName of [ TEST_CONSTANTS.ORGANIZATION_ID, TEST_CONSTANTS.INVALID_GUID_ORG_ID ]) {
-          const service = createService(orgName, { forceSso: true });
+          const service = createService(orgName, { enforceSso: true });
           const url = service.getAuthorizationUrl({ clientId, redirectUri, codeChallenge, scope });
           expect(url).not.toContain('acr_values');
         }


### PR DESCRIPTION
Adds an opt-in `enforceSso` flag that sends `acr_values=tenant:<orgId>` on the authorize request, so users land on the org's IdP instead of the UiPath account screen. Off by default; requires `orgName` to be the org id.

Context: https://uipath-product.slack.com/archives/C0175DZP4PQ/p1782397128159069?thread_ts=1777038498.265349&cid=C0175DZP4PQ -> acr_values was removed there because it blocks basic-auth users in mixed-auth orgs, so this stays opt-in.