### PR TITLE
docs(helpers): align helper methods page with SDK doc standards

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -12,7 +12,7 @@ Standalone helper functions that you call directly. Unlike the SDK's services, t
 
 ## httpRequest()
 
-Takes a URL and optional [`HttpRequestInit`](/uipath-typescript/api/interfaces/HttpRequestInit), and resolves to an [`HttpResponse`](/uipath-typescript/api/interfaces/HttpResponse). A status the server returned resolves rather than throwing, even a 4xx or 5xx, so check `ok` to spot a failed request. A call that never reached the server does throw — see [Error Handling](#error-handling).
+Takes a URL and optional [`HttpRequestInit`](/uipath-typescript/api/interfaces/HttpRequestInit), and resolves to an [`HttpResponse`](/uipath-typescript/api/interfaces/HttpResponse). A status the server returned does not by itself throw, even a 4xx or 5xx, so check `ok` to spot a failed request. A few conditions do throw — see [Error Handling](#error-handling).
 
 ```typescript
 import { httpRequest } from '@uipath/uipath-typescript/core';
@@ -35,7 +35,7 @@ Pass `retry` to change any of that. See [`RetryOptions`](/uipath-typescript/api/
 ```typescript
 import { httpRequest } from '@uipath/uipath-typescript/core';
 
-const response = await httpRequest('https://api.example.com/v1/orders', {
+await httpRequest('https://api.example.com/v1/orders', {
   method: 'POST',
   body: { sku: 'ABC-123' },
   retry: {
@@ -74,21 +74,21 @@ Objects and arrays are sent as JSON. Array values in `params` are sent as repeat
 ```typescript
 import { httpRequest } from '@uipath/uipath-typescript/core';
 
-const response = await httpRequest('https://api.example.com/v1/orders', {
+await httpRequest('https://api.example.com/v1/orders', {
   method: 'POST',
   headers: { 'x-api-key': '<apiKey>' },
-  params: { region: 'emea' },
+  params: { region: 'emea', status: ['open', 'shipped'] },
   body: { sku: 'ABC-123' }
 });
 ```
 
 ### Error Handling
 
-Because it makes arbitrary third-party calls, `httpRequest` handles errors differently from the SDK's service methods, which always throw. See the [Error Handling guide](/uipath-typescript/error-handling) for the SDK-wide error types.
+Because it makes arbitrary third-party calls, `httpRequest` handles errors differently from the SDK's service methods, which throw on any failed status. See the [Error Handling guide](/uipath-typescript/error-handling) for the SDK-wide error types.
 
 | Condition | Behavior |
 |-----------|----------|
-| The server returned a status, including 4xx and 5xx | Resolves with `ok: false`. Branch on `ok` or `status` |
+| The server returned a 4xx or 5xx | Resolves with `ok: false`. Branch on `ok` or `status` |
 | The request never produced a response | Throws [`NetworkError`](/uipath-typescript/api/classes/NetworkError) |
 | `responseType: 'json'` is set explicitly and the body does not parse | Throws [`ServerError`](/uipath-typescript/api/classes/ServerError) |
 | `body` is a `ReadableStream` | Throws [`ValidationError`](/uipath-typescript/api/classes/ValidationError) — streaming request bodies are not supported |

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,19 +1,18 @@
 # Helper Methods
 
-Standalone functions you call directly — no `UiPath` instance, no service class.
+Standalone helper functions that you call directly. Unlike the SDK's services, they need no `UiPath` instance and no `initialize()` call — just import them from `@uipath/uipath-typescript/core`.
 
-- **`httpRequest`** calls any URL, with optional retries, backoff, and a per-attempt timeout. It
-  sends no UiPath authentication and adds no UiPath headers, so it is for third-party endpoints —
-  use the SDK's service methods for UiPath itself.
-- **`wait`** pauses for a duration, useful between calls you are pacing yourself.
+| Helper | Description |
+|--------|-------------|
+| [`httpRequest()`](/uipath-typescript/api/functions/httpRequest) | Calls any URL, with optional retries and backoff |
+| [`wait()`](/uipath-typescript/api/functions/wait) | Pauses for a given duration, useful between calls you are pacing yourself |
 
-## Error contract
+!!! warning "For third-party endpoints"
+    `httpRequest` sends no UiPath authentication and adds no UiPath headers. Use the SDK's service methods for UiPath APIs.
 
-Because it proxies arbitrary third-party calls, `httpRequest` follows a different contract from the
-SDK's service methods.
+## httpRequest()
 
-**A status the server returned is never an exception.** A 404 or a 500 comes back as a resolved
-response with `ok: false` — branch on the status rather than catching:
+Takes a URL and optional [`HttpRequestInit`](/uipath-typescript/api/interfaces/HttpRequestInit), and resolves to an [`HttpResponse`](/uipath-typescript/api/interfaces/HttpResponse). A status the server returned resolves rather than throwing, even a 4xx or 5xx, so check `ok` to spot a failed request. A call that never reached the server does throw — see [Error Handling](#error-handling).
 
 ```typescript
 import { httpRequest } from '@uipath/uipath-typescript/core';
@@ -27,52 +26,22 @@ if (response.ok) {
 }
 ```
 
-**`data` is `unknown`.** The body is whatever the server sent — the shape you expect on a success,
-an error payload on a 4xx or 5xx, and nothing at all on a 204. Give it a type once you know which
-you have:
+### Retries and Backoff
+
+By default, the idempotent methods — `GET`, `HEAD`, `PUT`, `DELETE`, and `OPTIONS`, per RFC 9110 — are retried up to twice on a transient failure: a transport error, or a `408`, `429`, `500`, `502`, `503`, or `504`. `POST` and `PATCH` are not retried, since a replayed `POST` can create the same resource twice.
+
+Pass `retry` to change any of that. See [`RetryOptions`](/uipath-typescript/api/interfaces/RetryOptions) for every setting and its default.
 
 ```typescript
-if (response.ok) {
-  const order = response.data as { id: string };
-  console.log(order.id);
-}
-```
+import { httpRequest } from '@uipath/uipath-typescript/core';
 
-**A request that never produced a response still throws.** DNS failures, refused connections,
-a timeout, and caller cancellation all surface as a `NetworkError`:
-
-```typescript
-import { httpRequest, NetworkError } from '@uipath/uipath-typescript/core';
-
-try {
-  await httpRequest('https://api.example.com/v1/orders', { timeoutMs: 5000 });
-} catch (error) {
-  if (error instanceof NetworkError) {
-    console.log('The request never reached the server:', error.message);
-  }
-}
-```
-
-One other case throws: asking for `responseType: 'json'` explicitly when the body does not parse
-raises a `ServerError`. Without an explicit `responseType`, an unparseable body is returned as raw
-text instead — auto-detection is a guess, and a host can label an HTML error page as JSON.
-
-## Retries and backoff
-
-The idempotent methods — `GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS`, per RFC 9110 — are retried up
-to twice by default on a transient failure: a transport error, or a `408`, `429`, `500`, `502`,
-`503`, or `504`. `POST` and `PATCH` are not retried, since a replayed `POST` can create the same
-resource twice. Pass `retry` to change any of that:
-
-```typescript
 const response = await httpRequest('https://api.example.com/v1/orders', {
   method: 'POST',
   body: { sku: 'ABC-123' },
-  timeoutMs: 10000,              // bounds one attempt; each retry gets a fresh timeout
   retry: {
     maxRetries: 4,
-    initialDelayMs: 1000,   // the first delay; later ones grow from it
-    backoffStrategy: 'exponential',     // 1s, 2s, 4s, 8s
+    initialDelayMs: 1000,
+    backoffStrategy: 'exponential',
     backoffFactor: 2,
     backoffMaxDelayMs: 30000,
     retryMethods: ['GET', 'HEAD', 'POST']
@@ -80,36 +49,78 @@ const response = await httpRequest('https://api.example.com/v1/orders', {
 });
 ```
 
+Requests that never reached the server are retried too. Set `retryNetworkErrors` to `false` to retry only on response status codes, leaving connection failures and DNS errors to fail on the first attempt. `timeoutMs` bounds a single attempt rather than the call as a whole, so each retry gets a fresh one.
+
+#### Backoff Strategies
+
 `backoffStrategy` controls how the delay grows, given an `initialDelayMs` of `d` and a `backoffFactor` of `f`:
 
 | Strategy | Delays |
-|---|---|
+|----------|--------|
 | `constant` | `d, d, d, …` |
 | `linear` | `d, 2d, 3d, …` |
 | `exponential` (default) | `d, d×f, d×f², …` |
 
-`backoffFactor` applies only to `exponential`; the other strategies ignore it. Every computed delay
-is capped at `backoffMaxDelayMs`.
+`backoffFactor` applies only to `exponential`; the other strategies ignore it. Every computed delay is capped at `backoffMaxDelayMs`.
 
-A `Retry-After` response header overrides the computed delay unless `respectRetryAfter` is `false`.
-It is honoured as the server sent it — `backoffMaxDelayMs` does not apply to it — so set
-`maxRetryAfterMs` if you need a ceiling on how long a server can ask you to wait.
+#### Retry-After Header
 
-Set `retryNetworkErrors: false` to retry only on response status codes, leaving connection
-failures, DNS errors, and timeouts to fail on the first attempt.
+A `Retry-After` response header overrides the computed delay unless `respectRetryAfter` is `false`. It is applied exactly as the server sent it — `backoffMaxDelayMs` does not apply to it — so set `maxRetryAfterMs` if you need a ceiling on how long a server can ask you to wait.
 
-`timeoutMs` sits outside `retry` deliberately — it bounds a single attempt whether or not
-retrying is enabled, so a call that just needs a deadline does not have to open a bag of retry
-options to get one:
+### Sending a Body and Query Parameters
+
+Objects and arrays are sent as JSON. Array values in `params` are sent as repeated query parameters.
 
 ```typescript
-// one attempt, five second ceiling, no retrying involved
-const response = await httpRequest('https://api.example.com/v1/orders', { timeoutMs: 5000 });
+import { httpRequest } from '@uipath/uipath-typescript/core';
+
+const response = await httpRequest('https://api.example.com/v1/orders', {
+  method: 'POST',
+  headers: { 'x-api-key': apiKey },
+  params: { region: 'emea' },
+  body: { sku: 'ABC-123' }
+});
 ```
 
-A request cancelled through `signal` never retries, regardless of settings.
+### Error Handling
 
-Use `wait` to pause between calls of your own:
+Because it proxies arbitrary third-party calls, `httpRequest` handles errors differently from the SDK's service methods, which always throw. See the [Error Handling guide](/uipath-typescript/error-handling/) for the SDK-wide error types.
+
+| Condition | Behavior |
+|-----------|----------|
+| The server returned a status, including 4xx and 5xx | Resolves with `ok: false`, no exception. Branch on `ok` or `status` |
+| The request never produced a response | Throws [`NetworkError`](/uipath-typescript/api/classes/NetworkError) |
+| `responseType: 'json'` is set explicitly and the body does not parse | Throws [`ServerError`](/uipath-typescript/api/classes/ServerError) |
+
+DNS failures, refused connections, and timeouts all surface as a [`NetworkError`](/uipath-typescript/api/classes/NetworkError). Handling both a failed status and a failed connection looks like this:
+
+```typescript
+import { httpRequest, isNetworkError } from '@uipath/uipath-typescript/core';
+
+try {
+  const response = await httpRequest('https://api.example.com/v1/orders');
+
+  if (response.ok) {
+    console.log(response.data);
+  } else {
+    // The server answered, with a 404 or a 500 for example
+    console.log('Request failed with status', response.status);
+  }
+} catch (error) {
+  if (isNetworkError(error)) {
+    // No response at all
+    console.log('The request never reached the server:', error.message);
+  }
+}
+```
+
+Without an explicit `responseType`, an unparseable body is returned as raw text instead — auto-detection is a guess, and a host can label an HTML error page as JSON.
+
+`data` is typed as `unknown` because the body is whatever the server sent: the shape you expect on a success, an error payload on a 4xx or 5xx, and nothing at all on a 204.
+
+## wait()
+
+Pauses for a duration in milliseconds. Useful for pacing calls of your own, separate from the automatic waits `httpRequest` inserts between retries.
 
 ```typescript
 import { wait } from '@uipath/uipath-typescript/core';

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -49,9 +49,9 @@ const response = await httpRequest('https://api.example.com/v1/orders', {
 });
 ```
 
-Requests that never reached the server are retried too. Set `retryNetworkErrors` to `false` to retry only on response status codes, leaving connection failures and DNS errors to fail on the first attempt. `timeoutMs` bounds a single attempt rather than the call as a whole, so each retry gets a fresh one.
+A request that never reached the server is retried too, as long as its method is retryable. Set `retryNetworkErrors` to `false` to retry only on response status codes, leaving connection failures, DNS errors, and timeouts to fail on the first attempt. `timeoutMs` bounds a single attempt rather than the call as a whole, so each retry gets a fresh one.
 
-#### Backoff Strategies
+### Backoff Strategies
 
 `backoffStrategy` controls how the delay grows, given an `initialDelayMs` of `d` and a `backoffFactor` of `f`:
 
@@ -63,7 +63,7 @@ Requests that never reached the server are retried too. Set `retryNetworkErrors`
 
 `backoffFactor` applies only to `exponential`; the other strategies ignore it. Every computed delay is capped at `backoffMaxDelayMs`.
 
-#### Retry-After Header
+### Retry-After Header
 
 A `Retry-After` response header overrides the computed delay unless `respectRetryAfter` is `false`. It is applied exactly as the server sent it — `backoffMaxDelayMs` does not apply to it — so set `maxRetryAfterMs` if you need a ceiling on how long a server can ask you to wait.
 
@@ -76,7 +76,7 @@ import { httpRequest } from '@uipath/uipath-typescript/core';
 
 const response = await httpRequest('https://api.example.com/v1/orders', {
   method: 'POST',
-  headers: { 'x-api-key': apiKey },
+  headers: { 'x-api-key': '<apiKey>' },
   params: { region: 'emea' },
   body: { sku: 'ABC-123' }
 });
@@ -84,13 +84,14 @@ const response = await httpRequest('https://api.example.com/v1/orders', {
 
 ### Error Handling
 
-Because it proxies arbitrary third-party calls, `httpRequest` handles errors differently from the SDK's service methods, which always throw. See the [Error Handling guide](/uipath-typescript/error-handling/) for the SDK-wide error types.
+Because it makes arbitrary third-party calls, `httpRequest` handles errors differently from the SDK's service methods, which always throw. See the [Error Handling guide](/uipath-typescript/error-handling) for the SDK-wide error types.
 
 | Condition | Behavior |
 |-----------|----------|
-| The server returned a status, including 4xx and 5xx | Resolves with `ok: false`, no exception. Branch on `ok` or `status` |
+| The server returned a status, including 4xx and 5xx | Resolves with `ok: false`. Branch on `ok` or `status` |
 | The request never produced a response | Throws [`NetworkError`](/uipath-typescript/api/classes/NetworkError) |
 | `responseType: 'json'` is set explicitly and the body does not parse | Throws [`ServerError`](/uipath-typescript/api/classes/ServerError) |
+| `body` is a `ReadableStream` | Throws [`ValidationError`](/uipath-typescript/api/classes/ValidationError) — streaming request bodies are not supported |
 
 DNS failures, refused connections, and timeouts all surface as a [`NetworkError`](/uipath-typescript/api/classes/NetworkError). Handling both a failed status and a failed connection looks like this:
 
@@ -125,5 +126,5 @@ Pauses for a duration in milliseconds. Useful for pacing calls of your own, sepa
 ```typescript
 import { wait } from '@uipath/uipath-typescript/core';
 
-await wait(1000); // milliseconds
+await wait(1000); // pause for one second
 ```

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -28,7 +28,7 @@ if (response.ok) {
 
 ### Retries and Backoff
 
-By default, the idempotent methods — `GET`, `HEAD`, `PUT`, `DELETE`, and `OPTIONS`, per RFC 9110 — are retried up to twice on a transient failure: a transport error, or a `408`, `429`, `500`, `502`, `503`, or `504`. `POST` and `PATCH` are not retried, since a replayed `POST` can create the same resource twice.
+By default, the idempotent methods — `GET`, `HEAD`, `PUT`, `DELETE`, and `OPTIONS`, per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-9.2.2) — are retried up to twice on a transient failure: a transport error, or a `408`, `429`, `500`, `502`, `503`, or `504`. `POST` and `PATCH` are not retried, since a replayed `POST` can create the same resource twice.
 
 Pass `retry` to change any of that. See [`RetryOptions`](/uipath-typescript/api/interfaces/RetryOptions) for every setting and its default.
 


### PR DESCRIPTION
## What Changed

The [Helper Methods](https://uipath.github.io/uipath-typescript/helpers/) page had two sections and no usage examples, with its snippets embedded in prose.

It now follows the same shape as the other TypeScript SDK guide pages: sectioned by helper, with each concept carrying its own example and the interface types linked to their generated API reference pages. A minimal `httpRequest()` call opens the page, and retries and backoff — the main reason to reach for the helper — follow directly beneath it.

Docs-only. One file, no source or build changes.

## Structure

```
# Helper Methods           intro + helper table + !!! warning
## httpRequest()           basic call
### Retries and Backoff
### Backoff Strategies
### Retry-After Header
### Sending a Body and Query Parameters
### Error Handling         condition/behavior table + example
## wait()
```

## Consistency

| Before | After |
|--------|-------|
| All examples in a trailing `## Usage Examples` section; the first code on the page was a 12-line retry config | Organized by helper, each concept carrying its own example beneath it, as `error-handling.md` does per error type; a minimal call is now the first code |
| `HttpRequestInit`, `HttpResponse`, `RetryOptions` re-documented inline | Linked to their generated interface pages, as the Entities page does for `EntityCreateOptions` |
| "Error Contract", a term used nowhere else in the docs | "Error Handling", with a cross-link to that guide |
| `wait` listed as a helper but present only as the last example | Its own `## wait()` section |
| Network-error behavior split across two sections 60 lines apart | Merged into one |
| Third-party-endpoint caveat in a plain paragraph | `!!! warning` admonition, as `authentication.md` uses |
| `instanceof NetworkError` in examples | `isNetworkError()` guard, as `error-handling.md` uses |
| `####` headings, absent from the page TOC (`toc_depth: 3`) and used by no sibling page | `###` |

## Accuracy

The page's error contract was wrong in three ways, each verified against the implementation:

- **It advised checking `ok` "rather than catching"** — which reads as *never throws* — then showed an example that catches. Now stated non-exhaustively: a returned status does not by itself throw, and a few conditions do.
- **The error table omitted `ValidationError`.** `prepareBody()` runs outside the `try` wrapping `fetchWithRetry`, so a `ReadableStream` body throws `ValidationError`, not `NetworkError` (`http-request.ts:144` vs `:152`).
- **The network-retry claim was ungated.** `retriesAllowed` is `0` for a method outside `retryMethods` (`fetch-with-retry.ts:107`), so the `POST` in the example above it is not retried on a transport failure.

Smaller corrections: the first table row narrowed to 4xx/5xx, since a 200 also "returned a status" but resolves `ok: true`; "service methods, which always throw" → "throw on any failed status" (`api-client.ts:114`); "proxies arbitrary third-party calls" → "makes", since it calls `fetch` directly; the `<apiKey>` placeholder convention per `agent_docs/rules.md`; `params` now shows an array value, since the prose documents repeated query params but no example demonstrated it; two unused `const response` bindings dropped.

## Files

| Area | Files |
|------|-------|
| Docs | `docs/helpers.md` (224 → 130 lines) |

`mkdocs.yml` already lists the page. No new methods, so no `docs/oauth-scopes.md` entry is owed — `httpRequest` sends no UiPath authentication and consumes no scope, and `wait` makes no request. Not paginated, so no `docs/pagination.md` change.

*🤖 Auto-generated using [onboarding skills](https://github.com/UiPath/uipath-typescript/pull/302)*
