### PR TITLE
fix(data-fabric): correct the MULTILINE_MAX read contract in the SDK docs and restore list coverage

### DIFF
--- a/src/models/data-fabric/entities.models.ts
+++ b/src/models/data-fabric/entities.models.ts
@@ -147,8 +147,9 @@ export interface EntityServiceModel {
   /**
    * Gets entity records by entity ID
    *
-   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
-   * instead of the full content — use {@link getRecordById} to retrieve the full value.
+   * `MULTILINE_MAX` fields are returned as a bounded preview, not necessarily the whole
+   * value (see {@link EntityFieldDataType.MULTILINE_MAX}); use {@link getRecordById} for
+   * the guaranteed full value.
    *
    * @param entityId - UUID of the entity
    * @param options - Query options. The `folderKey` property is **experimental**.
@@ -191,8 +192,9 @@ export interface EntityServiceModel {
    * Sibling of {@link getAllRecords} that addresses the entity by name — useful when you only
    * have the resource name (e.g. solution binding overrides), avoiding a lookup to resolve the ID.
    *
-   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
-   * instead of the full content — use {@link getRecordByName} to retrieve the full value.
+   * `MULTILINE_MAX` fields are returned as a bounded preview, not necessarily the whole
+   * value (see {@link EntityFieldDataType.MULTILINE_MAX}); use {@link getRecordByName} for
+   * the guaranteed full value.
    *
    * @param entityName - Name of the entity
    * @param options - Query options. The `folderKey` property is **experimental**.
@@ -412,6 +414,11 @@ export interface EntityServiceModel {
   /**
    * Updates a single record in an entity, identified by ref (`{ id }` or `{ name }`)
    *
+   * Omit `MULTILINE_MAX` keys unless you intend to replace their content: a record echoed back
+   * from a list or query carries only a preview, and writing that overwrites the stored value
+   * (see {@link EntityFieldDataType.MULTILINE_MAX}). Those fields are not returned in the
+   * response either.
+   *
    * Note: Data Fabric supports trigger events only on individual updates, not on updating multiple records.
    * Use this method if you need trigger events to fire for the updated record.
    *
@@ -436,6 +443,11 @@ export interface EntityServiceModel {
 
   /**
    * Updates a single record in an entity by entity ID
+   *
+   * Omit `MULTILINE_MAX` keys unless you intend to replace their content: a record echoed back
+   * from a list or query carries only a preview, and writing that overwrites the stored value
+   * (see {@link EntityFieldDataType.MULTILINE_MAX}). Those fields are not returned in the
+   * response either.
    *
    * @deprecated Use {@link updateRecord} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
    *
@@ -468,6 +480,11 @@ export interface EntityServiceModel {
   /**
    * Updates data in an entity, identified by ref (`{ id }` or `{ name }`)
    *
+   * Omit `MULTILINE_MAX` keys unless you intend to replace their content: a record echoed back
+   * from a list or query carries only a preview, and writing that overwrites the stored value
+   * (see {@link EntityFieldDataType.MULTILINE_MAX}). Those fields are not returned in the
+   * response either.
+   *
    * Note: Records updated using updateRecords will not trigger Data Fabric trigger events. Use {@link updateRecord} if you need trigger events to fire for each updated record.
    *
    * @param entityRef - Entity ref (`{ id }` (GUID) or `{ name }`)
@@ -490,6 +507,11 @@ export interface EntityServiceModel {
 
   /**
    * Updates data in an entity by entity ID
+   *
+   * Omit `MULTILINE_MAX` keys unless you intend to replace their content: a record echoed back
+   * from a list or query carries only a preview, and writing that overwrites the stored value
+   * (see {@link EntityFieldDataType.MULTILINE_MAX}). Those fields are not returned in the
+   * response either.
    *
    * @deprecated Use {@link updateRecords} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
    *
@@ -615,8 +637,9 @@ export interface EntityServiceModel {
    * Queries entity records with filters, sorting, aggregates, and SDK-managed pagination,
    * identified by ref (`{ id }` or `{ name }`)
    *
-   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
-   * instead of the full content — use {@link getRecordById} to retrieve the full value.
+   * `MULTILINE_MAX` fields are returned as a bounded preview, not necessarily the whole
+   * value (see {@link EntityFieldDataType.MULTILINE_MAX}); use {@link getRecordById} for
+   * the guaranteed full value.
    *
    * Cross-entity joins are supported via the `joins` option — see {@link EntityJoin}
    * for constraints and the result-row key format.
@@ -658,8 +681,9 @@ export interface EntityServiceModel {
    *
    * @deprecated Use {@link queryRecords} with `{ id }` or `{ name }` instead. This method will be removed in a future major version.
    *
-   * `MULTILINE_MAX` fields are returned as a size marker (e.g. `"HasValue=true Length=512"`)
-   * instead of the full content — use {@link getRecordById} to retrieve the full value.
+   * `MULTILINE_MAX` fields are returned as a bounded preview, not necessarily the whole
+   * value (see {@link EntityFieldDataType.MULTILINE_MAX}); use {@link getRecordById} for
+   * the guaranteed full value.
    *
    * Cross-entity joins are supported via the `joins` option — see {@link EntityJoin}
    * for constraints and the result-row key format.
@@ -1099,6 +1123,11 @@ export interface EntityMethods {
   /**
    * Update a single record in this entity
    *
+   * Omit `MULTILINE_MAX` keys unless you intend to replace their content: a record echoed back
+   * from a list or query carries only a preview, and writing that overwrites the stored value
+   * (see {@link EntityFieldDataType.MULTILINE_MAX}). Those fields are not returned in the
+   * response either.
+   *
    * Note: Data Fabric supports trigger events only on individual updates, not on updating multiple records.
    * Use this method if you need trigger events to fire for the updated record.
    *
@@ -1111,6 +1140,11 @@ export interface EntityMethods {
 
   /**
    * Update data in this entity
+   *
+   * Omit `MULTILINE_MAX` keys unless you intend to replace their content: a record echoed back
+   * from a list or query carries only a preview, and writing that overwrites the stored value
+   * (see {@link EntityFieldDataType.MULTILINE_MAX}). Those fields are not returned in the
+   * response either.
    *
    * Note: Records updated using updateRecords will not trigger Data Fabric trigger events. Use {@link updateRecord} if you need
    * trigger events to fire for each updated record.
@@ -1148,6 +1182,10 @@ export interface EntityMethods {
   /**
    * Get all records from this entity
    *
+   * `MULTILINE_MAX` fields are returned as a bounded preview, not necessarily the whole
+   * value (see {@link EntityFieldDataType.MULTILINE_MAX}); use {@link getRecord} for the
+   * guaranteed full value.
+   *
    * @param options - Query options. The `folderKey` property is **experimental**.
    * @returns Promise resolving to query response
    */
@@ -1159,6 +1197,8 @@ export interface EntityMethods {
 
   /**
    * Gets a single record from this entity by record ID
+   *
+   * Returns the full record, including the complete content of `MULTILINE_MAX` fields.
    *
    * @param recordId - UUID of the record
    * @param options - Query options including expansionLevel
@@ -1211,6 +1251,10 @@ export interface EntityMethods {
 
   /**
    * Queries records in this entity with filters, sorting, aggregates, and SDK-managed pagination
+   *
+   * `MULTILINE_MAX` fields are returned as a bounded preview, not necessarily the whole
+   * value (see {@link EntityFieldDataType.MULTILINE_MAX}); use {@link getRecord} for the
+   * guaranteed full value.
    *
    * Cross-entity joins are supported via the `joins` option — see {@link EntityJoin}
    * for constraints and the result-row key format.

--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -30,10 +30,22 @@ export enum EntityFieldDataType {
   BIG_INTEGER = "BIG_INTEGER",
   MULTILINE_TEXT = "MULTILINE_TEXT",
   /**
-   * Large multi-line text (up to 128 KB). Unlike {@link MULTILINE_TEXT}, the full
-   * value is lazy-loaded: list/query operations return a size marker
-   * (e.g. `"HasValue=true Length=512"`) instead of the content; reading a single
-   * record by ID returns the full value.
+   * Large multi-line text, up to a 128 KB byte budget (about 65,536 characters). The
+   * Multi-line (Max) feature must be enabled for the tenant, otherwise creating the field or
+   * adding it to an existing entity is rejected.
+   *
+   * Reads are not uniform, and only a single-record read by ID is guaranteed to return the
+   * whole value. List and query return a bounded preview: the value itself when it is at most
+   * 10,000 characters, its first 10,000 characters followed by `"...[Truncated]"` when longer,
+   * or a size marker starting `"HasValue=true Length=N"`, sometimes with a trailing hint.
+   * Which of those a tenant returns depends on its rollout state, so treat a preview as
+   * opaque: do not parse or compare it, and never write it back, since that replaces the
+   * stored value with the preview. An encrypted field always returns the marker
+   * `"HasValue=true Encrypted=true"` and never content, on any tenant.
+   *
+   * The key is absent rather than null whenever there is no value to return: a null value on
+   * any read, a join query, and insert/update responses. The field cannot be used in
+   * `filterGroup`, `sortOptions`, or a join condition; those requests are rejected.
    */
   MULTILINE_MAX = "MULTILINE_MAX",
   FILE = "FILE",
@@ -311,7 +323,9 @@ export interface EntityHavingFilter {
  * resolve only while unique across the joined entities. Result rows use the
  * same qualified keys; a LEFT join with no match omits the related entity's
  * keys. Joins are not supported on choice-set, relationship, file, encrypted,
- * or system fields, nor on folder-scoped entities.
+ * or system fields, nor on folder-scoped entities. Naming a `MULTILINE_MAX` field in a
+ * join condition is rejected; selecting one is allowed, but its key is omitted from the
+ * result rows, so read the record by ID to get its value.
  *
  * @example
  * ```typescript

--- a/src/utils/constants/endpoints/data-fabric.ts
+++ b/src/utils/constants/endpoints/data-fabric.ts
@@ -23,7 +23,7 @@ export const DATA_FABRIC_ENDPOINTS = {
     GET_ENTITY_RECORDS: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/read`,
     GET_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/Entity/${entityId}`,
     // v2 single-record read. Returns the full record including complete MULTILINE_MAX
-    // content, unlike list/query endpoints which project a size marker for those fields.
+    // content, unlike list/query endpoints which project only a preview for those fields.
     GET_RECORD_BY_ID: (entityId: string, recordId: string) =>
       `${DATAFABRIC_BASE}/api/v2/EntityService/entity/${entityId}/read/${recordId}`,
     INSERT_BY_ID: (entityId: string) => `${DATAFABRIC_BASE}/api/EntityService/entity/${entityId}/insert`,

--- a/tests/integration/shared/data-fabric/entities-schema.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities-schema.integration.test.ts
@@ -9,6 +9,7 @@ import { registerResource } from '../../utils/cleanup';
 import { generateRandomString } from '../../utils/helpers';
 import {
   EntityFieldDataType,
+  EntityRecord,
   FieldDisplayType,
 } from '../../../../src/models/data-fabric/entities.types';
 
@@ -483,12 +484,13 @@ describe.each(modes)('Data Fabric Entities Schema - Integration Tests [%s]', (mo
     }, 150_000);
   });
 
-  // Verifies the MULTILINE_MAX round-trip end to end: create + insert + read the
-  // full value back via getRecordById (v2 read). The list endpoint's size-marker
-  // projection is not asserted — the server threshold is inconsistent and the
-  // consumer-facing guarantee is the full-content read.
+  // Verifies the MULTILINE_MAX read contract end to end. For content over the 10,000-char
+  // truncation limit, list returns one of two preview shapes depending on the tenant
+  // (truncated content, or a size marker), and getRecordById (v2 read) returns the whole
+  // value. The body is 12k to clear that threshold: at or under it list returns the value
+  // verbatim, and the preview assertions would not be exercised.
   describe('MULTILINE_MAX field lifecycle', () => {
-    it('should round-trip a MULTILINE_MAX value via getRecordById', async () => {
+    it('should preview on list and return the full value via getRecordById', async () => {
       const { entities } = getServices();
       const name = `sdk_mlmax_life_${generateRandomString(8).toLowerCase()}`;
 
@@ -497,11 +499,22 @@ describe.each(modes)('Data Fabric Entities Schema - Integration Tests [%s]', (mo
       ]);
       createdEntityIds.push(entityId);
 
-      const bodyValue = `Large body content ${generateRandomString(256)}`;
+      const bodyValue = `Large body content ${generateRandomString(12000)}`;
       const inserted = await entities.insertRecordById(entityId, { body: bodyValue });
       expect(inserted.Id).toBeDefined();
       registerResource('entityRecords', { entityId, recordIds: [inserted.Id] });
 
+      // Over the limit, so the preview must be the truncated content or a size marker.
+      const listed = await entities.getAllRecords(entityId, { pageSize: 50 });
+      const listedRecord = listed.items.find((r: EntityRecord) => r.Id === inserted.Id);
+      expect(listedRecord).toBeDefined();
+      expect(typeof listedRecord!.body).toBe('string');
+      const preview = listedRecord!.body as string;
+      const isTruncated = preview === `${bodyValue.slice(0, 10000)}...[Truncated]`;
+      const isMarker = /^HasValue=true Length=\d+/.test(preview);
+      expect(isTruncated || isMarker).toBe(true);
+
+      // getRecordById (v2 read) returns the full content.
       const full = await entities.getRecordById(entityId, inserted.Id);
       expect(full.body).toBe(bodyValue);
     }, 90_000);


### PR DESCRIPTION
## What

The SDK documented `MULTILINE_MAX` list and query reads as always returning a size marker (`"HasValue=true Length=512"`). That is one of several shapes the backend can return, so the docs promised a guarantee the platform does not make. This corrects the read contract across the whole read surface, adds the two facts a caller hits first (the tenant feature gate and the 400s on filter/sort/join), and restores the list assertions that were dropped from the `MULTILINE_MAX` integration test in #635.

Backend behavior, verified against `SelectQueryBuilder.cs` and the V1/V2/V3 controllers:

| Read | Returns |
|---|---|
| list / query, value <= 10,000 chars | the value verbatim (flag on) |
| list / query, value > 10,000 chars | first 10,000 chars + `...[Truncated]` (flag on) |
| list / query, flag off | `HasValue=true Length=N`, plus a trailing hint on the list route |
| list / query, encrypted field | `HasValue=true Encrypted=true`, never content, either flag state |
| single-record read by ID | the whole value |
| null value, join query, insert/update response | key absent from the row |

Which preview a tenant returns depends on `enable-multiline-max-truncated-content`: on for alpha, off for staging and both gov rings. `enable-multiline-text-max`, which allows the field type at all, is off on prod, agov and pgov, so the type cannot currently be created there.

## How

- `entities.types.ts`: the `MULTILINE_MAX` enum member is now the canonical contract (byte budget and tenant gate, the preview shapes and the instruction to treat a preview as opaque, the key-absent rule and the 400s). `EntityJoin` distinguishes the hard 400 on a join condition from the silently omitted key on `selectedFields`.
- `entities.models.ts`: all four public record-reading methods now carry the preview note and link to the enum (`getAllRecords`, `queryRecordsById` and the bound `EntityModel` twins), `getRecord` gains the full-value note its `getRecordById` twin already had, and both update methods carry the read-modify-write warning inline.
- `data-fabric.ts`: endpoint comment no longer says "size marker".
- Integration test: body raised from 276 to 12,000 characters so a truncating server has to shorten it, and the restored assertions pin the preview to one of the two known shapes rather than merely "different from the stored value", which an empty string also satisfied.

## Security

No authentication, authorization, tenant-isolation or secret-handling surface. Two changes reduce risk: the docs now state that encrypted `MULTILINE_MAX` never returns content on a list or query, and both update methods warn that echoing a preview back silently overwrites the stored value.

Zero executable production lines changed. Filtering the `src/` diff for any non-comment, non-blank line returns nothing.

## Tests

- `npm run build`: exit 0, warnings identical to a clean `main` baseline.
- `tsc --noEmit`: clean. `oxlint`: 0 warnings, 0 errors.
- `npm run test:unit`: 2528 passed, 93 files.
- `typedoc --options typedoc.validation.json`: 0 errors (2 pre-existing unrelated warnings about duplicate `metaData` comments).
- **Not run here:** the `MULTILINE_MAX` integration test. It needs a PAT carrying `DataFabric.Schema.Write` and it creates entities on the target tenant. It should be run once before merge, ideally on a tenant with `enable-multiline-max-truncated-content` on and one with it off, since the assertions are written to hold in both states.

## Review triage

Three adversarial review rounds by an independent reviewer given the diff and the backend source, not the author's rationale.

Round 1 raised 1 P1 and 6 P2/P3. Round 2 raised 2 P2 and 4 P3 (one a regression from the round 1 fix). Round 3 returned clean with an explicit safe-to-ship verdict.

**P1, fixed:** the first version of this change said list and query return a preview "never the full content". False. The truncated projection's inner branch is the bare column, so a value at or under 10,000 characters is returned complete. The words "never the full content" and "lazy-loaded" are gone.

**P2, all fixed:**
- "Encrypted fields always return `HasValue=true Encrypted=true`" was wrong on flag-off tenants because the list route appends a hint. Reworded to a prefix.
- The round 1 fix then over-corrected and made encrypted look as though a short value could arrive verbatim. It cannot. Encrypted is now its own sentence.
- The byte-exact `Length=512` example was accurate only for `queryRecordsById`; `getAllRecords` uses `Marker` mode and appends the hint. The marker is now described as a prefix.
- Half the public read surface had no note: the bound `EntityModel.getAllRecords`, `queryRecords` and `getRecord`. Added.
- Insert and update responses drop `MULTILINE_MAX` entirely, previously undocumented anywhere. Stated in the enum, and inline on the two update methods where the round-trip hazard actually lives. Insert methods intentionally left to the enum: there is no round-trip hazard when supplying new content.
- "Comes back empty" for join queries was imprecise. The key is removed by `ResponseNullRemover`, so consumers see `undefined`. Reworded.

**P3, fixed:** filter, sort and join-condition 400s documented; the test comment no longer restates the false invariant; test assertions tightened and the `typeof` check kept so a broken contract reports what it received; the 128 KB byte budget and the 10,000 character limit separated so the units cannot be conflated.

**P3, accepted as-is:** "sometimes with a trailing hint" attaches grammatically to the `Length=N` marker while the encrypted marker can also carry it on flag-off tenants. The only behavior this could mislead is an equality comparison against the quoted string, which the preceding sentence explicitly forbids. A further caveat would add words for no behavioral gain.

## Follow-ups, not in this PR

- `records list` / `records query` guidance in the `uipath-platform` skill and its `integration_multiline_max` eval encode the same stale marker contract, and the eval's judge rubric currently scores a correct truncation explanation as wrong.
- Join queries project `NULL` for `MULTILINE_MAX` because the original marker was a dot-aliased column pair that could not coexist with the multi-entity path's underscore-flattened aliases. The preview is now a single scalar expression, so that constraint no longer applies and the null could be replaced. Deliberately left alone: bounding join response size is arguably the more valuable property, and nobody has asked for the content.
