### PR TITLE
feat(core): add setDebugContext to attach X-UIPATH-JobKey on requests

### DIFF
--- a/packages/coded-action-app/src/types.ts
+++ b/packages/coded-action-app/src/types.ts
@@ -33,6 +33,14 @@ export type Task = {
   folderName: string;
   /** UI theme that Action Center is currently using. */
   theme: Theme;
+  /** Key of the job behind the task, when a running process created it. `null` otherwise. */
+  jobKey?: string | null;
+  /** Whether the task was created by a debug run. Pass `jobKey` to the SDK's `setDebugContext` so the app's calls join the debug session. */
+  isDebug?: boolean;
+  /** Solution id of the debug session, when the task is a debug task of a solution the app belongs to. */
+  solutionId?: string | null;
+  /** Design project id of the app, when the task is a debug task of a solution the app belongs to. */
+  appProjectKey?: string | null;
 };
 
 /** UI theme applied to Action Center, passed to the coded action app on load. */

--- a/src/core/context/execution.ts
+++ b/src/core/context/execution.ts
@@ -1,3 +1,6 @@
+/** Context key under which the SDK's debug context (parent job key) is stored. */
+export const DEBUG_CONTEXT_KEY = 'debugContext';
+
 /**
  * ExecutionContext manages the state and context of API operations.
  * It provides a way to share context across service calls and maintain

--- a/src/core/http/api-client.ts
+++ b/src/core/http/api-client.ts
@@ -1,11 +1,12 @@
 import { Config } from '../config/config';
-import { ExecutionContext } from '../context/execution';
+import { DEBUG_CONTEXT_KEY, ExecutionContext } from '../context/execution';
+import { DebugContext } from '../../models/common/types';
 import { RequestSpec } from '../../models/common/request-spec';
 import { TokenManager } from '../auth/token-manager';
 import { errorResponseParser } from '../errors/parser';
 import { ErrorFactory } from '../errors/error-factory';
 import { ServerError } from '../errors/server';
-import { CONTENT_TYPES, RESPONSE_TYPES, TRACEPARENT, UIPATH_TRACEPARENT_ID } from '../../utils/constants/headers';
+import { CONTENT_TYPES, JOB_KEY, RESPONSE_TYPES, TRACEPARENT, UIPATH_TRACEPARENT_ID } from '../../utils/constants/headers';
 import { toSearchParams } from '../../utils/http/params';
 import { fetchWithRetry } from '../../utils/http/fetch-with-retry';
 import { DEFAULT_API_CLIENT_RETRY, resolveRetryOptions } from '../../utils/http/retry-policy';
@@ -79,8 +80,13 @@ export class ApiClient {
     const spanId = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
     const traceparentValue = `00-${traceId}-${spanId}-01`;
 
+    // While a debug context is set, the platform routes runs triggered by these
+    // requests as debug sub-jobs of the parent job (JIT debug).
+    const debugContext = this.executionContext.get<DebugContext>(DEBUG_CONTEXT_KEY);
+
     const headers: Record<string, string> = {
       ...defaultHeaders,
+      ...(debugContext?.jobKey ? { [JOB_KEY]: debugContext.jobKey } : {}),
       [TRACEPARENT]: traceparentValue,
       [UIPATH_TRACEPARENT_ID]: traceparentValue,
       ...options.headers

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -10,6 +10,7 @@
 
 import type { BaseConfig } from './config/sdk-config';
 import type { TokenInfo, LogoutOptions } from './auth/types';
+import type { DebugContext } from '../models/common/types';
 
 export interface IUiPath {
   /** Read-only configuration for the SDK instance */
@@ -67,4 +68,11 @@ export interface IUiPath {
    * @param tokenInfo - The token information containing the access token, type, expiration, and optional refresh/ID tokens
    */
   updateToken(tokenInfo: TokenInfo): void;
+
+  /**
+   * Sets the debug context applied to all subsequent API requests, or clears it with `null`.
+   * While set, requests carry the parent job key so the platform routes runs they trigger
+   * as debug sub-jobs of that session.
+   */
+  setDebugContext(context: DebugContext | null): void;
 }

--- a/src/core/uipath.ts
+++ b/src/core/uipath.ts
@@ -1,7 +1,8 @@
 import { UiPathConfig } from './config/config';
-import { ExecutionContext } from './context/execution';
+import { DEBUG_CONTEXT_KEY, ExecutionContext } from './context/execution';
 import { AuthService } from './auth/service';
 import { TokenInfo, LogoutOptions } from './auth/types';
+import type { DebugContext } from '../models/common/types';
 import { UiPathSDKConfig, PartialUiPathConfig, BaseConfig, hasOAuthConfig, hasSecretConfig } from './config/sdk-config';
 import { validateConfig, normalizeBaseUrl, isCompleteConfig, compactConfig, missingConfigMessage } from './config/config-utils';
 import { telemetryClient, trackEvent } from './telemetry';
@@ -397,6 +398,27 @@ export class UiPath implements IUiPath {
    */
   public updateToken(tokenInfo: TokenInfo): void {
     this.#authService?.updateToken(tokenInfo);
+  }
+
+  /**
+   * Sets the debug context applied to all subsequent API requests made through this instance.
+   * While set, requests carry the parent job key so the platform routes runs they trigger as
+   * debug sub-jobs of that session — use it when the app is hosted inside a platform debug run
+   * (for example, a coded action app opened from a debug task in Action Center).
+   * Pass `null` to clear the context and return to normal request behavior.
+   *
+   * @param context - The debug context ({@link DebugContext}) with the parent job key, or `null` to clear it
+   *
+   * @example
+   * ```typescript
+   * const task = await codedActionApp.getTask();
+   * if (task.isDebug && task.jobKey) {
+   *   sdk.setDebugContext({ jobKey: task.jobKey });
+   * }
+   * ```
+   */
+  public setDebugContext(context: DebugContext | null): void {
+    SDKInternalsRegistry.get(this).context.set(DEBUG_CONTEXT_KEY, context ?? undefined);
   }
 
 }

--- a/src/models/common/types.ts
+++ b/src/models/common/types.ts
@@ -87,3 +87,14 @@ export interface FolderScopingOnly {
  * {@link FolderScopingOnly}.
  */
 export interface FolderScopedOptions extends BaseOptions, FolderScopingOnly {}
+
+/**
+ * Debug context applied to API requests while the app runs inside a platform
+ * debug session (for example, a coded action app opened from a debug task in
+ * Action Center). While set, every request carries the parent job key so the
+ * platform routes runs it triggers as debug sub-jobs of that session.
+ */
+export interface DebugContext {
+  /** Job key of the debug parent job, delivered to the app by its host (e.g. Action Center task context). */
+  jobKey: string;
+}

--- a/tests/unit/core/http/api-client.test.ts
+++ b/tests/unit/core/http/api-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ApiClient } from '../../../../src/core/http/api-client';
+import { DEBUG_CONTEXT_KEY, ExecutionContext } from '../../../../src/core/context/execution';
 import { ServerError } from '../../../../src/core/errors/server';
 import { NetworkError } from '../../../../src/core/errors/network';
 import { TEST_CONSTANTS } from '../../../utils/constants/common';
@@ -17,7 +18,7 @@ const mockConfig = {
   tenantName: TEST_CONSTANTS.TENANT_ID,
 };
 
-const mockExecutionContext = {};
+const mockExecutionContext = { get: vi.fn() };
 
 let capturedHeaders: Record<string, string> = {};
 let capturedUrl = '';
@@ -93,6 +94,51 @@ describe('ApiClient traceparent', () => {
     await client.get('/test', { headers: { traceparent: custom } });
 
     expect(capturedHeaders['traceparent']).toBe(custom);
+  });
+});
+
+describe('ApiClient debug context', () => {
+  function createClientWithContext(context: ExecutionContext) {
+    return new ApiClient(
+      mockConfig as any,
+      context,
+      mockTokenManager as any,
+      {},
+    );
+  }
+
+  it('injects X-UIPATH-JobKey while a debug context is set', async () => {
+    const context = new ExecutionContext();
+    context.set(DEBUG_CONTEXT_KEY, { jobKey: 'debug-job-key-1' });
+
+    await createClientWithContext(context).get('/test');
+
+    expect(capturedHeaders['X-UIPATH-JobKey']).toBe('debug-job-key-1');
+  });
+
+  it('omits X-UIPATH-JobKey when no debug context is set', async () => {
+    await createClientWithContext(new ExecutionContext()).get('/test');
+
+    expect(capturedHeaders['X-UIPATH-JobKey']).toBeUndefined();
+  });
+
+  it('omits X-UIPATH-JobKey after the debug context is cleared', async () => {
+    const context = new ExecutionContext();
+    context.set(DEBUG_CONTEXT_KEY, { jobKey: 'debug-job-key-1' });
+    context.set(DEBUG_CONTEXT_KEY, undefined);
+
+    await createClientWithContext(context).get('/test');
+
+    expect(capturedHeaders['X-UIPATH-JobKey']).toBeUndefined();
+  });
+
+  it('lets per-request options.headers override the debug job key', async () => {
+    const context = new ExecutionContext();
+    context.set(DEBUG_CONTEXT_KEY, { jobKey: 'debug-job-key-1' });
+
+    await createClientWithContext(context).get('/test', { headers: { 'X-UIPATH-JobKey': 'explicit-key' } });
+
+    expect(capturedHeaders['X-UIPATH-JobKey']).toBe('explicit-key');
   });
 });
 

--- a/tests/unit/core/uipath.test.ts
+++ b/tests/unit/core/uipath.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { TelemetryContext } from '@uipath/core-telemetry';
 import { UiPath } from '../../../src/core/uipath';
 import { UiPathConfig } from '../../../src/core/config/config';
-import { ExecutionContext } from '../../../src/core/context/execution';
+import { DEBUG_CONTEXT_KEY, ExecutionContext } from '../../../src/core/context/execution';
 import { telemetryClient } from '../../../src/core/telemetry';
 import { getConfig, getContext, getTokenManager, getPrivateSDK } from '../../utils/setup';
 import { TEST_CONSTANTS } from '../../utils/constants/common';
@@ -144,6 +144,16 @@ describe('UiPath Core', () => {
     it('should provide access token', () => {
       const token = sdk.getToken();
       expect(token).toBe('mock-access-token');
+    });
+
+    it('should store and clear the debug context on the execution context', () => {
+      const context = getContext(sdk);
+
+      sdk.setDebugContext({ jobKey: 'debug-job-key-1' });
+      expect(context.get(DEBUG_CONTEXT_KEY)).toEqual({ jobKey: 'debug-job-key-1' });
+
+      sdk.setDebugContext(null);
+      expect(context.get(DEBUG_CONTEXT_KEY)).toBeUndefined();
     });
   });
 

--- a/tests/unit/services/notification/notifications.test.ts
+++ b/tests/unit/services/notification/notifications.test.ts
@@ -306,7 +306,7 @@ describe('Notification org-level URL routing', () => {
     tenantName: TEST_CONSTANTS.TENANT_ID,
   };
 
-  const mockExecutionContext = {};
+  const mockExecutionContext = { get: () => undefined };
 
   let capturedUrl = '';
   let capturedHeaders: Record<string, string> = {};


### PR DESCRIPTION
## What & why

The SDK side of **L3 JIT debug for coded action apps**. A coded action app rendered in a workflow's HITL task (debug run) needs its own Orchestrator calls to marshal as **debug sub-jobs of the workflow's master job**. The platform does this when the request carries `X-UIPATH-JobKey`; this adds an opt-in way for the app to supply it.

## Changes

- **`UiPath.setDebugContext(context: DebugContext | null)`** — stores a `DebugContext` (`{ jobKey }`) in the execution context; pass `null` to clear it.
- **`ApiClient.request`** — injects `X-UIPATH-JobKey` on each request while a debug context is set (before `traceparent`, after defaults; per-request `options.headers` still win). No header is added when no debug context is set.
- **`DebugContext`** type (public via barrel) + `DEBUG_CONTEXT_KEY`; `IUiPath.setDebugContext` declaration.
- **`@uipath/coded-action-app` `Task`** gains `jobKey` / `isDebug` / `solutionId` / `appProjectKey` (Action Center already sends `jobKey`; the type lagged).

Usage in a coded app:
```ts
const task = await codedActionApps.getTask();
if (task.isDebug && task.jobKey) sdk.setDebugContext({ jobKey: task.jobKey });
```

## Blast radius

Opt-in and additive. No behavior change unless a caller invokes `setDebugContext` — the header is only attached while a debug context is set. No tokens cross any boundary; the JobKey is an identifier the app already receives from Action Center.

## Verification

- `npm run typecheck` clean, `npm run lint` (oxlint) 0 warnings/0 errors.
- `npm run test:unit`: **2793 passed** (incl. new api-client debug-context cases and the setter store/clear tests).
- One existing notification test constructed a real `ApiClient` with an empty `executionContext` mock; since `request()` now reads `executionContext.get()`, the mock is completed to match the real contract.

## Related

Consumed by the coded app after Action Center forwards debug context via `AC.loadApp` (business-apps-tasks PR). Pairs with StudioWeb (fps AppV2 entry) and Automation.Solutions#9583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)