### PR TITLE
test(maestro): fix resumes and size lifecycle waits to case tests

### DIFF
--- a/tests/integration/shared/data-fabric/entities-records.integration.test.ts
+++ b/tests/integration/shared/data-fabric/entities-records.integration.test.ts
@@ -16,6 +16,7 @@ import {
   QueryFilterOperator,
   RawEntityGetResponse,
 } from '../../../../src/models/data-fabric/entities.types';
+import { EntityGetResponse } from '../../../../src/models/data-fabric/entities.models';
 import { DATA_FABRIC_TENANT_FOLDER_ID } from '../../../../src/utils/constants/endpoints/data-fabric';
 
 // Cache for choice set values to avoid repeated API calls within a test run
@@ -587,20 +588,25 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
 
   describe('Entity-level methods (via getById)', () => {
     const entityMethodRecordIds: string[] = [];
+    let entity!: EntityGetResponse;
+    let entityId!: string;
 
-    it('should insert a single record via entity.insertRecord', async () => {
+    // One shared getById for the whole block (rules.md: shared lookups belong in
+    // beforeAll). Re-fetching inside each test also spent part of every write
+    // test's timeout budget on a read that can itself hit a tenant stall.
+    beforeAll(async () => {
       const { entities } = getServices();
       const config = getTestConfig();
-
-      const entityId = config.dataFabricTestEntityId || testEntityId;
-
-      if (!entityId) {
+      const resolved = config.dataFabricTestEntityId || testEntityId;
+      if (!resolved) {
         throw new Error('No entity ID available for testing');
       }
-
-      const entity = await entities.getById(entityId);
+      entityId = resolved;
+      entity = await entities.getById(entityId);
       entityMetadata = entity;
+    }, 90_000);
 
+    it('should insert a single record via entity.insertRecord', async () => {
       const testData = await buildDummyRecord(entity);
       const result = await entity.insertRecord(testData);
 
@@ -613,21 +619,9 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
         entityId,
         recordIds: [result.Id],
       });
-    });
+    }, 90_000);
 
     it('should insert multiple records via entity.insertRecords', async () => {
-      const { entities } = getServices();
-      const config = getTestConfig();
-
-      const entityId = config.dataFabricTestEntityId || testEntityId;
-
-      if (!entityId) {
-        throw new Error('No entity ID available for testing');
-      }
-
-      const entity = await entities.getById(entityId);
-      entityMetadata = entity;
-
       const testData = await Promise.all([buildDummyRecord(entity), buildDummyRecord(entity)]);
       const result = await entity.insertRecords(testData);
 
@@ -644,19 +638,9 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
         entityId,
         recordIds: insertedIds,
       });
-    });
+    }, 90_000);
 
     it('should retrieve all records via entity.getAllRecords', async () => {
-      const { entities } = getServices();
-      const config = getTestConfig();
-
-      const entityId = config.dataFabricTestEntityId || testEntityId;
-
-      if (!entityId) {
-        throw new Error('No entity ID available for testing');
-      }
-
-      const entity = await entities.getById(entityId);
       const result = await entity.getAllRecords({ pageSize: 5 });
 
       expect(result).toBeDefined();
@@ -666,16 +650,10 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
     });
 
     it('should retrieve a single record via entity.getRecord', async () => {
-      const { entities } = getServices();
-      const config = getTestConfig();
-
-      const entityId = config.dataFabricTestEntityId || testEntityId;
-
-      if (!entityId || entityMethodRecordIds.length === 0) {
+      if (entityMethodRecordIds.length === 0) {
         throw new Error('No records available to test getRecord');
       }
 
-      const entity = await entities.getById(entityId);
       const recordId = entityMethodRecordIds[0];
       const record = await entity.getRecord(recordId);
 
@@ -684,17 +662,9 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
     });
 
     it('should update records via entity.updateRecords', async () => {
-      const { entities } = getServices();
-      const config = getTestConfig();
-
-      const entityId = config.dataFabricTestEntityId || testEntityId;
-
-      if (!entityId || entityMethodRecordIds.length === 0) {
+      if (entityMethodRecordIds.length === 0) {
         throw new Error('No records available to update');
       }
-
-      const entity = await entities.getById(entityId);
-      entityMetadata = entity;
 
       const updateField = getWritableFields(entity.fields).find(
         (f) =>
@@ -714,19 +684,13 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
       expect(result).toBeDefined();
       expect(result.successRecords).toBeDefined();
       expect(Array.isArray(result.successRecords)).toBe(true);
-    });
+    }, 90_000);
 
     it('should delete records via entity.deleteRecords', async () => {
-      const { entities } = getServices();
-      const config = getTestConfig();
-
-      const entityId = config.dataFabricTestEntityId || testEntityId;
-
-      if (!entityId || entityMethodRecordIds.length === 0) {
+      if (entityMethodRecordIds.length === 0) {
         throw new Error('No records available to delete');
       }
 
-      const entity = await entities.getById(entityId);
       const result = await entity.deleteRecords(entityMethodRecordIds);
 
       expect(result).toBeDefined();
@@ -739,7 +703,7 @@ describe.each(modes)('Data Fabric Entities Records - Integration Tests [%s]', (m
         }
       }
       entityMethodRecordIds.length = 0;
-    });
+    }, 90_000);
   });
 
   describe('updateRecordById', () => {

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -333,16 +333,22 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
       const resumeResult = await caseInstances.resume(target.instanceId, target.folderKey);
       expect(resumeResult.success).toBe(true);
 
-      // The instance must return to Running so later tests can keep using it. The
-      // Paused→Running propagation is accepted immediately (success asserted above) but
-      // has been observed to take well over 20s under tenant load, so the wait window
-      // is sized for that tail rather than the ~5s typical case.
+      // The instance must return to Running so later tests can keep using it. A resume
+      // issued while the pause is still settling (status Pausing) is accepted but can be
+      // lost — the pause completes afterwards and wins, leaving the instance Paused
+      // (observed live: success=true resume, then Paused for 60s+). When the status
+      // settles on Paused without running again, re-issue the resume: it is idempotent
+      // from Paused and no longer races the pause transition.
       let resumedStatus = '';
       for (let attempt = 0; attempt < 30; attempt++) {
         const current = await caseInstances.getById(target.instanceId, target.folderKey);
         resumedStatus = current.latestRunStatus;
         if (resumedStatus === InstanceStatus.RUNNING) {
           break;
+        }
+        // ~every 10s of settled Paused, assume the earlier resume was lost and re-issue
+        if (resumedStatus === InstanceStatus.PAUSED && attempt % 5 === 4) {
+          await caseInstances.resume(target.instanceId, target.folderKey);
         }
         await new Promise((resolve) => setTimeout(resolve, 2000));
       }
@@ -422,9 +428,11 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
         instanceId = job.key;
       }
 
-      // Check immediately, then poll only if it has not completed yet
+      // Check immediately, then poll only if it has not completed yet. Completion takes
+      // ~45s idle but the execution engine stalls for minutes under load — sized to the
+      // same 180s ceiling the retry test uses for the equivalent fault wait.
       let completed = false;
-      for (let attempt = 0; attempt < 24; attempt++) {
+      for (let attempt = 0; attempt < 36; attempt++) {
         try {
           const instance = await caseInstances.getById(instanceId, config.folderKey);
           if (instance.latestRunStatus === InstanceStatus.COMPLETED) {
@@ -437,7 +445,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
       if (!completed) {
-        throw new Error('Seeded auto-completing case instance did not complete within 120s');
+        throw new Error('Seeded auto-completing case instance did not complete within 180s');
       }
 
       const stages = await caseInstances.getStages(instanceId, config.folderKey);
@@ -454,7 +462,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
       // Cleanup: close the reopened instance — reopened instances do NOT re-complete on
       // their own, and letting them accumulate saturates the tenant's execution queue.
       await caseInstances.close(instanceId, config.folderKey);
-    }, 180_000);
+    }, 240_000);
   });
 
   describe('Case instance structure validation', () => {

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -333,9 +333,12 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
       const resumeResult = await caseInstances.resume(target.instanceId, target.folderKey);
       expect(resumeResult.success).toBe(true);
 
-      // The instance must return to Running so later tests can keep using it
+      // The instance must return to Running so later tests can keep using it. The
+      // Paused→Running propagation is accepted immediately (success asserted above) but
+      // has been observed to take well over 20s under tenant load, so the wait window
+      // is sized for that tail rather than the ~5s typical case.
       let resumedStatus = '';
-      for (let attempt = 0; attempt < 10; attempt++) {
+      for (let attempt = 0; attempt < 30; attempt++) {
         const current = await caseInstances.getById(target.instanceId, target.folderKey);
         resumedStatus = current.latestRunStatus;
         if (resumedStatus === InstanceStatus.RUNNING) {
@@ -344,7 +347,7 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
         await new Promise((resolve) => setTimeout(resolve, 2000));
       }
       expect(resumedStatus).toBe(InstanceStatus.RUNNING);
-    }, 60_000);
+    }, 120_000);
   });
 
   // Runs after pause/resume (see note there): the ad-hoc trigger spawns an in-flight task

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -35,6 +35,22 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
       return null;
     }
 
+    // Reuse an existing Running instance of the fixture process before starting a new
+    // one — interrupted runs leave them Running indefinitely (the human task never
+    // completes), so scavenging them curbs instance growth in the tenant, where
+    // terminal instances cannot be deleted via API.
+    const existing = await caseInstances.getAll({
+      processKey: config.maestroCaseProcessKey,
+      pageSize: 20,
+    });
+    const runningOrphan = existing.items.find(
+      (inst) =>
+        inst.latestRunStatus === InstanceStatus.RUNNING && inst.folderKey === config.folderKey
+    );
+    if (runningOrphan) {
+      return { instanceId: runningOrphan.instanceId, folderKey: runningOrphan.folderKey };
+    }
+
     const [job] = await processes.start(
       { processKey: config.maestroCaseProcessKey },
       { folderId: Number(config.folderId) }
@@ -61,16 +77,32 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
   let seededCompletedJobKey: string | null = null;
 
   beforeAll(async () => {
-    const { processes } = getServices();
+    const { processes, caseInstances } = getServices();
     const config = getTestConfig();
 
-    // Fire-and-forget the reopen fixture first so its completion overlaps the suite
-    if (config.maestroCompletedCaseProcessKey && config.folderId) {
-      const [job] = await processes.start(
-        { processKey: config.maestroCompletedCaseProcessKey },
-        { folderId: Number(config.folderId) }
+    // Provide the reopen fixture first so any completion wait overlaps the suite.
+    // Reuse a Completed timer instance from an interrupted run before starting a new
+    // one — reuse keeps instance growth down, and an existing Completed instance means
+    // the reopen test has zero wait.
+    if (config.maestroCompletedCaseProcessKey && config.folderId && config.folderKey) {
+      const existing = await caseInstances.getAll({
+        processKey: config.maestroCompletedCaseProcessKey,
+        pageSize: 20,
+      });
+      const completedOrphan = existing.items.find(
+        (inst) =>
+          inst.latestRunStatus === InstanceStatus.COMPLETED &&
+          inst.folderKey === config.folderKey
       );
-      seededCompletedJobKey = job.key;
+      if (completedOrphan) {
+        seededCompletedJobKey = completedOrphan.instanceId;
+      } else {
+        const [job] = await processes.start(
+          { processKey: config.maestroCompletedCaseProcessKey },
+          { folderId: Number(config.folderId) }
+        );
+        seededCompletedJobKey = job.key;
+      }
     }
 
     seededInstance = await seedRunningInstance();

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -82,15 +82,33 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
     }
   }, 120_000);
 
-  /** Prefers the instance seeded for this run; falls back to any running instance. */
+  /**
+   * Prefers the instance seeded for this run; falls back to any running instance.
+   * The seeded instance can die on its own between tests (observed live: a transient
+   * platform fault moved it Running→Faulted, making the next pause fail with an invalid
+   * state transition), so its status is re-verified on every resolve and a replacement
+   * is seeded when it is no longer Running.
+   */
   const resolveRunningInstance = async (): Promise<{
     instanceId: string;
     folderKey: string;
   } | null> => {
-    if (seededInstance) {
-      return seededInstance;
-    }
     const { caseInstances } = getServices();
+
+    if (seededInstance) {
+      const current = await caseInstances.getById(
+        seededInstance.instanceId,
+        seededInstance.folderKey
+      );
+      if (current.latestRunStatus === InstanceStatus.RUNNING) {
+        return seededInstance;
+      }
+      seededInstance = await seedRunningInstance();
+      if (seededInstance) {
+        return seededInstance;
+      }
+    }
+
     const instances = await caseInstances.getAll({ pageSize: 20 });
     const found = instances.items.find(
       (inst) => inst.latestRunStatus === InstanceStatus.RUNNING && inst.folderKey
@@ -380,7 +398,8 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
           { itemData: { taskNames: [`sdk-integration-${generateRandomString(8)}`] } }
         )
       ).resolves.toBeUndefined();
-    });
+      // 120s: resolveRunningInstance may re-seed a dead fixture (up to ~90s)
+    }, 120_000);
   });
 
   describe('close', () => {
@@ -402,7 +421,8 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
         // Consumed the seeded instance; afterAll must not close it again
         seededInstance = null;
       }
-    });
+      // 120s: resolveRunningInstance may re-seed a dead fixture (up to ~90s)
+    }, 120_000);
   });
 
   // Reopen requires a Completed instance (close produces Cancelled, which PIMS rejects),

--- a/tests/integration/shared/maestro/case-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/case-instances.integration.test.ts
@@ -346,7 +346,9 @@ describe.each(modes)('Maestro Case Instances - Integration Tests [%s]', (mode) =
         if (resumedStatus === InstanceStatus.RUNNING) {
           break;
         }
-        // ~every 10s of settled Paused, assume the earlier resume was lost and re-issue
+        // On every 5th poll that reads Paused, assume the earlier resume was lost and
+        // re-issue it (a trailing re-issue also restores the shared instance for later
+        // tests even when this assertion is about to fail)
         if (resumedStatus === InstanceStatus.PAUSED && attempt % 5 === 4) {
           await caseInstances.resume(target.instanceId, target.folderKey);
         }

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -264,7 +264,9 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
       const instance = await processInstances.getById(job.key, config.folderKey);
       expect(instance.latestRunStatus).toMatch(/cancel|stopped|terminated/i);
-    }, 60_000);
+      // 120s: the wait-for-Running poll alone spans up to 60s (20 × 3s) before the cancel
+      // call and verification, and CI runs have timed this test out at 60s under load
+    }, 120_000);
   });
 
   // Self-seeding: starts a fresh instance of the deliberately-faulting process (faults in

--- a/tests/integration/shared/maestro/process-instances.integration.test.ts
+++ b/tests/integration/shared/maestro/process-instances.integration.test.ts
@@ -264,7 +264,8 @@ describe.each(modes)('Maestro Process Instances - Integration Tests [%s]', (mode
 
       const instance = await processInstances.getById(job.key, config.folderKey);
       expect(instance.latestRunStatus).toMatch(/cancel|stopped|terminated/i);
-      // 120s: the wait-for-Running poll alone spans up to 60s (20 × 3s) before the cancel
+      // 120s: the wait-for-Running poll alone spans ~40-60s (20 polls at 2s intervals
+      // plus per-request latency) before the cancel
       // call and verification, and CI runs have timed this test out at 60s under load
     }, 120_000);
   });


### PR DESCRIPTION
Re-lands the pause/resume fix from #693 (closed unmerged) and hardens the maestro suites against fixture death and tenant instance growth.

- **Lost-resume race** (the `expected 'Paused' to be 'Running'` flake): a resume issued while the pause is still settling is accepted but can be lost — the test now re-issues the resume when the status settles on `Paused`.
- **Fixture health-check**: the seeded Running.Case instance can fault on its own (observed live); `resolveRunningInstance` re-verifies its status on every use and seeds a replacement when it is no longer Running.
- **Reuse before seeding, all fixtures**: Running.Case scavenges an existing Running instance (interrupted runs leave them Running indefinitely), the timer case reuses a Completed leftover (also zero reopen wait), matching the pattern the faulted retry fixture already uses. Terminal instances cannot be deleted via API, so creation is the only growth lever — steady-state creation drops to one instance per consuming test.
- **Wait sizing**: cancel 120s (its poll alone spans ~40–60s), reopen completion 180s (matches the retry fault wait), per CI-observed tails.

Verified green in both init modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)