### PR TITLE
docs(coded-apps): document redirectUri override for multi-hostname apps

### DIFF
--- a/docs/coded-apps/getting-started.md
+++ b/docs/coded-apps/getting-started.md
@@ -260,6 +260,21 @@ const sdk = new UiPath()
 await sdk.initialize()
 ```
 
+!!! tip "Tip: Overriding the redirect URI"
+    By default, the SDK reads `redirectUri` from the `<meta name="uipath:redirect-uri">` tag. You can also compute it at runtime, which is useful when the same app is reachable at multiple URLs (for example, orgs whose name contains `_` are also reachable at the hyphen form, or apps served from both a self-hosted URL and `uipath.host`):
+
+    ```typescript
+    import { UiPath } from '@uipath/uipath-typescript/core'
+    import { getAppBase } from '@uipath/uipath-typescript'
+
+    const sdk = new UiPath({
+      redirectUri: window.location.origin + getAppBase(),
+    })
+    await sdk.initialize()
+    ```
+
+    `getAppBase()` returns the app root injected by the platform, so the URI stays stable regardless of which route the user is on.
+
 ---
 
 ## Deploy


### PR DESCRIPTION
Adds a tip under the `"Initialize the UiPath SDK"` section of the coded-apps getting-started guide, showing users how to override `redirectUri` at runtime when their app is reachable at multiple hostnames.

<img width="1494" height="995" alt="Screenshot 2026-09-01 at 7 59 11 PM" src="https://github.com/user-attachments/assets/34672dd7-d143-4c0f-98c3-e26084397545" />
