### PR TITLE
chore: bump version to 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uipath/uipath-typescript",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "license": "MIT",
             "dependencies": {
                 "@uipath/core-telemetry": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/uipath-typescript",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "UiPath TypeScript SDK",
     "license": "MIT",
     "keywords": [

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "sdkVersion": "1.7.0",
+  "sdkVersion": "1.7.1",
   "services": [
     {
       "name": "AgentMemory",
@@ -117,8 +117,16 @@
           "since": null
         },
         {
+          "name": "getByKey",
+          "since": "1.7.1"
+        },
+        {
           "name": "getByName",
           "since": null
+        },
+        {
+          "name": "updateValue",
+          "since": "1.7.1"
         },
         {
           "name": "updateValueById",
@@ -366,8 +374,16 @@
           "since": "1.7.0"
         },
         {
+          "name": "deleteRecord",
+          "since": "1.7.1"
+        },
+        {
           "name": "deleteRecordById",
           "since": null
+        },
+        {
+          "name": "deleteRecords",
+          "since": "1.7.1"
         },
         {
           "name": "deleteRecordsById",
@@ -390,12 +406,28 @@
           "since": null
         },
         {
+          "name": "getByName",
+          "since": "1.7.1"
+        },
+        {
           "name": "getRecordById",
           "since": null
         },
         {
+          "name": "getRecordByName",
+          "since": "1.7.1"
+        },
+        {
           "name": "getRecordsById",
           "since": null
+        },
+        {
+          "name": "getRecordsByName",
+          "since": "1.7.1"
+        },
+        {
+          "name": "importRecords",
+          "since": "1.7.1"
         },
         {
           "name": "importRecordsById",
@@ -406,12 +438,24 @@
           "since": null
         },
         {
+          "name": "insertRecord",
+          "since": "1.7.1"
+        },
+        {
           "name": "insertRecordById",
           "since": null
         },
         {
+          "name": "insertRecords",
+          "since": "1.7.1"
+        },
+        {
           "name": "insertRecordsById",
           "since": null
+        },
+        {
+          "name": "queryRecords",
+          "since": "1.7.1"
         },
         {
           "name": "queryRecordsById",
@@ -422,8 +466,16 @@
           "since": "1.7.0"
         },
         {
+          "name": "updateRecord",
+          "since": "1.7.1"
+        },
+        {
           "name": "updateRecordById",
           "since": null
+        },
+        {
+          "name": "updateRecords",
+          "since": "1.7.1"
         },
         {
           "name": "updateRecordsById",


### PR DESCRIPTION
Version bump `1.7.0` → `1.7.1` for today's release. Changes only `package.json` and `package-lock.json`; `release-metadata.json` is regenerated off a fresh build and committed on this branch (the `Regenerate release-metadata` workflow re-verifies it).

**Why patch, not minor:** no PR merged since `1.7.0` carries a breaking-change label, removes a public method, or changes an existing signature. Superseded methods (#682, #684) stay as `@deprecated` delegators.

## Draft release notes (1.7.1)

```
### New Features & Improvements

- Added `httpRequest()` helper method for calling third-party APIs with configurable retry & backoff, and `wait()` helper (#695)
- Added `getByName()`, `getRecordsByName()`, `getRecordByName()` methods in Entities, and ref-based `insertRecord()`, `updateRecord()`, `deleteRecord()`, `queryRecords()`, `importRecords()`, `uploadAttachment()`, `downloadAttachment()`, `deleteAttachment()` accepting `{ id }` or `{ name }`; `*ById` variants deprecated (#682)
- Added `updateValue()` and `getByKey()` methods in Assets; `updateValueById()` deprecated (#684)
- Fixed `MULTILINE_MAX` read contract in Data Fabric docs (#703)
- Added `JobAttachmentSchema` input type in Attachments (#705)
- Added QuickForm task support in `Tasks.create()` via `type: TaskType.QuickForm` (#488)

---

**Full Changelog**: https://github.com/UiPath/uipath-typescript/compare/1.7.0...1.7.1
```

Excluded as not user-facing: [#671](https://github.com/UiPath/uipath-typescript/pull/671) (Business Apps service — entirely `@internal`, hidden from docs and `release-metadata.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
