### PR TITLE
feat(queues): apply resource overrides on operational byName paths; adopt getByKeyLookup

### DIFF
--- a/src/services/orchestrator/queues/queues.ts
+++ b/src/services/orchestrator/queues/queues.ts
@@ -28,8 +28,7 @@ import {
   transformData,
   transformOptions
 } from '../../../utils/transform';
-import { NotFoundError, ValidationError } from '../../../core/errors';
-import { CollectionResponse } from '../../../models/common/types';
+import { ValidationError } from '../../../core/errors';
 import { createHeaders } from '../../../utils/http/headers';
 import { FOLDER_ID } from '../../../utils/constants/headers';
 import { resolveFolderHeaders } from '../../../utils/folder/folder-headers';
@@ -40,7 +39,7 @@ import { PaginationHelpers } from '../../../utils/pagination/helpers';
 import { PaginationType } from '../../../utils/pagination/internal-types';
 import { QueueMap, QueueItemMap, QueueItemProcessingErrorMap } from '../../../models/orchestrator/queues.constants';
 import { track } from '../../../core/telemetry';
-import { GUID_REGEX } from '../../../utils/validation/guid';
+import { resolveOverride } from '../../../utils/overrides/resolve-override';
 
 /**
  * Transforms a raw API queue item into the SDK shape. `SpecificContent` and
@@ -179,41 +178,18 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
 
   @track('Queues.GetByKey')
   async getByKey(key: string, options: QueueGetByKeyOptions = {}): Promise<QueueGetWithMethodsResponse> {
-    const trimmedKey = key?.trim();
-    if (!trimmedKey || !GUID_REGEX.test(trimmedKey)) {
-      throw new ValidationError({ message: 'key must be a GUID for getByKey' });
-    }
-
-    const { folderId, folderKey, folderPath, ...queryOptions } = options;
-    const headers = resolveFolderHeaders({
-      folderId,
-      folderKey,
-      folderPath,
-      resourceType: 'Queues.getByKey',
-      fallbackFolderKey: this.config.folderKey
-    });
-
-    const apiFieldOptions = transformOptions(queryOptions, QueueMap);
-    const apiOptions = {
-      ...addPrefixToKeys(apiFieldOptions, ODATA_PREFIX, Object.keys(apiFieldOptions)),
-      '$filter': `Key eq ${trimmedKey}`,
-      '$top': '1'
-    };
-
-    const response = await this.get<CollectionResponse<Record<string, unknown>>>(
+    const { result } = await this.getByKeyLookup<Record<string, unknown>, QueueGetWithMethodsResponse>(
+      'Queue',
       QUEUE_ENDPOINTS.GET_BY_FOLDER,
-      { headers, params: apiOptions }
+      key,
+      options,
+      (raw) => createQueueWithMethods(
+        transformData(pascalToCamelCaseKeys(raw) as QueueGetResponse, QueueMap),
+        this
+      ),
+      QueueMap,
     );
-
-    const items = response.data?.value;
-    if (!items?.length) {
-      throw new NotFoundError({ message: `Queue with key '${trimmedKey}' not found.` });
-    }
-
-    return createQueueWithMethods(
-      transformData(pascalToCamelCaseKeys(items[0]) as QueueGetResponse, QueueMap),
-      this
-    );
+    return result;
   }
 
   @track('Queues.GetAllItems')
@@ -276,10 +252,16 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
       throw new ValidationError({ message: 'queueName is required for insertItemByName' });
     }
 
+    // Runtime override redirects the design-time queue name (+ optionally folderPath) before the
+    // wire body and folder headers are built, mirroring how `getByNameLookup` handles it for reads.
+    const override = resolveOverride('Queue', queueName, options.folderPath);
+    const resolvedName = override?.name ?? queueName;
+    const resolvedFolderPath = override?.folderPath ?? options.folderPath;
+
     const headers = resolveFolderHeaders({
       folderId: options.folderId,
       folderKey: options.folderKey,
-      folderPath: options.folderPath,
+      folderPath: resolvedFolderPath,
       resourceType: 'Queues.insertItemByName',
       fallbackFolderKey: this.config.folderKey
     });
@@ -288,7 +270,7 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
       QUEUE_ENDPOINTS.ADD_ITEM,
       {
         itemData: {
-          Name: queueName,
+          Name: resolvedName,
           Priority: options.priority ?? QueuePriority.Normal,
           Reference: options.reference,
           Progress: options.progress,
@@ -307,23 +289,31 @@ export class QueueService extends FolderScopedService implements QueueServiceMod
 
   @track('Queues.StartTransaction')
   async startTransaction(queue: QueueRef, options: QueueStartTransactionOptions = {}): Promise<QueueItem | null> {
+    // Runtime override applies to the {name} branch — redirects both the wire name and folderPath
+    // header. The {id} branch resolves via the API's own id→name lookup, so overrides don't apply.
+    let resolvedFolderPath = options.folderPath;
+    let queueName: string;
+    if (queue?.name) {
+      const override = resolveOverride('Queue', queue.name, options.folderPath);
+      queueName = override?.name ?? queue.name;
+      resolvedFolderPath = override?.folderPath ?? options.folderPath;
+    } else if (queue?.id == null) {
+      throw new ValidationError({ message: 'queue id or name is required for startTransaction' });
+    } else {
+      queueName = '';
+    }
+
     const headers = resolveFolderHeaders({
       folderId: options.folderId,
       folderKey: options.folderKey,
-      folderPath: options.folderPath,
+      folderPath: resolvedFolderPath,
       resourceType: 'Queues.startTransaction',
       fallbackFolderKey: this.config.folderKey
     });
 
-    // The transaction API identifies the queue by name on the wire — an `id`
-    // selector is resolved to the queue's name first (one extra lookup).
-    let queueName: string;
-    if (queue?.name) {
-      queueName = queue.name;
-    } else if (queue?.id != null) {
-      queueName = await this.resolveQueueName(queue.id, headers);
-    } else {
-      throw new ValidationError({ message: 'queue id or name is required for startTransaction' });
+    if (!queueName) {
+      // {id} branch: resolve the queue name via the by-id lookup (headers already set).
+      queueName = await this.resolveQueueName(queue.id!, headers);
     }
 
     // RobotIdentifier is deliberately not exposed: the API defines it as the key

--- a/tests/unit/services/orchestrator/queues.test.ts
+++ b/tests/unit/services/orchestrator/queues.test.ts
@@ -25,6 +25,7 @@ import {
 import { NotFoundError, ValidationError } from '../../../../src/core/errors';
 import { QUEUE_TEST_CONSTANTS } from '../../../utils/constants/queues';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
+import { OVERRIDE_TEST_CONSTANTS } from '../../../utils/constants/overrides';
 import { QUEUE_ENDPOINTS } from '../../../../src/utils/constants/endpoints';
 import { FOLDER_ID, FOLDER_KEY, FOLDER_PATH_ENCODED } from '../../../../src/utils/constants/headers';
 
@@ -748,6 +749,34 @@ describe('QueueService Unit Tests', () => {
         })
       );
     });
+
+    it('redirects both the wire name and folderPath header when a runtime override matches the queueName', async () => {
+      // Publish an override: caller asks for QUEUE_NAME in Shared/Apps → redirects to
+      // TARGET_NAME in TARGET_FOLDER_PATH. The POST body and header must both scope to the target.
+      const OVERRIDE_KEY = Symbol.for(OVERRIDE_TEST_CONSTANTS.CHANNEL_KEY);
+      (globalThis as Record<symbol, unknown>)[OVERRIDE_KEY] = () => ({
+        [`queue.${QUEUE_TEST_CONSTANTS.QUEUE_NAME}.Shared/Apps`]: {
+          name: OVERRIDE_TEST_CONSTANTS.TARGET_NAME,
+          folderPath: OVERRIDE_TEST_CONSTANTS.TARGET_FOLDER_PATH,
+        },
+      });
+
+      try {
+        mockApiClient.post.mockResolvedValue(createMockRawQueueItem());
+
+        await queueService.insertItemByName(
+          QUEUE_TEST_CONSTANTS.QUEUE_NAME,
+          QUEUE_TEST_CONSTANTS.ITEM_SPECIFIC_CONTENT,
+          { folderPath: 'Shared/Apps' },
+        );
+
+        const [, body, opts] = mockApiClient.post.mock.calls[0];
+        expect(body.itemData.Name).toBe(OVERRIDE_TEST_CONSTANTS.TARGET_NAME);
+        expect(opts?.headers?.[FOLDER_PATH_ENCODED]).toBe(OVERRIDE_TEST_CONSTANTS.TARGET_FOLDER_PATH_ENCODED);
+      } finally {
+        delete (globalThis as Record<symbol, unknown>)[OVERRIDE_KEY];
+      }
+    });
   });
   describe('getByName', () => {
     it('should look up the queue by exact name and attach methods', async () => {
@@ -869,6 +898,7 @@ describe('QueueService Unit Tests', () => {
 
       expect(mockApiClient.get).not.toHaveBeenCalled();
     });
+
   });
 
   describe('startTransaction', () => {
@@ -986,6 +1016,31 @@ describe('QueueService Unit Tests', () => {
         { name: QUEUE_TEST_CONSTANTS.QUEUE_NAME },
         { folderId: TEST_CONSTANTS.FOLDER_ID }
       )).rejects.toThrow(TEST_CONSTANTS.ERROR_MESSAGE);
+    });
+
+    it('redirects both the wire name and folderPath header when a runtime override matches the {name} ref', async () => {
+      const OVERRIDE_KEY = Symbol.for(OVERRIDE_TEST_CONSTANTS.CHANNEL_KEY);
+      (globalThis as Record<symbol, unknown>)[OVERRIDE_KEY] = () => ({
+        [`queue.${QUEUE_TEST_CONSTANTS.QUEUE_NAME}.Shared/Apps`]: {
+          name: OVERRIDE_TEST_CONSTANTS.TARGET_NAME,
+          folderPath: OVERRIDE_TEST_CONSTANTS.TARGET_FOLDER_PATH,
+        },
+      });
+
+      try {
+        mockApiClient.post.mockResolvedValue(createMockRawQueueItem({ Status: 'InProgress' }));
+
+        await queueService.startTransaction(
+          { name: QUEUE_TEST_CONSTANTS.QUEUE_NAME },
+          { folderPath: 'Shared/Apps' },
+        );
+
+        const [, body, opts] = mockApiClient.post.mock.calls[0];
+        expect(body.transactionData.Name).toBe(OVERRIDE_TEST_CONSTANTS.TARGET_NAME);
+        expect(opts?.headers?.[FOLDER_PATH_ENCODED]).toBe(OVERRIDE_TEST_CONSTANTS.TARGET_FOLDER_PATH_ENCODED);
+      } finally {
+        delete (globalThis as Record<symbol, unknown>)[OVERRIDE_KEY];
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Two runtime-override gaps in the Queues service now closed:

- `startTransaction({ name })` now calls `resolveOverride('Queue', name, folderPath)` before building the wire body / folder headers. A cross-folder redirect steers both the transaction body (`transactionData.Name`) and the `X-UIPATH-FolderPath-Encoded` header to the override target. The `{ id }` branch is unaffected (the id → name lookup already hits the server's own id-based route).
- `insertItemByName` applies the same override resolution before posting to `ADD_ITEM`, so overrides published by the host reach the Add-Queue-Item wire body.

Cleanup: `getByKey` now delegates to the shared `FolderScopedService.getByKeyLookup` helper (added in the Assets ref-based PR #684). The service-local GUID/OData plumbing and the `NotFoundError` / `CollectionResponse` imports go away.

Behavior for the `getByName` read path is unchanged — it already went through `getByNameLookup`, which applies overrides internally.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0/0
- [x] `npm run test:unit` — 2731/2731 pass (single failing file is a pre-existing `check-samples.test.ts` module-not-found)
- [x] `npm run build` — exit 0
- New tests:
  - Override redirect on `insertItemByName` — wire `Name` + `X-UIPATH-FolderPath-Encoded` both target the override
  - Override redirect on `startTransaction({ name })` — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)