### PR TITLE
feat(data-fabric): preserve raw sqlType on entity field metadata

### DIFF
--- a/src/models/data-fabric/entities.types.ts
+++ b/src/models/data-fabric/entities.types.ts
@@ -728,7 +728,11 @@ export interface FieldMetaData {
   fieldDataType: FieldDataType;
   createdTime: string;
   createdBy: string;
-  /** Raw SQL type from API — present on raw GET responses, used on write payloads */
+  /**
+   * Raw SQL type as returned by the API (e.g., `NVARCHAR`, `INT`,
+   * `UNIQUEIDENTIFIER`). Preserved alongside {@link FieldMetaData.fieldDataType},
+   * which exposes the friendly {@link EntityFieldDataType} name.
+   */
   sqlType?: SqlType;
   updatedTime?: string;
   updatedBy?: string;

--- a/src/services/data-fabric/entities.ts
+++ b/src/services/data-fabric/entities.ts
@@ -568,15 +568,21 @@ export class EntityService extends BaseService implements EntityServiceModel {
     if (!metadata.fields?.length) return;
 
     metadata.fields = metadata.fields.map(field => {
-      // Rename sqlType to fieldDataType
+      // Snapshot the raw sqlType before transformData/mutation — the rename below aliases
+      // sqlType to fieldDataType (same object reference) and we then overwrite its .name.
+      const rawSqlType = field.sqlType ? { ...field.sqlType } : undefined;
       let transformedField = transformData(field, EntityMap);
 
       // Map field type: prefer fieldDisplayType for types that share SQL types (File, ChoiceSet, AutoNumber)
       if (transformedField.fieldDataType?.name) {
-        const mapped = this.tryResolveFieldDataType(transformedField.fieldDisplayType, field.sqlType?.name);
+        const mapped = this.tryResolveFieldDataType(transformedField.fieldDisplayType, rawSqlType?.name);
         if (mapped) {
           transformedField.fieldDataType.name = mapped;
         }
+      }
+
+      if (rawSqlType) {
+        transformedField.sqlType = rawSqlType;
       }
 
       this.transformNestedReferences(transformedField);
@@ -629,7 +635,13 @@ export class EntityService extends BaseService implements EntityServiceModel {
         externalSource.fields = externalSource.fields.map(field => {
           const transformedField = transformData(field, EntityMap);
           if (transformedField.fieldMetaData) {
+            const rawSqlType = transformedField.fieldMetaData.sqlType
+              ? { ...transformedField.fieldMetaData.sqlType }
+              : undefined;
             transformedField.fieldMetaData = transformData(transformedField.fieldMetaData, EntityMap);
+            if (rawSqlType) {
+              transformedField.fieldMetaData.sqlType = rawSqlType;
+            }
             this.transformNestedReferences(transformedField.fieldMetaData);
           }
           return transformedField;

--- a/tests/integration/shared/data-fabric/entities-records.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities-records.integration.test.ts
@@ -317,6 +317,8 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
       expect(field.name).toBeDefined();
       expect(field.fieldDataType).toBeDefined();
       expect(field.fieldDataType?.name).toBeDefined();
+      expect(field.sqlType).toBeDefined();
+      expect(typeof field.sqlType?.name).toBe('string');
       expect(typeof field.isSystemField).toBe('boolean');
       expect(typeof field.isRequired).toBe('boolean');
 

--- a/tests/unit/services/data-fabric/entities.test.ts
+++ b/tests/unit/services/data-fabric/entities.test.ts
@@ -401,10 +401,11 @@ describe("EntityService Unit Tests", () => {
 
         // Verify field-level transformations
         entity.fields.forEach((field) => {
-          // sqlType -> fieldDataType
+          // sqlType preserved as raw wire type alongside friendly fieldDataType
           expect(field.fieldDataType).toBeDefined();
           expect(field.fieldDataType.name).toBeDefined();
-          expect(field).not.toHaveProperty("sqlType"); // Raw field should not exist
+          expect(field.sqlType).toBeDefined();
+          expect(typeof field.sqlType!.name).toBe("string");
 
           // Use type assertion to check for any remaining raw field names
           const fieldAsAny = field as any;
@@ -2149,7 +2150,8 @@ describe("EntityService Unit Tests", () => {
       expect(result.fields[0].fieldDataType.name).toBe(
         ENTITY_TEST_CONSTANTS.FIELD_TYPE_UUID,
       );
-      expect(result.fields[0]).not.toHaveProperty("sqlType");
+      // sqlType preserved with raw wire name
+      expect(result.fields[0].sqlType).toEqual({ name: "UNIQUEIDENTIFIER" });
 
       // Bound methods attached (same as getById)
       expect(typeof result.insertRecord).toBe("function");


### PR DESCRIPTION
Snapshot the raw sqlType before transformData renames+mutates it into fieldDataType so callers of getById / getByName / getAll now see the raw API wire type (e.g. NVARCHAR, INT, UNIQUEIDENTIFIER) alongside the friendly EntityFieldDataType name.